### PR TITLE
feat(m3): surrogate metric framework (M2.10)

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -15,7 +15,7 @@
 |-------|--------|--------|----------------|-------------------|------------|-------|
 | Agent-1 | M1 Assignment | 🟢 Phase 1 Complete | agent-1/feat/layer-session-assignment | Phase 2: GetInterleavedList (2.7) | — | M1.1–1.5 all complete. Session-level bucketing + layer exclusivity. |
 | Agent-2 | M2 Pipeline | 🟢 Phase 1 Complete | — | Phase 2: Operational hardening | — | M1.6–1.9 all merged (PRs #1, #8). All Phase 1 milestones done. |
-| Agent-3 | M3 Metrics | 🟢 Phase 1 Complete | — | Phase 2: Surrogate metrics / SVOD (2.10–2.11) | — | M1.10–1.13 all merged (PRs #3, #5, #9, #16). All Phase 1 milestones done. |
+| Agent-3 | M3 Metrics | 🔵 Phase 2 In Progress | agent-3/feat/surrogate-metric-framework | M2.10 Surrogate Metric Framework | — | Phase 1 done. M2.11 done (PR #26). M2.10 in progress (PR #35). |
 | Agent-4 | M4a Analysis + M4b Bandit | 🟢 Phase 1 Complete | — | Phase 2: GST, Bootstrap CI | — | M1.14–1.19 all merged (PRs #2, #14, #25). All Phase 1 milestones done. |
 | Agent-5 | M5 Management | 🟢 Phase 1 Complete | — | STARTING validation + targeting rule CRUD | — | M1.20–1.24 all merged (PRs #7, #10, #15, #18, #24). All Phase 1 milestones done. |
 | Agent-6 | M6 UI | 🟡 Not Started | — | Experiment list + detail shell (1.25) | — | Unblocked by M1.20. Agent-5 CRUD API available. Can use live backend. |
@@ -92,7 +92,7 @@
 | 2.7 | GetInterleavedList RPC (Team Draft) | Agent-1 | ⚪ | — |
 | 2.8 | Results dashboard (treatment effects, CI chart, sequential boundary) | Agent-6 | ⚪ | Stakeholder demo |
 | 2.9 | Notebook export (.ipynb from query log) | Agent-6 | ⚪ | — |
-| 2.10 | Surrogate metric framework (M3 + M4a) | Agent-3/4 | ⚪ | — |
+| 2.10 | Surrogate metric framework (M3 + M4a) | Agent-3/4 | 🔵 | Agent-3 part: PR #35 (model loading, projection, SQL transparency). Agent-4 part pending. |
 | 2.11 | SVOD-specific metrics (QoE, lifecycle, content consumption) | Agent-3 | 🟢 | Agent-4 (interference, novelty), Agent-6 (QoE dashboard) |
 
 ### Phase 3: SVOD-Native + Bandits (Weeks 10–17)
@@ -157,8 +157,10 @@ Track any changes to proto schemas, shared crate APIs, or database schemas.
 - [x] M1.20–1.24 Management service complete (Agent-5, PRs #7, #10, #15, #18, #24)
 - [x] M1.28–1.30 Flag service complete (Agent-7, PR #13)
 - [x] M2.11 SVOD-specific metrics (Agent-3, PR #26)
+- [x] M2.10 Surrogate metric framework — Agent-3 part (PR #35): model loading, projection, SQL transparency
 
 **In progress:**
+- Agent-3: M2.10 surrogate metric framework (Agent-3 part complete in PR #35, Agent-4 part pending)
 - Agent-5: Phase 1 polish — STARTING validation gate, targeting rule CRUD, integration tests
 - Agent-6: experiment list + detail shell (1.25, not started)
 

--- a/services/metrics/cmd/main.go
+++ b/services/metrics/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/jobs"
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/surrogate"
 )
 
 func main() {
@@ -52,7 +53,12 @@ func main() {
 	gVP := jobs.NewMockValueProvider()
 	gJob := jobs.NewGuardrailJob(cfgStore, renderer, executor, qlWriter, gPublisher, gTracker, gVP)
 	ccJob := jobs.NewContentConsumptionJob(cfgStore, renderer, executor, qlWriter)
-	metricsHandler := handler.NewMetricsHandler(stdJob, gJob, ccJob, qlWriter)
+	// Surrogate metric framework: mock input provider + mock model loader for dev.
+	mockInputProvider := &jobs.MockInputMetricsProvider{}
+	modelLoader := surrogate.NewMockModelLoader()
+	projWriter := surrogate.NewMemProjectionWriter()
+	surrJob := jobs.NewSurrogateJob(cfgStore, renderer, mockInputProvider, qlWriter, modelLoader, projWriter)
+	metricsHandler := handler.NewMetricsHandler(stdJob, gJob, ccJob, surrJob, qlWriter)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200); fmt.Fprint(w, "ok") })
 	path, h := metricsv1connect.NewMetricComputationServiceHandler(metricsHandler)

--- a/services/metrics/internal/config/loader.go
+++ b/services/metrics/internal/config/loader.go
@@ -33,6 +33,21 @@ type ExperimentConfig struct {
 	GuardrailAction              string            `json:"guardrail_action,omitempty"`
 	LifecycleStratificationEnabled bool            `json:"lifecycle_stratification_enabled,omitempty"`
 	LifecycleSegments            []string          `json:"lifecycle_segments,omitempty"`
+	SurrogateModelID             string            `json:"surrogate_model_id,omitempty"`
+}
+
+type SurrogateModelConfig struct {
+	ModelID               string   `json:"model_id"`
+	TargetMetricID        string   `json:"target_metric_id"`
+	InputMetricIDs        []string `json:"input_metric_ids"`
+	ObservationWindowDays int      `json:"observation_window_days"`
+	PredictionHorizonDays int      `json:"prediction_horizon_days"`
+	ModelType             string   `json:"model_type"` // LINEAR, GRADIENT_BOOSTED, NEURAL
+	CalibrationRSquared   float64  `json:"calibration_r_squared"`
+	MLflowModelURI        string   `json:"mlflow_model_uri,omitempty"`
+	// For mock linear models: coefficients per input metric
+	Coefficients          map[string]float64 `json:"coefficients,omitempty"`
+	Intercept             float64            `json:"intercept,omitempty"`
 }
 
 type MetricConfig struct {
@@ -49,15 +64,17 @@ type MetricConfig struct {
 }
 
 type seedFile struct {
-	Experiments []ExperimentConfig `json:"experiments"`
-	Metrics     []MetricConfig     `json:"metrics"`
+	Experiments     []ExperimentConfig     `json:"experiments"`
+	Metrics         []MetricConfig         `json:"metrics"`
+	SurrogateModels []SurrogateModelConfig `json:"surrogate_models,omitempty"`
 }
 
 type ConfigStore struct {
-	mu          sync.RWMutex
-	experiments map[string]*ExperimentConfig
-	metrics     map[string]*MetricConfig
-	expMetrics  map[string][]string
+	mu              sync.RWMutex
+	experiments     map[string]*ExperimentConfig
+	metrics         map[string]*MetricConfig
+	expMetrics      map[string][]string
+	surrogateModels map[string]*SurrogateModelConfig
 }
 
 func LoadFromFile(path string) (*ConfigStore, error) {
@@ -70,13 +87,18 @@ func LoadFromFile(path string) (*ConfigStore, error) {
 		return nil, fmt.Errorf("config: parse JSON: %w", err)
 	}
 	cs := &ConfigStore{
-		experiments: make(map[string]*ExperimentConfig, len(sf.Experiments)),
-		metrics:     make(map[string]*MetricConfig, len(sf.Metrics)),
-		expMetrics:  make(map[string][]string, len(sf.Experiments)),
+		experiments:     make(map[string]*ExperimentConfig, len(sf.Experiments)),
+		metrics:         make(map[string]*MetricConfig, len(sf.Metrics)),
+		expMetrics:      make(map[string][]string, len(sf.Experiments)),
+		surrogateModels: make(map[string]*SurrogateModelConfig, len(sf.SurrogateModels)),
 	}
 	for i := range sf.Metrics {
 		m := sf.Metrics[i]
 		cs.metrics[m.MetricID] = &m
+	}
+	for i := range sf.SurrogateModels {
+		sm := sf.SurrogateModels[i]
+		cs.surrogateModels[sm.ModelID] = &sm
 	}
 	for i := range sf.Experiments {
 		e := sf.Experiments[i]
@@ -145,6 +167,31 @@ func (e *ExperimentConfig) ControlVariantID() string {
 		}
 	}
 	return ""
+}
+
+func (c *ConfigStore) GetSurrogateModel(id string) (*SurrogateModelConfig, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	sm, ok := c.surrogateModels[id]
+	if !ok {
+		return nil, fmt.Errorf("config: surrogate model %q not found", id)
+	}
+	return sm, nil
+}
+
+// GetSurrogateModelForExperiment returns the surrogate model linked to an experiment, or nil if none.
+func (c *ConfigStore) GetSurrogateModelForExperiment(experimentID string) *SurrogateModelConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.experiments[experimentID]
+	if !ok || e.SurrogateModelID == "" {
+		return nil
+	}
+	sm, ok := c.surrogateModels[e.SurrogateModelID]
+	if !ok {
+		return nil
+	}
+	return sm
 }
 
 func (c *ConfigStore) RunningExperimentIDs() []string {

--- a/services/metrics/internal/config/testdata/seed_config.json
+++ b/services/metrics/internal/config/testdata/seed_config.json
@@ -38,7 +38,8 @@
           "consecutive_breaches_required": 2
         }
       ],
-      "guardrail_action": "AUTO_PAUSE"
+      "guardrail_action": "AUTO_PAUSE",
+      "surrogate_model_id": "sm-churn-predictor-001"
     },
     {
       "experiment_id": "e0000000-0000-0000-0000-000000000003",
@@ -177,6 +178,22 @@
       "is_qoe_metric": true,
       "qoe_field": "rebuffer_ratio",
       "lower_is_better": true
+    }
+  ],
+  "surrogate_models": [
+    {
+      "model_id": "sm-churn-predictor-001",
+      "target_metric_id": "churn_7d",
+      "input_metric_ids": ["watch_time_minutes", "stream_start_rate"],
+      "observation_window_days": 7,
+      "prediction_horizon_days": 90,
+      "model_type": "LINEAR",
+      "calibration_r_squared": 0.72,
+      "coefficients": {
+        "watch_time_minutes": -0.015,
+        "stream_start_rate": -0.25
+      },
+      "intercept": 0.35
     }
   ]
 }

--- a/services/metrics/internal/handler/handler.go
+++ b/services/metrics/internal/handler/handler.go
@@ -22,11 +22,12 @@ type MetricsHandler struct {
 	job                 *jobs.StandardJob
 	guardrailJob        *jobs.GuardrailJob
 	contentConsumption  *jobs.ContentConsumptionJob
+	surrogateJob        *jobs.SurrogateJob
 	queryLog            querylog.Writer
 }
 
-func NewMetricsHandler(job *jobs.StandardJob, gj *jobs.GuardrailJob, ccj *jobs.ContentConsumptionJob, ql querylog.Writer) *MetricsHandler {
-	return &MetricsHandler{job: job, guardrailJob: gj, contentConsumption: ccj, queryLog: ql}
+func NewMetricsHandler(job *jobs.StandardJob, gj *jobs.GuardrailJob, ccj *jobs.ContentConsumptionJob, sj *jobs.SurrogateJob, ql querylog.Writer) *MetricsHandler {
+	return &MetricsHandler{job: job, guardrailJob: gj, contentConsumption: ccj, surrogateJob: sj, queryLog: ql}
 }
 
 func (h *MetricsHandler) ComputeMetrics(ctx context.Context, req *connect.Request[metricsv1.ComputeMetricsRequest]) (*connect.Response[metricsv1.ComputeMetricsResponse], error) {
@@ -41,6 +42,12 @@ func (h *MetricsHandler) ComputeMetrics(ctx context.Context, req *connect.Reques
 	// Also compute content consumption distributions for interference analysis.
 	if h.contentConsumption != nil {
 		if _, err := h.contentConsumption.Run(ctx, id); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+	}
+	// Compute surrogate projections if a model is linked.
+	if h.surrogateJob != nil {
+		if _, err := h.surrogateJob.Run(ctx, id); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
 	}

--- a/services/metrics/internal/handler/handler_test.go
+++ b/services/metrics/internal/handler/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/jobs"
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/surrogate"
 )
 
 func setupTestServer(t *testing.T) (metricsv1connect.MetricComputationServiceClient, *querylog.MemWriter) {
@@ -40,7 +41,16 @@ func setupTestServer(t *testing.T) (metricsv1connect.MetricComputationServiceCli
 	vp.SetVariantValue("error_rate", "f0000000-0000-0000-0000-000000000002", 0.008)
 	gj := jobs.NewGuardrailJob(cfgStore, renderer, executor, qlWriter, publisher, tracker, vp)
 	ccj := jobs.NewContentConsumptionJob(cfgStore, renderer, executor, qlWriter)
-	h := NewMetricsHandler(stdJob, gj, ccj, qlWriter)
+	// Surrogate job: provide mock inputs so projections are computed for homepage_recs_v2.
+	mockInputs := surrogate.InputMetrics{
+		"f0000000-0000-0000-0000-000000000001": {"watch_time_minutes": 45.0, "stream_start_rate": 0.8},
+		"f0000000-0000-0000-0000-000000000002": {"watch_time_minutes": 52.0, "stream_start_rate": 0.85},
+	}
+	surrInputProvider := &jobs.MockInputMetricsProvider{Inputs: mockInputs}
+	modelLoader := surrogate.NewMockModelLoader()
+	projWriter := surrogate.NewMemProjectionWriter()
+	sj := jobs.NewSurrogateJob(cfgStore, renderer, surrInputProvider, qlWriter, modelLoader, projWriter)
+	h := NewMetricsHandler(stdJob, gj, ccj, sj, qlWriter)
 	mux := http.NewServeMux()
 	path, handler := metricsv1connect.NewMetricComputationServiceHandler(h)
 	mux.Handle(path, handler)
@@ -55,8 +65,8 @@ func TestComputeMetrics(t *testing.T) {
 	resp, err := client.ComputeMetrics(context.Background(), connect.NewRequest(&metricsv1.ComputeMetricsRequest{ExperimentId: "e0000000-0000-0000-0000-000000000001"}))
 	require.NoError(t, err)
 	assert.Equal(t, int32(4), resp.Msg.GetMetricsComputed())
-	// 4 daily_metric + 1 delta_method + 2 cuped_covariate + 4 daily_treatment_effect + 1 content_consumption = 12
-	assert.Len(t, qlWriter.AllEntries(), 12)
+	// 4 daily_metric + 1 delta_method + 2 cuped_covariate + 4 daily_treatment_effect + 1 content_consumption + 1 surrogate_input = 13
+	assert.Len(t, qlWriter.AllEntries(), 13)
 }
 
 func TestComputeMetrics_EmptyID(t *testing.T) {
@@ -78,8 +88,8 @@ func TestGetQueryLog(t *testing.T) {
 	_, _ = client.ComputeMetrics(ctx, connect.NewRequest(&metricsv1.ComputeMetricsRequest{ExperimentId: "e0000000-0000-0000-0000-000000000001"}))
 	resp, err := client.GetQueryLog(ctx, connect.NewRequest(&metricsv1.GetQueryLogRequest{ExperimentId: "e0000000-0000-0000-0000-000000000001"}))
 	require.NoError(t, err)
-	// 4 daily_metric + 1 delta_method + 2 cuped_covariate + 4 daily_treatment_effect + 1 content_consumption = 12
-	assert.Len(t, resp.Msg.GetEntries(), 12)
+	// 4 daily_metric + 1 delta_method + 2 cuped_covariate + 4 daily_treatment_effect + 1 content_consumption + 1 surrogate_input = 13
+	assert.Len(t, resp.Msg.GetEntries(), 13)
 }
 
 func TestGetQueryLog_FilterByMetric(t *testing.T) {
@@ -103,8 +113,8 @@ func TestExportNotebook(t *testing.T) {
 	err = json.Unmarshal(resp.Msg.GetNotebookContent(), &nb)
 	require.NoError(t, err)
 	assert.Equal(t, 4, nb.NBFormat)
-	// 2 header cells + 2 * 12 query entries = 26 cells
-	assert.Equal(t, 26, len(nb.Cells))
+	// 2 header cells + 2 * 13 query entries = 28 cells
+	assert.Equal(t, 28, len(nb.Cells))
 }
 
 func TestExportNotebook_NoLogs(t *testing.T) {

--- a/services/metrics/internal/jobs/surrogate.go
+++ b/services/metrics/internal/jobs/surrogate.go
@@ -1,0 +1,167 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
+	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/surrogate"
+)
+
+// InputMetricsProvider fetches aggregated per-variant metric values from Spark SQL.
+// In production, this executes the SQL against a Spark cluster and parses the result set.
+// In tests, a mock implementation returns predefined values.
+type InputMetricsProvider interface {
+	Fetch(ctx context.Context, sql string) (surrogate.InputMetrics, error)
+}
+
+// SurrogateJob orchestrates surrogate metric computation for a single experiment.
+// It renders input aggregation SQL, fetches per-variant metric averages, loads the
+// surrogate model, computes projected treatment effects, and writes projections.
+type SurrogateJob struct {
+	config        *config.ConfigStore
+	renderer      *spark.SQLRenderer
+	inputProvider InputMetricsProvider
+	queryLog      querylog.Writer
+	modelLoader   surrogate.ModelLoader
+	projWriter    surrogate.ProjectionWriter
+}
+
+// NewSurrogateJob creates a new surrogate metric computation job.
+func NewSurrogateJob(
+	cfg *config.ConfigStore,
+	renderer *spark.SQLRenderer,
+	inputProvider InputMetricsProvider,
+	ql querylog.Writer,
+	loader surrogate.ModelLoader,
+	writer surrogate.ProjectionWriter,
+) *SurrogateJob {
+	return &SurrogateJob{
+		config:        cfg,
+		renderer:      renderer,
+		inputProvider: inputProvider,
+		queryLog:      ql,
+		modelLoader:   loader,
+		projWriter:    writer,
+	}
+}
+
+// Run computes surrogate projections for the given experiment.
+// Returns nil JobResult (no rows written to metric_summaries) if the experiment
+// has no linked surrogate model.
+func (j *SurrogateJob) Run(ctx context.Context, experimentID string) (*JobResult, error) {
+	smCfg := j.config.GetSurrogateModelForExperiment(experimentID)
+	if smCfg == nil {
+		slog.Debug("no surrogate model linked", "experiment_id", experimentID)
+		return &JobResult{
+			ExperimentID:    experimentID,
+			MetricsComputed: 0,
+			CompletedAt:     time.Now(),
+		}, nil
+	}
+
+	exp, err := j.config.GetExperiment(experimentID)
+	if err != nil {
+		return nil, fmt.Errorf("surrogate job: %w", err)
+	}
+
+	controlVariantID := exp.ControlVariantID()
+	if controlVariantID == "" {
+		return nil, fmt.Errorf("surrogate job: experiment %q has no control variant", experimentID)
+	}
+
+	computationDate := time.Now().Format("2006-01-02")
+
+	// Step 1: Render input aggregation SQL.
+	params := spark.TemplateParams{
+		ExperimentID:          experimentID,
+		ComputationDate:       computationDate,
+		InputMetricIDs:        smCfg.InputMetricIDs,
+		ObservationWindowDays: smCfg.ObservationWindowDays,
+	}
+
+	inputSQL, err := j.renderer.RenderSurrogateInput(params)
+	if err != nil {
+		return nil, fmt.Errorf("surrogate job: render input SQL: %w", err)
+	}
+
+	// Step 2: Execute SQL to fetch per-variant metric averages.
+	start := time.Now()
+	inputs, err := j.inputProvider.Fetch(ctx, inputSQL)
+	if err != nil {
+		return nil, fmt.Errorf("surrogate job: fetch input metrics: %w", err)
+	}
+	fetchDuration := time.Since(start)
+
+	// Log the input aggregation SQL for transparency.
+	if err := j.queryLog.Log(ctx, querylog.Entry{
+		ExperimentID: experimentID,
+		MetricID:     smCfg.TargetMetricID,
+		SQLText:      inputSQL,
+		RowCount:     int64(len(inputs)),
+		DurationMs:   fetchDuration.Milliseconds(),
+		JobType:      "surrogate_input",
+	}); err != nil {
+		return nil, fmt.Errorf("surrogate job: log input query: %w", err)
+	}
+
+	// Step 3: Load the surrogate model.
+	model, err := j.modelLoader.Load(smCfg)
+	if err != nil {
+		return nil, fmt.Errorf("surrogate job: load model %q: %w", smCfg.ModelID, err)
+	}
+
+	// Step 4: Compute projected treatment effects.
+	projections, err := model.Predict(inputs, controlVariantID)
+	if err != nil {
+		return nil, fmt.Errorf("surrogate job: predict: %w", err)
+	}
+
+	// Step 5: Write projections to PostgreSQL.
+	computedAt := time.Now()
+	for _, p := range projections {
+		record := surrogate.ProjectionRecord{
+			ExperimentID:        experimentID,
+			VariantID:           p.VariantID,
+			ModelID:             smCfg.ModelID,
+			ProjectedEffect:     p.ProjectedEffect,
+			ProjectionCILower:   p.ProjectionCILower,
+			ProjectionCIUpper:   p.ProjectionCIUpper,
+			CalibrationRSquared: p.CalibrationRSquared,
+			ComputedAt:          computedAt,
+		}
+		if err := j.projWriter.Write(ctx, record); err != nil {
+			return nil, fmt.Errorf("surrogate job: write projection for variant %q: %w", p.VariantID, err)
+		}
+	}
+
+	slog.Info("computed surrogate projections",
+		"experiment_id", experimentID,
+		"model_id", smCfg.ModelID,
+		"target_metric", smCfg.TargetMetricID,
+		"variants_projected", len(projections),
+	)
+
+	return &JobResult{
+		ExperimentID:    experimentID,
+		MetricsComputed: len(projections),
+		CompletedAt:     computedAt,
+	}, nil
+}
+
+// MockInputMetricsProvider returns empty InputMetrics for development use.
+// In production, this would execute SQL against a Spark cluster and parse result rows.
+type MockInputMetricsProvider struct {
+	Inputs surrogate.InputMetrics
+}
+
+func (m *MockInputMetricsProvider) Fetch(_ context.Context, _ string) (surrogate.InputMetrics, error) {
+	if m.Inputs != nil {
+		return m.Inputs, nil
+	}
+	return surrogate.InputMetrics{}, nil
+}

--- a/services/metrics/internal/jobs/surrogate_test.go
+++ b/services/metrics/internal/jobs/surrogate_test.go
@@ -1,0 +1,194 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
+	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/surrogate"
+)
+
+// testInputProvider tracks the SQL received during Fetch, wrapping MockInputMetricsProvider.
+type testInputProvider struct {
+	MockInputMetricsProvider
+	SQLReceived string
+}
+
+func (m *testInputProvider) Fetch(ctx context.Context, sql string) (surrogate.InputMetrics, error) {
+	m.SQLReceived = sql
+	return m.MockInputMetricsProvider.Fetch(ctx, sql)
+}
+
+func setupSurrogateJob(t *testing.T, inputs surrogate.InputMetrics) (*SurrogateJob, *testInputProvider, *querylog.MemWriter, *surrogate.MemProjectionWriter) {
+	t.Helper()
+
+	cfgStore, err := config.LoadFromFile("../config/testdata/seed_config.json")
+	require.NoError(t, err)
+
+	renderer, err := spark.NewSQLRenderer()
+	require.NoError(t, err)
+
+	provider := &testInputProvider{MockInputMetricsProvider: MockInputMetricsProvider{Inputs: inputs}}
+	qlWriter := querylog.NewMemWriter()
+	modelLoader := surrogate.NewMockModelLoader()
+	projWriter := surrogate.NewMemProjectionWriter()
+
+	job := NewSurrogateJob(cfgStore, renderer, provider, qlWriter, modelLoader, projWriter)
+	return job, provider, qlWriter, projWriter
+}
+
+func TestSurrogateJob_Run(t *testing.T) {
+	inputs := surrogate.InputMetrics{
+		// control variant
+		"f0000000-0000-0000-0000-000000000001": {
+			"watch_time_minutes": 45.0,
+			"stream_start_rate":  0.8,
+		},
+		// treatment variant
+		"f0000000-0000-0000-0000-000000000002": {
+			"watch_time_minutes": 52.0,
+			"stream_start_rate":  0.85,
+		},
+	}
+
+	job, provider, qlWriter, projWriter := setupSurrogateJob(t, inputs)
+	ctx := context.Background()
+
+	// homepage_recs_v2 has surrogate_model_id = "sm-churn-predictor-001"
+	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+
+	assert.Equal(t, "e0000000-0000-0000-0000-000000000001", result.ExperimentID)
+	assert.Equal(t, 1, result.MetricsComputed, "should project 1 treatment variant")
+	assert.False(t, result.CompletedAt.IsZero())
+
+	// Verify SQL was rendered and passed to the input provider.
+	assert.Contains(t, provider.SQLReceived, "delta.metric_summaries")
+	assert.Contains(t, provider.SQLReceived, "'watch_time_minutes', 'stream_start_rate'")
+
+	// Verify query log: 1 surrogate_input entry.
+	entries := qlWriter.AllEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "surrogate_input", entries[0].JobType)
+	assert.Equal(t, "e0000000-0000-0000-0000-000000000001", entries[0].ExperimentID)
+	assert.Equal(t, "churn_7d", entries[0].MetricID, "should log target metric ID")
+	assert.NotEmpty(t, entries[0].SQLText)
+
+	// Verify projection was written.
+	records := projWriter.AllRecords()
+	require.Len(t, records, 1)
+	assert.Equal(t, "e0000000-0000-0000-0000-000000000001", records[0].ExperimentID)
+	assert.Equal(t, "f0000000-0000-0000-0000-000000000002", records[0].VariantID)
+	assert.Equal(t, "sm-churn-predictor-001", records[0].ModelID)
+	assert.Equal(t, 0.72, records[0].CalibrationRSquared)
+	assert.False(t, records[0].ComputedAt.IsZero())
+}
+
+func TestSurrogateJob_Run_ProjectedEffect(t *testing.T) {
+	// Model: y = 0.35 + (-0.015 * watch_time) + (-0.25 * stream_start_rate)
+	// Control: 0.35 + (-0.015 * 45.0) + (-0.25 * 0.8) = 0.35 - 0.675 - 0.2 = -0.525
+	// Treatment: 0.35 + (-0.015 * 52.0) + (-0.25 * 0.85) = 0.35 - 0.78 - 0.2125 = -0.6425
+	// Effect = treatment - control = -0.6425 - (-0.525) = -0.1175
+	inputs := surrogate.InputMetrics{
+		"f0000000-0000-0000-0000-000000000001": {
+			"watch_time_minutes": 45.0,
+			"stream_start_rate":  0.8,
+		},
+		"f0000000-0000-0000-0000-000000000002": {
+			"watch_time_minutes": 52.0,
+			"stream_start_rate":  0.85,
+		},
+	}
+
+	job, _, _, projWriter := setupSurrogateJob(t, inputs)
+	ctx := context.Background()
+
+	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+
+	records := projWriter.AllRecords()
+	require.Len(t, records, 1)
+
+	// Verify the projected effect matches the linear model calculation.
+	assert.InDelta(t, -0.1175, records[0].ProjectedEffect, 1e-6)
+
+	// CI should bracket the effect: lower < effect < upper
+	assert.Less(t, records[0].ProjectionCILower, records[0].ProjectedEffect)
+	assert.Greater(t, records[0].ProjectionCIUpper, records[0].ProjectedEffect)
+}
+
+func TestSurrogateJob_Run_NoSurrogateModel(t *testing.T) {
+	job, _, _, projWriter := setupSurrogateJob(t, nil)
+	ctx := context.Background()
+
+	// search_ranking_interleave has no surrogate_model_id
+	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000003")
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.MetricsComputed)
+	assert.Len(t, projWriter.AllRecords(), 0, "no projections should be written")
+}
+
+func TestSurrogateJob_Run_ExperimentNotFound(t *testing.T) {
+	job, _, _, _ := setupSurrogateJob(t, nil)
+	ctx := context.Background()
+
+	_, err := job.Run(ctx, "nonexistent")
+	require.NoError(t, err, "should return 0 metrics, not error, since no surrogate model is linked")
+}
+
+func TestSurrogateJob_Run_InputSQLContainsKeyFields(t *testing.T) {
+	inputs := surrogate.InputMetrics{
+		"f0000000-0000-0000-0000-000000000001": {"watch_time_minutes": 45.0, "stream_start_rate": 0.8},
+		"f0000000-0000-0000-0000-000000000002": {"watch_time_minutes": 52.0, "stream_start_rate": 0.85},
+	}
+
+	job, provider, _, _ := setupSurrogateJob(t, inputs)
+	ctx := context.Background()
+
+	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+
+	sql := provider.SQLReceived
+	assert.Contains(t, sql, "e0000000-0000-0000-0000-000000000001")
+	assert.Contains(t, sql, "AVG(ms.metric_value)")
+	assert.Contains(t, sql, "GROUP BY ms.variant_id, ms.metric_id")
+	assert.Contains(t, sql, "DATE_SUB")
+	assert.Contains(t, sql, "7", "observation window should be 7 days")
+}
+
+func TestSurrogateJob_Run_MultipleVariants(t *testing.T) {
+	// Add a third variant to test multiple projections.
+	inputs := surrogate.InputMetrics{
+		"f0000000-0000-0000-0000-000000000001": {"watch_time_minutes": 45.0, "stream_start_rate": 0.8},
+		"f0000000-0000-0000-0000-000000000002": {"watch_time_minutes": 52.0, "stream_start_rate": 0.85},
+		"f0000000-0000-0000-0000-extra-variant": {"watch_time_minutes": 40.0, "stream_start_rate": 0.75},
+	}
+
+	job, _, _, projWriter := setupSurrogateJob(t, inputs)
+	ctx := context.Background()
+
+	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+
+	// Should produce projections for 2 non-control variants.
+	assert.Equal(t, 2, result.MetricsComputed)
+
+	records := projWriter.AllRecords()
+	assert.Len(t, records, 2)
+
+	variantIDs := map[string]bool{}
+	for _, r := range records {
+		variantIDs[r.VariantID] = true
+		assert.Equal(t, "sm-churn-predictor-001", r.ModelID)
+		assert.NotEqual(t, "f0000000-0000-0000-0000-000000000001", r.VariantID,
+			"control variant should not have a projection")
+	}
+	assert.True(t, variantIDs["f0000000-0000-0000-0000-000000000002"])
+	assert.True(t, variantIDs["f0000000-0000-0000-0000-extra-variant"])
+}

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -27,6 +27,9 @@ type TemplateParams struct {
 	ControlVariantID string // variant_id of the control variant
 	LifecycleEnabled bool   // whether to include lifecycle_segment in GROUP BY
 	ContentIDField   string // field name for content identifier (default: "content_id")
+	// Surrogate metric fields
+	InputMetricIDs        []string // list of metric_ids to aggregate for surrogate input
+	ObservationWindowDays int      // how many days of recent data to aggregate
 }
 
 type SQLRenderer struct {
@@ -60,6 +63,7 @@ func (r *SQLRenderer) RenderQoEMetric(p TemplateParams) (string, error)      { r
 func (r *SQLRenderer) RenderContentConsumption(p TemplateParams) (string, error) { return r.Render("content_consumption.sql.tmpl", p) }
 func (r *SQLRenderer) RenderDailyTreatmentEffect(p TemplateParams) (string, error) { return r.Render("daily_treatment_effect.sql.tmpl", p) }
 func (r *SQLRenderer) RenderLifecycleMean(p TemplateParams) (string, error)  { return r.Render("lifecycle_mean.sql.tmpl", p) }
+func (r *SQLRenderer) RenderSurrogateInput(p TemplateParams) (string, error) { return r.Render("surrogate_input.sql.tmpl", p) }
 
 func (r *SQLRenderer) RenderForType(metricType string, p TemplateParams) (string, error) {
 	switch strings.ToUpper(metricType) {

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -243,3 +243,31 @@ func TestRenderLifecycleMean_ContainsKeyFields(t *testing.T) {
 	assert.Contains(t, sql, "lifecycle_segment")
 	assert.Contains(t, sql, "GROUP BY metric_data.user_id, metric_data.variant_id, metric_data.lifecycle_segment")
 }
+
+func TestRenderSurrogateInput(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+	p := testParams
+	p.InputMetricIDs = []string{"watch_time_minutes", "stream_start_rate"}
+	p.ObservationWindowDays = 7
+	sql, err := r.RenderSurrogateInput(p)
+	require.NoError(t, err)
+	assert.Equal(t, readGolden(t, "surrogate_input_expected.sql"), sql)
+}
+
+func TestRenderSurrogateInput_ContainsKeyFields(t *testing.T) {
+	r, _ := NewSQLRenderer()
+	p := TemplateParams{
+		ExperimentID:          "test-exp-surr",
+		ComputationDate:       "2024-06-01",
+		InputMetricIDs:        []string{"metric_a", "metric_b", "metric_c"},
+		ObservationWindowDays: 14,
+	}
+	sql, _ := r.RenderSurrogateInput(p)
+	assert.Contains(t, sql, "delta.metric_summaries")
+	assert.Contains(t, sql, "'metric_a', 'metric_b', 'metric_c'")
+	assert.Contains(t, sql, "DATE_SUB")
+	assert.Contains(t, sql, "14")
+	assert.Contains(t, sql, "GROUP BY ms.variant_id, ms.metric_id")
+	assert.Contains(t, sql, "avg_value")
+}

--- a/services/metrics/internal/spark/templates/surrogate_input.sql.tmpl
+++ b/services/metrics/internal/spark/templates/surrogate_input.sql.tmpl
@@ -1,0 +1,11 @@
+SELECT
+    ms.variant_id,
+    ms.metric_id,
+    AVG(ms.metric_value) AS avg_value,
+    COUNT(DISTINCT ms.user_id) AS user_count
+FROM delta.metric_summaries ms
+WHERE ms.experiment_id = '{{.ExperimentID}}'
+  AND ms.metric_id IN ({{range $i, $id := .InputMetricIDs}}{{if $i}}, {{end}}'{{$id}}'{{end}})
+  AND ms.computation_date >= DATE_SUB(CAST('{{.ComputationDate}}' AS DATE), {{.ObservationWindowDays}})
+GROUP BY ms.variant_id, ms.metric_id
+ORDER BY ms.variant_id, ms.metric_id

--- a/services/metrics/internal/surrogate/model.go
+++ b/services/metrics/internal/surrogate/model.go
@@ -1,0 +1,116 @@
+// Package surrogate provides model loading and prediction for surrogate metrics.
+// A surrogate model projects long-horizon outcomes (e.g., 90-day churn) from
+// short-term input signals (e.g., 7-day watch time, session frequency).
+package surrogate
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+)
+
+// InputMetrics maps metric_id → per-variant mean value.
+// Outer key is variant_id, inner key is metric_id.
+type InputMetrics map[string]map[string]float64
+
+// Projection is the result of applying a surrogate model to input metrics.
+type Projection struct {
+	VariantID           string
+	ProjectedEffect     float64 // treatment effect on target metric
+	ProjectionCILower   float64
+	ProjectionCIUpper   float64
+	CalibrationRSquared float64
+}
+
+// Model predicts long-term effects from short-term input metrics.
+type Model interface {
+	// Predict computes projected treatment effects for each variant relative to control.
+	Predict(inputs InputMetrics, controlVariantID string) ([]Projection, error)
+}
+
+// ModelLoader loads a trained model from a registry (MLflow, local mock, etc.).
+type ModelLoader interface {
+	Load(cfg *config.SurrogateModelConfig) (Model, error)
+}
+
+// LinearModel is a simple linear surrogate: y = intercept + sum(coeff_i * x_i).
+// Used for testing and as a baseline before real MLflow models are available.
+type LinearModel struct {
+	Coefficients        map[string]float64
+	Intercept           float64
+	CalibrationRSquared float64
+}
+
+// Predict computes the treatment effect for each non-control variant by applying
+// the linear model to both control and treatment inputs and taking the difference.
+func (m *LinearModel) Predict(inputs InputMetrics, controlVariantID string) ([]Projection, error) {
+	controlInputs, ok := inputs[controlVariantID]
+	if !ok {
+		return nil, fmt.Errorf("surrogate: control variant %q not found in inputs", controlVariantID)
+	}
+
+	controlPrediction := m.predict(controlInputs)
+
+	var projections []Projection
+	for variantID, variantInputs := range inputs {
+		if variantID == controlVariantID {
+			continue
+		}
+
+		treatmentPrediction := m.predict(variantInputs)
+		effect := treatmentPrediction - controlPrediction
+
+		// Analytic CI approximation: use R² to scale uncertainty.
+		// Higher R² → tighter CI. SE ≈ |effect| * sqrt((1 - R²) / R²) when R² > 0.
+		se := m.estimateSE(effect)
+
+		projections = append(projections, Projection{
+			VariantID:           variantID,
+			ProjectedEffect:     effect,
+			ProjectionCILower:   effect - 1.96*se,
+			ProjectionCIUpper:   effect + 1.96*se,
+			CalibrationRSquared: m.CalibrationRSquared,
+		})
+	}
+
+	return projections, nil
+}
+
+func (m *LinearModel) predict(metricValues map[string]float64) float64 {
+	y := m.Intercept
+	for metricID, coeff := range m.Coefficients {
+		if val, ok := metricValues[metricID]; ok {
+			y += coeff * val
+		}
+	}
+	return y
+}
+
+func (m *LinearModel) estimateSE(effect float64) float64 {
+	if m.CalibrationRSquared <= 0 || m.CalibrationRSquared >= 1 {
+		return math.Abs(effect) * 0.5 // fallback: 50% relative SE
+	}
+	return math.Abs(effect) * math.Sqrt((1-m.CalibrationRSquared)/m.CalibrationRSquared)
+}
+
+// MockModelLoader returns LinearModel instances from config coefficients.
+type MockModelLoader struct{}
+
+func NewMockModelLoader() *MockModelLoader {
+	return &MockModelLoader{}
+}
+
+func (l *MockModelLoader) Load(cfg *config.SurrogateModelConfig) (Model, error) {
+	if cfg.ModelType != "LINEAR" {
+		return nil, fmt.Errorf("surrogate: mock loader only supports LINEAR models, got %q", cfg.ModelType)
+	}
+	if len(cfg.Coefficients) == 0 {
+		return nil, fmt.Errorf("surrogate: LINEAR model %q has no coefficients", cfg.ModelID)
+	}
+	return &LinearModel{
+		Coefficients:        cfg.Coefficients,
+		Intercept:           cfg.Intercept,
+		CalibrationRSquared: cfg.CalibrationRSquared,
+	}, nil
+}

--- a/services/metrics/internal/surrogate/model_test.go
+++ b/services/metrics/internal/surrogate/model_test.go
@@ -1,0 +1,121 @@
+package surrogate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+)
+
+func TestLinearModel_Predict(t *testing.T) {
+	model := &LinearModel{
+		Coefficients: map[string]float64{
+			"watch_time_minutes": -0.015,
+			"stream_start_rate":  -0.25,
+		},
+		Intercept:           0.35,
+		CalibrationRSquared: 0.72,
+	}
+
+	inputs := InputMetrics{
+		"control": {
+			"watch_time_minutes": 10.0,
+			"stream_start_rate":  0.80,
+		},
+		"treatment": {
+			"watch_time_minutes": 12.0, // higher watch time
+			"stream_start_rate":  0.85, // higher stream start
+		},
+	}
+
+	projections, err := model.Predict(inputs, "control")
+	require.NoError(t, err)
+	require.Len(t, projections, 1)
+
+	p := projections[0]
+	assert.Equal(t, "treatment", p.VariantID)
+
+	// Control: 0.35 + (-0.015 * 10) + (-0.25 * 0.80) = 0.35 - 0.15 - 0.20 = 0.00
+	// Treatment: 0.35 + (-0.015 * 12) + (-0.25 * 0.85) = 0.35 - 0.18 - 0.2125 = -0.0425
+	// Effect: -0.0425 - 0.00 = -0.0425
+	assert.InDelta(t, -0.0425, p.ProjectedEffect, 1e-6)
+	assert.Equal(t, 0.72, p.CalibrationRSquared)
+	assert.True(t, p.ProjectionCILower < p.ProjectedEffect)
+	assert.True(t, p.ProjectionCIUpper > p.ProjectedEffect)
+}
+
+func TestLinearModel_Predict_MultipleVariants(t *testing.T) {
+	model := &LinearModel{
+		Coefficients:        map[string]float64{"metric_a": 1.0},
+		Intercept:           0.0,
+		CalibrationRSquared: 0.80,
+	}
+
+	inputs := InputMetrics{
+		"control":     {"metric_a": 5.0},
+		"treatment_a": {"metric_a": 7.0},
+		"treatment_b": {"metric_a": 3.0},
+	}
+
+	projections, err := model.Predict(inputs, "control")
+	require.NoError(t, err)
+	require.Len(t, projections, 2)
+
+	effectMap := make(map[string]float64)
+	for _, p := range projections {
+		effectMap[p.VariantID] = p.ProjectedEffect
+	}
+
+	assert.InDelta(t, 2.0, effectMap["treatment_a"], 1e-6)  // 7 - 5
+	assert.InDelta(t, -2.0, effectMap["treatment_b"], 1e-6) // 3 - 5
+}
+
+func TestLinearModel_Predict_ControlNotFound(t *testing.T) {
+	model := &LinearModel{
+		Coefficients:        map[string]float64{"x": 1.0},
+		CalibrationRSquared: 0.8,
+	}
+	inputs := InputMetrics{"treatment": {"x": 5.0}}
+	_, err := model.Predict(inputs, "control")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "control variant")
+}
+
+func TestMockModelLoader_Load(t *testing.T) {
+	loader := NewMockModelLoader()
+
+	cfg := &config.SurrogateModelConfig{
+		ModelID:             "test-model",
+		ModelType:           "LINEAR",
+		CalibrationRSquared: 0.75,
+		Coefficients:        map[string]float64{"a": 1.0, "b": 2.0},
+		Intercept:           0.5,
+	}
+
+	model, err := loader.Load(cfg)
+	require.NoError(t, err)
+
+	inputs := InputMetrics{
+		"ctrl": {"a": 1.0, "b": 1.0},
+		"tx":   {"a": 2.0, "b": 2.0},
+	}
+
+	projections, err := model.Predict(inputs, "ctrl")
+	require.NoError(t, err)
+	require.Len(t, projections, 1)
+	// ctrl: 0.5 + 1*1 + 2*1 = 3.5, tx: 0.5 + 1*2 + 2*2 = 6.5, effect: 3.0
+	assert.InDelta(t, 3.0, projections[0].ProjectedEffect, 1e-6)
+}
+
+func TestMockModelLoader_Load_NonLinear(t *testing.T) {
+	loader := NewMockModelLoader()
+	cfg := &config.SurrogateModelConfig{
+		ModelID:   "nn-model",
+		ModelType: "NEURAL",
+	}
+	_, err := loader.Load(cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "LINEAR")
+}

--- a/services/metrics/internal/surrogate/writer.go
+++ b/services/metrics/internal/surrogate/writer.go
@@ -1,0 +1,77 @@
+package surrogate
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ProjectionRecord is a row in the surrogate_projections table.
+type ProjectionRecord struct {
+	ExperimentID        string
+	VariantID           string
+	ModelID             string
+	ProjectedEffect     float64
+	ProjectionCILower   float64
+	ProjectionCIUpper   float64
+	CalibrationRSquared float64
+	ComputedAt          time.Time
+}
+
+// ProjectionWriter persists surrogate projections.
+type ProjectionWriter interface {
+	Write(ctx context.Context, record ProjectionRecord) error
+}
+
+// PgProjectionWriter writes to PostgreSQL surrogate_projections table.
+type PgProjectionWriter struct {
+	pool *pgxpool.Pool
+}
+
+func NewPgProjectionWriter(pool *pgxpool.Pool) *PgProjectionWriter {
+	return &PgProjectionWriter{pool: pool}
+}
+
+func (w *PgProjectionWriter) Write(ctx context.Context, record ProjectionRecord) error {
+	_, err := w.pool.Exec(ctx, `
+		INSERT INTO surrogate_projections
+			(experiment_id, variant_id, model_id, projected_effect,
+			 projection_ci_lower, projection_ci_upper, calibration_r_squared, computed_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		record.ExperimentID, record.VariantID, record.ModelID,
+		record.ProjectedEffect, record.ProjectionCILower, record.ProjectionCIUpper,
+		record.CalibrationRSquared, record.ComputedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("surrogate: write projection: %w", err)
+	}
+	return nil
+}
+
+// MemProjectionWriter is an in-memory writer for tests.
+type MemProjectionWriter struct {
+	mu      sync.Mutex
+	Records []ProjectionRecord
+}
+
+func NewMemProjectionWriter() *MemProjectionWriter {
+	return &MemProjectionWriter{}
+}
+
+func (w *MemProjectionWriter) Write(_ context.Context, record ProjectionRecord) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.Records = append(w.Records, record)
+	return nil
+}
+
+func (w *MemProjectionWriter) AllRecords() []ProjectionRecord {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]ProjectionRecord, len(w.Records))
+	copy(out, w.Records)
+	return out
+}

--- a/services/metrics/testdata/golden/surrogate_input_expected.sql
+++ b/services/metrics/testdata/golden/surrogate_input_expected.sql
@@ -1,0 +1,11 @@
+SELECT
+    ms.variant_id,
+    ms.metric_id,
+    AVG(ms.metric_value) AS avg_value,
+    COUNT(DISTINCT ms.user_id) AS user_count
+FROM delta.metric_summaries ms
+WHERE ms.experiment_id = 'exp-001'
+  AND ms.metric_id IN ('watch_time_minutes', 'stream_start_rate')
+  AND ms.computation_date >= DATE_SUB(CAST('2024-01-15' AS DATE), 7)
+GROUP BY ms.variant_id, ms.metric_id
+ORDER BY ms.variant_id, ms.metric_id


### PR DESCRIPTION
## Summary
- Implements Agent-3's part of M2.10 Surrogate Metric Framework
- `SurrogateModelConfig` with LINEAR model type, coefficients, and calibration R²
- `surrogate.Model` interface with `LinearModel`: `y = intercept + Σ(coeff × x)`, analytic CI from R²
- `surrogate.ProjectionWriter` (PostgreSQL + in-memory test double) for `surrogate_projections` table
- `surrogate_input.sql.tmpl`: aggregates per-variant metric means from `delta.metric_summaries` within observation window
- `SurrogateJob` orchestrator: render SQL → fetch inputs → load model → predict → write projections
- `InputMetricsProvider` interface abstracts Spark data fetching (mock for dev/test)
- All SQL logged to `query_log` with `job_type="surrogate_input"` for notebook export transparency
- Wired into `ComputeMetrics` RPC via handler + main.go

## Files Changed (14 files, +836 lines)
- **New**: `surrogate/model.go`, `surrogate/model_test.go`, `surrogate/writer.go`
- **New**: `jobs/surrogate.go`, `jobs/surrogate_test.go`
- **New**: `spark/templates/surrogate_input.sql.tmpl`, golden file
- **Modified**: `config/loader.go`, `seed_config.json`, `handler.go`, `handler_test.go`, `renderer.go`, `renderer_test.go`, `main.go`

## Test plan
- [x] `TestLinearModel_Predict` — correct projected effect from known coefficients
- [x] `TestLinearModel_Predict_MultipleVariants` — projects all non-control variants
- [x] `TestLinearModel_Predict_ControlNotFound` — returns error when control missing
- [x] `TestMockModelLoader_Load` / `_NonLinear` — LINEAR model loading + rejection of unsupported types
- [x] `TestSurrogateJob_Run` — end-to-end: SQL rendered, inputs fetched, model loaded, projection written, query logged
- [x] `TestSurrogateJob_Run_ProjectedEffect` — verifies exact linear algebra: `-0.1175` effect with correct CI bracketing
- [x] `TestSurrogateJob_Run_NoSurrogateModel` — graceful skip for experiments without linked model
- [x] `TestSurrogateJob_Run_MultipleVariants` — 2 treatment variants → 2 projections
- [x] `TestRenderSurrogateInput` — golden file match for SQL template
- [x] All 52+ tests pass with `-race` across 8 packages

## Dependencies
- This unblocks Agent-4 M2.10 (statistical analysis of surrogate projections)
- Uses `MockModelLoader` until real MLflow integration (Agent-5 CRUD stubs unimplemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)