### PR TITLE
feat(m5): StreamConfigUpdates RPC for real-time config streaming

### DIFF
--- a/services/management/cmd/main.go
+++ b/services/management/cmd/main.go
@@ -9,17 +9,56 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/org/experimentation/gen/go/experimentation/assignment/v1/assignmentv1connect"
+	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
+
+	"github.com/org/experimentation-platform/services/management/internal/handlers"
+	"github.com/org/experimentation-platform/services/management/internal/store"
+	"github.com/org/experimentation-platform/services/management/internal/streaming"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "50055"
 	}
 
+	// Database connection pool.
+	pool, err := store.NewPool(ctx)
+	if err != nil {
+		slog.Error("failed to create database pool", "error", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	// Stores.
+	experimentStore := store.NewExperimentStore(pool)
+	auditStore := store.NewAuditStore(pool)
+	layerStore := store.NewLayerStore(pool)
+
+	// Notifier for streaming config updates.
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://experimentation:localdev@localhost:5432/experimentation?sslmode=disable"
+	}
+	notifier := streaming.NewNotifier(pool, dsn)
+	notifier.Start(ctx)
+	defer notifier.Stop()
+
+	// Service handlers.
+	expSvc := handlers.NewExperimentService(experimentStore, auditStore, layerStore, notifier)
+	streamSvc := handlers.NewConfigStreamService(experimentStore, notifier)
+
+	// Register ConnectRPC handlers on mux.
 	mux := http.NewServeMux()
 
 	// Health check endpoint.
@@ -28,20 +67,18 @@ func main() {
 		fmt.Fprint(w, "ok")
 	})
 
