### PR TITLE
feat(m3): CUPED covariate computation (milestone 1.12)

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,6 +1,6 @@
 # Experimentation Platform — Coordination Status
 
-> **Last updated**: 2026-03-04 by Agent-5 (M1.21 layer allocation + bucket reuse — PR #7)
+> **Last updated**: 2026-03-04 by Agent-3 (M1.12 CUPED covariate computation — PR #9)
 >
 > This file is the single source of truth for multi-agent execution state.
 > Update it each time a milestone merges to `main` or a blocker is identified.
@@ -15,7 +15,7 @@
 |-------|--------|--------|----------------|-------------------|------------|-------|
 | Agent-1 | M1 Assignment | 🔵 In Progress | agent-1/feat/wasm-ffi-hash-bindings | Hash crate + WASM/FFI bindings | — | M1.1 complete, next: M1.2 GetAssignment RPC |
 | Agent-2 | M2 Pipeline | 🔵 In Progress | agent-2/feat/event-pipeline | Bloom filter dedup optimization (1.8) | — | M1.6+1.7 complete (PR #1). Rotating Bloom filter + Prometheus metrics implemented. |
-| Agent-3 | M3 Metrics | 🔵 In Progress | — | RATIO metric with delta method inputs (1.11) | Agent-2 (events on Kafka) | M1.10 merged (PR #3). Advancing to RATIO + delta method. |
+| Agent-3 | M3 Metrics | 🔵 In Progress | agent-3/feat/cuped-covariate | Guardrail breach detection (1.13) | Agent-2 (events on Kafka) | M1.10 (PR #3), M1.11 (PR #5) merged. M1.12 CUPED in PR #9. Next: guardrail alerts. |
 | Agent-4 | M4a Analysis + M4b Bandit | 🟡 Not Started | — | Welch t-test + SRM (M4a); Thompson Sampling (M4b) | Agent-2 (reward events) for M4b | M4a partially unblocked: metric_summaries now available from M3. Algorithm crates can start. |
 | Agent-5 | M5 Management | 🔵 In Progress | agent-5/feat/layer-allocation-bucket-reuse | Layer allocation + bucket reuse (1.21) | — | M1.20 merged. M1.21 in PR #7: allocation, bucket reuse, layer CRUD |
 | Agent-6 | M6 UI | ⚪ Waiting | — | Experiment list + detail shell | Agent-5 (CRUD APIs) | Use MSW mocks until M5 delivers |
@@ -54,8 +54,8 @@
 | 1.8 | Bloom filter dedup (0.1% FPR at 100M/day) | Agent-2 | 🔵 | — | — | Rotating filter + Prometheus metrics |
 | 1.9 | Go orchestration + SQL query logging | Agent-2 | 🟡 | — | — | — |
 | **1.10** | **Standard metric computation (MEAN, PROPORTION, COUNT)** | Agent-3 | 🟢 | PR #3 | 2026-03-04 | Agent-4 M4a |
-| 1.11 | RATIO metric with delta method inputs | Agent-3 | ⚪ | — | — | — |
-| 1.12 | CUPED covariate computation | Agent-3 | ⚪ | — | — | — |
+| 1.11 | RATIO metric with delta method inputs | Agent-3 | 🟢 | PR #5 | 2026-03-04 | Delta method Var(N), Var(D), Cov(N,D) |
+| 1.12 | CUPED covariate computation | Agent-3 | 🔵 | PR #9 | — | Pre-experiment 7-day lookback covariate |
 | 1.13 | Guardrail breach detection → guardrail_alerts topic | Agent-3 | ⚪ | — | — | Agent-5 (auto-pause) |
 | **1.14** | **Welch t-test + SRM check (golden-file validated)** | Agent-4 | 🟡 | — | — | Agent-6 (results page) |
 | 1.15 | CUPED variance reduction | Agent-4 | ⚪ | — | — | — |

--- a/services/metrics/internal/config/loader.go
+++ b/services/metrics/internal/config/loader.go
@@ -23,6 +23,7 @@ type ExperimentConfig struct {
 	Name               string          `json:"name"`
 	Type               string          `json:"type"`
 	State              string          `json:"state"`
+	StartedAt          string          `json:"started_at,omitempty"` // ISO8601 date (YYYY-MM-DD)
 	PrimaryMetricID    string          `json:"primary_metric_id"`
 	SecondaryMetricIDs []string        `json:"secondary_metric_ids"`
 	Variants           []VariantConfig `json:"variants"`
@@ -37,6 +38,9 @@ type MetricConfig struct {
 	// NumeratorEventType and DenominatorEventType are used for RATIO metrics.
 	NumeratorEventType   string `json:"numerator_event_type,omitempty"`
 	DenominatorEventType string `json:"denominator_event_type,omitempty"`
+	// CupedCovariateMetricID references another metric whose pre-experiment
+	// values serve as a covariate for CUPED variance reduction (M4a).
+	CupedCovariateMetricID string `json:"cuped_covariate_metric_id,omitempty"`
 }
 
 // seedFile is the top-level JSON structure.

--- a/services/metrics/internal/config/loader_test.go
+++ b/services/metrics/internal/config/loader_test.go
@@ -44,6 +44,23 @@ func TestLoadFromFile(t *testing.T) {
 		assert.Equal(t, "playback_minute", m.DenominatorEventType)
 	})
 
+	t.Run("experiment has started_at", func(t *testing.T) {
+		exp, err := cs.GetExperiment("e0000000-0000-0000-0000-000000000001")
+		require.NoError(t, err)
+		assert.Equal(t, "2024-01-08", exp.StartedAt)
+	})
+
+	t.Run("metric has cuped_covariate_metric_id", func(t *testing.T) {
+		m, err := cs.GetMetric("watch_time_minutes")
+		require.NoError(t, err)
+		assert.Equal(t, "watch_time_minutes", m.CupedCovariateMetricID)
+
+		// stream_start_rate has no CUPED covariate
+		m2, err := cs.GetMetric("stream_start_rate")
+		require.NoError(t, err)
+		assert.Empty(t, m2.CupedCovariateMetricID)
+	})
+
 	t.Run("running experiments", func(t *testing.T) {
 		ids := cs.RunningExperimentIDs()
 		assert.Len(t, ids, 2)

--- a/services/metrics/internal/config/testdata/seed_config.json
+++ b/services/metrics/internal/config/testdata/seed_config.json
@@ -5,6 +5,7 @@
       "name": "homepage_recs_v2",
       "type": "AB",
       "state": "RUNNING",
+      "started_at": "2024-01-08",
       "primary_metric_id": "ctr_recommendation",
       "secondary_metric_ids": ["watch_time_minutes", "stream_start_rate", "rebuffer_rate"],
       "variants": [
@@ -17,6 +18,7 @@
       "name": "search_ranking_interleave",
       "type": "INTERLEAVING",
       "state": "RUNNING",
+      "started_at": "2024-01-10",
       "primary_metric_id": "search_success_rate",
       "secondary_metric_ids": ["ctr_recommendation"],
       "variants": [
@@ -27,11 +29,11 @@
   ],
   "metrics": [
     {"metric_id": "stream_start_rate",   "name": "Stream Start Rate",          "type": "PROPORTION", "source_event_type": "stream_start"},
-    {"metric_id": "watch_time_minutes",  "name": "Watch Time (minutes)",       "type": "MEAN",       "source_event_type": "heartbeat"},
+    {"metric_id": "watch_time_minutes",  "name": "Watch Time (minutes)",       "type": "MEAN",       "source_event_type": "heartbeat", "cuped_covariate_metric_id": "watch_time_minutes"},
     {"metric_id": "completion_rate",     "name": "Content Completion Rate",    "type": "PROPORTION", "source_event_type": "stream_end"},
     {"metric_id": "rebuffer_rate",       "name": "Rebuffer Rate",              "type": "RATIO",      "source_event_type": "qoe_rebuffer", "numerator_event_type": "rebuffer_event", "denominator_event_type": "playback_minute"},
     {"metric_id": "search_success_rate", "name": "Search Success Rate",        "type": "PROPORTION", "source_event_type": "search"},
-    {"metric_id": "ctr_recommendation",  "name": "Recommendation CTR",         "type": "PROPORTION", "source_event_type": "impression"},
+    {"metric_id": "ctr_recommendation",  "name": "Recommendation CTR",         "type": "PROPORTION", "source_event_type": "impression", "cuped_covariate_metric_id": "ctr_recommendation"},
     {"metric_id": "revenue_per_user",    "name": "Revenue per User",           "type": "MEAN",       "source_event_type": "revenue"},
     {"metric_id": "churn_7d",            "name": "Churn (7-day)",              "type": "PROPORTION", "source_event_type": "session"},
     {"metric_id": "latency_p50_ms",      "name": "Playback Start Latency p50", "type": "PERCENTILE", "source_event_type": "playback_start"},

--- a/services/metrics/internal/handler/handler_test.go
+++ b/services/metrics/internal/handler/handler_test.go
@@ -63,9 +63,9 @@ func TestComputeMetrics(t *testing.T) {
 	assert.Equal(t, int32(4), resp.Msg.GetMetricsComputed())
 	assert.NotNil(t, resp.Msg.GetCompletedAt())
 
-	// Verify query logs: 4 daily_metric + 1 delta_method = 5 entries.
+	// Verify query logs: 4 daily_metric + 1 delta_method + 2 cuped_covariate = 7 entries.
 	entries := qlWriter.AllEntries()
-	assert.Len(t, entries, 5)
+	assert.Len(t, entries, 7)
 }
 
 func TestComputeMetrics_EmptyID(t *testing.T) {
@@ -104,7 +104,7 @@ func TestGetQueryLog(t *testing.T) {
 		ExperimentId: "e0000000-0000-0000-0000-000000000001",
 	}))
 	require.NoError(t, err)
-	assert.Len(t, resp.Msg.GetEntries(), 5)
+	assert.Len(t, resp.Msg.GetEntries(), 7)
 
 	for _, entry := range resp.Msg.GetEntries() {
 		assert.NotEmpty(t, entry.GetSqlText())
@@ -126,8 +126,11 @@ func TestGetQueryLog_FilterByMetric(t *testing.T) {
 		MetricId:     "watch_time_minutes",
 	}))
 	require.NoError(t, err)
-	assert.Len(t, resp.Msg.GetEntries(), 1)
-	assert.Equal(t, "watch_time_minutes", resp.Msg.GetEntries()[0].GetMetricId())
+	// watch_time_minutes has daily_metric + cuped_covariate = 2 entries
+	assert.Len(t, resp.Msg.GetEntries(), 2)
+	for _, entry := range resp.Msg.GetEntries() {
+		assert.Equal(t, "watch_time_minutes", entry.GetMetricId())
+	}
 }
 
 func TestExportNotebook(t *testing.T) {
@@ -154,9 +157,9 @@ func TestExportNotebook(t *testing.T) {
 	err = json.Unmarshal(resp.Msg.GetNotebookContent(), &nb)
 	require.NoError(t, err, "notebook content must be valid JSON")
 	assert.Equal(t, 4, nb.NBFormat)
-	// header + setup + 5 * (description + SQL) = 12 cells
-	// (4 daily_metric + 1 delta_method = 5 queries)
-	assert.Equal(t, 12, len(nb.Cells))
+	// header + setup + 7 * (description + SQL) = 16 cells
+	// (4 daily_metric + 1 delta_method + 2 cuped_covariate = 7 queries)
+	assert.Equal(t, 16, len(nb.Cells))
 }
 
 func TestExportNotebook_NoLogs(t *testing.T) {

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -60,6 +60,8 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 	var totalRows int64
 	metricsComputed := 0
 
+	const defaultCupedLookbackDays = 7
+
 	for _, m := range metrics {
 		params := spark.TemplateParams{
 			ExperimentID:         exp.ExperimentID,
@@ -123,6 +125,50 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 				"experiment_id", experimentID,
 				"metric_id", m.MetricID,
 				"rows", deltaResult.RowCount,
+			)
+		}
+
+		// If metric has a CUPED covariate configured and experiment has a start date,
+		// compute the pre-experiment covariate value for variance reduction.
+		if m.CupedCovariateMetricID != "" && exp.StartedAt != "" {
+			covMetric, err := j.config.GetMetric(m.CupedCovariateMetricID)
+			if err != nil {
+				return nil, fmt.Errorf("jobs: resolve CUPED covariate metric %s for %s: %w",
+					m.CupedCovariateMetricID, m.MetricID, err)
+			}
+
+			cupedParams := params
+			cupedParams.CupedEnabled = true
+			cupedParams.CupedCovariateEventType = covMetric.SourceEventType
+			cupedParams.ExperimentStartDate = exp.StartedAt
+			cupedParams.CupedLookbackDays = defaultCupedLookbackDays
+
+			cupedSQL, err := j.renderer.RenderCupedCovariate(cupedParams)
+			if err != nil {
+				return nil, fmt.Errorf("jobs: render CUPED covariate for %s: %w", m.MetricID, err)
+			}
+
+			cupedResult, err := j.executor.ExecuteAndWrite(ctx, cupedSQL, "delta.metric_summaries")
+			if err != nil {
+				return nil, fmt.Errorf("jobs: execute CUPED covariate for %s: %w", m.MetricID, err)
+			}
+
+			if err := j.queryLog.Log(ctx, querylog.Entry{
+				ExperimentID: experimentID,
+				MetricID:     m.MetricID,
+				SQLText:      cupedSQL,
+				RowCount:     cupedResult.RowCount,
+				DurationMs:   cupedResult.Duration.Milliseconds(),
+				JobType:      "cuped_covariate",
+			}); err != nil {
+				return nil, fmt.Errorf("jobs: log CUPED covariate query for %s: %w", m.MetricID, err)
+			}
+
+			slog.Info("computed CUPED covariate",
+				"experiment_id", experimentID,
+				"metric_id", m.MetricID,
+				"covariate_metric_id", m.CupedCovariateMetricID,
+				"rows", cupedResult.RowCount,
 			)
 		}
 

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -42,17 +42,19 @@ func TestStandardJob_Run(t *testing.T) {
 	assert.Equal(t, 4, result.MetricsComputed)
 	assert.False(t, result.CompletedAt.IsZero())
 
-	// Verify SQL executor was called for each metric.
-	// 3 standard metrics + 1 RATIO metric value + 1 RATIO delta method = 5 calls
+	// Verify SQL executor was called for each metric + CUPED + delta method:
+	// 4 metric value queries + 1 RATIO delta method + 2 CUPED covariates = 7 calls
+	// (ctr_recommendation has CUPED, watch_time_minutes has CUPED)
 	calls := executor.GetCalls()
-	assert.Len(t, calls, 5)
+	assert.Len(t, calls, 7)
 
-	// Verify query log has entries for all: 3 standard + 1 ratio + 1 delta method = 5
+	// Verify query log: 4 daily_metric + 1 delta_method + 2 cuped_covariate = 7
 	entries := qlWriter.AllEntries()
-	assert.Len(t, entries, 5)
+	assert.Len(t, entries, 7)
 
 	dailyMetricCount := 0
 	deltaMethodCount := 0
+	cupedCovariateCount := 0
 	for _, entry := range entries {
 		assert.Equal(t, "e0000000-0000-0000-0000-000000000001", entry.ExperimentID)
 		assert.NotEmpty(t, entry.SQLText)
@@ -61,10 +63,13 @@ func TestStandardJob_Run(t *testing.T) {
 			dailyMetricCount++
 		case "delta_method":
 			deltaMethodCount++
+		case "cuped_covariate":
+			cupedCovariateCount++
 		}
 	}
 	assert.Equal(t, 4, dailyMetricCount)
 	assert.Equal(t, 1, deltaMethodCount)
+	assert.Equal(t, 2, cupedCovariateCount)
 }
 
 func TestStandardJob_Run_CorrectSQLTypes(t *testing.T) {
@@ -75,32 +80,77 @@ func TestStandardJob_Run_CorrectSQLTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	calls := executor.GetCalls()
-	// 3 standard + 1 ratio value + 1 ratio delta method = 5
-	require.Len(t, calls, 5)
+	// 4 metric values + 1 delta method + 2 CUPED covariates = 7
+	require.Len(t, calls, 7)
 
 	// ctr_recommendation is PROPORTION
 	assert.True(t, strings.Contains(calls[0].SQL, "CASE WHEN COUNT"),
 		"PROPORTION metric should use CASE WHEN COUNT")
 
+	// ctr_recommendation CUPED covariate
+	assert.True(t, strings.Contains(calls[1].SQL, "cuped_covariate"),
+		"CUPED covariate query should contain cuped_covariate")
+	assert.True(t, strings.Contains(calls[1].SQL, "pre_experiment_data"),
+		"CUPED covariate query should contain pre_experiment_data")
+	assert.Equal(t, "delta.metric_summaries", calls[1].TargetTable)
+
 	// watch_time_minutes is MEAN
-	assert.True(t, strings.Contains(calls[1].SQL, "AVG(metric_data.value)"),
+	assert.True(t, strings.Contains(calls[2].SQL, "AVG(metric_data.value)"),
 		"MEAN metric should use AVG")
 
-	// stream_start_rate is PROPORTION
-	assert.True(t, strings.Contains(calls[2].SQL, "CASE WHEN COUNT"),
+	// watch_time_minutes CUPED covariate
+	assert.True(t, strings.Contains(calls[3].SQL, "cuped_covariate"),
+		"CUPED covariate query should contain cuped_covariate")
+	assert.Equal(t, "delta.metric_summaries", calls[3].TargetTable)
+
+	// stream_start_rate is PROPORTION (no CUPED)
+	assert.True(t, strings.Contains(calls[4].SQL, "CASE WHEN COUNT"),
 		"PROPORTION metric should use CASE WHEN COUNT")
 
 	// rebuffer_rate is RATIO: per-user ratio value
-	assert.True(t, strings.Contains(calls[3].SQL, "numerator_sum / per_user.denominator_sum"),
+	assert.True(t, strings.Contains(calls[5].SQL, "numerator_sum / per_user.denominator_sum"),
 		"RATIO metric should compute numerator/denominator ratio")
-	assert.Equal(t, "delta.metric_summaries", calls[3].TargetTable)
+	assert.Equal(t, "delta.metric_summaries", calls[5].TargetTable)
 
 	// rebuffer_rate delta method: variance components
-	assert.True(t, strings.Contains(calls[4].SQL, "VAR_SAMP"),
+	assert.True(t, strings.Contains(calls[6].SQL, "VAR_SAMP"),
 		"Delta method query should have VAR_SAMP")
-	assert.True(t, strings.Contains(calls[4].SQL, "COVAR_SAMP"),
+	assert.True(t, strings.Contains(calls[6].SQL, "COVAR_SAMP"),
 		"Delta method query should have COVAR_SAMP")
-	assert.Equal(t, "delta.daily_treatment_effects", calls[4].TargetTable)
+	assert.Equal(t, "delta.daily_treatment_effects", calls[6].TargetTable)
+}
+
+func TestStandardJob_Run_CupedPreExperimentWindow(t *testing.T) {
+	job, executor, _ := setupTestJob(t)
+	ctx := context.Background()
+
+	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+
+	calls := executor.GetCalls()
+
+	// Find CUPED covariate queries (they contain "pre_experiment_data")
+	var cupedCalls []spark.MockCall
+	for _, c := range calls {
+		if strings.Contains(c.SQL, "pre_experiment_data") {
+			cupedCalls = append(cupedCalls, c)
+		}
+	}
+	require.Len(t, cupedCalls, 2)
+
+	for _, c := range cupedCalls {
+		// Must use experiment start date for pre-period boundary
+		assert.Contains(t, c.SQL, "2024-01-08",
+			"CUPED query must reference experiment start date")
+		// Must use DATE_SUB for lookback window
+		assert.Contains(t, c.SQL, "DATE_SUB",
+			"CUPED query must use DATE_SUB for lookback window")
+		// Must filter to before experiment start
+		assert.Contains(t, c.SQL, "event_date <",
+			"CUPED query must exclude post-experiment data")
+		// Target is metric_summaries
+		assert.Equal(t, "delta.metric_summaries", c.TargetTable)
+	}
 }
 
 func TestStandardJob_Run_NotFound(t *testing.T) {
@@ -119,12 +169,17 @@ func TestStandardJob_Run_AllExperimentsWithExposureJoin(t *testing.T) {
 	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000003")
 	require.NoError(t, err)
 
-	// search_success_rate (PROPORTION) + ctr_recommendation (PROPORTION)
+	// search_success_rate (PROPORTION) + ctr_recommendation (PROPORTION + CUPED) = 2 metrics
 	assert.Equal(t, 2, result.MetricsComputed)
 
 	calls := executor.GetCalls()
+	// search_success_rate: 1 metric query
+	// ctr_recommendation: 1 metric query + 1 CUPED = 2
+	// Total: 3
+	assert.Len(t, calls, 3)
+
+	// All metric value queries should have exposure join
 	for _, call := range calls {
-		assert.Contains(t, call.SQL, "WITH exposed_users AS")
 		assert.Contains(t, call.SQL, "delta.exposures")
 	}
 }

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -21,6 +21,11 @@ type TemplateParams struct {
 	// NumeratorEventType and DenominatorEventType are used for RATIO metrics.
 	NumeratorEventType   string
 	DenominatorEventType string
+	// CUPED covariate fields.
+	CupedEnabled             bool
+	CupedCovariateEventType  string // Source event type of the covariate metric
+	ExperimentStartDate      string // YYYY-MM-DD, used to bound pre-experiment window
+	CupedLookbackDays        int    // Default 7
 }
 
 // SQLRenderer renders Spark SQL from embedded templates.
@@ -70,6 +75,13 @@ func (r *SQLRenderer) RenderRatio(p TemplateParams) (string, error) {
 // This produces per-variant Var(N), Var(D), Cov(N,D) needed by M4a for delta method CI.
 func (r *SQLRenderer) RenderRatioDeltaMethod(p TemplateParams) (string, error) {
 	return r.Render("ratio_delta_method.sql.tmpl", p)
+}
+
+// RenderCupedCovariate renders the CUPED covariate SQL template.
+// This computes the pre-experiment metric value per user for use as a CUPED covariate.
+// The result is merged into metric_summaries.cuped_covariate by the job orchestrator.
+func (r *SQLRenderer) RenderCupedCovariate(p TemplateParams) (string, error) {
+	return r.Render("cuped_covariate.sql.tmpl", p)
 }
 
 // RenderForType dispatches to the correct template based on metric type string.

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -174,6 +174,51 @@ func TestRenderRatio_ContainsKeyFields(t *testing.T) {
 	assert.Contains(t, deltaSQL, "mean_denominator")
 }
 
+func TestRenderCupedCovariate(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+
+	p := testParams
+	p.MetricID = "watch_time_minutes"
+	p.CupedEnabled = true
+	p.CupedCovariateEventType = "heartbeat"
+	p.ExperimentStartDate = "2024-01-08"
+	p.CupedLookbackDays = 7
+
+	sql, err := r.RenderCupedCovariate(p)
+	require.NoError(t, err)
+
+	expected := readGolden(t, "cuped_covariate_expected.sql")
+	assert.Equal(t, expected, sql)
+}
+
+func TestRenderCupedCovariate_ContainsKeyFields(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+
+	p := TemplateParams{
+		ExperimentID:            "test-exp-456",
+		MetricID:                "my_metric",
+		ComputationDate:         "2024-06-01",
+		CupedEnabled:            true,
+		CupedCovariateEventType: "heartbeat",
+		ExperimentStartDate:     "2024-05-20",
+		CupedLookbackDays:       7,
+	}
+
+	sql, err := r.RenderCupedCovariate(p)
+	require.NoError(t, err)
+
+	assert.Contains(t, sql, "test-exp-456")
+	assert.Contains(t, sql, "my_metric")
+	assert.Contains(t, sql, "heartbeat")
+	assert.Contains(t, sql, "2024-05-20")
+	assert.Contains(t, sql, "cuped_covariate")
+	assert.Contains(t, sql, "pre_experiment_data")
+	assert.Contains(t, sql, "DATE_SUB")
+	assert.Contains(t, sql, "7")
+}
+
 func TestRenderSQL_ContainsKeyFields(t *testing.T) {
 	r, err := NewSQLRenderer()
 	require.NoError(t, err)

--- a/services/metrics/internal/spark/templates/cuped_covariate.sql.tmpl
+++ b/services/metrics/internal/spark/templates/cuped_covariate.sql.tmpl
@@ -1,0 +1,22 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+pre_experiment_data AS (
+    SELECT me.user_id, me.value
+    FROM delta.metric_events me
+    WHERE me.event_type = '{{.CupedCovariateEventType}}'
+      AND me.event_date >= DATE_SUB(CAST('{{.ExperimentStartDate}}' AS DATE), {{.CupedLookbackDays}})
+      AND me.event_date < CAST('{{.ExperimentStartDate}}' AS DATE)
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    COALESCE(AVG(ped.value), 0.0) AS cuped_covariate,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM exposed_users eu
+LEFT JOIN pre_experiment_data ped ON eu.user_id = ped.user_id
+GROUP BY eu.user_id, eu.variant_id

--- a/services/metrics/testdata/golden/cuped_covariate_expected.sql
+++ b/services/metrics/testdata/golden/cuped_covariate_expected.sql
@@ -1,0 +1,22 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+),
+pre_experiment_data AS (
+    SELECT me.user_id, me.value
+    FROM delta.metric_events me
+    WHERE me.event_type = 'heartbeat'
+      AND me.event_date >= DATE_SUB(CAST('2024-01-08' AS DATE), 7)
+      AND me.event_date < CAST('2024-01-08' AS DATE)
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'watch_time_minutes' AS metric_id,
+    COALESCE(AVG(ped.value), 0.0) AS cuped_covariate,
+    CAST('2024-01-15' AS DATE) AS computation_date
+FROM exposed_users eu
+LEFT JOIN pre_experiment_data ped ON eu.user_id = ped.user_id
+GROUP BY eu.user_id, eu.variant_id


### PR DESCRIPTION
## Summary
- Add CUPED covariate computation to the metric computation pipeline
- For metrics with `cuped_covariate_metric_id` configured, computes the pre-experiment metric mean over a 7-day lookback window before `experiment.started_at`
- Writes `cuped_covariate` values to `delta.metric_summaries` for M4a to apply CUPED regression (theta-hat estimator)
- All CUPED SQL queries logged to `query_log` with `job_type = "cuped_covariate"` for full SQL transparency

## Changes
- `config/loader.go`: Add `StartedAt` to `ExperimentConfig`, `CupedCovariateMetricID` to `MetricConfig`
- `spark/renderer.go`: Add CUPED template params and `RenderCupedCovariate()` method
- `spark/templates/cuped_covariate.sql.tmpl`: New SQL template with `pre_experiment_data` CTE bounded by experiment start date
- `jobs/standard.go`: After metric value computation, resolve covariate metric and run CUPED query if configured
- `seed_config.json`: Add `started_at` on experiments, `cuped_covariate_metric_id` on `watch_time_minutes` and `ctr_recommendation`
- Golden file + tests updated for CUPED coverage

## Test plan
- [x] Golden file test: `TestRenderCupedCovariate` validates SQL output matches expected
- [x] Key fields test: `TestRenderCupedCovariate_ContainsKeyFields` verifies template params substitution
- [x] Job test: `TestStandardJob_Run` verifies 7 total queries (4 daily + 1 delta + 2 CUPED)
- [x] Pre-experiment window test: `TestStandardJob_Run_CupedPreExperimentWindow` verifies DATE_SUB and experiment start date
- [x] Handler tests updated for new query counts (7 entries, 16 notebook cells)
- [x] All 6 packages pass with `-race -count=1`

## Unblocks
- **Agent-4 M1.15**: CUPED variance reduction requires `metric_summaries.cuped_covariate` populated
- **Agent-6**: UI can show CUPED indicator when covariate data is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)