### PR TITLE
feat(m5): metric definition CRUD (milestone 1.24)

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,6 +1,6 @@
 # Experimentation Platform — Coordination Status
 
-> **Last updated**: 2026-03-04 by Agent-5 (M1.23 guardrail alert consumer PR #18)
+> **Last updated**: 2026-03-05 by Agent-5 (M1.24 metric definition CRUD PR #24)
 >
 > This file is the single source of truth for multi-agent execution state.
 > Update it each time a milestone merges to `main` or a blocker is identified.
@@ -17,7 +17,7 @@
 | Agent-2 | M2 Pipeline | 🔵 In Progress | agent-2/feat/go-orchestration-querylog | Go orchestration + SQL query logging (1.9) | — | M1.6+1.7+1.8 merged (PR #1). PR #8 open for M1.9. |
 | Agent-3 | M3 Metrics | 🔵 In Progress | agent-3/feat/cuped-covariate | CUPED covariate computation (1.12) | — | M1.10 (PR #3), M1.11 (PR #5) merged. PR #9 open for M1.12. |
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 In Progress | agent-4/feat/golden-validation-lmax-core | t-test + SRM + Thompson + LMAX + RocksDB (1.14–1.19) | — | PR #2 open. CI unblocked by PR #6 merge. |
-| Agent-5 | M5 Management | 🔵 In Progress | agent-5/feat/guardrail-alert-consumer | Metric definition CRUD (1.24) | — | M1.20–1.23 complete. PRs #7, #10, #15, #18. Next: metric definition CRUD. |
+| Agent-5 | M5 Management | 🔵 In Progress | agent-5/feat/metric-definition-crud | Metric definition CRUD (1.24) | — | M1.20–1.23 merged. PR #24 open for 1.24. All Phase 1 milestones addressed. |
 | Agent-6 | M6 UI | 🟡 Not Started | — | Experiment list + detail shell (1.25) | — | Unblocked by M1.20 merge. Can start with MSW mocks. |
 | Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/flag-service | PR open: CRUD + eval + CGo bridge + audit (1.28–1.30) | — | Phase 1+2 complete. 10K hash vectors pass. CGo bridge parity confirmed. |
 
@@ -66,8 +66,8 @@
 | **1.20** | **Experiment CRUD + state machine enforcement** | Agent-5 | 🟢 | agent-5/feat/experiment-crud-handlers | 2026-03-04 | Agent-6 (list/detail), Agent-1 (configs), Agent-3 (experiment list) |
 | 1.21 | Layer allocation + bucket reuse | Agent-5 | 🟢 | PR #7, #10 | 2026-03-04 | Merged |
 | 1.22 | StreamConfigUpdates RPC | Agent-5 | 🟢 | PR #15 | 2026-03-04 | Merged. Unblocks Agent-1 config cache. |
-| 1.23 | Guardrail alert consumer → auto-pause | Agent-5 | 🔵 | PR #18 | — | In review. Kafka consumer + processor per ADR-008. |
-| 1.24 | Metric definition CRUD | Agent-5 | 🟡 | — | — | Agent-3 |
+| 1.23 | Guardrail alert consumer → auto-pause | Agent-5 | 🟢 | PR #18 | 2026-03-05 | Merged. Kafka consumer + processor per ADR-008. |
+| 1.24 | Metric definition CRUD | Agent-5 | 🔵 | PR #24 | — | Create/Get/List RPCs. 14 unit + 12 integration tests. |
 | **1.25** | **Experiment list + detail shell (MSW mocked)** | Agent-6 | 🟡 | — | — | Stakeholder demo. Unblocked by M1.20. Ready to start. |
 | 1.26 | State indicator component (color-coded lifecycle) | Agent-6 | ⚪ | — | — | — |
 | 1.27 | View SQL page (query log from M3) | Agent-6 | ⚪ | — | — | — |

--- a/services/management/cmd/main.go
+++ b/services/management/cmd/main.go
@@ -46,6 +46,7 @@ func main() {
 	experimentStore := store.NewExperimentStore(pool)
 	auditStore := store.NewAuditStore(pool)
 	layerStore := store.NewLayerStore(pool)
+	metricStore := store.NewMetricStore(pool)
 
 	// Notifier for streaming config updates.
 	dsn := os.Getenv("DATABASE_URL")
@@ -68,7 +69,7 @@ func main() {
 	}
 
 	// Service handlers.
-	expSvc := handlers.NewExperimentService(experimentStore, auditStore, layerStore, notifier)
+	expSvc := handlers.NewExperimentService(experimentStore, auditStore, layerStore, metricStore, notifier)
 	streamSvc := handlers.NewConfigStreamService(experimentStore, notifier)
 
 	// Register ConnectRPC handlers on mux.

--- a/services/management/internal/handlers/integration_test.go
+++ b/services/management/internal/handlers/integration_test.go
@@ -40,7 +40,8 @@ func setupTestServer(t *testing.T) (testEnv, func()) {
 	es := store.NewExperimentStore(pool)
 	as := store.NewAuditStore(pool)
 	ls := store.NewLayerStore(pool)
-	svc := handlers.NewExperimentService(es, as, ls, nil)
+	ms := store.NewMetricStore(pool)
+	svc := handlers.NewExperimentService(es, as, ls, ms, nil)
 
 	mux := http.NewServeMux()
 	path, handler := managementv1connect.NewExperimentManagementServiceHandler(svc)

--- a/services/management/internal/handlers/metric.go
+++ b/services/management/internal/handlers/metric.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+
+	"github.com/org/experimentation-platform/services/management/internal/store"
+	"github.com/org/experimentation-platform/services/management/internal/validation"
+)
+
+// CreateMetricDefinition validates the request, inserts the metric definition,
+// and returns the created metric.
+func (s *ExperimentService) CreateMetricDefinition(
+	ctx context.Context,
+	req *connect.Request[mgmtv1.CreateMetricDefinitionRequest],
+) (*connect.Response[commonv1.MetricDefinition], error) {
+	m := req.Msg.GetMetric()
+
+	if err := validation.ValidateCreateMetricDefinition(m); err != nil {
+		return nil, err
+	}
+
+	row := store.MetricDefinitionToRow(m)
+
+	// Generate metric_id if not provided.
+	if row.MetricID == "" {
+		row.MetricID = uuid.NewString()
+	}
+
+	created, err := s.metrics.Insert(ctx, row)
+	if err != nil {
+		return nil, wrapDBError(err, "metric_definition", row.MetricID)
+	}
+
+	slog.Info("metric definition created", "metric_id", created.MetricID, "name", created.Name, "type", created.Type)
+	return connect.NewResponse(store.RowToMetricDefinition(created)), nil
+}
+
+// GetMetricDefinition retrieves a single metric definition by ID.
+func (s *ExperimentService) GetMetricDefinition(
+	ctx context.Context,
+	req *connect.Request[mgmtv1.GetMetricDefinitionRequest],
+) (*connect.Response[commonv1.MetricDefinition], error) {
+	id := req.Msg.GetMetricId()
+	if id == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, nil)
+	}
+
+	row, err := s.metrics.GetByID(ctx, id)
+	if err != nil {
+		return nil, wrapDBError(err, "metric_definition", id)
+	}
+
+	return connect.NewResponse(store.RowToMetricDefinition(row)), nil
+}
+
+// ListMetricDefinitions returns a paginated list of metric definitions.
+func (s *ExperimentService) ListMetricDefinitions(
+	ctx context.Context,
+	req *connect.Request[mgmtv1.ListMetricDefinitionsRequest],
+) (*connect.Response[mgmtv1.ListMetricDefinitionsResponse], error) {
+	rows, nextToken, err := s.metrics.ListMetrics(ctx, req.Msg.GetPageSize(), req.Msg.GetPageToken())
+	if err != nil {
+		return nil, internalError("list metric definitions", err)
+	}
+
+	resp := &mgmtv1.ListMetricDefinitionsResponse{
+		NextPageToken: nextToken,
+	}
+	for _, row := range rows {
+		resp.Metrics = append(resp.Metrics, store.RowToMetricDefinition(row))
+	}
+
+	return connect.NewResponse(resp), nil
+}

--- a/services/management/internal/handlers/metric_integration_test.go
+++ b/services/management/internal/handlers/metric_integration_test.go
@@ -1,0 +1,289 @@
+//go:build integration
+
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+)
+
+func TestCreateMetricDefinition_Mean(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	resp, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+			Metric: &commonv1.MetricDefinition{
+				Name:            "avg_watch_time",
+				Description:     "Average watch time per session",
+				Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+				SourceEventType: "watch_event",
+				LowerIsBetter:   false,
+			},
+		}))
+	require.NoError(t, err)
+	m := resp.Msg
+	assert.NotEmpty(t, m.GetMetricId(), "metric_id should be auto-generated")
+	assert.Equal(t, "avg_watch_time", m.GetName())
+	assert.Equal(t, commonv1.MetricType_METRIC_TYPE_MEAN, m.GetType())
+	assert.Equal(t, "watch_event", m.GetSourceEventType())
+}
+
+func TestCreateMetricDefinition_WithExplicitID(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	resp, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+			Metric: &commonv1.MetricDefinition{
+				MetricId:        "custom-metric-001",
+				Name:            "explicit_id_metric",
+				Type:            commonv1.MetricType_METRIC_TYPE_COUNT,
+				SourceEventType: "click",
+			},
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, "custom-metric-001", resp.Msg.GetMetricId())
+}
+
+func TestCreateMetricDefinition_Ratio(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	resp, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+			Metric: &commonv1.MetricDefinition{
+				Name:                 "revenue_per_session",
+				Type:                 commonv1.MetricType_METRIC_TYPE_RATIO,
+				NumeratorEventType:   "revenue",
+				DenominatorEventType: "session",
+			},
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, "revenue", resp.Msg.GetNumeratorEventType())
+	assert.Equal(t, "session", resp.Msg.GetDenominatorEventType())
+}
+
+func TestCreateMetricDefinition_Percentile(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	resp, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+			Metric: &commonv1.MetricDefinition{
+				Name:            "p95_ttff",
+				Type:            commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+				SourceEventType: "ttff_event",
+				Percentile:      0.95,
+				LowerIsBetter:   true,
+				IsQoeMetric:     true,
+			},
+		}))
+	require.NoError(t, err)
+	assert.InDelta(t, 0.95, resp.Msg.GetPercentile(), 0.001)
+	assert.True(t, resp.Msg.GetLowerIsBetter())
+	assert.True(t, resp.Msg.GetIsQoeMetric())
+}
+
+func TestCreateMetricDefinition_Custom(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	resp, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+			Metric: &commonv1.MetricDefinition{
+				Name:      "custom_engagement",
+				Type:      commonv1.MetricType_METRIC_TYPE_CUSTOM,
+				CustomSql: "SELECT AVG(score) FROM engagement_events",
+			},
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT AVG(score) FROM engagement_events", resp.Msg.GetCustomSql())
+}
+
+func TestCreateMetricDefinition_ValidationErrors(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	tests := []struct {
+		name   string
+		metric *commonv1.MetricDefinition
+		errMsg string
+	}{
+		{
+			name:   "nil metric",
+			metric: nil,
+			errMsg: "metric is required",
+		},
+		{
+			name:   "missing name",
+			metric: &commonv1.MetricDefinition{Type: commonv1.MetricType_METRIC_TYPE_MEAN, SourceEventType: "e"},
+			errMsg: "name is required",
+		},
+		{
+			name:   "missing type",
+			metric: &commonv1.MetricDefinition{Name: "m"},
+			errMsg: "type is required",
+		},
+		{
+			name:   "mean missing source_event",
+			metric: &commonv1.MetricDefinition{Name: "m", Type: commonv1.MetricType_METRIC_TYPE_MEAN},
+			errMsg: "source_event_type is required",
+		},
+		{
+			name:   "ratio missing numerator",
+			metric: &commonv1.MetricDefinition{Name: "m", Type: commonv1.MetricType_METRIC_TYPE_RATIO},
+			errMsg: "numerator_event_type is required",
+		},
+		{
+			name: "percentile out of range",
+			metric: &commonv1.MetricDefinition{
+				Name: "m", Type: commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+				SourceEventType: "e", Percentile: 1.5,
+			},
+			errMsg: "percentile must be in (0.0, 1.0)",
+		},
+		{
+			name:   "custom missing sql",
+			metric: &commonv1.MetricDefinition{Name: "m", Type: commonv1.MetricType_METRIC_TYPE_CUSTOM},
+			errMsg: "custom_sql is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := env.client.CreateMetricDefinition(context.Background(),
+				connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{Metric: tt.metric}))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestGetMetricDefinition(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// Create first.
+	createResp, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+			Metric: &commonv1.MetricDefinition{
+				Name:            "get_test_metric",
+				Type:            commonv1.MetricType_METRIC_TYPE_PROPORTION,
+				SourceEventType: "conversion",
+			},
+		}))
+	require.NoError(t, err)
+	metricID := createResp.Msg.GetMetricId()
+
+	// Get.
+	getResp, err := env.client.GetMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.GetMetricDefinitionRequest{MetricId: metricID}))
+	require.NoError(t, err)
+	assert.Equal(t, metricID, getResp.Msg.GetMetricId())
+	assert.Equal(t, "get_test_metric", getResp.Msg.GetName())
+}
+
+func TestGetMetricDefinition_NotFound(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	_, err := env.client.GetMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.GetMetricDefinitionRequest{MetricId: "nonexistent"}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+func TestGetMetricDefinition_EmptyID(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	_, err := env.client.GetMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.GetMetricDefinitionRequest{MetricId: ""}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestListMetricDefinitions(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// Create 3 metrics.
+	for i := 0; i < 3; i++ {
+		_, err := env.client.CreateMetricDefinition(context.Background(),
+			connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+				Metric: &commonv1.MetricDefinition{
+					Name:            fmt.Sprintf("list_test_%d", i),
+					Type:            commonv1.MetricType_METRIC_TYPE_COUNT,
+					SourceEventType: "click",
+				},
+			}))
+		require.NoError(t, err)
+	}
+
+	// List with page_size=2.
+	listResp, err := env.client.ListMetricDefinitions(context.Background(),
+		connect.NewRequest(&mgmtv1.ListMetricDefinitionsRequest{PageSize: 2}))
+	require.NoError(t, err)
+	// There may be seed data metrics too, so just check we got at least 2.
+	assert.GreaterOrEqual(t, len(listResp.Msg.GetMetrics()), 2)
+
+	// If there's a next_page_token, fetch next page.
+	if listResp.Msg.GetNextPageToken() != "" {
+		page2, err := env.client.ListMetricDefinitions(context.Background(),
+			connect.NewRequest(&mgmtv1.ListMetricDefinitionsRequest{
+				PageSize:  2,
+				PageToken: listResp.Msg.GetNextPageToken(),
+			}))
+		require.NoError(t, err)
+		assert.NotEmpty(t, page2.Msg.GetMetrics())
+	}
+}
+
+func TestCreateMetricDefinition_DuplicateID(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	m := &commonv1.MetricDefinition{
+		MetricId:        "dup-metric-id",
+		Name:            "dup_metric",
+		Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType: "ev",
+	}
+
+	_, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{Metric: m}))
+	require.NoError(t, err)
+
+	// Second insert with same ID should fail.
+	_, err = env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{Metric: m}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeAlreadyExists, connect.CodeOf(err))
+}
+
+func TestCreateMetricDefinition_WithCupedCovariate(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	resp, err := env.client.CreateMetricDefinition(context.Background(),
+		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
+			Metric: &commonv1.MetricDefinition{
+				Name:                    "cuped_metric",
+				Type:                    commonv1.MetricType_METRIC_TYPE_MEAN,
+				SourceEventType:         "view",
+				CupedCovariateMetricId:  "some-covariate-id",
+				MinimumDetectableEffect: 0.02,
+			},
+		}))
+	require.NoError(t, err)
+	assert.Equal(t, "some-covariate-id", resp.Msg.GetCupedCovariateMetricId())
+	assert.InDelta(t, 0.02, resp.Msg.GetMinimumDetectableEffect(), 0.001)
+}

