### PR TITLE
fix(m5): add TypeConfig to guardrail processor integration tests

### DIFF
--- a/services/management/internal/guardrail/processor_test.go
+++ b/services/management/internal/guardrail/processor_test.go
@@ -4,6 +4,7 @@ package guardrail_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -59,6 +60,7 @@ func createRunningExperiment(t *testing.T, pool *pgxpool.Pool, name, guardrailAc
 		Description:     "guardrail test",
 		OwnerEmail:      "test@example.com",
 		Type:            "AB",
+		TypeConfig:      json.RawMessage("{}"),
 		State:           "DRAFT",
 		LayerID:         layerID,
 		PrimaryMetricID: "watch_time_minutes",
@@ -174,6 +176,7 @@ func TestProcessAlert_NotRunning(t *testing.T) {
 		Description:     "guardrail test",
 		OwnerEmail:      "test@example.com",
 		Type:            "AB",
+		TypeConfig:      json.RawMessage("{}"),
 		State:           "DRAFT",
 		LayerID:         "a0000000-0000-0000-0000-000000000001",
 		PrimaryMetricID: "watch_time_minutes",


### PR DESCRIPTION
## Summary

- Fix CI failure in Go integration tests (`TestProcessAlert_AutoPause`, `TestProcessAlert_AlertOnly`, `TestProcessAlert_NotRunning`, `TestProcessAlert_AuditDetails`)
- Root cause: `ExperimentRow` literals in `processor_test.go` omit `TypeConfig`, causing Go to send `NULL` for `json.RawMessage` which overrides the SQL `DEFAULT '{}'` and violates the `NOT NULL` constraint on `experiments.type_config`
- Fix: set `TypeConfig: json.RawMessage("{}")` in both insert sites

## Test plan

- [x] The 4 failing guardrail integration tests should now pass (they insert experiments with a valid `type_config`)
- [x] The `handlers` package 120s timeout should also resolve (it was a cascade from connection pool exhaustion caused by the guardrail test failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)