### PR TITLE
feat(m7): flag-experiment linkage + dependency tracking

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -19,7 +19,7 @@
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 2 In Progress | agent-4/feat/novelty-interference-interleaving | Phase 2: Novelty, Interference, Interleaving | — | M2.4–2.6 in progress. M2.1–2.3 done (PRs #25, #29). |
 | Agent-5 | M5 Management | 🟢 Phase 1 Complete | — | STARTING validation + targeting rule CRUD | — | M1.20–1.24 all merged (PRs #7, #10, #15, #18, #24). All Phase 1 milestones done. |
 | Agent-6 | M6 UI | 🟡 Not Started | — | Experiment list + detail shell (1.25) | — | Unblocked by M1.20. Agent-5 CRUD API available. Can use live backend. |
-| Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/production-wiring | PostgreSQL wiring + integration tests | — | M1.28–1.30 merged (PR #13). Production wiring: DATABASE_URL → pgxpool → PostgresStore + audit. Integration tests for full CRUD + audit against real DB. |
+| Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/flag-experiment-linkage | Phase 2+3: Flag-experiment linkage + dependency tracking | — | M1.28–1.30 merged (PR #13). PR #36: production wiring. Flag-experiment linkage: PromoteToExperiment records experiment ID, ResolvePromotedExperiment auto-updates flag when experiment concludes. Dependency tracking: query flags by targeting rule. |
 
 **Legend**: 🟢 Complete | 🔵 In Progress | 🟡 Not Started (unblocked) | ⚪ Waiting (blocked) | 🔴 Blocked (critical path)
 

--- a/services/flags/cmd/main.go
+++ b/services/flags/cmd/main.go
@@ -93,6 +93,9 @@ func main() {
 	// Register audit endpoints.
 	svc.RegisterAuditRoutes(mux)
 
+	// Register linkage + dependency tracking endpoints.
+	svc.RegisterLinkageRoutes(mux)
+
 	srv := &http.Server{
 		Addr:    ":" + port,
 		Handler: mux,

--- a/services/flags/internal/handlers/linkage.go
+++ b/services/flags/internal/handlers/linkage.go
@@ -1,0 +1,208 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"connectrpc.com/connect"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+)
+
+// RegisterLinkageRoutes adds internal HTTP endpoints for flag-experiment linkage
+// and targeting rule dependency tracking.
+func (s *FlagService) RegisterLinkageRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/internal/flags/promoted", s.handleGetPromotedFlags)
+	mux.HandleFunc("/internal/flags/by-targeting-rule", s.handleGetFlagsByTargetingRule)
+	mux.HandleFunc("/internal/flags/resolve", s.handleResolvePromotedExperiment)
+}
+
+// handleGetPromotedFlags lists all flags that have been promoted to experiments.
+func (s *FlagService) handleGetPromotedFlags(w http.ResponseWriter, r *http.Request) {
+	flags, err := s.store.GetPromotedFlags(r.Context())
+	if err != nil {
+		http.Error(w, fmt.Sprintf("get promoted flags: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	type promotedFlagResponse struct {
+		FlagID               string  `json:"flag_id"`
+		Name                 string  `json:"name"`
+		Enabled              bool    `json:"enabled"`
+		RolloutPercentage    float64 `json:"rollout_percentage"`
+		PromotedExperimentID string  `json:"promoted_experiment_id"`
+		PromotedAt           string  `json:"promoted_at"`
+	}
+
+	var resp []promotedFlagResponse
+	for _, f := range flags {
+		resp = append(resp, promotedFlagResponse{
+			FlagID:               f.FlagID,
+			Name:                 f.Name,
+			Enabled:              f.Enabled,
+			RolloutPercentage:    f.RolloutPercentage,
+			PromotedExperimentID: f.PromotedExperimentID,
+			PromotedAt:           f.PromotedAt.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// handleGetFlagsByTargetingRule returns all flags that reference a given targeting rule.
+func (s *FlagService) handleGetFlagsByTargetingRule(w http.ResponseWriter, r *http.Request) {
+	ruleID := r.URL.Query().Get("rule_id")
+	if ruleID == "" {
+		http.Error(w, "rule_id query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	flags, err := s.store.GetFlagsByTargetingRule(r.Context(), ruleID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("get flags by targeting rule: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	type flagRef struct {
+		FlagID            string  `json:"flag_id"`
+		Name              string  `json:"name"`
+		Enabled           bool    `json:"enabled"`
+		RolloutPercentage float64 `json:"rollout_percentage"`
+	}
+
+	var resp []flagRef
+	for _, f := range flags {
+		resp = append(resp, flagRef{
+			FlagID:            f.FlagID,
+			Name:              f.Name,
+			Enabled:           f.Enabled,
+			RolloutPercentage: f.RolloutPercentage,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// ResolutionAction defines how a flag should be updated when its promoted experiment concludes.
+type ResolutionAction string
+
+const (
+	// ResolutionRolloutFull sets the flag to 100% rollout (treatment won).
+	ResolutionRolloutFull ResolutionAction = "rollout_full"
+	// ResolutionRollback disables the flag (control won / experiment failed).
+	ResolutionRollback ResolutionAction = "rollback"
+	// ResolutionKeep leaves the flag unchanged (manual follow-up needed).
+	ResolutionKeep ResolutionAction = "keep"
+)
+
+// handleResolvePromotedExperiment checks the experiment state via M5 and
+// updates the flag based on the resolution action.
+//
+// POST /internal/flags/resolve?flag_id=...&action=rollout_full|rollback|keep
+func (s *FlagService) handleResolvePromotedExperiment(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+
+	flagID := r.URL.Query().Get("flag_id")
+	if flagID == "" {
+		http.Error(w, "flag_id query parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	action := ResolutionAction(r.URL.Query().Get("action"))
+	if action != ResolutionRolloutFull && action != ResolutionRollback && action != ResolutionKeep {
+		http.Error(w, "action must be rollout_full, rollback, or keep", http.StatusBadRequest)
+		return
+	}
+
+	// Fetch the flag.
+	f, err := s.store.GetFlag(r.Context(), flagID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			http.Error(w, "flag not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, fmt.Sprintf("get flag: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if f.PromotedExperimentID == "" {
+		http.Error(w, "flag has not been promoted to an experiment", http.StatusBadRequest)
+		return
+	}
+
+	// Check experiment state via M5 (if management client is available).
+	var experimentState commonv1.ExperimentState
+	if s.managementClient != nil {
+		resp, err := s.managementClient.GetExperiment(r.Context(), connect.NewRequest(&mgmtv1.GetExperimentRequest{
+			ExperimentId: f.PromotedExperimentID,
+		}))
+		if err != nil {
+			slog.Error("M5 GetExperiment failed", "error", err, "experiment_id", f.PromotedExperimentID)
+			http.Error(w, fmt.Sprintf("check experiment status: %v", err), http.StatusInternalServerError)
+			return
+		}
+		experimentState = resp.Msg.GetState()
+
+		if experimentState != commonv1.ExperimentState_EXPERIMENT_STATE_CONCLUDED &&
+			experimentState != commonv1.ExperimentState_EXPERIMENT_STATE_ARCHIVED {
+			http.Error(w, fmt.Sprintf("experiment is not concluded (current state: %s); cannot resolve yet", experimentState.String()), http.StatusConflict)
+			return
+		}
+	}
+
+	// Apply the resolution action.
+	previous := *f
+	switch action {
+	case ResolutionRolloutFull:
+		f.RolloutPercentage = 1.0
+		f.Enabled = true
+	case ResolutionRollback:
+		f.RolloutPercentage = 0.0
+		f.Enabled = false
+	case ResolutionKeep:
+		// No change to the flag itself.
+	}
+
+	if action != ResolutionKeep {
+		if _, err := s.store.UpdateFlag(r.Context(), f); err != nil {
+			http.Error(w, fmt.Sprintf("update flag: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	s.recordAudit(r.Context(), flagID, "resolve_experiment", &previous, f)
+
+	slog.Info("flag experiment resolved",
+		"flag_id", flagID,
+		"experiment_id", f.PromotedExperimentID,
+		"action", string(action),
+		"experiment_state", experimentState.String(),
+	)
+
+	type resolveResponse struct {
+		FlagID               string `json:"flag_id"`
+		PromotedExperimentID string `json:"promoted_experiment_id"`
+		Action               string `json:"action"`
+		ExperimentState      string `json:"experiment_state"`
+		FlagEnabled          bool   `json:"flag_enabled"`
+		RolloutPercentage    float64 `json:"rollout_percentage"`
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resolveResponse{
+		FlagID:               flagID,
+		PromotedExperimentID: f.PromotedExperimentID,
+		Action:               string(action),
+		ExperimentState:      experimentState.String(),
+		FlagEnabled:          f.Enabled,
+		RolloutPercentage:    f.RolloutPercentage,
+	})
+}

--- a/services/flags/internal/handlers/linkage_test.go
+++ b/services/flags/internal/handlers/linkage_test.go
@@ -1,0 +1,444 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/org/experimentation-platform/services/flags/internal/store"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	flagsv1 "github.com/org/experimentation/gen/go/experimentation/flags/v1"
+	"github.com/org/experimentation/gen/go/experimentation/flags/v1/flagsv1connect"
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fullMockManagementHandler supports both CreateExperiment and GetExperiment.
+type fullMockManagementHandler struct {
+	managementv1connect.UnimplementedExperimentManagementServiceHandler
+	experiments map[string]*commonv1.Experiment
+}
+
+func newFullMockManagementHandler() *fullMockManagementHandler {
+	return &fullMockManagementHandler{
+		experiments: make(map[string]*commonv1.Experiment),
+	}
+}
+
+func (m *fullMockManagementHandler) CreateExperiment(_ context.Context, req *connect.Request[mgmtv1.CreateExperimentRequest]) (*connect.Response[commonv1.Experiment], error) {
+	exp := req.Msg.GetExperiment()
+	result := &commonv1.Experiment{
+		ExperimentId:       fmt.Sprintf("exp-%d", len(m.experiments)+1),
+		Name:               exp.GetName(),
+		Description:        exp.GetDescription(),
+		OwnerEmail:         exp.GetOwnerEmail(),
+		Type:               exp.GetType(),
+		State:              commonv1.ExperimentState_EXPERIMENT_STATE_DRAFT,
+		Variants:           exp.GetVariants(),
+		PrimaryMetricId:    exp.GetPrimaryMetricId(),
+		SecondaryMetricIds: exp.GetSecondaryMetricIds(),
+		HashSalt:           "test-salt",
+	}
+	m.experiments[result.ExperimentId] = result
+	return connect.NewResponse(result), nil
+}
+
+func (m *fullMockManagementHandler) GetExperiment(_ context.Context, req *connect.Request[mgmtv1.GetExperimentRequest]) (*connect.Response[commonv1.Experiment], error) {
+	exp, ok := m.experiments[req.Msg.GetExperimentId()]
+	if !ok {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("experiment not found"))
+	}
+	return connect.NewResponse(exp), nil
+}
+
+// setupTestWithLinkage creates a test environment with linkage routes registered.
+func setupTestWithLinkage(t *testing.T) (flagsv1connect.FeatureFlagServiceClient, *store.MockStore, *fullMockManagementHandler, *httptest.Server) {
+	t.Helper()
+
+	mgmtHandler := newFullMockManagementHandler()
+	mgmtMux := http.NewServeMux()
+	mgmtPath, mgmtH := managementv1connect.NewExperimentManagementServiceHandler(mgmtHandler)
+	mgmtMux.Handle(mgmtPath, mgmtH)
+	mgmtServer := httptest.NewServer(mgmtMux)
+	t.Cleanup(mgmtServer.Close)
+
+	mgmtClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, mgmtServer.URL,
+	)
+
+	mockStore := store.NewMockStore()
+	auditStore := store.NewMockAuditStore(mockStore)
+	svc := NewFlagServiceFull(mockStore, auditStore, mgmtClient)
+
+	mux := http.NewServeMux()
+	path, handler := flagsv1connect.NewFeatureFlagServiceHandler(svc)
+	mux.Handle(path, handler)
+	svc.RegisterAuditRoutes(mux)
+	svc.RegisterLinkageRoutes(mux)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := flagsv1connect.NewFeatureFlagServiceClient(http.DefaultClient, server.URL)
+	return client, mockStore, mgmtHandler, server
+}
+
+// createAndPromoteFlag is a helper that creates an enabled flag and promotes it.
+func createAndPromoteFlag(t *testing.T, client flagsv1connect.FeatureFlagServiceClient, name string) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	created, err := client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+		Flag: &flagsv1.Flag{
+			Name:              name,
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			Enabled:           true,
+			RolloutPercentage: 0.5,
+		},
+	}))
+	require.NoError(t, err)
+
+	resp, err := client.PromoteToExperiment(ctx, connect.NewRequest(&flagsv1.PromoteToExperimentRequest{
+		FlagId:          created.Msg.GetFlagId(),
+		ExperimentType:  commonv1.ExperimentType_EXPERIMENT_TYPE_AB,
+		PrimaryMetricId: "ctr",
+	}))
+	require.NoError(t, err)
+
+	return created.Msg.GetFlagId(), resp.Msg.GetExperimentId()
+}
+
+func TestPromoteToExperiment_LinksFlagToExperiment(t *testing.T) {
+	client, mockStore, _, _ := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	flagID, experimentID := createAndPromoteFlag(t, client, "linkage-test")
+
+	// The flag should now have promoted_experiment_id set.
+	f, err := mockStore.GetFlag(ctx, flagID)
+	require.NoError(t, err)
+	assert.Equal(t, experimentID, f.PromotedExperimentID)
+	assert.False(t, f.PromotedAt.IsZero())
+}
+
+func TestGetFlagByExperiment(t *testing.T) {
+	client, mockStore, _, _ := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	flagID, experimentID := createAndPromoteFlag(t, client, "by-experiment-test")
+
+	f, err := mockStore.GetFlagByExperiment(ctx, experimentID)
+	require.NoError(t, err)
+	assert.Equal(t, flagID, f.FlagID)
+	assert.Equal(t, "by-experiment-test", f.Name)
+}
+
+func TestGetFlagByExperiment_NotFound(t *testing.T) {
+	_, mockStore, _, _ := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	_, err := mockStore.GetFlagByExperiment(ctx, "nonexistent-experiment")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no flag found")
+}
+
+func TestGetPromotedFlags(t *testing.T) {
+	client, mockStore, _, _ := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	// Create 3 flags, promote 2.
+	createAndPromoteFlag(t, client, "promoted-1")
+	createAndPromoteFlag(t, client, "promoted-2")
+
+	_, err := client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+		Flag: &flagsv1.Flag{
+			Name:              "not-promoted",
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			Enabled:           true,
+			RolloutPercentage: 0.5,
+		},
+	}))
+	require.NoError(t, err)
+
+	promoted, err := mockStore.GetPromotedFlags(ctx)
+	require.NoError(t, err)
+	assert.Len(t, promoted, 2)
+}
+
+func TestGetFlagsByTargetingRule(t *testing.T) {
+	_, mockStore, _, _ := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	ruleID := "rule-abc-123"
+
+	// Create 3 flags: 2 with the targeting rule, 1 without.
+	_, err := mockStore.CreateFlag(ctx, &store.Flag{
+		Name: "rule-flag-a", Type: "BOOLEAN", DefaultValue: "false",
+		TargetingRuleID: ruleID,
+	})
+	require.NoError(t, err)
+
+	_, err = mockStore.CreateFlag(ctx, &store.Flag{
+		Name: "rule-flag-b", Type: "BOOLEAN", DefaultValue: "false",
+		TargetingRuleID: ruleID,
+	})
+	require.NoError(t, err)
+
+	_, err = mockStore.CreateFlag(ctx, &store.Flag{
+		Name: "no-rule-flag", Type: "BOOLEAN", DefaultValue: "false",
+	})
+	require.NoError(t, err)
+
+	flags, err := mockStore.GetFlagsByTargetingRule(ctx, ruleID)
+	require.NoError(t, err)
+	assert.Len(t, flags, 2)
+
+	// Empty result for unknown rule.
+	flags, err = mockStore.GetFlagsByTargetingRule(ctx, "unknown-rule")
+	require.NoError(t, err)
+	assert.Len(t, flags, 0)
+}
+
+func TestHandleGetPromotedFlags(t *testing.T) {
+	client, _, _, server := setupTestWithLinkage(t)
+
+	createAndPromoteFlag(t, client, "http-promoted-1")
+	createAndPromoteFlag(t, client, "http-promoted-2")
+
+	resp, err := http.Get(server.URL + "/internal/flags/promoted")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var flags []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&flags))
+	assert.Len(t, flags, 2)
+	assert.NotEmpty(t, flags[0]["promoted_experiment_id"])
+}
+
+func TestHandleGetFlagsByTargetingRule(t *testing.T) {
+	_, mockStore, _, server := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	ruleID := "targeting-rule-xyz"
+	_, err := mockStore.CreateFlag(ctx, &store.Flag{
+		Name: "tr-flag", Type: "BOOLEAN", DefaultValue: "false",
+		TargetingRuleID: ruleID, Enabled: true,
+	})
+	require.NoError(t, err)
+
+	// With rule_id.
+	resp, err := http.Get(server.URL + "/internal/flags/by-targeting-rule?rule_id=" + ruleID)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var flags []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&flags))
+	assert.Len(t, flags, 1)
+	assert.Equal(t, "tr-flag", flags[0]["name"])
+
+	// Missing rule_id → 400.
+	resp2, err := http.Get(server.URL + "/internal/flags/by-targeting-rule")
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp2.StatusCode)
+}
+
+func TestResolvePromotedExperiment_RolloutFull(t *testing.T) {
+	client, mockStore, mgmtHandler, server := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	flagID, experimentID := createAndPromoteFlag(t, client, "resolve-full")
+
+	// Simulate experiment conclusion.
+	mgmtHandler.experiments[experimentID].State = commonv1.ExperimentState_EXPERIMENT_STATE_CONCLUDED
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id="+flagID+"&action=rollout_full",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "rollout_full", result["action"])
+	assert.Equal(t, float64(1.0), result["rollout_percentage"])
+	assert.Equal(t, true, result["flag_enabled"])
+
+	// Verify flag was actually updated.
+	f, err := mockStore.GetFlag(ctx, flagID)
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, f.RolloutPercentage)
+	assert.True(t, f.Enabled)
+}
+
+func TestResolvePromotedExperiment_Rollback(t *testing.T) {
+	client, mockStore, mgmtHandler, server := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	flagID, experimentID := createAndPromoteFlag(t, client, "resolve-rollback")
+
+	mgmtHandler.experiments[experimentID].State = commonv1.ExperimentState_EXPERIMENT_STATE_CONCLUDED
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id="+flagID+"&action=rollback",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	f, err := mockStore.GetFlag(ctx, flagID)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, f.RolloutPercentage)
+	assert.False(t, f.Enabled)
+}
+
+func TestResolvePromotedExperiment_Keep(t *testing.T) {
+	client, mockStore, mgmtHandler, server := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	flagID, experimentID := createAndPromoteFlag(t, client, "resolve-keep")
+
+	mgmtHandler.experiments[experimentID].State = commonv1.ExperimentState_EXPERIMENT_STATE_CONCLUDED
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id="+flagID+"&action=keep",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Flag should be unchanged.
+	f, err := mockStore.GetFlag(ctx, flagID)
+	require.NoError(t, err)
+	assert.Equal(t, 0.5, f.RolloutPercentage)
+	assert.True(t, f.Enabled)
+}
+
+func TestResolvePromotedExperiment_NotConcluded(t *testing.T) {
+	client, _, _, server := setupTestWithLinkage(t)
+
+	flagID, _ := createAndPromoteFlag(t, client, "resolve-running")
+
+	// Experiment is still DRAFT (not concluded).
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id="+flagID+"&action=rollout_full",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
+func TestResolvePromotedExperiment_NotPromoted(t *testing.T) {
+	client, _, _, server := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	created, err := client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+		Flag: &flagsv1.Flag{
+			Name:              "never-promoted",
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			Enabled:           true,
+			RolloutPercentage: 0.5,
+		},
+	}))
+	require.NoError(t, err)
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id="+created.Msg.GetFlagId()+"&action=rollout_full",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestResolvePromotedExperiment_InvalidAction(t *testing.T) {
+	_, _, _, server := setupTestWithLinkage(t)
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id=abc&action=invalid",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestResolvePromotedExperiment_MissingFlagID(t *testing.T) {
+	_, _, _, server := setupTestWithLinkage(t)
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?action=rollout_full",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestResolvePromotedExperiment_Archived(t *testing.T) {
+	client, mockStore, mgmtHandler, server := setupTestWithLinkage(t)
+	ctx := context.Background()
+
+	flagID, experimentID := createAndPromoteFlag(t, client, "resolve-archived")
+
+	// ARCHIVED is also a valid terminal state for resolution.
+	mgmtHandler.experiments[experimentID].State = commonv1.ExperimentState_EXPERIMENT_STATE_ARCHIVED
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id="+flagID+"&action=rollout_full",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	f, err := mockStore.GetFlag(ctx, flagID)
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, f.RolloutPercentage)
+}
+
+func TestResolvePromotedExperiment_AuditEntry(t *testing.T) {
+	client, _, mgmtHandler, server := setupTestWithLinkage(t)
+
+	flagID, experimentID := createAndPromoteFlag(t, client, "resolve-audit")
+	mgmtHandler.experiments[experimentID].State = commonv1.ExperimentState_EXPERIMENT_STATE_CONCLUDED
+
+	resp, err := http.Post(
+		server.URL+"/internal/flags/resolve?flag_id="+flagID+"&action=rollout_full",
+		"application/json", nil,
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Check that audit entries include both promote_to_experiment and resolve_experiment.
+	auditResp, err := http.Get(server.URL + "/internal/flags/audit?flag_id=" + flagID)
+	require.NoError(t, err)
+	defer auditResp.Body.Close()
+
+	var entries []map[string]any
+	require.NoError(t, json.NewDecoder(auditResp.Body).Decode(&entries))
+
+	actions := make(map[string]bool)
+	for _, e := range entries {
+		actions[e["action"].(string)] = true
+	}
+	assert.True(t, actions["promote_to_experiment"], "should have promote audit entry")
+	assert.True(t, actions["resolve_experiment"], "should have resolve audit entry")
+}

--- a/services/flags/internal/handlers/promote.go
+++ b/services/flags/internal/handlers/promote.go
@@ -70,6 +70,14 @@ func (s *FlagService) PromoteToExperiment(ctx context.Context, req *connect.Requ
 		result = s.createExperimentMock(experiment, f)
 	}
 
+	// Link the flag to the created experiment for lifecycle tracking.
+	if experimentID := result.GetExperimentId(); experimentID != "" {
+		if linkErr := s.store.LinkFlagToExperiment(ctx, flagID, experimentID); linkErr != nil {
+			slog.Error("failed to link flag to experiment (non-fatal)",
+				"error", linkErr, "flag_id", flagID, "experiment_id", experimentID)
+		}
+	}
+
 	s.recordAudit(ctx, flagID, "promote_to_experiment", f, f)
 
 	return connect.NewResponse(result), nil

--- a/services/flags/internal/store/mock.go
+++ b/services/flags/internal/store/mock.go
@@ -189,6 +189,60 @@ func (m *MockStore) GetAllEnabledFlags(ctx context.Context) ([]*Flag, error) {
 	return result, nil
 }
 
+func (m *MockStore) LinkFlagToExperiment(ctx context.Context, flagID, experimentID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	f, ok := m.flags[flagID]
+	if !ok {
+		return fmt.Errorf("flag not found: %s", flagID)
+	}
+	f.PromotedExperimentID = experimentID
+	f.PromotedAt = time.Now()
+	f.UpdatedAt = time.Now()
+	return nil
+}
+
+func (m *MockStore) GetFlagByExperiment(ctx context.Context, experimentID string) (*Flag, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, f := range m.flags {
+		if f.PromotedExperimentID == experimentID {
+			return copyFlag(f), nil
+		}
+	}
+	return nil, fmt.Errorf("no flag found for experiment: %s", experimentID)
+}
+
+func (m *MockStore) GetFlagsByTargetingRule(ctx context.Context, targetingRuleID string) ([]*Flag, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []*Flag
+	for _, f := range m.flags {
+		if f.TargetingRuleID == targetingRuleID {
+			result = append(result, copyFlag(f))
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
+}
+
+func (m *MockStore) GetPromotedFlags(ctx context.Context) ([]*Flag, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []*Flag
+	for _, f := range m.flags {
+		if f.PromotedExperimentID != "" {
+			result = append(result, copyFlag(f))
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].PromotedAt.After(result[j].PromotedAt) })
+	return result, nil
+}
+
 // SetUpdatedAt sets the updated_at timestamp for a flag (for testing staleness).
 func (m *MockStore) SetUpdatedAt(flagID string, t time.Time) {
 	m.mu.Lock()

--- a/services/flags/internal/store/postgres.go
+++ b/services/flags/internal/store/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -34,7 +35,7 @@ func (s *PostgresStore) CreateFlag(ctx context.Context, f *Flag) (*Flag, error) 
 	row := tx.QueryRow(ctx,
 		`INSERT INTO feature_flags (name, description, type, default_value, enabled, rollout_percentage, targeting_rule_id)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)
-		 RETURNING flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at`,
+		 RETURNING flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at`,
 		f.Name, f.Description, f.Type, f.DefaultValue, f.Enabled, f.RolloutPercentage, targetingRuleID,
 	)
 
@@ -65,7 +66,7 @@ func (s *PostgresStore) CreateFlag(ctx context.Context, f *Flag) (*Flag, error) 
 
 func (s *PostgresStore) GetFlag(ctx context.Context, flagID string) (*Flag, error) {
 	row := s.pool.QueryRow(ctx,
-		`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at
+		`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at
 		 FROM feature_flags WHERE flag_id = $1`, flagID,
 	)
 
@@ -167,12 +168,12 @@ func (s *PostgresStore) ListFlags(ctx context.Context, pageSize int, pageToken s
 	var err error
 	if cursor == "" {
 		rows, err = s.pool.Query(ctx,
-			`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at
+			`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at
 			 FROM feature_flags ORDER BY flag_id LIMIT $1`, pageSize+1,
 		)
 	} else {
 		rows, err = s.pool.Query(ctx,
-			`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at
+			`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at
 			 FROM feature_flags WHERE flag_id > $1 ORDER BY flag_id LIMIT $2`, cursor, pageSize+1,
 		)
 	}
@@ -210,7 +211,7 @@ func (s *PostgresStore) ListFlags(ctx context.Context, pageSize int, pageToken s
 
 func (s *PostgresStore) GetAllEnabledFlags(ctx context.Context) ([]*Flag, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at
+		`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at
 		 FROM feature_flags WHERE enabled = TRUE ORDER BY flag_id`,
 	)
 	if err != nil {
@@ -266,16 +267,24 @@ type scannable interface {
 func scanFlag(row scannable) (*Flag, error) {
 	var f Flag
 	var targetingRuleID *string
+	var promotedExperimentID *string
+	var promotedAt *time.Time
 	err := row.Scan(
 		&f.FlagID, &f.Name, &f.Description, &f.Type, &f.DefaultValue,
 		&f.Enabled, &f.RolloutPercentage, &f.Salt, &targetingRuleID,
-		&f.CreatedAt, &f.UpdatedAt,
+		&f.CreatedAt, &f.UpdatedAt, &promotedExperimentID, &promotedAt,
 	)
 	if err != nil {
 		return nil, err
 	}
 	if targetingRuleID != nil {
 		f.TargetingRuleID = *targetingRuleID
+	}
+	if promotedExperimentID != nil {
+		f.PromotedExperimentID = *promotedExperimentID
+	}
+	if promotedAt != nil {
+		f.PromotedAt = *promotedAt
 	}
 	return &f, nil
 }
@@ -283,10 +292,12 @@ func scanFlag(row scannable) (*Flag, error) {
 func scanFlagFromRows(rows pgx.Rows) (*Flag, error) {
 	var f Flag
 	var targetingRuleID *string
+	var promotedExperimentID *string
+	var promotedAt *time.Time
 	err := rows.Scan(
 		&f.FlagID, &f.Name, &f.Description, &f.Type, &f.DefaultValue,
 		&f.Enabled, &f.RolloutPercentage, &f.Salt, &targetingRuleID,
-		&f.CreatedAt, &f.UpdatedAt,
+		&f.CreatedAt, &f.UpdatedAt, &promotedExperimentID, &promotedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -294,5 +305,111 @@ func scanFlagFromRows(rows pgx.Rows) (*Flag, error) {
 	if targetingRuleID != nil {
 		f.TargetingRuleID = *targetingRuleID
 	}
+	if promotedExperimentID != nil {
+		f.PromotedExperimentID = *promotedExperimentID
+	}
+	if promotedAt != nil {
+		f.PromotedAt = *promotedAt
+	}
 	return &f, nil
+}
+
+// --- Flag-experiment linkage ---
+
+func (s *PostgresStore) LinkFlagToExperiment(ctx context.Context, flagID, experimentID string) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE feature_flags
+		 SET promoted_experiment_id = $2, promoted_at = NOW(), updated_at = NOW()
+		 WHERE flag_id = $1`,
+		flagID, experimentID,
+	)
+	if err != nil {
+		return fmt.Errorf("link flag to experiment: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("flag not found: %s", flagID)
+	}
+	return nil
+}
+
+func (s *PostgresStore) GetFlagByExperiment(ctx context.Context, experimentID string) (*Flag, error) {
+	row := s.pool.QueryRow(ctx,
+		`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at
+		 FROM feature_flags WHERE promoted_experiment_id = $1`, experimentID,
+	)
+
+	f, err := scanFlag(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, fmt.Errorf("no flag found for experiment: %s", experimentID)
+		}
+		return nil, fmt.Errorf("get flag by experiment: %w", err)
+	}
+
+	variants, err := s.getVariants(ctx, f.FlagID)
+	if err != nil {
+		return nil, err
+	}
+	f.Variants = variants
+	return f, nil
+}
+
+// --- Dependency tracking ---
+
+func (s *PostgresStore) GetFlagsByTargetingRule(ctx context.Context, targetingRuleID string) ([]*Flag, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at
+		 FROM feature_flags WHERE targeting_rule_id = $1 ORDER BY name`, targetingRuleID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get flags by targeting rule: %w", err)
+	}
+	defer rows.Close()
+
+	var flags []*Flag
+	for rows.Next() {
+		f, err := scanFlagFromRows(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan flag: %w", err)
+		}
+		flags = append(flags, f)
+	}
+
+	for _, f := range flags {
+		variants, err := s.getVariants(ctx, f.FlagID)
+		if err != nil {
+			return nil, err
+		}
+		f.Variants = variants
+	}
+	return flags, nil
+}
+
+func (s *PostgresStore) GetPromotedFlags(ctx context.Context) ([]*Flag, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT flag_id, name, description, type, default_value, enabled, rollout_percentage, salt, targeting_rule_id, created_at, updated_at, promoted_experiment_id, promoted_at
+		 FROM feature_flags WHERE promoted_experiment_id IS NOT NULL ORDER BY promoted_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get promoted flags: %w", err)
+	}
+	defer rows.Close()
+
+	var flags []*Flag
+	for rows.Next() {
+		f, err := scanFlagFromRows(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan flag: %w", err)
+		}
+		flags = append(flags, f)
+	}
+
+	for _, f := range flags {
+		variants, err := s.getVariants(ctx, f.FlagID)
+		if err != nil {
+			return nil, err
+		}
+		f.Variants = variants
+	}
+	return flags, nil
 }

--- a/services/flags/internal/store/store.go
+++ b/services/flags/internal/store/store.go
@@ -19,6 +19,10 @@ type Flag struct {
 	Variants          []FlagVariant
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
+
+	// Flag-experiment linkage (Phase 3): set when PromoteToExperiment succeeds.
+	PromotedExperimentID string
+	PromotedAt           time.Time
 }
 
 // FlagVariant is a variant within a feature flag.
@@ -38,4 +42,14 @@ type Store interface {
 	DeleteFlag(ctx context.Context, flagID string) error
 	ListFlags(ctx context.Context, pageSize int, pageToken string) ([]*Flag, string, error)
 	GetAllEnabledFlags(ctx context.Context) ([]*Flag, error)
+
+	// Flag-experiment linkage: record which experiment a flag was promoted to.
+	LinkFlagToExperiment(ctx context.Context, flagID, experimentID string) error
+	// GetFlagByExperiment returns the flag that was promoted to a given experiment.
+	GetFlagByExperiment(ctx context.Context, experimentID string) (*Flag, error)
+
+	// Dependency tracking: find all flags using a targeting rule.
+	GetFlagsByTargetingRule(ctx context.Context, targetingRuleID string) ([]*Flag, error)
+	// GetPromotedFlags returns all flags that have been promoted to experiments.
+	GetPromotedFlags(ctx context.Context) ([]*Flag, error)
 }

--- a/sql/migrations/003_flag_audit_trail.sql
+++ b/sql/migrations/003_flag_audit_trail.sql
@@ -8,7 +8,7 @@ CREATE TABLE flag_audit_trail (
     flag_id         UUID NOT NULL REFERENCES feature_flags(flag_id) ON DELETE CASCADE,
     action          TEXT NOT NULL CHECK (action IN (
         'create', 'update', 'delete', 'enable', 'disable',
-        'rollout_change', 'promote_to_experiment'
+        'rollout_change', 'promote_to_experiment', 'resolve_experiment'
     )),
     actor_email     TEXT NOT NULL DEFAULT 'system',
     previous_value  JSONB DEFAULT '{}',

--- a/sql/migrations/004_flag_experiment_linkage.sql
+++ b/sql/migrations/004_flag_experiment_linkage.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- Flag-Experiment Linkage: M7 Phase 3
+-- Tracks which experiment was created from a flag via PromoteToExperiment,
+-- enabling auto-resolution when the experiment concludes.
+-- ============================================================================
+
+-- Track the promoted experiment for each flag.
+ALTER TABLE feature_flags
+    ADD COLUMN promoted_experiment_id UUID,
+    ADD COLUMN promoted_at TIMESTAMPTZ;
+
+-- Index for looking up which flag produced a given experiment.
+CREATE INDEX idx_feature_flags_promoted_experiment
+    ON feature_flags(promoted_experiment_id) WHERE promoted_experiment_id IS NOT NULL;
+
+-- Index for dependency tracking: find all flags using a targeting rule.
+CREATE INDEX idx_feature_flags_targeting_rule
+    ON feature_flags(targeting_rule_id) WHERE targeting_rule_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- **Flag-experiment linkage** (Phase 3): `PromoteToExperiment` now records `promoted_experiment_id` on the flag. New `ResolvePromotedExperiment` endpoint checks experiment state via M5 `GetExperiment` and auto-updates the flag when concluded (`rollout_full` → 100%, `rollback` → disabled, `keep` → unchanged).
- **Dependency tracking** (Phase 2): `GetFlagsByTargetingRule` queries all flags referencing a targeting rule. Enables safe rule modification and deletion checks.
- **DDL**: `004_flag_experiment_linkage.sql` adds `promoted_experiment_id`, `promoted_at` columns and partial indexes.

### New Internal HTTP Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/internal/flags/promoted` | List all promoted flags with experiment IDs |
| GET | `/internal/flags/by-targeting-rule?rule_id=...` | Find flags using a targeting rule |
| POST | `/internal/flags/resolve?flag_id=...&action=...` | Resolve flag after experiment concludes |

### What this unblocks

- Agent-6: flag management UI can show experiment linkage status
- Agent-5: targeting rule CRUD can check flag dependencies before modification

## Test plan

- [x] 14 new linkage tests covering all resolution actions (rollout_full, rollback, keep)
- [x] Tests for not-concluded experiments (409 Conflict), not-promoted flags (400), archived experiments
- [x] Audit trail integration: both `promote_to_experiment` and `resolve_experiment` entries recorded
- [x] Dependency tracking: flags by targeting rule, promoted flags listing
- [x] All 35+ handler tests pass with `-race`
- [x] `go vet ./flags/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)