--- a/services/management/internal/handlers/service.go
+++ b/services/management/internal/handlers/service.go
@@ -22,27 +22,16 @@ type ExperimentService struct {
 	store    *store.ExperimentStore
 	audit    *store.AuditStore
 	layers   *store.LayerStore
+	metrics  *store.MetricStore
 	notifier *streaming.Notifier
 }
 
 // NewExperimentService creates a new handler with the given stores and notifier.
-func NewExperimentService(es *store.ExperimentStore, as *store.AuditStore, ls *store.LayerStore, n *streaming.Notifier) *ExperimentService {
-	return &ExperimentService{store: es, audit: as, layers: ls, notifier: n}
+func NewExperimentService(es *store.ExperimentStore, as *store.AuditStore, ls *store.LayerStore, ms *store.MetricStore, n *streaming.Notifier) *ExperimentService {
+	return &ExperimentService{store: es, audit: as, layers: ls, metrics: ms, notifier: n}
 }
 
-// --- Unimplemented stubs for metric/layer/targeting/surrogate RPCs ---
-
-func (s *ExperimentService) CreateMetricDefinition(_ context.Context, _ *connect.Request[mgmtv1.CreateMetricDefinitionRequest]) (*connect.Response[commonv1.MetricDefinition], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, nil)
-}
-
-func (s *ExperimentService) GetMetricDefinition(_ context.Context, _ *connect.Request[mgmtv1.GetMetricDefinitionRequest]) (*connect.Response[commonv1.MetricDefinition], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, nil)
-}
-
-func (s *ExperimentService) ListMetricDefinitions(_ context.Context, _ *connect.Request[mgmtv1.ListMetricDefinitionsRequest]) (*connect.Response[mgmtv1.ListMetricDefinitionsResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, nil)
-}
+// --- Unimplemented stubs for targeting/surrogate RPCs ---
 
 func (s *ExperimentService) CreateTargetingRule(_ context.Context, _ *connect.Request[mgmtv1.CreateTargetingRuleRequest]) (*connect.Response[commonv1.TargetingRule], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, nil)

