### PR TITLE
fix(ci): add sccache fallback for cache outages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.4
 
+      - name: Ensure sccache is working
+        run: |
+          if ! sccache --show-stats > /dev/null 2>&1; then
+            echo "sccache is not available; disabling RUSTC_WRAPPER"
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+          fi
+
       - name: Clippy (all features)
         working-directory: crates
         run: cargo clippy --workspace --all-features -- -D warnings


### PR DESCRIPTION
## Summary
- Adds a health check step after `mozilla-actions/sccache-action` that verifies sccache is functional
- If `sccache --show-stats` fails (e.g. GitHub Actions cache service outage), clears `RUSTC_WRAPPER` via `$GITHUB_ENV` so cargo runs directly
- Prevents CI from failing when GitHub's caching infrastructure is temporarily unavailable

## Context
CI job `65812459484` failed because sccache couldn't connect to the GitHub Actions cache backend ("Our services aren't available right now"). This made the entire Rust build stage fail despite being unrelated to any code change.

## Test plan
- [ ] CI passes on this PR (sccache works normally — fallback not triggered)
- [ ] If sccache is unavailable, build proceeds without caching instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>