### PR TITLE
feat(m3): RATIO metric with delta method inputs

### DIFF
--- a/services/metrics/internal/config/loader.go
+++ b/services/metrics/internal/config/loader.go
@@ -34,6 +34,9 @@ type MetricConfig struct {
 	Name            string `json:"name"`
 	Type            string `json:"type"` // MEAN, PROPORTION, COUNT, RATIO, PERCENTILE, CUSTOM
 	SourceEventType string `json:"source_event_type"`
+	// NumeratorEventType and DenominatorEventType are used for RATIO metrics.
+	NumeratorEventType   string `json:"numerator_event_type,omitempty"`
+	DenominatorEventType string `json:"denominator_event_type,omitempty"`
 }
 
 // seedFile is the top-level JSON structure.

--- a/services/metrics/internal/config/loader_test.go
+++ b/services/metrics/internal/config/loader_test.go
@@ -31,9 +31,17 @@ func TestLoadFromFile(t *testing.T) {
 	t.Run("metrics for experiment", func(t *testing.T) {
 		metrics, err := cs.GetMetricsForExperiment("e0000000-0000-0000-0000-000000000001")
 		require.NoError(t, err)
-		// primary (ctr_recommendation) + secondary (watch_time_minutes, stream_start_rate)
-		assert.Len(t, metrics, 3)
+		// primary (ctr_recommendation) + secondary (watch_time_minutes, stream_start_rate, rebuffer_rate)
+		assert.Len(t, metrics, 4)
 		assert.Equal(t, "ctr_recommendation", metrics[0].MetricID)
+	})
+
+	t.Run("ratio metric has numerator and denominator", func(t *testing.T) {
+		m, err := cs.GetMetric("rebuffer_rate")
+		require.NoError(t, err)
+		assert.Equal(t, "RATIO", m.Type)
+		assert.Equal(t, "rebuffer_event", m.NumeratorEventType)
+		assert.Equal(t, "playback_minute", m.DenominatorEventType)
 	})
 
 	t.Run("running experiments", func(t *testing.T) {

--- a/services/metrics/internal/config/testdata/seed_config.json
+++ b/services/metrics/internal/config/testdata/seed_config.json
@@ -6,7 +6,7 @@
       "type": "AB",
       "state": "RUNNING",
       "primary_metric_id": "ctr_recommendation",
-      "secondary_metric_ids": ["watch_time_minutes", "stream_start_rate"],
+      "secondary_metric_ids": ["watch_time_minutes", "stream_start_rate", "rebuffer_rate"],
       "variants": [
         {"variant_id": "f0000000-0000-0000-0000-000000000001", "name": "control", "traffic_fraction": 0.5, "is_control": true},
         {"variant_id": "f0000000-0000-0000-0000-000000000002", "name": "collab_filter_v2", "traffic_fraction": 0.5, "is_control": false}
@@ -29,7 +29,7 @@
     {"metric_id": "stream_start_rate",   "name": "Stream Start Rate",          "type": "PROPORTION", "source_event_type": "stream_start"},
     {"metric_id": "watch_time_minutes",  "name": "Watch Time (minutes)",       "type": "MEAN",       "source_event_type": "heartbeat"},
     {"metric_id": "completion_rate",     "name": "Content Completion Rate",    "type": "PROPORTION", "source_event_type": "stream_end"},
-    {"metric_id": "rebuffer_rate",       "name": "Rebuffer Rate",              "type": "RATIO",      "source_event_type": "qoe_rebuffer"},
+    {"metric_id": "rebuffer_rate",       "name": "Rebuffer Rate",              "type": "RATIO",      "source_event_type": "qoe_rebuffer", "numerator_event_type": "rebuffer_event", "denominator_event_type": "playback_minute"},
     {"metric_id": "search_success_rate", "name": "Search Success Rate",        "type": "PROPORTION", "source_event_type": "search"},
     {"metric_id": "ctr_recommendation",  "name": "Recommendation CTR",         "type": "PROPORTION", "source_event_type": "impression"},
     {"metric_id": "revenue_per_user",    "name": "Revenue per User",           "type": "MEAN",       "source_event_type": "revenue"},

--- a/services/metrics/internal/handler/handler_test.go
+++ b/services/metrics/internal/handler/handler_test.go
@@ -59,12 +59,13 @@ func TestComputeMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "e0000000-0000-0000-0000-000000000001", resp.Msg.GetExperimentId())
-	assert.Equal(t, int32(3), resp.Msg.GetMetricsComputed())
+	// 4 metrics: ctr_recommendation, watch_time_minutes, stream_start_rate, rebuffer_rate (RATIO)
+	assert.Equal(t, int32(4), resp.Msg.GetMetricsComputed())
 	assert.NotNil(t, resp.Msg.GetCompletedAt())
 
-	// Verify query logs were written.
+	// Verify query logs: 4 daily_metric + 1 delta_method = 5 entries.
 	entries := qlWriter.AllEntries()
-	assert.Len(t, entries, 3)
+	assert.Len(t, entries, 5)
 }
 
 func TestComputeMetrics_EmptyID(t *testing.T) {
@@ -103,7 +104,7 @@ func TestGetQueryLog(t *testing.T) {
 		ExperimentId: "e0000000-0000-0000-0000-000000000001",
 	}))
 	require.NoError(t, err)
-	assert.Len(t, resp.Msg.GetEntries(), 3)
+	assert.Len(t, resp.Msg.GetEntries(), 5)
 
 	for _, entry := range resp.Msg.GetEntries() {
 		assert.NotEmpty(t, entry.GetSqlText())
@@ -153,8 +154,9 @@ func TestExportNotebook(t *testing.T) {
 	err = json.Unmarshal(resp.Msg.GetNotebookContent(), &nb)
 	require.NoError(t, err, "notebook content must be valid JSON")
 	assert.Equal(t, 4, nb.NBFormat)
-	// header + setup + 3 * (description + SQL) = 8 cells
-	assert.Equal(t, 8, len(nb.Cells))
+	// header + setup + 5 * (description + SQL) = 12 cells
+	// (4 daily_metric + 1 delta_method = 5 queries)
+	assert.Equal(t, 12, len(nb.Cells))
 }
 
 func TestExportNotebook_NoLogs(t *testing.T) {

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
@@ -61,10 +62,12 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 	for _, m := range metrics {
 		params := spark.TemplateParams{
-			ExperimentID:    exp.ExperimentID,
-			MetricID:        m.MetricID,
-			SourceEventType: m.SourceEventType,
-			ComputationDate: computationDate,
+			ExperimentID:         exp.ExperimentID,
+			MetricID:             m.MetricID,
+			SourceEventType:      m.SourceEventType,
+			ComputationDate:      computationDate,
+			NumeratorEventType:   m.NumeratorEventType,
+			DenominatorEventType: m.DenominatorEventType,
 		}
 
 		sql, err := j.renderer.RenderForType(m.Type, params)
@@ -92,6 +95,36 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 		totalRows += result.RowCount
 		metricsComputed++
+
+		// For RATIO metrics, also compute delta method variance components.
+		if strings.ToUpper(m.Type) == "RATIO" {
+			deltaSQL, err := j.renderer.RenderRatioDeltaMethod(params)
+			if err != nil {
+				return nil, fmt.Errorf("jobs: render delta method for %s: %w", m.MetricID, err)
+			}
+
+			deltaResult, err := j.executor.ExecuteAndWrite(ctx, deltaSQL, "delta.daily_treatment_effects")
+			if err != nil {
+				return nil, fmt.Errorf("jobs: execute delta method for %s: %w", m.MetricID, err)
+			}
+
+			if err := j.queryLog.Log(ctx, querylog.Entry{
+				ExperimentID: experimentID,
+				MetricID:     m.MetricID,
+				SQLText:      deltaSQL,
+				RowCount:     deltaResult.RowCount,
+				DurationMs:   deltaResult.Duration.Milliseconds(),
+				JobType:      "delta_method",
+			}); err != nil {
+				return nil, fmt.Errorf("jobs: log delta method query for %s: %w", m.MetricID, err)
+			}
+
+			slog.Info("computed delta method inputs",
+				"experiment_id", experimentID,
+				"metric_id", m.MetricID,
+				"rows", deltaResult.RowCount,
+			)
+		}
 
 		slog.Info("computed metric",
 			"experiment_id", experimentID,

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -37,26 +37,34 @@ func TestStandardJob_Run(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "e0000000-0000-0000-0000-000000000001", result.ExperimentID)
-	// homepage_recs_v2 has: ctr_recommendation (PROPORTION), watch_time_minutes (MEAN), stream_start_rate (PROPORTION)
-	assert.Equal(t, 3, result.MetricsComputed)
+	// homepage_recs_v2 has: ctr_recommendation (PROPORTION), watch_time_minutes (MEAN),
+	// stream_start_rate (PROPORTION), rebuffer_rate (RATIO)
+	assert.Equal(t, 4, result.MetricsComputed)
 	assert.False(t, result.CompletedAt.IsZero())
 
-	// Verify SQL executor was called for each supported metric.
+	// Verify SQL executor was called for each metric.
+	// 3 standard metrics + 1 RATIO metric value + 1 RATIO delta method = 5 calls
 	calls := executor.GetCalls()
-	assert.Len(t, calls, 3)
-	for _, call := range calls {
-		assert.Equal(t, "delta.metric_summaries", call.TargetTable)
-		assert.NotEmpty(t, call.SQL)
-	}
+	assert.Len(t, calls, 5)
 
-	// Verify query log has one entry per metric.
+	// Verify query log has entries for all: 3 standard + 1 ratio + 1 delta method = 5
 	entries := qlWriter.AllEntries()
-	assert.Len(t, entries, 3)
+	assert.Len(t, entries, 5)
+
+	dailyMetricCount := 0
+	deltaMethodCount := 0
 	for _, entry := range entries {
 		assert.Equal(t, "e0000000-0000-0000-0000-000000000001", entry.ExperimentID)
-		assert.Equal(t, "daily_metric", entry.JobType)
 		assert.NotEmpty(t, entry.SQLText)
+		switch entry.JobType {
+		case "daily_metric":
+			dailyMetricCount++
+		case "delta_method":
+			deltaMethodCount++
+		}
 	}
+	assert.Equal(t, 4, dailyMetricCount)
+	assert.Equal(t, 1, deltaMethodCount)
 }
 
 func TestStandardJob_Run_CorrectSQLTypes(t *testing.T) {
@@ -67,19 +75,32 @@ func TestStandardJob_Run_CorrectSQLTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	calls := executor.GetCalls()
-	require.Len(t, calls, 3)
+	// 3 standard + 1 ratio value + 1 ratio delta method = 5
+	require.Len(t, calls, 5)
 
-	// ctr_recommendation is PROPORTION → should have CASE WHEN COUNT
+	// ctr_recommendation is PROPORTION
 	assert.True(t, strings.Contains(calls[0].SQL, "CASE WHEN COUNT"),
 		"PROPORTION metric should use CASE WHEN COUNT")
 
-	// watch_time_minutes is MEAN → should have AVG
+	// watch_time_minutes is MEAN
 	assert.True(t, strings.Contains(calls[1].SQL, "AVG(metric_data.value)"),
 		"MEAN metric should use AVG")
 
-	// stream_start_rate is PROPORTION → should have CASE WHEN COUNT
+	// stream_start_rate is PROPORTION
 	assert.True(t, strings.Contains(calls[2].SQL, "CASE WHEN COUNT"),
 		"PROPORTION metric should use CASE WHEN COUNT")
+
+	// rebuffer_rate is RATIO: per-user ratio value
+	assert.True(t, strings.Contains(calls[3].SQL, "numerator_sum / per_user.denominator_sum"),
+		"RATIO metric should compute numerator/denominator ratio")
+	assert.Equal(t, "delta.metric_summaries", calls[3].TargetTable)
+
+	// rebuffer_rate delta method: variance components
+	assert.True(t, strings.Contains(calls[4].SQL, "VAR_SAMP"),
+		"Delta method query should have VAR_SAMP")
+	assert.True(t, strings.Contains(calls[4].SQL, "COVAR_SAMP"),
+		"Delta method query should have COVAR_SAMP")
+	assert.Equal(t, "delta.daily_treatment_effects", calls[4].TargetTable)
 }
 
 func TestStandardJob_Run_NotFound(t *testing.T) {

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -18,6 +18,9 @@ type TemplateParams struct {
 	MetricID        string
 	SourceEventType string
 	ComputationDate string // YYYY-MM-DD
+	// NumeratorEventType and DenominatorEventType are used for RATIO metrics.
+	NumeratorEventType   string
+	DenominatorEventType string
 }
 
 // SQLRenderer renders Spark SQL from embedded templates.
@@ -58,6 +61,17 @@ func (r *SQLRenderer) RenderCount(p TemplateParams) (string, error) {
 	return r.Render("count.sql.tmpl", p)
 }
 
+// RenderRatio renders the RATIO metric SQL template (per-user ratio value).
+func (r *SQLRenderer) RenderRatio(p TemplateParams) (string, error) {
+	return r.Render("ratio.sql.tmpl", p)
+}
+
+// RenderRatioDeltaMethod renders the delta method variance components SQL for RATIO metrics.
+// This produces per-variant Var(N), Var(D), Cov(N,D) needed by M4a for delta method CI.
+func (r *SQLRenderer) RenderRatioDeltaMethod(p TemplateParams) (string, error) {
+	return r.Render("ratio_delta_method.sql.tmpl", p)
+}
+
 // RenderForType dispatches to the correct template based on metric type string.
 func (r *SQLRenderer) RenderForType(metricType string, p TemplateParams) (string, error) {
 	switch strings.ToUpper(metricType) {
@@ -67,7 +81,9 @@ func (r *SQLRenderer) RenderForType(metricType string, p TemplateParams) (string
 		return r.RenderProportion(p)
 	case "COUNT":
 		return r.RenderCount(p)
+	case "RATIO":
+		return r.RenderRatio(p)
 	default:
-		return "", fmt.Errorf("spark: unsupported metric type %q (supported: MEAN, PROPORTION, COUNT)", metricType)
+		return "", fmt.Errorf("spark: unsupported metric type %q (supported: MEAN, PROPORTION, COUNT, RATIO)", metricType)
 	}
 }

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -73,6 +73,38 @@ func TestRenderCount(t *testing.T) {
 	assert.Equal(t, expected, sql)
 }
 
+func TestRenderRatio(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+
+	p := testParams
+	p.MetricID = "rebuffer_rate"
+	p.NumeratorEventType = "rebuffer_event"
+	p.DenominatorEventType = "playback_minute"
+
+	sql, err := r.RenderRatio(p)
+	require.NoError(t, err)
+
+	expected := readGolden(t, "ratio_expected.sql")
+	assert.Equal(t, expected, sql)
+}
+
+func TestRenderRatioDeltaMethod(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+
+	p := testParams
+	p.MetricID = "rebuffer_rate"
+	p.NumeratorEventType = "rebuffer_event"
+	p.DenominatorEventType = "playback_minute"
+
+	sql, err := r.RenderRatioDeltaMethod(p)
+	require.NoError(t, err)
+
+	expected := readGolden(t, "ratio_delta_method_expected.sql")
+	assert.Equal(t, expected, sql)
+}
+
 func TestRenderForType(t *testing.T) {
 	r, err := NewSQLRenderer()
 	require.NoError(t, err)
@@ -80,6 +112,8 @@ func TestRenderForType(t *testing.T) {
 	p := testParams
 	p.MetricID = "test_metric"
 	p.SourceEventType = "test_event"
+	p.NumeratorEventType = "num_event"
+	p.DenominatorEventType = "denom_event"
 
 	tests := []struct {
 		metricType string
@@ -88,9 +122,10 @@ func TestRenderForType(t *testing.T) {
 		{"MEAN", false},
 		{"PROPORTION", false},
 		{"COUNT", false},
+		{"RATIO", false},
 		{"mean", false},   // case-insensitive
-		{"RATIO", true},   // unsupported in this milestone
-		{"CUSTOM", true},  // unsupported in this milestone
+		{"ratio", false},  // case-insensitive
+		{"CUSTOM", true},  // unsupported
 		{"INVALID", true},
 	}
 
@@ -104,6 +139,39 @@ func TestRenderForType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderRatio_ContainsKeyFields(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+
+	p := TemplateParams{
+		ExperimentID:         "test-exp-123",
+		MetricID:             "my_ratio",
+		NumeratorEventType:   "revenue",
+		DenominatorEventType: "sessions",
+		ComputationDate:      "2024-06-01",
+	}
+
+	sql, err := r.RenderRatio(p)
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "test-exp-123")
+	assert.Contains(t, sql, "my_ratio")
+	assert.Contains(t, sql, "revenue")
+	assert.Contains(t, sql, "sessions")
+	assert.Contains(t, sql, "numerator_sum")
+	assert.Contains(t, sql, "denominator_sum")
+	assert.Contains(t, sql, "numerator_sum / per_user.denominator_sum")
+
+	deltaSQL, err := r.RenderRatioDeltaMethod(p)
+	require.NoError(t, err)
+
+	assert.Contains(t, deltaSQL, "VAR_SAMP(per_user.numerator_sum)")
+	assert.Contains(t, deltaSQL, "VAR_SAMP(per_user.denominator_sum)")
+	assert.Contains(t, deltaSQL, "COVAR_SAMP(per_user.numerator_sum, per_user.denominator_sum)")
+	assert.Contains(t, deltaSQL, "mean_numerator")
+	assert.Contains(t, deltaSQL, "mean_denominator")
 }
 
 func TestRenderSQL_ContainsKeyFields(t *testing.T) {

--- a/services/metrics/internal/spark/templates/ratio.sql.tmpl
+++ b/services/metrics/internal/spark/templates/ratio.sql.tmpl
@@ -1,0 +1,39 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+numerator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.NumeratorEventType}}'
+),
+denominator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.DenominatorEventType}}'
+),
+per_user AS (
+    SELECT
+        eu.user_id,
+        eu.variant_id,
+        COALESCE(SUM(n.value), 0.0) AS numerator_sum,
+        COALESCE(SUM(d.value), 0.0) AS denominator_sum
+    FROM exposed_users eu
+    LEFT JOIN numerator_data n ON eu.user_id = n.user_id AND eu.variant_id = n.variant_id
+    LEFT JOIN denominator_data d ON eu.user_id = d.user_id AND eu.variant_id = d.variant_id
+    GROUP BY eu.user_id, eu.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    per_user.user_id,
+    per_user.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CASE
+        WHEN per_user.denominator_sum = 0.0 THEN 0.0
+        ELSE per_user.numerator_sum / per_user.denominator_sum
+    END AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM per_user

--- a/services/metrics/internal/spark/templates/ratio_delta_method.sql.tmpl
+++ b/services/metrics/internal/spark/templates/ratio_delta_method.sql.tmpl
@@ -1,0 +1,41 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+numerator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.NumeratorEventType}}'
+),
+denominator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.DenominatorEventType}}'
+),
+per_user AS (
+    SELECT
+        eu.user_id,
+        eu.variant_id,
+        COALESCE(SUM(n.value), 0.0) AS numerator_sum,
+        COALESCE(SUM(d.value), 0.0) AS denominator_sum
+    FROM exposed_users eu
+    LEFT JOIN numerator_data n ON eu.user_id = n.user_id AND eu.variant_id = n.variant_id
+    LEFT JOIN denominator_data d ON eu.user_id = d.user_id AND eu.variant_id = d.variant_id
+    GROUP BY eu.user_id, eu.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    per_user.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    COUNT(*) AS user_count,
+    AVG(per_user.numerator_sum) AS mean_numerator,
+    AVG(per_user.denominator_sum) AS mean_denominator,
+    VAR_SAMP(per_user.numerator_sum) AS var_numerator,
+    VAR_SAMP(per_user.denominator_sum) AS var_denominator,
+    COVAR_SAMP(per_user.numerator_sum, per_user.denominator_sum) AS cov_numerator_denominator,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM per_user
+GROUP BY per_user.variant_id

--- a/services/metrics/testdata/golden/ratio_delta_method_expected.sql
+++ b/services/metrics/testdata/golden/ratio_delta_method_expected.sql
@@ -1,0 +1,41 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+),
+numerator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'rebuffer_event'
+),
+denominator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'playback_minute'
+),
+per_user AS (
+    SELECT
+        eu.user_id,
+        eu.variant_id,
+        COALESCE(SUM(n.value), 0.0) AS numerator_sum,
+        COALESCE(SUM(d.value), 0.0) AS denominator_sum
+    FROM exposed_users eu
+    LEFT JOIN numerator_data n ON eu.user_id = n.user_id AND eu.variant_id = n.variant_id
+    LEFT JOIN denominator_data d ON eu.user_id = d.user_id AND eu.variant_id = d.variant_id
+    GROUP BY eu.user_id, eu.variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    per_user.variant_id,
+    'rebuffer_rate' AS metric_id,
+    COUNT(*) AS user_count,
+    AVG(per_user.numerator_sum) AS mean_numerator,
+    AVG(per_user.denominator_sum) AS mean_denominator,
+    VAR_SAMP(per_user.numerator_sum) AS var_numerator,
+    VAR_SAMP(per_user.denominator_sum) AS var_denominator,
+    COVAR_SAMP(per_user.numerator_sum, per_user.denominator_sum) AS cov_numerator_denominator,
+    CAST('2024-01-15' AS DATE) AS computation_date
+FROM per_user
+GROUP BY per_user.variant_id

--- a/services/metrics/testdata/golden/ratio_expected.sql
+++ b/services/metrics/testdata/golden/ratio_expected.sql
@@ -1,0 +1,39 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+),
+numerator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'rebuffer_event'
+),
+denominator_data AS (
+    SELECT me.user_id, eu.variant_id, me.value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'playback_minute'
+),
+per_user AS (
+    SELECT
+        eu.user_id,
+        eu.variant_id,
+        COALESCE(SUM(n.value), 0.0) AS numerator_sum,
+        COALESCE(SUM(d.value), 0.0) AS denominator_sum
+    FROM exposed_users eu
+    LEFT JOIN numerator_data n ON eu.user_id = n.user_id AND eu.variant_id = n.variant_id
+    LEFT JOIN denominator_data d ON eu.user_id = d.user_id AND eu.variant_id = d.variant_id
+    GROUP BY eu.user_id, eu.variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    per_user.user_id,
+    per_user.variant_id,
+    'rebuffer_rate' AS metric_id,
+    CASE
+        WHEN per_user.denominator_sum = 0.0 THEN 0.0
+        ELSE per_user.numerator_sum / per_user.denominator_sum
+    END AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date
+FROM per_user


### PR DESCRIPTION
## Summary
- Add RATIO metric type to the M3 metric computation engine
- New `ratio.sql.tmpl` computes per-user numerator/denominator ratio with safe division (0 when denominator is 0)
- New `ratio_delta_method.sql.tmpl` computes per-variant variance components: Var(N), Var(D), Cov(N,D) needed by M4a for delta method confidence intervals
- Extended `MetricConfig` with `NumeratorEventType`/`DenominatorEventType` fields
- `StandardJob` now runs both ratio value + delta method queries for RATIO metrics, logging both to `query_log`
- Updated seed config: `rebuffer_rate` RATIO metric with numerator/denominator event types, added to `homepage_recs_v2` experiment

## What this unblocks
- **Agent-4 M4a**: Delta method analysis for ratio metrics requires variance components (Var(N), Var(D), Cov(N,D)) in `daily_treatment_effects`
- All SQL queries for RATIO metrics are logged to `query_log` and included in notebook exports

## Test plan
- [x] 31 tests pass with `-race -cover` (4 new tests)
- [x] Golden file validation: `ratio_expected.sql` and `ratio_delta_method_expected.sql`
- [x] `RenderRatio` + `RenderRatioDeltaMethod` produce correct SQL with numerator/denominator event types
- [x] `StandardJob.Run` produces 5 executor calls for experiment with RATIO metric (4 daily_metric + 1 delta_method)
- [x] Query log has separate entries for daily_metric and delta_method job types
- [x] Notebook export includes all 5 queries (12 cells total)
- [x] Only `services/metrics/` files modified — no cross-boundary changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)