### PR TITLE
feat(m6): ConnectRPC integration + View SQL page

### DIFF
--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -1,80 +1,73 @@
 import { http, HttpResponse } from 'msw';
-import { SEED_EXPERIMENTS } from './seed-data';
+import { SEED_EXPERIMENTS, SEED_QUERY_LOG } from './seed-data';
+
+const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
+const METRICS_SVC = '*/experimentation.metrics.v1.MetricComputationService';
 
 export const handlers = [
-  http.get('*/api/experiments', ({ request }) => {
-    const url = new URL(request.url);
-    const stateFilter = url.searchParams.get('state');
-    const typeFilter = url.searchParams.get('type');
-
-    let experiments = [...SEED_EXPERIMENTS];
-
-    if (stateFilter) {
-      experiments = experiments.filter((e) => e.state === stateFilter);
-    }
-    if (typeFilter) {
-      experiments = experiments.filter((e) => e.type === typeFilter);
-    }
-
+  // ListExperiments
+  http.post(`${MGMT_SVC}/ListExperiments`, async () => {
     return HttpResponse.json({
-      experiments,
-      totalCount: experiments.length,
+      experiments: SEED_EXPERIMENTS,
+      nextPageToken: '',
     });
   }),
 
-  http.get('*/api/experiments/:id', ({ params }) => {
-    const { id } = params;
-    const experiment = SEED_EXPERIMENTS.find((e) => e.experimentId === id);
+  // GetExperiment
+  http.post(`${MGMT_SVC}/GetExperiment`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const experiment = SEED_EXPERIMENTS.find((e) => e.experimentId === body.experimentId);
 
     if (!experiment) {
       return HttpResponse.json(
-        { error: `Experiment ${id} not found` },
+        { code: 'not_found', message: `Experiment ${body.experimentId} not found` },
         { status: 404 },
       );
     }
 
-    return HttpResponse.json(experiment);
+    return HttpResponse.json({ experiment });
   }),
 
-  // Update experiment (DRAFT only)
-  http.put('*/api/experiments/:id', async ({ params, request }) => {
-    const { id } = params;
+  // UpdateExperiment
+  http.post(`${MGMT_SVC}/UpdateExperiment`, async ({ request }) => {
+    const body = await request.json() as { experiment: Record<string, unknown> };
+    const exp = body.experiment;
+    const id = exp.experimentId as string;
     const idx = SEED_EXPERIMENTS.findIndex((e) => e.experimentId === id);
 
     if (idx === -1) {
       return HttpResponse.json(
-        { error: `Experiment ${id} not found` },
+        { code: 'not_found', message: `Experiment ${id} not found` },
         { status: 404 },
       );
     }
 
     if (SEED_EXPERIMENTS[idx].state !== 'DRAFT') {
       return HttpResponse.json(
-        { error: 'Only DRAFT experiments can be updated' },
+        { code: 'failed_precondition', message: 'Only DRAFT experiments can be updated' },
         { status: 400 },
       );
     }
 
-    const body = await request.json() as Record<string, unknown>;
-    SEED_EXPERIMENTS[idx] = { ...SEED_EXPERIMENTS[idx], ...body } as typeof SEED_EXPERIMENTS[number];
-    return HttpResponse.json(SEED_EXPERIMENTS[idx]);
+    SEED_EXPERIMENTS[idx] = { ...SEED_EXPERIMENTS[idx], ...exp } as typeof SEED_EXPERIMENTS[number];
+    return HttpResponse.json({ experiment: SEED_EXPERIMENTS[idx] });
   }),
 
-  // Start experiment: DRAFT → RUNNING (mock skips STARTING)
-  http.post('*/api/experiments/:id/start', ({ params }) => {
-    const { id } = params;
-    const idx = SEED_EXPERIMENTS.findIndex((e) => e.experimentId === id);
+  // StartExperiment: DRAFT → RUNNING (mock skips STARTING)
+  http.post(`${MGMT_SVC}/StartExperiment`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const idx = SEED_EXPERIMENTS.findIndex((e) => e.experimentId === body.experimentId);
 
     if (idx === -1) {
       return HttpResponse.json(
-        { error: `Experiment ${id} not found` },
+        { code: 'not_found', message: `Experiment ${body.experimentId} not found` },
         { status: 404 },
       );
     }
 
     if (SEED_EXPERIMENTS[idx].state !== 'DRAFT') {
       return HttpResponse.json(
-        { error: 'Only DRAFT experiments can be started' },
+        { code: 'failed_precondition', message: 'Only DRAFT experiments can be started' },
         { status: 400 },
       );
     }
@@ -84,24 +77,24 @@ export const handlers = [
       state: 'RUNNING',
       startedAt: new Date().toISOString(),
     };
-    return HttpResponse.json(SEED_EXPERIMENTS[idx]);
+    return HttpResponse.json({ experiment: SEED_EXPERIMENTS[idx] });
   }),
 
-  // Conclude experiment: RUNNING → CONCLUDED (mock skips CONCLUDING)
-  http.post('*/api/experiments/:id/conclude', ({ params }) => {
-    const { id } = params;
-    const idx = SEED_EXPERIMENTS.findIndex((e) => e.experimentId === id);
+  // ConcludeExperiment: RUNNING → CONCLUDED (mock skips CONCLUDING)
+  http.post(`${MGMT_SVC}/ConcludeExperiment`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const idx = SEED_EXPERIMENTS.findIndex((e) => e.experimentId === body.experimentId);
 
     if (idx === -1) {
       return HttpResponse.json(
-        { error: `Experiment ${id} not found` },
+        { code: 'not_found', message: `Experiment ${body.experimentId} not found` },
         { status: 404 },
       );
     }
 
     if (SEED_EXPERIMENTS[idx].state !== 'RUNNING') {
       return HttpResponse.json(
-        { error: 'Only RUNNING experiments can be concluded' },
+        { code: 'failed_precondition', message: 'Only RUNNING experiments can be concluded' },
         { status: 400 },
       );
     }
@@ -111,24 +104,24 @@ export const handlers = [
       state: 'CONCLUDED',
       concludedAt: new Date().toISOString(),
     };
-    return HttpResponse.json(SEED_EXPERIMENTS[idx]);
+    return HttpResponse.json({ experiment: SEED_EXPERIMENTS[idx] });
   }),
 
-  // Archive experiment: CONCLUDED → ARCHIVED
-  http.post('*/api/experiments/:id/archive', ({ params }) => {
-    const { id } = params;
-    const idx = SEED_EXPERIMENTS.findIndex((e) => e.experimentId === id);
+  // ArchiveExperiment: CONCLUDED → ARCHIVED
+  http.post(`${MGMT_SVC}/ArchiveExperiment`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const idx = SEED_EXPERIMENTS.findIndex((e) => e.experimentId === body.experimentId);
 
     if (idx === -1) {
       return HttpResponse.json(
-        { error: `Experiment ${id} not found` },
+        { code: 'not_found', message: `Experiment ${body.experimentId} not found` },
         { status: 404 },
       );
     }
 
     if (SEED_EXPERIMENTS[idx].state !== 'CONCLUDED') {
       return HttpResponse.json(
-        { error: 'Only CONCLUDED experiments can be archived' },
+        { code: 'failed_precondition', message: 'Only CONCLUDED experiments can be archived' },
         { status: 400 },
       );
     }
@@ -137,6 +130,30 @@ export const handlers = [
       ...SEED_EXPERIMENTS[idx],
       state: 'ARCHIVED',
     };
-    return HttpResponse.json(SEED_EXPERIMENTS[idx]);
+    return HttpResponse.json({ experiment: SEED_EXPERIMENTS[idx] });
+  }),
+
+  // GetQueryLog
+  http.post(`${METRICS_SVC}/GetQueryLog`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string; metricId?: string };
+    let entries = SEED_QUERY_LOG[body.experimentId] || [];
+
+    if (body.metricId) {
+      entries = entries.filter((e) => e.metricId === body.metricId);
+    }
+
+    return HttpResponse.json({ entries });
+  }),
+
+  // ExportNotebook
+  http.post(`${METRICS_SVC}/ExportNotebook`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const experiment = SEED_EXPERIMENTS.find((e) => e.experimentId === body.experimentId);
+    const name = experiment?.name || 'experiment';
+
+    return HttpResponse.json({
+      content: btoa(`{"cells": [], "metadata": {"experiment_id": "${body.experimentId}"}}`),
+      filename: `${name}_analysis.ipynb`,
+    });
   }),
 ];

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -1,4 +1,4 @@
-import type { Experiment } from '@/lib/types';
+import type { Experiment, QueryLogEntry } from '@/lib/types';
 
 const INITIAL_EXPERIMENTS: Experiment[] = [
   {
@@ -237,10 +237,60 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
   },
 ];
 
+/** Mock query log entries for RUNNING experiments. */
+const INITIAL_QUERY_LOG: Record<string, QueryLogEntry[]> = {
+  '11111111-1111-1111-1111-111111111111': [
+    {
+      experimentId: '11111111-1111-1111-1111-111111111111',
+      metricId: 'click_through_rate',
+      sqlText: 'SELECT variant_id, COUNT(DISTINCT user_id) AS users, SUM(CASE WHEN clicked THEN 1 ELSE 0 END) AS clicks, SUM(CASE WHEN clicked THEN 1 ELSE 0 END)::FLOAT / COUNT(DISTINCT user_id) AS ctr FROM events.homepage_interactions WHERE experiment_id = \'11111111-1111-1111-1111-111111111111\' AND event_date BETWEEN \'2026-02-16\' AND \'2026-03-05\' GROUP BY variant_id',
+      rowCount: 125000,
+      durationMs: 3200,
+      computedAt: '2026-03-05T14:30:00Z',
+    },
+    {
+      experimentId: '11111111-1111-1111-1111-111111111111',
+      metricId: 'watch_time_per_session',
+      sqlText: 'SELECT variant_id, AVG(watch_duration_seconds) AS avg_watch_time, STDDEV(watch_duration_seconds) AS stddev_watch_time FROM events.playback_sessions WHERE experiment_id = \'11111111-1111-1111-1111-111111111111\' AND session_date BETWEEN \'2026-02-16\' AND \'2026-03-05\' GROUP BY variant_id',
+      rowCount: 98500,
+      durationMs: 4100,
+      computedAt: '2026-03-05T14:30:05Z',
+    },
+    {
+      experimentId: '11111111-1111-1111-1111-111111111111',
+      metricId: 'crash_rate',
+      sqlText: 'SELECT variant_id, COUNT(DISTINCT CASE WHEN crashed THEN session_id END)::FLOAT / COUNT(DISTINCT session_id) AS crash_rate FROM events.app_sessions WHERE experiment_id = \'11111111-1111-1111-1111-111111111111\' AND session_date BETWEEN \'2026-02-16\' AND \'2026-03-05\' GROUP BY variant_id',
+      rowCount: 250000,
+      durationMs: 1800,
+      computedAt: '2026-03-05T14:30:10Z',
+    },
+  ],
+  '33333333-3333-3333-3333-333333333333': [
+    {
+      experimentId: '33333333-3333-3333-3333-333333333333',
+      metricId: 'search_success_rate',
+      sqlText: 'SELECT variant_id, COUNT(DISTINCT CASE WHEN result_clicked THEN search_id END)::FLOAT / COUNT(DISTINCT search_id) AS success_rate FROM events.search_queries WHERE experiment_id = \'33333333-3333-3333-3333-333333333333\' AND query_date BETWEEN \'2026-02-21\' AND \'2026-03-05\' GROUP BY variant_id',
+      rowCount: 75000,
+      durationMs: 2400,
+      computedAt: '2026-03-05T14:35:00Z',
+    },
+    {
+      experimentId: '33333333-3333-3333-3333-333333333333',
+      metricId: 'clicks_per_search',
+      sqlText: 'SELECT variant_id, AVG(click_count) AS avg_clicks FROM events.search_queries WHERE experiment_id = \'33333333-3333-3333-3333-333333333333\' AND query_date BETWEEN \'2026-02-21\' AND \'2026-03-05\' GROUP BY variant_id',
+      rowCount: 75000,
+      durationMs: 450,
+      computedAt: '2026-03-05T14:35:02Z',
+    },
+  ],
+};
+
 /** Mutable copy of seed data — MSW handlers mutate this in-place. */
 export let SEED_EXPERIMENTS: Experiment[] = structuredClone(INITIAL_EXPERIMENTS);
+export let SEED_QUERY_LOG: Record<string, QueryLogEntry[]> = structuredClone(INITIAL_QUERY_LOG);
 
 /** Reset seed data to initial state. Call in afterEach for test isolation. */
 export function resetSeedData(): void {
   SEED_EXPERIMENTS = structuredClone(INITIAL_EXPERIMENTS);
+  SEED_QUERY_LOG = structuredClone(INITIAL_QUERY_LOG);
 }

--- a/ui/src/__tests__/sql-page.test.tsx
+++ b/ui/src/__tests__/sql-page.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import SqlPage from '@/app/experiments/[id]/sql/page';
+
+let mockExperimentId = '11111111-1111-1111-1111-111111111111';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: mockExperimentId }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe('SQL Page', () => {
+  beforeEach(() => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+  });
+
+  it('shows loading state initially', () => {
+    render(<SqlPage />);
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('renders query log entries after load', async () => {
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('click_through_rate')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('watch_time_per_session')).toBeInTheDocument();
+    expect(screen.getByText('crash_rate')).toBeInTheDocument();
+  });
+
+  it('shows metric ID for each entry', async () => {
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('click_through_rate')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('watch_time_per_session')).toBeInTheDocument();
+    expect(screen.getByText('crash_rate')).toBeInTheDocument();
+  });
+
+  it('shows formatted duration and row count', async () => {
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('3.2s')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('125,000')).toBeInTheDocument();
+    expect(screen.getByText('4.1s')).toBeInTheDocument();
+    expect(screen.getByText('1.8s')).toBeInTheDocument();
+  });
+
+  it('expands row to show full SQL text', async () => {
+    const user = userEvent.setup();
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('click_through_rate')).toBeInTheDocument();
+    });
+
+    // Click the SQL preview button for the first entry
+    const sqlPreviews = screen.getAllByRole('button', { name: /SELECT/i });
+    await user.click(sqlPreviews[0]);
+
+    // Should show the full SQL in a <pre> block
+    const preElements = document.querySelectorAll('pre');
+    expect(preElements.length).toBeGreaterThanOrEqual(1);
+    expect(preElements[0].textContent).toContain('experiment_id');
+  });
+
+  it('shows empty state when no entries', async () => {
+    mockExperimentId = '44444444-4444-4444-4444-444444444444';
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No query log entries found for this experiment.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Export Notebook button', async () => {
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Export Notebook')).toBeInTheDocument();
+    });
+  });
+
+  it('renders error state on API failure', async () => {
+    server.use(
+      http.post('*/experimentation.metrics.v1.MetricComputationService/GetQueryLog', () => {
+        return HttpResponse.json(
+          { code: 'internal', message: 'Internal server error' },
+          { status: 500 },
+        );
+      }),
+    );
+
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/RPC GetQueryLog failed: 500/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders breadcrumb navigation', async () => {
+    render(<SqlPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Query Log')).toBeInTheDocument();
+    });
+
+    const experimentsLink = screen.getAllByText('Experiments')[0];
+    expect(experimentsLink.closest('a')).toHaveAttribute('href', '/');
+
+    const detailLink = screen.getAllByText('Detail')[0];
+    expect(detailLink.closest('a')).toHaveAttribute(
+      'href',
+      '/experiments/11111111-1111-1111-1111-111111111111',
+    );
+  });
+});