--- a/services/management/internal/handlers/stream_test.go
+++ b/services/management/internal/handlers/stream_test.go
@@ -47,7 +47,8 @@ func setupStreamTest(t *testing.T) (
 	notifier = streaming.NewNotifier(pool, dsn)
 	notifier.Start(ctx)
 
-	expSvc := handlers.NewExperimentService(es, as, ls, notifier)
+	ms := store.NewMetricStore(pool)
+	expSvc := handlers.NewExperimentService(es, as, ls, ms, notifier)
 	streamSvc := handlers.NewConfigStreamService(es, notifier)
 
 	mux := http.NewServeMux()

--- a/services/management/internal/store/metric.go
+++ b/services/management/internal/store/metric.go
@@ -1,0 +1,181 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// MetricDefinitionRow mirrors the metric_definitions table.
+type MetricDefinitionRow struct {
+	MetricID               string
+	Name                   string
+	Description            string
+	Type                   string
+	SourceEventType        string
+	NumeratorEventType     string
+	DenominatorEventType   string
+	Percentile             *float64
+	CustomSQL              string
+	LowerIsBetter          bool
+	IsQoeMetric            bool
+	CupedCovariateMetricID string
+	MinimumDetectableEffect *float64
+	CreatedAt              time.Time
+}
+
+const metricCols = `metric_id, name, description, type, source_event_type,
+	numerator_event_type, denominator_event_type, percentile, custom_sql,
+	lower_is_better, is_qoe_metric, cuped_covariate_metric_id,
+	minimum_detectable_effect, created_at`
+
+// MetricStore provides database operations for metric definitions.
+type MetricStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewMetricStore creates a new MetricStore.
+func NewMetricStore(pool *pgxpool.Pool) *MetricStore {
+	return &MetricStore{pool: pool}
+}
+
+// Insert creates a new metric definition.
+func (s *MetricStore) Insert(ctx context.Context, row MetricDefinitionRow) (MetricDefinitionRow, error) {
+	var out MetricDefinitionRow
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO metric_definitions (
+			metric_id, name, description, type, source_event_type,
+			numerator_event_type, denominator_event_type, percentile, custom_sql,
+			lower_is_better, is_qoe_metric, cuped_covariate_metric_id,
+			minimum_detectable_effect
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+		RETURNING `+metricCols,
+		row.MetricID, row.Name, row.Description, row.Type, row.SourceEventType,
+		row.NumeratorEventType, row.DenominatorEventType, row.Percentile, row.CustomSQL,
+		row.LowerIsBetter, row.IsQoeMetric, row.CupedCovariateMetricID,
+		row.MinimumDetectableEffect,
+	).Scan(
+		&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
+		&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
+		&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
+		&out.MinimumDetectableEffect, &out.CreatedAt,
+	)
+	return out, err
+}
+
+// GetByID retrieves a metric definition by its ID.
+func (s *MetricStore) GetByID(ctx context.Context, metricID string) (MetricDefinitionRow, error) {
+	var out MetricDefinitionRow
+	err := s.pool.QueryRow(ctx,
+		`SELECT `+metricCols+` FROM metric_definitions WHERE metric_id = $1`, metricID,
+	).Scan(
+		&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
+		&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
+		&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
+		&out.MinimumDetectableEffect, &out.CreatedAt,
+	)
+	if err != nil {
+		return MetricDefinitionRow{}, err
+	}
+	return out, nil
+}
+
+// ListMetrics queries metric definitions with keyset pagination.
+func (s *MetricStore) ListMetrics(ctx context.Context, pageSize int32, pageToken string) ([]MetricDefinitionRow, string, error) {
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 20
+	}
+
+	args := []any{}
+	where := "WHERE 1=1"
+	argN := 0
+
+	nextArg := func() string {
+		argN++
+		return fmt.Sprintf("$%d", argN)
+	}
+
+	if pageToken != "" {
+		parts := splitPageToken(pageToken)
+		if len(parts) == 2 {
+			tokenTime, parseErr := time.Parse(time.RFC3339Nano, parts[0])
+			if parseErr == nil {
+				tokenID := parts[1]
+				p1 := nextArg()
+				p2 := nextArg()
+				where += fmt.Sprintf(" AND (created_at, metric_id) < (%s, %s)", p1, p2)
+				args = append(args, tokenTime, tokenID)
+			}
+		}
+	}
+
+	query := fmt.Sprintf(
+		`SELECT %s FROM metric_definitions %s ORDER BY created_at DESC, metric_id DESC LIMIT %s`,
+		metricCols, where, nextArg(),
+	)
+	args = append(args, pageSize+1)
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+
+	var results []MetricDefinitionRow
+	for rows.Next() {
+		var out MetricDefinitionRow
+		if err := rows.Scan(
+			&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
+			&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
+			&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
+			&out.MinimumDetectableEffect, &out.CreatedAt,
+		); err != nil {
+			return nil, "", err
+		}
+		results = append(results, out)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+
+	var nextToken string
+	if int32(len(results)) > pageSize {
+		last := results[pageSize-1]
+		nextToken = last.CreatedAt.Format(time.RFC3339Nano) + "|" + last.MetricID
+		results = results[:pageSize]
+	}
+
+	return results, nextToken, nil
+}
+
+// Exists checks whether a metric definition with the given ID exists.
+func (s *MetricStore) Exists(ctx context.Context, metricID string) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM metric_definitions WHERE metric_id = $1)`, metricID,
+	).Scan(&exists)
+	return exists, err
+}
+
+// scanMetricRow is unused currently but provided for symmetry with experiment store.
+var _ = (*MetricStore)(nil) // ensure MetricStore is used by the compiler even if Exists is unused
+
+// GetByIDTx retrieves a metric definition within a transaction (for future use).
+func (s *MetricStore) GetByIDTx(ctx context.Context, tx pgx.Tx, metricID string) (MetricDefinitionRow, error) {
+	var out MetricDefinitionRow
+	err := tx.QueryRow(ctx,
+		`SELECT `+metricCols+` FROM metric_definitions WHERE metric_id = $1`, metricID,
+	).Scan(
+		&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
+		&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
+		&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
+		&out.MinimumDetectableEffect, &out.CreatedAt,
+	)
+	if err != nil {
+		return MetricDefinitionRow{}, err
+	}
+	return out, nil
+}

--- a/services/management/internal/store/metric_convert.go
+++ b/services/management/internal/store/metric_convert.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+)
+
+// --- MetricType conversions ---
+
+var metricTypeToString = map[commonv1.MetricType]string{
+	commonv1.MetricType_METRIC_TYPE_MEAN:       "MEAN",
+	commonv1.MetricType_METRIC_TYPE_PROPORTION: "PROPORTION",
+	commonv1.MetricType_METRIC_TYPE_RATIO:      "RATIO",
+	commonv1.MetricType_METRIC_TYPE_COUNT:      "COUNT",
+	commonv1.MetricType_METRIC_TYPE_PERCENTILE: "PERCENTILE",
+	commonv1.MetricType_METRIC_TYPE_CUSTOM:     "CUSTOM",
+}
+
+var stringToMetricType = map[string]commonv1.MetricType{
+	"MEAN":       commonv1.MetricType_METRIC_TYPE_MEAN,
+	"PROPORTION": commonv1.MetricType_METRIC_TYPE_PROPORTION,
+	"RATIO":      commonv1.MetricType_METRIC_TYPE_RATIO,
+	"COUNT":      commonv1.MetricType_METRIC_TYPE_COUNT,
+	"PERCENTILE": commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+	"CUSTOM":     commonv1.MetricType_METRIC_TYPE_CUSTOM,
+}
+
+// MetricTypeToString converts a proto MetricType to a DB string.
+func MetricTypeToString(t commonv1.MetricType) string {
+	return metricTypeToString[t]
+}
+
+// StringToMetricType converts a DB string to a proto MetricType.
+func StringToMetricType(s string) commonv1.MetricType {
+	return stringToMetricType[s]
+}
+
+// MetricDefinitionToRow converts a proto MetricDefinition to a DB row.
+func MetricDefinitionToRow(m *commonv1.MetricDefinition) MetricDefinitionRow {
+	row := MetricDefinitionRow{
+		MetricID:               m.GetMetricId(),
+		Name:                   m.GetName(),
+		Description:            m.GetDescription(),
+		Type:                   MetricTypeToString(m.GetType()),
+		SourceEventType:        m.GetSourceEventType(),
+		NumeratorEventType:     m.GetNumeratorEventType(),
+		DenominatorEventType:   m.GetDenominatorEventType(),
+		CustomSQL:              m.GetCustomSql(),
+		LowerIsBetter:          m.GetLowerIsBetter(),
+		IsQoeMetric:            m.GetIsQoeMetric(),
+		CupedCovariateMetricID: m.GetCupedCovariateMetricId(),
+	}
+
+	if p := m.GetPercentile(); p != 0 {
+		row.Percentile = &p
+	}
+	if mde := m.GetMinimumDetectableEffect(); mde != 0 {
+		row.MinimumDetectableEffect = &mde
+	}
+
+	return row
+}
+
+// RowToMetricDefinition converts a DB row to a proto MetricDefinition.
+func RowToMetricDefinition(row MetricDefinitionRow) *commonv1.MetricDefinition {
+	m := &commonv1.MetricDefinition{
+		MetricId:               row.MetricID,
+		Name:                   row.Name,
+		Description:            row.Description,
+		Type:                   StringToMetricType(row.Type),
+		SourceEventType:        row.SourceEventType,
+		NumeratorEventType:     row.NumeratorEventType,
+		DenominatorEventType:   row.DenominatorEventType,
+		CustomSql:              row.CustomSQL,
+		LowerIsBetter:          row.LowerIsBetter,
+		IsQoeMetric:            row.IsQoeMetric,
+		CupedCovariateMetricId: row.CupedCovariateMetricID,
+	}
+
+	if row.Percentile != nil {
+		m.Percentile = *row.Percentile
+	}
+	if row.MinimumDetectableEffect != nil {
+		m.MinimumDetectableEffect = *row.MinimumDetectableEffect
+	}
+
+	return m
+}