-	// TODO: Register ConnectRPC service handlers here.
-	// Example:
-	//   path, handler := mgmtv1connect.NewExperimentManagementServiceHandler(svc)
-	//   mux.Handle(path, handler)
+	mgmtPath, mgmtHandler := managementv1connect.NewExperimentManagementServiceHandler(expSvc)
+	mux.Handle(mgmtPath, mgmtHandler)
+
+	streamPath, streamHandler := assignmentv1connect.NewAssignmentServiceHandler(streamSvc)
+	mux.Handle(streamPath, streamHandler)
 
 	srv := &http.Server{
 		Addr:    ":" + port,
-		Handler: mux,
+		Handler: h2c.NewHandler(mux, &http2.Server{}),
 	}
 
 	// Graceful shutdown.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
 	go func() {
 		slog.Info("management service starting", "port", port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/services/management/internal/handlers/integration_test.go
+++ b/services/management/internal/handlers/integration_test.go
@@ -40,7 +40,7 @@ func setupTestServer(t *testing.T) (testEnv, func()) {
 	es := store.NewExperimentStore(pool)
 	as := store.NewAuditStore(pool)
 	ls := store.NewLayerStore(pool)
-	svc := handlers.NewExperimentService(es, as, ls)
+	svc := handlers.NewExperimentService(es, as, ls, nil)
 
 	mux := http.NewServeMux()
 	path, handler := managementv1connect.NewExperimentManagementServiceHandler(svc)

--- a/services/management/internal/handlers/lifecycle.go
+++ b/services/management/internal/handlers/lifecycle.go
@@ -43,7 +43,7 @@ func (s *ExperimentService) rollbackToDraft(ctx context.Context, id, reason stri
 	}
 }
 
-// StartExperiment transitions DRAFT → STARTING → RUNNING with bucket allocation
+// StartExperiment transitions DRAFT -> STARTING -> RUNNING with bucket allocation
 // and audit trail entries. Both transitions are audited. If allocation fails in
 // STARTING, rolls back to DRAFT.
 func (s *ExperimentService) StartExperiment(
@@ -55,7 +55,7 @@ func (s *ExperimentService) StartExperiment(
 		return nil, connect.NewError(connect.CodeInvalidArgument, nil)
 	}
 
-	// Transition 1: DRAFT → STARTING
+	// Transition 1: DRAFT -> STARTING
 	tx1, err := s.store.BeginTx(ctx)
 	if err != nil {
 		return nil, internalError("begin tx1", err)
@@ -86,7 +86,7 @@ func (s *ExperimentService) StartExperiment(
 	// TODO(M5): Validate metrics availability, check power, warm bandit policy.
 	slog.Info("starting experiment: validation passed", "id", id)
 
-	// Transition 2: STARTING → RUNNING (with bucket allocation)
+	// Transition 2: STARTING -> RUNNING (with bucket allocation)
 	tx2, err := s.store.BeginTx(ctx)
 	if err != nil {
 		return nil, internalError("begin tx2", err)
@@ -157,11 +157,11 @@ func (s *ExperimentService) StartExperiment(
 	}
 
 	allocDetails, _ := json.Marshal(map[string]any{
-		"phase":            "activated",
-		"allocation_id":    alloc.AllocationID,
-		"start_bucket":     alloc.StartBucket,
-		"end_bucket":       alloc.EndBucket,
-		"traffic_pct":      trafficPct,
+		"phase":             "activated",
+		"allocation_id":     alloc.AllocationID,
+		"start_bucket":      alloc.StartBucket,
+		"end_bucket":        alloc.EndBucket,
+		"traffic_pct":       trafficPct,
 		"buckets_allocated": bucketsNeeded,
 	})
 	if err := s.audit.Insert(ctx, tx2, store.AuditEntry{
@@ -179,6 +179,11 @@ func (s *ExperimentService) StartExperiment(
 		return nil, internalError("commit tx2", err)
 	}
 
+	// Notify subscribers that this experiment is now RUNNING.
+	if s.notifier != nil {
+		s.notifier.Publish(ctx, id, "upsert")
+	}
+
 	// Read back full experiment.
 	finalRow, variants, guardrails, err := s.store.GetByID(ctx, id)
 	if err != nil {
@@ -190,7 +195,7 @@ func (s *ExperimentService) StartExperiment(
 	return connect.NewResponse(store.RowToExperiment(finalRow, variants, guardrails)), nil
 }
 
-// ConcludeExperiment transitions RUNNING → CONCLUDING → CONCLUDED
+// ConcludeExperiment transitions RUNNING -> CONCLUDING -> CONCLUDED
 // and releases the experiment's bucket allocation with a cooldown period.
 func (s *ExperimentService) ConcludeExperiment(
 	ctx context.Context,
@@ -201,7 +206,7 @@ func (s *ExperimentService) ConcludeExperiment(
 		return nil, connect.NewError(connect.CodeInvalidArgument, nil)
 	}
 
-	// Transition 1: RUNNING → CONCLUDING
+	// Transition 1: RUNNING -> CONCLUDING
 	tx1, err := s.store.BeginTx(ctx)
 	if err != nil {
 		return nil, internalError("begin tx1", err)
@@ -232,7 +237,7 @@ func (s *ExperimentService) ConcludeExperiment(
 	// TODO(M4a): Trigger final analysis. For now, transition synchronously.
 	slog.Info("concluding experiment: final analysis mocked", "id", id)
 
-	// Transition 2: CONCLUDING → CONCLUDED (with allocation release)
+	// Transition 2: CONCLUDING -> CONCLUDED (with allocation release)
 	tx2, err := s.store.BeginTx(ctx)
 	if err != nil {
 		return nil, internalError("begin tx2", err)
@@ -281,6 +286,11 @@ func (s *ExperimentService) ConcludeExperiment(
 		return nil, internalError("commit tx2", err)
 	}
 
+	// Notify subscribers that this experiment is no longer RUNNING.
+	if s.notifier != nil {
+		s.notifier.Publish(ctx, id, "delete")
+	}
+
 	finalRow, variants, guardrails, err := s.store.GetByID(ctx, concluded.ExperimentID)
 	if err != nil {
 		return nil, internalError("read back experiment", err)
@@ -290,7 +300,7 @@ func (s *ExperimentService) ConcludeExperiment(
 	return connect.NewResponse(store.RowToExperiment(finalRow, variants, guardrails)), nil
 }
 
-// ArchiveExperiment transitions CONCLUDED → ARCHIVED.
+// ArchiveExperiment transitions CONCLUDED -> ARCHIVED.
 func (s *ExperimentService) ArchiveExperiment(
 	ctx context.Context,
 	req *connect.Request[mgmtv1.ArchiveExperimentRequest],
@@ -326,6 +336,11 @@ func (s *ExperimentService) ArchiveExperiment(
 		return nil, internalError("commit tx", err)
 	}
 
+	// Notify subscribers that this experiment is archived.
+	if s.notifier != nil {
+		s.notifier.Publish(ctx, id, "delete")
+	}
+
 	expRow, variants, guardrails, err := s.store.GetByID(ctx, archived.ExperimentID)
 	if err != nil {
 		return nil, internalError("read back experiment", err)
@@ -336,7 +351,7 @@ func (s *ExperimentService) ArchiveExperiment(
 }
 
 // PauseExperiment records a pause event. The experiment stays in RUNNING state
-// (RUNNING→RUNNING is valid per ADR-005). Traffic zeroing deferred to M1.23.
+// (RUNNING->RUNNING is valid per ADR-005). Traffic zeroing deferred to M1.23.
 func (s *ExperimentService) PauseExperiment(
 	ctx context.Context,
 	req *connect.Request[mgmtv1.PauseExperimentRequest],
@@ -372,6 +387,11 @@ func (s *ExperimentService) PauseExperiment(
 		return nil, internalError("audit pause", err)
 	}
 
+	// Notify subscribers of the pause (traffic config may have changed).
+	if s.notifier != nil {
+		s.notifier.Publish(ctx, id, "upsert")
+	}
+
 	slog.Info("experiment paused", "id", id, "reason", req.Msg.GetReason())
 	return connect.NewResponse(store.RowToExperiment(expRow, variants, guardrails)), nil
 }
@@ -402,6 +422,11 @@ func (s *ExperimentService) ResumeExperiment(
 		NewState:      "RUNNING",
 	}); err != nil {
 		return nil, internalError("audit resume", err)
+	}
+
+	// Notify subscribers of the resume.
+	if s.notifier != nil {
+		s.notifier.Publish(ctx, id, "upsert")
 	}
 
 	slog.Info("experiment resumed", "id", id)

--- a/services/management/internal/handlers/service.go
+++ b/services/management/internal/handlers/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
 
 	"github.com/org/experimentation-platform/services/management/internal/store"
+	"github.com/org/experimentation-platform/services/management/internal/streaming"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -18,14 +19,15 @@ var _ managementv1connect.ExperimentManagementServiceHandler = (*ExperimentServi
 
 // ExperimentService implements the ExperimentManagementService ConnectRPC handler.
 type ExperimentService struct {
-	store  *store.ExperimentStore
-	audit  *store.AuditStore
-	layers *store.LayerStore
+	store    *store.ExperimentStore
+	audit    *store.AuditStore
+	layers   *store.LayerStore
+	notifier *streaming.Notifier
 }
 
-// NewExperimentService creates a new handler with the given stores.
-func NewExperimentService(es *store.ExperimentStore, as *store.AuditStore, ls *store.LayerStore) *ExperimentService {
-	return &ExperimentService{store: es, audit: as, layers: ls}
+// NewExperimentService creates a new handler with the given stores and notifier.
+func NewExperimentService(es *store.ExperimentStore, as *store.AuditStore, ls *store.LayerStore, n *streaming.Notifier) *ExperimentService {
+	return &ExperimentService{store: es, audit: as, layers: ls, notifier: n}
 }
 
 // --- Unimplemented stubs for metric/layer/targeting/surrogate RPCs ---
@@ -41,7 +43,6 @@ func (s *ExperimentService) GetMetricDefinition(_ context.Context, _ *connect.Re
 func (s *ExperimentService) ListMetricDefinitions(_ context.Context, _ *connect.Request[mgmtv1.ListMetricDefinitionsRequest]) (*connect.Response[mgmtv1.ListMetricDefinitionsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, nil)
 }
-
 
 func (s *ExperimentService) CreateTargetingRule(_ context.Context, _ *connect.Request[mgmtv1.CreateTargetingRuleRequest]) (*connect.Response[commonv1.TargetingRule], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, nil)

--- a/services/management/internal/handlers/stream.go
+++ b/services/management/internal/handlers/stream.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+
+	"connectrpc.com/connect"
+
+	assignmentv1 "github.com/org/experimentation/gen/go/experimentation/assignment/v1"
+	"github.com/org/experimentation/gen/go/experimentation/assignment/v1/assignmentv1connect"
+
+	"github.com/org/experimentation-platform/services/management/internal/store"
+	"github.com/org/experimentation-platform/services/management/internal/streaming"
+)
+
+// Compile-time check that ConfigStreamService implements the handler interface.
+var _ assignmentv1connect.AssignmentServiceHandler = (*ConfigStreamService)(nil)
+
+// ConfigStreamService implements the StreamConfigUpdates RPC from the
+// AssignmentService proto. M5 serves this endpoint so M1 can subscribe
+// to real-time config changes.
+type ConfigStreamService struct {
+	assignmentv1connect.UnimplementedAssignmentServiceHandler
+	store    *store.ExperimentStore
+	notifier *streaming.Notifier
+	version  atomic.Int64
+}
+
+// NewConfigStreamService creates a new ConfigStreamService.
+func NewConfigStreamService(es *store.ExperimentStore, n *streaming.Notifier) *ConfigStreamService {
+	return &ConfigStreamService{
+		store:    es,
+		notifier: n,
+	}
+}
+
+// StreamConfigUpdates sends a full snapshot of RUNNING experiments on connect,
+// then streams delta updates as experiments change state.
+func (s *ConfigStreamService) StreamConfigUpdates(
+	ctx context.Context,
+	req *connect.Request[assignmentv1.StreamConfigUpdatesRequest],
+	stream *connect.ServerStream[assignmentv1.ConfigUpdate],
+) error {
+	slog.Info("stream: client connected", "last_known_version", req.Msg.GetLastKnownVersion())
+
+	// Phase 1: Send snapshot of all RUNNING experiments.
+	experiments, allVariants, allGuardrails, err := s.store.ListRunning(ctx)
+	if err != nil {
+		return internalError("list running experiments", err)
+	}
+
+	for i, exp := range experiments {
+		proto := store.RowToExperiment(exp, allVariants[i], allGuardrails[i])
+		update := &assignmentv1.ConfigUpdate{
+			Experiment: proto,
+			IsDeletion: false,
+			Version:    s.version.Add(1),
+		}
+		if err := stream.Send(update); err != nil {
+			return err
+		}
+	}
+
+	slog.Info("stream: snapshot sent", "experiment_count", len(experiments))
+
+	// Phase 2: Subscribe to notifications and stream deltas.
+	ch, unsubscribe := s.notifier.Subscribe()
+	defer unsubscribe()
+
+	for {
+		select {
+		case notif, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			update, err := s.buildUpdate(ctx, notif)
+			if err != nil {
+				slog.Error("stream: build update failed", "error", err, "experiment_id", notif.ExperimentID)
+				continue
+			}
+			if err := stream.Send(update); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			slog.Info("stream: client disconnected")
+			return nil
+		}
+	}
+}
+
+func (s *ConfigStreamService) buildUpdate(ctx context.Context, notif streaming.Notification) (*assignmentv1.ConfigUpdate, error) {
+	if notif.Operation == "delete" {
+		return &assignmentv1.ConfigUpdate{
+			Experiment: nil,
+			IsDeletion: true,
+			Version:    s.version.Add(1),
+		}, nil
+	}
+
+	expRow, variants, guardrails, err := s.store.GetByID(ctx, notif.ExperimentID)
+	if err != nil {
+		// Experiment not found or in terminal state — treat as deletion.
+		return &assignmentv1.ConfigUpdate{
+			IsDeletion: true,
+			Version:    s.version.Add(1),
+		}, nil
+	}
+
+	// If experiment is no longer RUNNING (concluded/archived), treat as deletion.
+	if expRow.State != "RUNNING" {
+		return &assignmentv1.ConfigUpdate{
+			IsDeletion: true,
+			Version:    s.version.Add(1),
+		}, nil
+	}
+
+	proto := store.RowToExperiment(expRow, variants, guardrails)
+	return &assignmentv1.ConfigUpdate{
+		Experiment: proto,
+		IsDeletion: false,
+		Version:    s.version.Add(1),
+	}, nil
+}

--- a/services/management/internal/handlers/stream_test.go
+++ b/services/management/internal/handlers/stream_test.go
@@ -1,0 +1,210 @@
+//go:build integration
+
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+
+	assignmentv1 "github.com/org/experimentation/gen/go/experimentation/assignment/v1"
+	"github.com/org/experimentation/gen/go/experimentation/assignment/v1/assignmentv1connect"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
+
+	"github.com/org/experimentation-platform/services/management/internal/handlers"
+	"github.com/org/experimentation-platform/services/management/internal/store"
+	"github.com/org/experimentation-platform/services/management/internal/streaming"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const defaultLayerID = "a0000000-0000-0000-0000-000000000001"
+
+func setupStreamTest(t *testing.T) (
+	mgmtClient managementv1connect.ExperimentManagementServiceClient,
+	streamClient assignmentv1connect.AssignmentServiceClient,
+	notifier *streaming.Notifier,
+	cleanup func(),
+) {
+	t.Helper()
+
+	ctx := context.Background()
+	pool, err := store.NewPool(ctx)
+	require.NoError(t, err)
+
+	es := store.NewExperimentStore(pool)
+	as := store.NewAuditStore(pool)
+	ls := store.NewLayerStore(pool)
+
+	dsn := "postgres://experimentation:localdev@localhost:5432/experimentation?sslmode=disable"
+	notifier = streaming.NewNotifier(pool, dsn)
+	notifier.Start(ctx)
+
+	expSvc := handlers.NewExperimentService(es, as, ls, notifier)
+	streamSvc := handlers.NewConfigStreamService(es, notifier)
+
+	mux := http.NewServeMux()
+	mgmtPath, mgmtHandler := managementv1connect.NewExperimentManagementServiceHandler(expSvc)
+	mux.Handle(mgmtPath, mgmtHandler)
+	streamPath, streamHandler := assignmentv1connect.NewAssignmentServiceHandler(streamSvc)
+	mux.Handle(streamPath, streamHandler)
+
+	srv := httptest.NewUnstartedServer(mux)
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+
+	mgmtClient = managementv1connect.NewExperimentManagementServiceClient(srv.Client(), srv.URL)
+	streamClient = assignmentv1connect.NewAssignmentServiceClient(srv.Client(), srv.URL)
+
+	cleanup = func() {
+		notifier.Stop()
+		srv.Close()
+		pool.Close()
+	}
+
+	return mgmtClient, streamClient, notifier, cleanup
+}
+
+func createAndStartExperiment(t *testing.T, mgmt managementv1connect.ExperimentManagementServiceClient, name string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	resp, err := mgmt.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: &commonv1.Experiment{
+			Name:            name,
+			OwnerEmail:      "stream-test@example.com",
+			Type:            commonv1.ExperimentType_EXPERIMENT_TYPE_AB,
+			LayerId:         defaultLayerID,
+			PrimaryMetricId: "metric-1",
+			GuardrailAction: commonv1.GuardrailAction_GUARDRAIL_ACTION_ALERT_ONLY,
+			Variants: []*commonv1.Variant{
+				{Name: "control", TrafficFraction: 0.5, IsControl: true},
+				{Name: "treatment", TrafficFraction: 0.5},
+			},
+		},
+	}))
+	require.NoError(t, err)
+	id := resp.Msg.GetExperimentId()
+
+	_, err = mgmt.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+		ExperimentId: id,
+	}))
+	require.NoError(t, err)
+
+	return id
+}
+
+func TestStreamConfigUpdates_Snapshot(t *testing.T) {
+	mgmt, streamClient, _, cleanup := setupStreamTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Create and start an experiment so there's something to snapshot.
+	expID := createAndStartExperiment(t, mgmt, "stream-snapshot-test")
+
+	// Connect to stream.
+	stream, err := streamClient.StreamConfigUpdates(ctx, connect.NewRequest(
+		&assignmentv1.StreamConfigUpdatesRequest{LastKnownVersion: 0},
+	))
+	require.NoError(t, err)
+	defer stream.Close()
+
+	// Should receive at least our experiment in the snapshot.
+	found := false
+	for stream.Receive() {
+		update := stream.Msg()
+		if update.GetExperiment() != nil && update.GetExperiment().GetExperimentId() == expID {
+			found = true
+			assert.False(t, update.GetIsDeletion())
+			assert.Greater(t, update.GetVersion(), int64(0))
+			assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_RUNNING, update.GetExperiment().GetState())
+			break
+		}
+	}
+	assert.True(t, found, "expected to find experiment %s in snapshot", expID)
+}
+
+func TestStreamConfigUpdates_DeltaOnStart(t *testing.T) {
+	mgmt, streamClient, _, cleanup := setupStreamTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Connect to stream first (before starting experiment).
+	stream, err := streamClient.StreamConfigUpdates(ctx, connect.NewRequest(
+		&assignmentv1.StreamConfigUpdatesRequest{LastKnownVersion: 0},
+	))
+	require.NoError(t, err)
+	defer stream.Close()
+
+	// Drain snapshot (may be empty or have other experiments).
+	// We need to consume the snapshot before we can receive deltas.
+	// Give it a moment then start our experiment.
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		createAndStartExperiment(t, mgmt, "stream-delta-test")
+	}()
+
+	// Read updates until we find our delta.
+	found := false
+	for stream.Receive() {
+		update := stream.Msg()
+		if update.GetExperiment() != nil && update.GetExperiment().GetName() == "stream-delta-test" {
+			found = true
+			assert.False(t, update.GetIsDeletion())
+			assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_RUNNING, update.GetExperiment().GetState())
+			break
+		}
+	}
+	assert.True(t, found, "expected to receive delta update for started experiment")
+}
+
+func TestStreamConfigUpdates_DeletionOnConclude(t *testing.T) {
+	mgmt, streamClient, _, cleanup := setupStreamTest(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Create and start an experiment.
+	expID := createAndStartExperiment(t, mgmt, "stream-deletion-test")
+
+	// Connect to stream.
+	stream, err := streamClient.StreamConfigUpdates(ctx, connect.NewRequest(
+		&assignmentv1.StreamConfigUpdatesRequest{LastKnownVersion: 0},
+	))
+	require.NoError(t, err)
+	defer stream.Close()
+
+	// Drain snapshot, then conclude.
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		_, err := mgmt.ConcludeExperiment(ctx, connect.NewRequest(&mgmtv1.ConcludeExperimentRequest{
+			ExperimentId: expID,
+		}))
+		if err != nil {
+			t.Logf("conclude failed: %v", err)
+		}
+	}()
+
+	// Look for the deletion update.
+	found := false
+	for stream.Receive() {
+		update := stream.Msg()
+		if update.GetIsDeletion() {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected deletion update after conclude")
+}

--- a/services/management/internal/store/experiment.go
+++ b/services/management/internal/store/experiment.go
@@ -51,10 +51,10 @@ type VariantRow struct {
 
 // GuardrailConfigRow mirrors the guardrail_configs table.
 type GuardrailConfigRow struct {
-	GuardrailID                string
-	ExperimentID               string
-	MetricID                   string
-	Threshold                  float64
+	GuardrailID                 string
+	ExperimentID                string
+	MetricID                    string
+	Threshold                   float64
 	ConsecutiveBreachesRequired int32
 }
 
@@ -423,4 +423,44 @@ func (s *ExperimentStore) GetVariantsByExperiment(ctx context.Context, experimen
 // GetGuardrailsByExperiment returns guardrails for a given experiment (using pool, no tx).
 func (s *ExperimentStore) GetGuardrailsByExperiment(ctx context.Context, experimentID string) ([]GuardrailConfigRow, error) {
 	return s.getGuardrails(ctx, s.pool, experimentID)
+}
+
+// ListRunning returns all experiments in RUNNING state with their variants and guardrails.
+func (s *ExperimentStore) ListRunning(ctx context.Context) ([]ExperimentRow, [][]VariantRow, [][]GuardrailConfigRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+experimentCols+` FROM experiments WHERE state = 'RUNNING' ORDER BY started_at`)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer rows.Close()
+
+	var experiments []ExperimentRow
+	for rows.Next() {
+		r, scanErr := scanExperimentRows(rows)
+		if scanErr != nil {
+			return nil, nil, nil, scanErr
+		}
+		experiments = append(experiments, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, nil, err
+	}
+
+	allVariants := make([][]VariantRow, len(experiments))
+	allGuardrails := make([][]GuardrailConfigRow, len(experiments))
+	for i, exp := range experiments {
+		v, err := s.getVariants(ctx, s.pool, exp.ExperimentID)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("variants for %s: %w", exp.ExperimentID, err)
+		}
+		allVariants[i] = v
+
+		g, err := s.getGuardrails(ctx, s.pool, exp.ExperimentID)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("guardrails for %s: %w", exp.ExperimentID, err)
+		}
+		allGuardrails[i] = g
+	}
+
+	return experiments, allVariants, allGuardrails, nil
 }

--- a/services/management/internal/streaming/notifier.go
+++ b/services/management/internal/streaming/notifier.go
@@ -1,0 +1,161 @@
+// Package streaming provides PostgreSQL LISTEN/NOTIFY fan-out for experiment config changes.
+package streaming
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Notification represents a config change event.
+type Notification struct {
+	ExperimentID string `json:"experiment_id"`
+	Operation    string `json:"operation"` // "upsert" or "delete"
+}
+
+const (
+	channelName      = "experiment_config_changes"
+	subscriberBuffer = 64
+)
+
+// Notifier listens on a PostgreSQL NOTIFY channel and fans out notifications
+// to all registered subscribers.
+type Notifier struct {
+	pool        *pgxpool.Pool
+	databaseURL string
+
+	mu          sync.RWMutex
+	subscribers map[uint64]chan<- Notification
+	nextID      uint64
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewNotifier creates a new Notifier. Call Start() to begin listening.
+func NewNotifier(pool *pgxpool.Pool, databaseURL string) *Notifier {
+	return &Notifier{
+		pool:        pool,
+		databaseURL: databaseURL,
+		subscribers: make(map[uint64]chan<- Notification),
+		done:        make(chan struct{}),
+	}
+}
+
+// Start spawns a goroutine that connects to PostgreSQL, issues LISTEN,
+// and fans out notifications to subscribers.
+func (n *Notifier) Start(ctx context.Context) {
+	ctx, n.cancel = context.WithCancel(ctx)
+	go n.listen(ctx)
+}
+
+func (n *Notifier) listen(ctx context.Context) {
+	defer close(n.done)
+
+	for {
+		if err := n.listenLoop(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			slog.Error("notifier: listen connection failed, retrying", "error", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}
+}
+
+func (n *Notifier) listenLoop(ctx context.Context) error {
+	conn, err := pgx.Connect(ctx, n.databaseURL)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	if _, err := conn.Exec(ctx, "LISTEN "+channelName); err != nil {
+		return fmt.Errorf("LISTEN: %w", err)
+	}
+
+	slog.Info("notifier: listening for config changes", "channel", channelName)
+
+	for {
+		notification, err := conn.WaitForNotification(ctx)
+		if err != nil {
+			return fmt.Errorf("wait: %w", err)
+		}
+
+		var notif Notification
+		if err := json.Unmarshal([]byte(notification.Payload), &notif); err != nil {
+			slog.Warn("notifier: invalid payload", "payload", notification.Payload, "error", err)
+			continue
+		}
+
+		n.fanOut(notif)
+	}
+}
+
+func (n *Notifier) fanOut(notif Notification) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	for id, ch := range n.subscribers {
+		select {
+		case ch <- notif:
+		default:
+			slog.Warn("notifier: dropping notification for slow subscriber", "subscriber_id", id, "experiment_id", notif.ExperimentID)
+		}
+	}
+}
+
+// Subscribe registers a new subscriber. Returns a read-only channel for notifications
+// and an unsubscribe function that must be called to clean up.
+func (n *Notifier) Subscribe() (<-chan Notification, func()) {
+	ch := make(chan Notification, subscriberBuffer)
+
+	n.mu.Lock()
+	id := n.nextID
+	n.nextID++
+	n.subscribers[id] = ch
+	n.mu.Unlock()
+
+	unsubscribe := func() {
+		n.mu.Lock()
+		delete(n.subscribers, id)
+		n.mu.Unlock()
+	}
+
+	return ch, unsubscribe
+}
+
+// Publish sends a notification to the PostgreSQL NOTIFY channel.
+// Called by handlers after successful mutations.
+func (n *Notifier) Publish(ctx context.Context, experimentID, operation string) {
+	payload, err := json.Marshal(Notification{
+		ExperimentID: experimentID,
+		Operation:    operation,
+	})
+	if err != nil {
+		slog.Error("notifier: marshal payload", "error", err)
+		return
+	}
+
+	if _, err := n.pool.Exec(ctx, "SELECT pg_notify($1, $2)", channelName, string(payload)); err != nil {
+		slog.Error("notifier: publish failed", "error", err, "experiment_id", experimentID)
+	}
+}
+
+// Stop cancels the listener goroutine and waits for it to finish.
+func (n *Notifier) Stop() {
+	if n.cancel != nil {
+		n.cancel()
+	}
+	<-n.done
+}

--- a/services/management/internal/streaming/notifier_test.go
+++ b/services/management/internal/streaming/notifier_test.go
@@ -1,0 +1,156 @@
+package streaming
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscribeUnsubscribe(t *testing.T) {
+	n := &Notifier{
+		subscribers: make(map[uint64]chan<- Notification),
+		done:        make(chan struct{}),
+	}
+
+	ch, unsub := n.Subscribe()
+	require.NotNil(t, ch)
+
+	n.mu.RLock()
+	assert.Len(t, n.subscribers, 1)
+	n.mu.RUnlock()
+
+	unsub()
+
+	n.mu.RLock()
+	assert.Len(t, n.subscribers, 0)
+	n.mu.RUnlock()
+}
+
+func TestFanOutToMultipleSubscribers(t *testing.T) {
+	n := &Notifier{
+		subscribers: make(map[uint64]chan<- Notification),
+		done:        make(chan struct{}),
+	}
+
+	ch1, unsub1 := n.Subscribe()
+	defer unsub1()
+	ch2, unsub2 := n.Subscribe()
+	defer unsub2()
+	ch3, unsub3 := n.Subscribe()
+	defer unsub3()
+
+	notif := Notification{ExperimentID: "exp-1", Operation: "upsert"}
+	n.fanOut(notif)
+
+	for _, ch := range []<-chan Notification{ch1, ch2, ch3} {
+		select {
+		case got := <-ch:
+			assert.Equal(t, "exp-1", got.ExperimentID)
+			assert.Equal(t, "upsert", got.Operation)
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for notification")
+		}
+	}
+}
+
+func TestSlowConsumerDoesNotBlock(t *testing.T) {
+	n := &Notifier{
+		subscribers: make(map[uint64]chan<- Notification),
+		done:        make(chan struct{}),
+	}
+
+	// slow subscriber with tiny buffer
+	slowCh := make(chan Notification, 1)
+	n.mu.Lock()
+	n.subscribers[0] = slowCh
+	n.nextID = 1
+	n.mu.Unlock()
+
+	// fast subscriber
+	fastCh, unsub := n.Subscribe()
+	defer unsub()
+
+	// Fill the slow subscriber's buffer
+	slowCh <- Notification{ExperimentID: "fill", Operation: "upsert"}
+
+	// This should not block even though slowCh is full
+	done := make(chan struct{})
+	go func() {
+		n.fanOut(Notification{ExperimentID: "exp-2", Operation: "delete"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good — fanOut didn't block
+	case <-time.After(time.Second):
+		t.Fatal("fanOut blocked on slow subscriber")
+	}
+
+	// Fast subscriber should still receive it
+	select {
+	case got := <-fastCh:
+		assert.Equal(t, "exp-2", got.ExperimentID)
+	case <-time.After(time.Second):
+		t.Fatal("fast subscriber didn't receive notification")
+	}
+}
+
+func TestUnsubscribeCleansUpChannel(t *testing.T) {
+	n := &Notifier{
+		subscribers: make(map[uint64]chan<- Notification),
+		done:        make(chan struct{}),
+	}
+
+	_, unsub1 := n.Subscribe()
+	ch2, unsub2 := n.Subscribe()
+	_, unsub3 := n.Subscribe()
+
+	unsub1()
+	unsub3()
+
+	n.mu.RLock()
+	assert.Len(t, n.subscribers, 1)
+	n.mu.RUnlock()
+
+	// Remaining subscriber still works
+	n.fanOut(Notification{ExperimentID: "exp-3", Operation: "upsert"})
+	select {
+	case got := <-ch2:
+		assert.Equal(t, "exp-3", got.ExperimentID)
+	case <-time.After(time.Second):
+		t.Fatal("remaining subscriber didn't receive notification")
+	}
+
+	unsub2()
+	n.mu.RLock()
+	assert.Len(t, n.subscribers, 0)
+	n.mu.RUnlock()
+}
+
+func TestConcurrentSubscribeUnsubscribe(t *testing.T) {
+	n := &Notifier{
+		subscribers: make(map[uint64]chan<- Notification),
+		done:        make(chan struct{}),
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, unsub := n.Subscribe()
+			// Simulate some usage
+			n.fanOut(Notification{ExperimentID: "race", Operation: "upsert"})
+			unsub()
+		}()
+	}
+	wg.Wait()
+
+	n.mu.RLock()
+	assert.Len(t, n.subscribers, 0)
+	n.mu.RUnlock()
+}


### PR DESCRIPTION
## Summary

- Implement `StreamConfigUpdates` server-streaming RPC on M5 so Agent-1 (M1) can subscribe to real-time experiment config changes
- Add PostgreSQL LISTEN/NOTIFY fan-out system (`streaming/notifier.go`) for broadcasting experiment mutations to all connected subscribers
- Wire lifecycle handlers (Start, Conclude, Archive, Pause, Resume) to publish notifications after each successful state transition
- Fully wire `cmd/main.go` with DB pool, notifier, and both ConnectRPC service handlers (management + assignment/streaming)

## New Files

| File | Purpose |
|------|---------|
| `streaming/notifier.go` | PG LISTEN/NOTIFY listener with buffered channel fan-out |
| `streaming/notifier_test.go` | 5 unit tests (subscribe/unsub, fan-out, slow consumer, concurrent) |
| `handlers/stream.go` | `ConfigStreamService` implementing `StreamConfigUpdates` |
| `handlers/stream_test.go` | Integration tests for snapshot + delta + deletion streaming |

## Modified Files

| File | Change |
|------|--------|
| `store/experiment.go` | Add `ListRunning()` method for snapshot queries |
| `handlers/service.go` | Add `notifier` field to `ExperimentService`, update constructor |
| `handlers/lifecycle.go` | Publish notifications after each lifecycle transition |
| `handlers/integration_test.go` | Update constructor call for new notifier param |
| `cmd/main.go` | Wire DB pool, stores, notifier, both ConnectRPC handlers with h2c |

## Design

- **No SQL migration needed**: Uses `pg_notify()` application-level calls (not DB triggers)
- **In-memory versioning**: `atomic.Int64` version counter, resets on restart (clients get full snapshot on reconnect)
- **Dedicated LISTEN connection**: `pgx.Connect()` for notification listener (separate from pool)
- **Non-blocking fan-out**: Slow subscribers get dropped notifications (logged), never block others

## Test plan

- [x] `go vet ./management/...` — compiles cleanly
- [x] `go test ./management/internal/streaming/...` — 5/5 notifier unit tests pass
- [x] `go test ./management/...` — all existing tests still pass
- [ ] Integration test with `just dev`: connect to streaming endpoint, start experiment, verify config update received

## Unblocks

This unblocks Agent-1 (M1) for real-time config cache via `StreamConfigUpdates`, replacing `dev/config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)