--- a/ui/src/app/experiments/[id]/sql/page.tsx
+++ b/ui/src/app/experiments/[id]/sql/page.tsx
@@ -1,10 +1,71 @@
 'use client';
 
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import type { QueryLogEntry } from '@/lib/types';
+import { getQueryLog, exportNotebook } from '@/lib/api';
+import { QueryLogTable } from '@/components/query-log-table';
 
 export default function SqlPage() {
   const params = useParams<{ id: string }>();
+  const [entries, setEntries] = useState<QueryLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  useEffect(() => {
+    if (!params.id) return;
+
+    getQueryLog(params.id)
+      .then(setEntries)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [params.id]);
+
+  const handleExport = useCallback(async () => {
+    if (!params.id) return;
+    setExporting(true);
+    try {
+      const result = await exportNotebook(params.id);
+      const blob = new Blob([atob(result.content)], { type: 'application/x-ipynb+json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = result.filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError('Failed to export notebook');
+    } finally {
+      setExporting(false);
+    }
+  }, [params.id]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div>
+        <nav className="mb-4 text-sm text-gray-500">
+          <Link href="/" className="hover:text-indigo-600">Experiments</Link>
+          <span className="mx-2">/</span>
+          <Link href={`/experiments/${params.id}`} className="hover:text-indigo-600">Detail</Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">SQL</span>
+        </nav>
+        <div className="rounded-md bg-red-50 p-4">
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -15,10 +76,16 @@ export default function SqlPage() {
         <span className="mx-2">/</span>
         <span className="text-gray-900">SQL</span>
       </nav>
-      <h1 className="text-2xl font-bold text-gray-900">Query Log</h1>
-      <p className="mt-2 text-sm text-gray-500">
-        SQL transparency view will be implemented in Phase 2 when M3 query log APIs are available.
-      </p>
+
+      <h1 className="mb-4 text-2xl font-bold text-gray-900">Query Log</h1>
+
+      {entries.length === 0 ? (
+        <div className="py-12 text-center">
+          <p className="text-sm text-gray-500">No query log entries found for this experiment.</p>
+        </div>
+      ) : (
+        <QueryLogTable entries={entries} onExport={handleExport} exporting={exporting} />
+      )}
     </div>
   );
 }

--- a/ui/src/components/query-log-table.tsx
+++ b/ui/src/components/query-log-table.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import type { QueryLogEntry } from '@/lib/types';
+
+function formatDuration(ms: number): string {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+  return `${ms}ms`;
+}
+
+function formatRowCount(count: number): string {
+  return count.toLocaleString('en-US');
+}
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+interface QueryLogTableProps {
+  entries: QueryLogEntry[];
+  onExport: () => void;
+  exporting: boolean;
+}
+
+export function QueryLogTable({ entries, onExport, exporting }: QueryLogTableProps) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-sm text-gray-500">{entries.length} queries</p>
+        <button
+          onClick={onExport}
+          disabled={exporting}
+          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          {exporting ? 'Exporting…' : 'Export Notebook'}
+        </button>
+      </div>
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Metric
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                SQL Preview
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Rows
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Duration
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Computed
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {entries.map((entry, i) => (
+              <tr key={`${entry.metricId}-${i}`} className="group">
+                <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                  {entry.metricId}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  <button
+                    onClick={() => setExpandedIndex(expandedIndex === i ? null : i)}
+                    className="max-w-md truncate text-left font-mono text-xs text-gray-600 hover:text-indigo-600"
+                  >
+                    {entry.sqlText.slice(0, 100)}{entry.sqlText.length > 100 ? '…' : ''}
+                  </button>
+                  {expandedIndex === i && (
+                    <pre className="mt-2 overflow-x-auto rounded bg-gray-50 p-3 font-mono text-xs text-gray-800">
+                      {entry.sqlText}
+                    </pre>
+                  )}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                  {formatRowCount(entry.rowCount)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                  {formatDuration(entry.durationMs)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                  {entry.computedAt ? formatRelativeTime(entry.computedAt) : '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,61 +1,121 @@
-import type { Experiment, ListExperimentsResponse } from './types';
+import type { Experiment, ListExperimentsResponse, QueryLogEntry } from './types';
+import type { ExperimentState, ExperimentType } from './types';
 
-const API_URL = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:50055';
+const MGMT_URL = process.env.NEXT_PUBLIC_MANAGEMENT_URL || 'http://localhost:50055';
+const MGMT_SVC = 'experimentation.management.v1.ExperimentManagementService';
+
+const METRICS_URL = process.env.NEXT_PUBLIC_METRICS_URL || 'http://localhost:50054';
+const METRICS_SVC = 'experimentation.metrics.v1.MetricComputationService';
+
+async function callRpc<Req, Res>(baseUrl: string, service: string, method: string, request: Req): Promise<Res> {
+  const res = await fetch(`${baseUrl}/${service}/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!res.ok) throw new Error(`RPC ${method} failed: ${res.status}`);
+  return res.json();
+}
+
+/** Strip proto enum prefix if present. e.g. "EXPERIMENT_STATE_DRAFT" → "DRAFT" */
+function stripEnumPrefix(value: string, prefix: string): string {
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+/** Convert proto JSON experiment to local Experiment type. */
+function adaptExperiment(proto: Record<string, unknown>): Experiment {
+  const state = stripEnumPrefix(
+    (proto.state as string) || 'DRAFT',
+    'EXPERIMENT_STATE_',
+  ) as ExperimentState;
+
+  const type = stripEnumPrefix(
+    (proto.type as string) || 'AB',
+    'EXPERIMENT_TYPE_',
+  ) as ExperimentType;
+
+  return {
+    experimentId: proto.experimentId as string,
+    name: proto.name as string,
+    description: (proto.description as string) || '',
+    ownerEmail: (proto.ownerEmail as string) || '',
+    type,
+    state,
+    variants: (proto.variants as Experiment['variants']) || [],
+    layerId: (proto.layerId as string) || '',
+    hashSalt: (proto.hashSalt as string) || '',
+    primaryMetricId: (proto.primaryMetricId as string) || '',
+    secondaryMetricIds: (proto.secondaryMetricIds as string[]) || [],
+    guardrailConfigs: (proto.guardrailConfigs as Experiment['guardrailConfigs']) || [],
+    guardrailAction: stripEnumPrefix(
+      (proto.guardrailAction as string) || 'AUTO_PAUSE',
+      'GUARDRAIL_ACTION_',
+    ) as Experiment['guardrailAction'],
+    sequentialTestConfig: proto.sequentialTestConfig as Experiment['sequentialTestConfig'],
+    targetingRuleId: proto.targetingRuleId as string | undefined,
+    surrogateModelId: proto.surrogateModelId as string | undefined,
+    isCumulativeHoldout: (proto.isCumulativeHoldout as boolean) || false,
+    createdAt: (proto.createdAt as string) || '',
+    startedAt: proto.startedAt as string | undefined,
+    concludedAt: proto.concludedAt as string | undefined,
+  };
+}
 
 export async function listExperiments(): Promise<ListExperimentsResponse> {
-  const res = await fetch(`${API_URL}/api/experiments`);
-  if (!res.ok) {
-    throw new Error(`Failed to list experiments: ${res.status}`);
-  }
-  return res.json();
+  const raw = await callRpc<object, { experiments?: Record<string, unknown>[]; nextPageToken?: string }>(
+    MGMT_URL, MGMT_SVC, 'ListExperiments', {},
+  );
+  return {
+    experiments: (raw.experiments || []).map(adaptExperiment),
+    nextPageToken: raw.nextPageToken || '',
+  };
 }
 
 export async function getExperiment(id: string): Promise<Experiment> {
-  const res = await fetch(`${API_URL}/api/experiments/${id}`);
-  if (!res.ok) {
-    throw new Error(`Failed to get experiment: ${res.status}`);
-  }
-  return res.json();
+  const raw = await callRpc<{ experimentId: string }, { experiment?: Record<string, unknown> }>(
+    MGMT_URL, MGMT_SVC, 'GetExperiment', { experimentId: id },
+  );
+  return adaptExperiment(raw.experiment || raw as Record<string, unknown>);
 }
 
 export async function updateExperiment(experiment: Experiment): Promise<Experiment> {
-  const res = await fetch(`${API_URL}/api/experiments/${experiment.experimentId}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(experiment),
-  });
-  if (!res.ok) {
-    throw new Error(`Failed to update experiment: ${res.status}`);
-  }
-  return res.json();
+  const raw = await callRpc<{ experiment: Experiment }, { experiment?: Record<string, unknown> }>(
+    MGMT_URL, MGMT_SVC, 'UpdateExperiment', { experiment },
+  );
+  return adaptExperiment(raw.experiment || raw as Record<string, unknown>);
 }
 
 export async function startExperiment(id: string): Promise<Experiment> {
-  const res = await fetch(`${API_URL}/api/experiments/${id}/start`, {
-    method: 'POST',
-  });
-  if (!res.ok) {
-    throw new Error(`Failed to start experiment: ${res.status}`);
-  }
-  return res.json();
+  const raw = await callRpc<{ experimentId: string }, { experiment?: Record<string, unknown> }>(
+    MGMT_URL, MGMT_SVC, 'StartExperiment', { experimentId: id },
+  );
+  return adaptExperiment(raw.experiment || raw as Record<string, unknown>);
 }
 
 export async function concludeExperiment(id: string): Promise<Experiment> {
-  const res = await fetch(`${API_URL}/api/experiments/${id}/conclude`, {
-    method: 'POST',
-  });
-  if (!res.ok) {
-    throw new Error(`Failed to conclude experiment: ${res.status}`);
-  }
-  return res.json();
+  const raw = await callRpc<{ experimentId: string }, { experiment?: Record<string, unknown> }>(
+    MGMT_URL, MGMT_SVC, 'ConcludeExperiment', { experimentId: id },
+  );
+  return adaptExperiment(raw.experiment || raw as Record<string, unknown>);
 }
 
 export async function archiveExperiment(id: string): Promise<Experiment> {
-  const res = await fetch(`${API_URL}/api/experiments/${id}/archive`, {
-    method: 'POST',
-  });
-  if (!res.ok) {
-    throw new Error(`Failed to archive experiment: ${res.status}`);
-  }
-  return res.json();
+  const raw = await callRpc<{ experimentId: string }, { experiment?: Record<string, unknown> }>(
+    MGMT_URL, MGMT_SVC, 'ArchiveExperiment', { experimentId: id },
+  );
+  return adaptExperiment(raw.experiment || raw as Record<string, unknown>);
+}
+
+export async function getQueryLog(experimentId: string, metricId?: string): Promise<QueryLogEntry[]> {
+  const raw = await callRpc<{ experimentId: string; metricId?: string }, { entries?: QueryLogEntry[] }>(
+    METRICS_URL, METRICS_SVC, 'GetQueryLog', { experimentId, ...(metricId ? { metricId } : {}) },
+  );
+  return raw.entries || [];
+}
+
+export async function exportNotebook(experimentId: string): Promise<{ content: string; filename: string }> {
+  const raw = await callRpc<{ experimentId: string }, { content: string; filename: string }>(
+    METRICS_URL, METRICS_SVC, 'ExportNotebook', { experimentId },
+  );
+  return raw;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -69,5 +69,14 @@ export interface Experiment {
 
 export interface ListExperimentsResponse {
   experiments: Experiment[];
-  totalCount: number;
+  nextPageToken: string;
+}
+
+export interface QueryLogEntry {
+  experimentId: string;
+  metricId: string;
+  sqlText: string;
+  rowCount: number;
+  durationMs: number;
+  computedAt?: string;
 }


### PR DESCRIPTION
## Summary

- **Switch api.ts to ConnectRPC JSON wire protocol** — all experiment CRUD calls now use `POST /<service>/<method>` with JSON body, matching Agent-5's backend. Raw `fetch` avoids the `@bufbuild/protobuf` v1/v2 version conflict in `gen/ts/`.
- **Add `adaptExperiment` adapter** — strips proto enum prefixes (`EXPERIMENT_STATE_DRAFT` → `DRAFT`), handles both proto-format and local-format responses for seamless MSW ↔ live backend switching.
- **Implement View SQL page** (`/experiments/[id]/sql`) — query log table with expandable SQL rows, duration/row count formatting, Export Notebook button with browser download.
- **New `QueryLogTable` component** — expandable rows, relative timestamps, formatted metrics.
- **MSW handlers updated to ConnectRPC URL patterns** — `http.post('*/...Service/Method')` replacing `http.get('*/api/...')`. Added `GetQueryLog` and `ExportNotebook` handlers for metrics service.
- **64 tests pass** (was 55 → +9 new SQL page tests), TypeScript compiles clean.

## What This Unblocks

- **Live integration with Agent-5**: Set `NEXT_PUBLIC_MANAGEMENT_URL=http://<host>:50055` — zero code changes needed
- **Live integration with Agent-3**: Set `NEXT_PUBLIC_METRICS_URL=http://<host>:50054` for query log data
- **Phase 2 results dashboard (M2.8)**: Same `callRpc` pattern for Agent-4 analysis RPCs

## Test plan

- [x] `npx vitest run` — 64/64 tests pass
- [x] `npx tsc --noEmit` — no TypeScript errors
- [ ] Manual: browse to RUNNING experiment → "View SQL" link → query log table renders
- [ ] Manual: click SQL preview → expands to full SQL in monospace block
- [ ] Manual: click "Export Notebook" → triggers `.ipynb` download
- [ ] Manual: browse to DRAFT experiment → "View SQL" → empty state message

🤖 Generated with [Claude Code](https://claude.com/claude-code)