--- a/services/management/internal/validation/metric.go
+++ b/services/management/internal/validation/metric.go
@@ -1,0 +1,70 @@
+package validation
+
+import (
+	"fmt"
+
+	"connectrpc.com/connect"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+)
+
+// ValidateCreateMetricDefinition validates a metric definition for creation.
+func ValidateCreateMetricDefinition(m *commonv1.MetricDefinition) *connect.Error {
+	if m == nil {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("metric is required"))
+	}
+	if m.GetName() == "" {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name is required"))
+	}
+	if m.GetType() == commonv1.MetricType_METRIC_TYPE_UNSPECIFIED {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("type is required"))
+	}
+
+	return validateMetricTypeFields(m)
+}
+
+func validateMetricTypeFields(m *commonv1.MetricDefinition) *connect.Error {
+	switch m.GetType() {
+	case commonv1.MetricType_METRIC_TYPE_MEAN,
+		commonv1.MetricType_METRIC_TYPE_PROPORTION,
+		commonv1.MetricType_METRIC_TYPE_COUNT:
+		if m.GetSourceEventType() == "" {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("source_event_type is required for %s metrics", m.GetType()))
+		}
+
+	case commonv1.MetricType_METRIC_TYPE_RATIO:
+		if m.GetNumeratorEventType() == "" {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("numerator_event_type is required for RATIO metrics"))
+		}
+		if m.GetDenominatorEventType() == "" {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("denominator_event_type is required for RATIO metrics"))
+		}
+
+	case commonv1.MetricType_METRIC_TYPE_PERCENTILE:
+		if m.GetSourceEventType() == "" {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("source_event_type is required for PERCENTILE metrics"))
+		}
+		p := m.GetPercentile()
+		if p <= 0 || p >= 1 {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("percentile must be in (0.0, 1.0), got %f", p))
+		}
+
+	case commonv1.MetricType_METRIC_TYPE_CUSTOM:
+		if m.GetCustomSql() == "" {
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("custom_sql is required for CUSTOM metrics"))
+		}
+	}
+
+	if mde := m.GetMinimumDetectableEffect(); mde < 0 {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("minimum_detectable_effect must be non-negative, got %f", mde))
+	}
+
+	return nil
+}

--- a/services/management/internal/validation/metric_test.go
+++ b/services/management/internal/validation/metric_test.go
@@ -1,0 +1,162 @@
+package validation
+
+import (
+	"testing"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateCreateMetricDefinition_RequiresName(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType: "page_view",
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "name is required")
+}
+
+func TestValidateCreateMetricDefinition_RequiresType(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "test_metric",
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "type is required")
+}
+
+func TestValidateCreateMetricDefinition_NilMetric(t *testing.T) {
+	err := ValidateCreateMetricDefinition(nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "metric is required")
+}
+
+func TestValidateCreateMetricDefinition_MeanRequiresSourceEvent(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "test",
+		Type: commonv1.MetricType_METRIC_TYPE_MEAN,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "source_event_type is required")
+}
+
+func TestValidateCreateMetricDefinition_ProportionRequiresSourceEvent(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "test",
+		Type: commonv1.MetricType_METRIC_TYPE_PROPORTION,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "source_event_type is required")
+}
+
+func TestValidateCreateMetricDefinition_CountRequiresSourceEvent(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "test",
+		Type: commonv1.MetricType_METRIC_TYPE_COUNT,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "source_event_type is required")
+}
+
+func TestValidateCreateMetricDefinition_RatioRequiresNumeratorDenominator(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "test",
+		Type: commonv1.MetricType_METRIC_TYPE_RATIO,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "numerator_event_type is required")
+
+	m.NumeratorEventType = "revenue"
+	err = ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "denominator_event_type is required")
+}
+
+func TestValidateCreateMetricDefinition_PercentileRequiresSourceAndValue(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "test",
+		Type: commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "source_event_type is required")
+
+	m.SourceEventType = "latency"
+	err = ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "percentile must be in (0.0, 1.0)")
+
+	m.Percentile = 1.5
+	err = ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "percentile must be in (0.0, 1.0)")
+}
+
+func TestValidateCreateMetricDefinition_CustomRequiresSQL(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "test",
+		Type: commonv1.MetricType_METRIC_TYPE_CUSTOM,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "custom_sql is required")
+}
+
+func TestValidateCreateMetricDefinition_NegativeMDE(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:                    "test",
+		Type:                    commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType:         "view",
+		MinimumDetectableEffect: -0.5,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "minimum_detectable_effect must be non-negative")
+}
+
+func TestValidateCreateMetricDefinition_ValidMean(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:            "avg_watch_time",
+		Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType: "watch_event",
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.Nil(t, err)
+}
+
+func TestValidateCreateMetricDefinition_ValidRatio(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:                 "revenue_per_session",
+		Type:                 commonv1.MetricType_METRIC_TYPE_RATIO,
+		NumeratorEventType:   "revenue",
+		DenominatorEventType: "session",
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.Nil(t, err)
+}
+
+func TestValidateCreateMetricDefinition_ValidPercentile(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:            "p95_ttff",
+		Type:            commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+		SourceEventType: "ttff_event",
+		Percentile:      0.95,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.Nil(t, err)
+}
+
+func TestValidateCreateMetricDefinition_ValidCustom(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:      "custom_engagement",
+		Type:      commonv1.MetricType_METRIC_TYPE_CUSTOM,
+		CustomSql: "SELECT AVG(engagement_score) FROM events",
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
## Summary

- Implement `CreateMetricDefinition`, `GetMetricDefinition`, and `ListMetricDefinitions` ConnectRPC handlers
- Add `MetricStore` with keyset pagination (same pattern as ExperimentStore)
- Add type-specific validation: MEAN/PROPORTION/COUNT require `source_event_type`, RATIO requires numerator+denominator, PERCENTILE requires valid percentile value, CUSTOM requires `custom_sql`
- Auto-generate `metric_id` (UUID) if not provided by client
- 14 validation unit tests + 12 integration tests covering all metric types, pagination, error cases, and duplicate detection

## What this unblocks

- **Agent-3 (M3)**: metric definitions for computation jobs — M3 can now query metric configs from M5 instead of local JSON
- **Agent-6 (M6)**: metric definition management UI

## Test plan

- [x] `go vet ./management/...` — compiles cleanly
- [x] `go test ./management/...` — all unit tests pass
- [ ] `go test -tags integration ./management/...` — integration tests (requires `just dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)