### PR TITLE
feat(m6): analysis tabs — novelty, interference, interleaving (M2.4–2.6)

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,6 +1,6 @@
 # Experimentation Platform — Coordination Status
 
-> **Last updated**: 2026-03-08 by Agent-6 (M2.8–2.9 complete, create experiment form)
+> **Last updated**: 2026-03-08 by Agent-6 (analysis tabs M2.4–2.6 UI complete)
 >
 > This file is the single source of truth for multi-agent execution state.
 > Update it each time a milestone merges to `main` or a blocker is identified.
@@ -18,7 +18,7 @@
 | Agent-3 | M3 Metrics | 🔵 Phase 2 In Progress | agent-3/feat/surrogate-metric-framework | M2.10 Surrogate Metric Framework | — | Phase 1 done. M2.11 done (PR #26). M2.10 in progress (PR #35). |
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 3 In Progress | agent-4/feat/linucb-contextual-bandit | M3.1 LinUCB Contextual Bandit | — | M1.14–1.19 merged. M2.1–2.6 complete (PRs #25, #29, #38). M2.10 (Agent-4 part) in progress. M3.1 LinUCB PR open. |
 | Agent-5 | M5 Management | 🔵 Phase 2 | agent-5/feat/surrogate-crud | Sequential auto-conclude (Phase 2) | — | Surrogate CRUD + sequential auto-conclude. Unblocks Agent-4 (boundary crossing → auto-conclude integration). |
-| Agent-6 | M6 UI | 🔵 In Progress | agent-6/feat/results-dashboard | Create experiment form + M2.8–2.9 complete | — | M1.25–1.27 done, M2.8–2.9 done. 87 tests pass. Create experiment form with full field coverage. |
+| Agent-6 | M6 UI | 🔵 In Progress | agent-6/feat/analysis-tabs | Analysis tabs (M2.4–2.6 UI) complete, PR #56 | — | M1.25–1.27 done, M2.8–2.9 done. Analysis tabs: novelty, interference, interleaving. 104 tests pass. Next: bandit dashboard (M3.3, blocked on M3.1) or live API integration. |
 | Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/flag-experiment-linkage | Phase 2+3: Flag-experiment linkage + dependency tracking | — | M1.28–1.30 merged (PR #13). PR #36: production wiring. Flag-experiment linkage: PromoteToExperiment records experiment ID, ResolvePromotedExperiment auto-updates flag when experiment concludes. Dependency tracking: query flags by targeting rule. |
 
 **Legend**: 🟢 Complete | 🔵 In Progress | 🟡 Not Started (unblocked) | ⚪ Waiting (blocked) | 🔴 Blocked (critical path)
@@ -162,7 +162,7 @@ Track any changes to proto schemas, shared crate APIs, or database schemas.
 **In progress:**
 - Agent-3: M2.10 surrogate metric framework (Agent-3 part complete in PR #35, Agent-4 part pending)
 - Agent-5: Surrogate model CRUD (Phase 2) — CreateSurrogateModel, ListSurrogateModels, GetSurrogateCalibration, TriggerSurrogateRecalibration
-- Agent-6: M1.25–1.27 complete, M2.8–2.9 complete, create experiment form in progress
+- Agent-6: M1.25–1.27 complete, M2.8–2.9 complete, create experiment form done (PR #49 merged), analysis tabs M2.4–2.6 UI done (PR #56)
 
 **Unblocked this week:**
 - Agent-1 unblocked for 1.3 (config cache) by Agent-5 StreamConfigUpdates (PR #15)

--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -1,5 +1,8 @@
 import { http, HttpResponse } from 'msw';
-import { SEED_EXPERIMENTS, SEED_QUERY_LOG, SEED_ANALYSIS_RESULTS } from './seed-data';
+import {
+  SEED_EXPERIMENTS, SEED_QUERY_LOG, SEED_ANALYSIS_RESULTS,
+  SEED_NOVELTY_RESULTS, SEED_INTERFERENCE_RESULTS, SEED_INTERLEAVING_RESULTS,
+} from './seed-data';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
 const METRICS_SVC = '*/experimentation.metrics.v1.MetricComputationService';
@@ -207,5 +210,44 @@ export const handlers = [
       content: btoa(`{"cells": [], "metadata": {"experiment_id": "${body.experimentId}"}}`),
       filename: `${name}_analysis.ipynb`,
     });
+  }),
+
+  // GetNoveltyAnalysis
+  http.post(`${ANALYSIS_SVC}/GetNoveltyAnalysis`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_NOVELTY_RESULTS[body.experimentId];
+    if (!result) {
+      return HttpResponse.json(
+        { error: `No novelty analysis for experiment ${body.experimentId}` },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(result);
+  }),
+
+  // GetInterferenceAnalysis
+  http.post(`${ANALYSIS_SVC}/GetInterferenceAnalysis`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_INTERFERENCE_RESULTS[body.experimentId];
+    if (!result) {
+      return HttpResponse.json(
+        { error: `No interference analysis for experiment ${body.experimentId}` },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(result);
+  }),
+
+  // GetInterleavingAnalysis
+  http.post(`${ANALYSIS_SVC}/GetInterleavingAnalysis`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_INTERLEAVING_RESULTS[body.experimentId];
+    if (!result) {
+      return HttpResponse.json(
+        { error: `No interleaving analysis for experiment ${body.experimentId}` },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(result);
   }),
 ];

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -1,4 +1,7 @@
-import type { AnalysisResult, Experiment, QueryLogEntry } from '@/lib/types';
+import type {
+  AnalysisResult, Experiment, QueryLogEntry,
+  NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
+} from '@/lib/types';
 
 const INITIAL_EXPERIMENTS: Experiment[] = [
   {
@@ -413,16 +416,124 @@ const INITIAL_ANALYSIS_RESULTS: AnalysisResult[] = [
     },
     computedAt: '2026-03-04T18:30:00Z',
   },
+  {
+    experimentId: '33333333-3333-3333-3333-333333333333',
+    metricResults: [
+      {
+        metricId: 'search_success_rate',
+        variantId: 'v3-semantic',
+        controlMean: 0.62,
+        treatmentMean: 0.68,
+        absoluteEffect: 0.06,
+        relativeEffect: 0.0968,
+        ciLower: 0.02,
+        ciUpper: 0.10,
+        pValue: 0.004,
+        isSignificant: true,
+        cupedAdjustedEffect: 0,
+        cupedCiLower: 0,
+        cupedCiUpper: 0,
+        varianceReductionPct: 0,
+      },
+      {
+        metricId: 'clicks_per_search',
+        variantId: 'v3-semantic',
+        controlMean: 1.8,
+        treatmentMean: 2.1,
+        absoluteEffect: 0.3,
+        relativeEffect: 0.1667,
+        ciLower: 0.05,
+        ciUpper: 0.55,
+        pValue: 0.019,
+        isSignificant: true,
+        cupedAdjustedEffect: 0,
+        cupedCiLower: 0,
+        cupedCiUpper: 0,
+        varianceReductionPct: 0,
+      },
+    ],
+    srmResult: {
+      chiSquared: 0.18,
+      pValue: 0.671,
+      isMismatch: false,
+      observedCounts: { 'v3-bm25': 37650, 'v3-semantic': 37350 },
+      expectedCounts: { 'v3-bm25': 37500, 'v3-semantic': 37500 },
+    },
+    computedAt: '2026-03-05T14:35:00Z',
+  },
 ];
+
+/** Novelty analysis mock — homepage_recs_v2 shows novelty decay in CTR. */
+const INITIAL_NOVELTY_RESULTS: Record<string, NoveltyAnalysisResult> = {
+  '11111111-1111-1111-1111-111111111111': {
+    experimentId: '11111111-1111-1111-1111-111111111111',
+    metricId: 'click_through_rate',
+    noveltyDetected: true,
+    rawTreatmentEffect: 0.014,
+    projectedSteadyStateEffect: 0.009,
+    noveltyAmplitude: 0.018,
+    decayConstantDays: 4.2,
+    isStabilized: false,
+    daysUntilProjectedStability: 6,
+    computedAt: '2026-03-05T12:00:00Z',
+  },
+};
+
+/** Interference analysis mock — homepage_recs_v2 shows content consumption interference. */
+const INITIAL_INTERFERENCE_RESULTS: Record<string, InterferenceAnalysisResult> = {
+  '11111111-1111-1111-1111-111111111111': {
+    experimentId: '11111111-1111-1111-1111-111111111111',
+    interferenceDetected: true,
+    jensenShannonDivergence: 0.042,
+    jaccardSimilarityTop100: 0.73,
+    treatmentGiniCoefficient: 0.61,
+    controlGiniCoefficient: 0.58,
+    treatmentCatalogCoverage: 0.34,
+    controlCatalogCoverage: 0.31,
+    spilloverTitles: [
+      { contentId: 'title-1234', treatmentWatchRate: 0.082, controlWatchRate: 0.041, pValue: 0.002 },
+      { contentId: 'title-5678', treatmentWatchRate: 0.015, controlWatchRate: 0.044, pValue: 0.008 },
+      { contentId: 'title-9012', treatmentWatchRate: 0.063, controlWatchRate: 0.038, pValue: 0.031 },
+    ],
+    computedAt: '2026-03-05T12:00:00Z',
+  },
+};
+
+/** Interleaving analysis mock — search_ranking_interleave comparing BM25 vs semantic. */
+const INITIAL_INTERLEAVING_RESULTS: Record<string, InterleavingAnalysisResult> = {
+  '33333333-3333-3333-3333-333333333333': {
+    experimentId: '33333333-3333-3333-3333-333333333333',
+    algorithmWinRates: { bm25_baseline: 0.42, semantic_search: 0.58 },
+    signTestPValue: 0.003,
+    algorithmStrengths: [
+      { algorithmId: 'bm25_baseline', strength: 0.45, ciLower: 0.39, ciUpper: 0.51 },
+      { algorithmId: 'semantic_search', strength: 0.55, ciLower: 0.49, ciUpper: 0.61 },
+    ],
+    positionAnalyses: [
+      { position: 1, algorithmEngagementRates: { bm25_baseline: 0.31, semantic_search: 0.38 } },
+      { position: 2, algorithmEngagementRates: { bm25_baseline: 0.24, semantic_search: 0.29 } },
+      { position: 3, algorithmEngagementRates: { bm25_baseline: 0.18, semantic_search: 0.23 } },
+      { position: 4, algorithmEngagementRates: { bm25_baseline: 0.12, semantic_search: 0.17 } },
+      { position: 5, algorithmEngagementRates: { bm25_baseline: 0.09, semantic_search: 0.14 } },
+    ],
+    computedAt: '2026-03-05T14:35:00Z',
+  },
+};
 
 /** Mutable copy of seed data — MSW handlers mutate this in-place. */
 export let SEED_EXPERIMENTS: Experiment[] = structuredClone(INITIAL_EXPERIMENTS);
 export let SEED_QUERY_LOG: Record<string, QueryLogEntry[]> = structuredClone(INITIAL_QUERY_LOG);
 export let SEED_ANALYSIS_RESULTS: AnalysisResult[] = structuredClone(INITIAL_ANALYSIS_RESULTS);
+export let SEED_NOVELTY_RESULTS: Record<string, NoveltyAnalysisResult> = structuredClone(INITIAL_NOVELTY_RESULTS);
+export let SEED_INTERFERENCE_RESULTS: Record<string, InterferenceAnalysisResult> = structuredClone(INITIAL_INTERFERENCE_RESULTS);
+export let SEED_INTERLEAVING_RESULTS: Record<string, InterleavingAnalysisResult> = structuredClone(INITIAL_INTERLEAVING_RESULTS);
 
 /** Reset seed data to initial state. Call in afterEach for test isolation. */
 export function resetSeedData(): void {
   SEED_EXPERIMENTS = structuredClone(INITIAL_EXPERIMENTS);
   SEED_QUERY_LOG = structuredClone(INITIAL_QUERY_LOG);
   SEED_ANALYSIS_RESULTS = structuredClone(INITIAL_ANALYSIS_RESULTS);
+  SEED_NOVELTY_RESULTS = structuredClone(INITIAL_NOVELTY_RESULTS);
+  SEED_INTERFERENCE_RESULTS = structuredClone(INITIAL_INTERFERENCE_RESULTS);
+  SEED_INTERLEAVING_RESULTS = structuredClone(INITIAL_INTERLEAVING_RESULTS);
 }

--- a/ui/src/__tests__/analysis-tabs.test.tsx
+++ b/ui/src/__tests__/analysis-tabs.test.tsx
@@ -1,0 +1,334 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ResultsPage from '@/app/experiments/[id]/results/page';
+
+let mockExperimentId = '11111111-1111-1111-1111-111111111111';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: mockExperimentId }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// Mock recharts to avoid SVG rendering issues in jsdom
+vi.mock('recharts', async () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  );
+  const Noop = () => null;
+
+  return {
+    ResponsiveContainer: Passthrough,
+    ComposedChart: Passthrough,
+    BarChart: Passthrough,
+    Bar: Noop,
+    Scatter: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    ReferenceLine: Noop,
+    Tooltip: Noop,
+    ErrorBar: Noop,
+    Cell: Noop,
+  };
+});
+
+describe('Analysis Tabs - Tab Navigation', () => {
+  beforeEach(() => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+  });
+
+  it('renders tab buttons for all analysis views', async () => {
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Results Dashboard' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Novelty Effects' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Content Interference' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Interleaving' })).toBeInTheDocument();
+  });
+
+  it('defaults to Overview tab showing treatment effects', async () => {
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Metric Results')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('switches to Novelty tab when clicked', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Novelty Effects' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Novelty Effects' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Novelty Effect Detected')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to Interference tab when clicked', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Content Interference' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Content Interference' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Content Interference Detected')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Novelty Tab - homepage_recs_v2', () => {
+  beforeEach(() => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+  });
+
+  it('shows novelty detection banner with metric name', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Novelty Effects' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Novelty Effects' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Novelty Effect Detected')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('click_through_rate')).toBeInTheDocument();
+  });
+
+  it('shows current effect and steady-state projection', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Novelty Effects' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Novelty Effects' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('+0.0140')).toBeInTheDocument();
+    });
+
+    // Steady-state projection
+    expect(screen.getByText('+0.0090')).toBeInTheDocument();
+  });
+
+  it('shows decay constant and stability status', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Novelty Effects' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Novelty Effects' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('4.2 days')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('~6 days until projected stability')).toBeInTheDocument();
+  });
+});
+
+describe('Interference Tab - homepage_recs_v2', () => {
+  beforeEach(() => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+  });
+
+  it('shows interference detection banner', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Content Interference' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Content Interference' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Content Interference Detected')).toBeInTheDocument();
+    });
+  });
+
+  it('shows JS divergence and Jaccard similarity', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Content Interference' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Content Interference' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('0.0420')).toBeInTheDocument();
+    });
+
+    // Jaccard similarity 73%
+    expect(screen.getByText('73.0%')).toBeInTheDocument();
+  });
+
+  it('shows spillover titles table', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Content Interference' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Content Interference' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Spillover Titles (3)')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('title-1234')).toBeInTheDocument();
+    expect(screen.getByText('title-5678')).toBeInTheDocument();
+    expect(screen.getByText('title-9012')).toBeInTheDocument();
+  });
+
+  it('shows Gini coefficient comparison', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Content Interference' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Content Interference' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Concentration (Gini Coefficient)')).toBeInTheDocument();
+    });
+
+    // Treatment Gini 0.61, Control Gini 0.58
+    expect(screen.getByText('0.61')).toBeInTheDocument();
+    expect(screen.getByText('0.58')).toBeInTheDocument();
+  });
+});
+
+describe('Interleaving Tab - search_ranking_interleave', () => {
+  beforeEach(() => {
+    mockExperimentId = '33333333-3333-3333-3333-333333333333';
+  });
+
+  it('switches to Interleaving tab and shows sign test result', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Interleaving' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Interleaving' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sign Test: p = 0.003/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Significant difference detected between algorithms.')).toBeInTheDocument();
+  });
+
+  it('shows Bradley-Terry strength estimates', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Interleaving' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Interleaving' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Bradley-Terry Strength Estimates')).toBeInTheDocument();
+    });
+
+    // Algorithm names appear in both the strengths table and position header
+    expect(screen.getAllByText('bm25_baseline').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('semantic_search').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('0.450')).toBeInTheDocument();
+    expect(screen.getByText('0.550')).toBeInTheDocument();
+  });
+
+  it('shows position engagement rates table', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Interleaving' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Interleaving' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Position Engagement Rates')).toBeInTheDocument();
+    });
+
+    // Position #1
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    // bm25 position 1 rate = 31.0%
+    expect(screen.getByText('31.0%')).toBeInTheDocument();
+    // semantic position 1 rate = 38.0%
+    expect(screen.getByText('38.0%')).toBeInTheDocument();
+  });
+});
+
+describe('Analysis Tabs - No Data States', () => {
+  it('shows empty state for novelty tab when no data', async () => {
+    mockExperimentId = '33333333-3333-3333-3333-333333333333';
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Novelty Effects' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Novelty Effects' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No novelty analysis available for this experiment.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state for interleaving tab when no data', async () => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Interleaving' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Interleaving' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No interleaving analysis available for this experiment.')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/app/experiments/[id]/results/page.tsx
+++ b/ui/src/app/experiments/[id]/results/page.tsx
@@ -11,6 +11,18 @@ import { CupedToggle } from '@/components/cuped-toggle';
 import { TreatmentEffectsTable } from '@/components/treatment-effects-table';
 import { ForestPlot } from '@/components/charts/forest-plot';
 import { SequentialBoundaryPlot } from '@/components/charts/sequential-boundary-plot';
+import { NoveltyTab } from '@/components/novelty-tab';
+import { InterferenceTab } from '@/components/interference-tab';
+import { InterleavingTab } from '@/components/interleaving-tab';
+
+type AnalysisTab = 'overview' | 'novelty' | 'interference' | 'interleaving';
+
+const TABS: { key: AnalysisTab; label: string }[] = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'novelty', label: 'Novelty Effects' },
+  { key: 'interference', label: 'Content Interference' },
+  { key: 'interleaving', label: 'Interleaving' },
+];
 
 export default function ResultsPage() {
   const params = useParams<{ id: string }>();
@@ -19,6 +31,7 @@ export default function ResultsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showCuped, setShowCuped] = useState(false);
+  const [activeTab, setActiveTab] = useState<AnalysisTab>('overview');
 
   useEffect(() => {
     if (!params.id) return;
@@ -61,6 +74,7 @@ export default function ResultsPage() {
 
   const hasCupedData = analysisResult.metricResults.some((m) => m.varianceReductionPct > 0);
   const maxVarianceReduction = Math.max(...analysisResult.metricResults.map((m) => m.varianceReductionPct));
+  const isInterleaving = experiment.type === 'INTERLEAVING';
 
   return (
     <div>
@@ -81,30 +95,68 @@ export default function ResultsPage() {
       {/* Summary */}
       <ResultsSummary analysisResult={analysisResult} experiment={experiment} />
 
-      {/* CUPED Toggle */}
-      {hasCupedData && (
-        <CupedToggle
-          enabled={showCuped}
-          onToggle={() => setShowCuped((prev) => !prev)}
-          varianceReductionPct={maxVarianceReduction}
-        />
+      {/* Tab navigation */}
+      <div className="mb-6 border-b border-gray-200">
+        <nav className="-mb-px flex space-x-6" aria-label="Analysis tabs">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`whitespace-nowrap border-b-2 pb-3 pt-1 text-sm font-medium transition-colors ${
+                activeTab === tab.key
+                  ? 'border-indigo-600 text-indigo-600'
+                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+              }`}
+              aria-selected={activeTab === tab.key}
+              role="tab"
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'overview' && (
+        <>
+          {/* CUPED Toggle */}
+          {hasCupedData && (
+            <CupedToggle
+              enabled={showCuped}
+              onToggle={() => setShowCuped((prev) => !prev)}
+              varianceReductionPct={maxVarianceReduction}
+            />
+          )}
+
+          {/* Treatment Effects Table */}
+          <section className="mb-6">
+            <h2 className="mb-3 text-lg font-semibold text-gray-900">Metric Results</h2>
+            <TreatmentEffectsTable metricResults={analysisResult.metricResults} showCuped={showCuped} />
+          </section>
+
+          {/* Forest Plot */}
+          <ForestPlot metricResults={analysisResult.metricResults} showCuped={showCuped} />
+
+          {/* Sequential Boundary Plot */}
+          {experiment.sequentialTestConfig && (
+            <SequentialBoundaryPlot
+              metricResults={analysisResult.metricResults}
+              overallAlpha={experiment.sequentialTestConfig.overallAlpha}
+            />
+          )}
+        </>
       )}
 
-      {/* Treatment Effects Table */}
-      <section className="mb-6">
-        <h2 className="mb-3 text-lg font-semibold text-gray-900">Metric Results</h2>
-        <TreatmentEffectsTable metricResults={analysisResult.metricResults} showCuped={showCuped} />
-      </section>
+      {activeTab === 'novelty' && (
+        <NoveltyTab experimentId={params.id} />
+      )}
 
-      {/* Forest Plot */}
-      <ForestPlot metricResults={analysisResult.metricResults} showCuped={showCuped} />
+      {activeTab === 'interference' && (
+        <InterferenceTab experimentId={params.id} />
+      )}
 
-      {/* Sequential Boundary Plot */}
-      {experiment.sequentialTestConfig && (
-        <SequentialBoundaryPlot
-          metricResults={analysisResult.metricResults}
-          overallAlpha={experiment.sequentialTestConfig.overallAlpha}
-        />
+      {activeTab === 'interleaving' && (
+        <InterleavingTab experimentId={params.id} />
       )}
     </div>
   );

--- a/ui/src/components/interference-tab.tsx
+++ b/ui/src/components/interference-tab.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { InterferenceAnalysisResult } from '@/lib/types';
+import { getInterferenceAnalysis } from '@/lib/api';
+import { formatPValue } from '@/lib/utils';
+
+interface InterferenceTabProps {
+  experimentId: string;
+}
+
+export function InterferenceTab({ experimentId }: InterferenceTabProps) {
+  const [result, setResult] = useState<InterferenceAnalysisResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getInterferenceAnalysis(experimentId)
+      .then(setResult)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [experimentId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error || !result) {
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+        No interference analysis available for this experiment.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Detection banner */}
+      {result.interferenceDetected ? (
+        <div className="rounded-md bg-red-50 border border-red-200 p-4">
+          <h4 className="text-sm font-semibold text-red-800">Content Interference Detected</h4>
+          <p className="mt-1 text-sm text-red-700">
+            Treatment and control groups show significant differences in content consumption patterns.
+            This may indicate spillover effects between experiment arms.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md bg-green-50 border border-green-200 p-4">
+          <h4 className="text-sm font-semibold text-green-800">No Interference Detected</h4>
+          <p className="mt-1 text-sm text-green-700">
+            Content consumption patterns are similar across experiment arms.
+          </p>
+        </div>
+      )}
+
+      {/* Distribution metrics */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">JS Divergence</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {result.jensenShannonDivergence.toFixed(4)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Jaccard Similarity (Top 100)</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {(result.jaccardSimilarityTop100 * 100).toFixed(1)}%
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Catalog Coverage</span>
+          <p className="mt-1 text-sm text-gray-900">
+            Treatment: {(result.treatmentCatalogCoverage * 100).toFixed(1)}% /
+            Control: {(result.controlCatalogCoverage * 100).toFixed(1)}%
+          </p>
+        </div>
+      </div>
+
+      {/* Gini comparison */}
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <h4 className="text-sm font-semibold text-gray-900">Concentration (Gini Coefficient)</h4>
+        <div className="mt-3 space-y-2">
+          <div className="flex items-center gap-3">
+            <span className="w-24 text-xs text-gray-500">Treatment</span>
+            <div className="flex-1 h-4 rounded bg-gray-100 overflow-hidden">
+              <div
+                className="h-full rounded bg-indigo-500"
+                style={{ width: `${result.treatmentGiniCoefficient * 100}%` }}
+              />
+            </div>
+            <span className="w-12 text-right text-xs font-medium text-gray-700">
+              {result.treatmentGiniCoefficient.toFixed(2)}
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="w-24 text-xs text-gray-500">Control</span>
+            <div className="flex-1 h-4 rounded bg-gray-100 overflow-hidden">
+              <div
+                className="h-full rounded bg-gray-500"
+                style={{ width: `${result.controlGiniCoefficient * 100}%` }}
+              />
+            </div>
+            <span className="w-12 text-right text-xs font-medium text-gray-700">
+              {result.controlGiniCoefficient.toFixed(2)}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Spillover titles table */}
+      {result.spilloverTitles.length > 0 && (
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-900">
+            Spillover Titles ({result.spilloverTitles.length})
+          </h4>
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Content ID</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Treatment Rate</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Control Rate</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">p-value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {result.spilloverTitles.map((t) => (
+                  <tr key={t.contentId}>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">{t.contentId}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{(t.treatmentWatchRate * 100).toFixed(2)}%</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{(t.controlWatchRate * 100).toFixed(2)}%</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{formatPValue(t.pValue)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/interleaving-tab.tsx
+++ b/ui/src/components/interleaving-tab.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import type { InterleavingAnalysisResult } from '@/lib/types';
+import { getInterleavingAnalysis } from '@/lib/api';
+import { formatPValue } from '@/lib/utils';
+
+interface InterleavingTabProps {
+  experimentId: string;
+}
+
+export function InterleavingTab({ experimentId }: InterleavingTabProps) {
+  const [result, setResult] = useState<InterleavingAnalysisResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getInterleavingAnalysis(experimentId)
+      .then(setResult)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [experimentId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error || !result) {
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+        No interleaving analysis available for this experiment.
+      </div>
+    );
+  }
+
+  const winRateData = Object.entries(result.algorithmWinRates).map(([id, rate]) => ({
+    algorithm: id,
+    winRate: rate,
+  }));
+
+  const strengthData = result.algorithmStrengths.map((s) => ({
+    algorithm: s.algorithmId,
+    strength: s.strength,
+    ciLower: s.ciLower,
+    ciUpper: s.ciUpper,
+  }));
+
+  const algorithms = Object.keys(result.algorithmWinRates);
+
+  return (
+    <div className="space-y-4">
+      {/* Sign test result */}
+      <div className={`rounded-md border p-4 ${
+        result.signTestPValue < 0.05
+          ? 'bg-green-50 border-green-200'
+          : 'bg-gray-50 border-gray-200'
+      }`}>
+        <h4 className={`text-sm font-semibold ${
+          result.signTestPValue < 0.05 ? 'text-green-800' : 'text-gray-800'
+        }`}>
+          Sign Test: p = {formatPValue(result.signTestPValue)}
+        </h4>
+        <p className={`mt-1 text-sm ${
+          result.signTestPValue < 0.05 ? 'text-green-700' : 'text-gray-600'
+        }`}>
+          {result.signTestPValue < 0.05
+            ? 'Significant difference detected between algorithms.'
+            : 'No significant difference between algorithms.'}
+        </p>
+      </div>
+
+      {/* Win rates chart */}
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <h4 className="mb-3 text-sm font-semibold text-gray-900">Algorithm Win Rates</h4>
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={winRateData} margin={{ left: 20, right: 20, top: 10, bottom: 10 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="algorithm" tick={{ fontSize: 12 }} />
+            <YAxis domain={[0, 1]} tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`} />
+            <Tooltip formatter={(v: number) => `${(v * 100).toFixed(1)}%`} />
+            <Bar dataKey="winRate" isAnimationActive={false}>
+              {winRateData.map((entry, index) => (
+                <Cell key={entry.algorithm} fill={index === 0 ? '#9ca3af' : '#4f46e5'} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Bradley-Terry strengths table */}
+      <div>
+        <h4 className="mb-2 text-sm font-semibold text-gray-900">Bradley-Terry Strength Estimates</h4>
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Algorithm</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Strength</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">95% CI</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {strengthData.map((s) => (
+                <tr key={s.algorithm}>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">{s.algorithm}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{s.strength.toFixed(3)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                    [{s.ciLower.toFixed(3)}, {s.ciUpper.toFixed(3)}]
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Position analysis heatmap */}
+      {result.positionAnalyses.length > 0 && (
+        <div>
+          <h4 className="mb-2 text-sm font-semibold text-gray-900">Position Engagement Rates</h4>
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Position</th>
+                  {algorithms.map((alg) => (
+                    <th key={alg} className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">{alg}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {result.positionAnalyses.map((pa) => (
+                  <tr key={pa.position}>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">#{pa.position}</td>
+                    {algorithms.map((alg) => {
+                      const rate = pa.algorithmEngagementRates[alg] ?? 0;
+                      const opacity = Math.max(0.1, rate);
+                      return (
+                        <td key={alg} className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                          <span
+                            className="inline-block rounded px-2 py-0.5"
+                            style={{ backgroundColor: `rgba(79, 70, 229, ${opacity})`, color: rate > 0.2 ? 'white' : '#374151' }}
+                          >
+                            {(rate * 100).toFixed(1)}%
+                          </span>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/novelty-tab.tsx
+++ b/ui/src/components/novelty-tab.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { NoveltyAnalysisResult } from '@/lib/types';
+import { getNoveltyAnalysis } from '@/lib/api';
+import { formatEffect } from '@/lib/utils';
+
+interface NoveltyTabProps {
+  experimentId: string;
+}
+
+export function NoveltyTab({ experimentId }: NoveltyTabProps) {
+  const [result, setResult] = useState<NoveltyAnalysisResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getNoveltyAnalysis(experimentId)
+      .then(setResult)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [experimentId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error || !result) {
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+        No novelty analysis available for this experiment.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Detection banner */}
+      {result.noveltyDetected ? (
+        <div className="rounded-md bg-amber-50 border border-amber-200 p-4">
+          <h4 className="text-sm font-semibold text-amber-800">Novelty Effect Detected</h4>
+          <p className="mt-1 text-sm text-amber-700">
+            The treatment effect for <span className="font-medium">{result.metricId}</span> shows
+            an exponential decay pattern. The current effect may overestimate the long-term impact.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md bg-green-50 border border-green-200 p-4">
+          <h4 className="text-sm font-semibold text-green-800">No Novelty Effect</h4>
+          <p className="mt-1 text-sm text-green-700">
+            Treatment effect appears stable over time.
+          </p>
+        </div>
+      )}
+
+      {/* Key metrics grid */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Current Effect</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {formatEffect(result.rawTreatmentEffect)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Steady-State Projection</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {formatEffect(result.projectedSteadyStateEffect)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Novelty Amplitude</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {formatEffect(result.noveltyAmplitude)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Decay Constant</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {result.decayConstantDays.toFixed(1)} days
+          </p>
+        </div>
+      </div>
+
+      {/* Stability status */}
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <h4 className="text-sm font-semibold text-gray-900">Stability Status</h4>
+        <div className="mt-2 flex items-center gap-3">
+          {result.isStabilized ? (
+            <>
+              <span className="inline-flex h-2.5 w-2.5 rounded-full bg-green-500" />
+              <span className="text-sm text-gray-700">Effect has stabilized</span>
+            </>
+          ) : (
+            <>
+              <span className="inline-flex h-2.5 w-2.5 animate-pulse rounded-full bg-amber-500" />
+              <span className="text-sm text-gray-700">
+                ~{result.daysUntilProjectedStability} days until projected stability
+              </span>
+            </>
+          )}
+        </div>
+        <p className="mt-2 text-xs text-gray-500">
+          Metric: {result.metricId}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,7 @@
-import type { AnalysisResult, CreateExperimentRequest, Experiment, ListExperimentsResponse, QueryLogEntry } from './types';
+import type {
+  AnalysisResult, CreateExperimentRequest, Experiment, ListExperimentsResponse,
+  QueryLogEntry, NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
+} from './types';
 import type { ExperimentState, ExperimentType } from './types';
 
 const MGMT_URL = process.env.NEXT_PUBLIC_MANAGEMENT_URL || 'http://localhost:50055';
@@ -133,5 +136,23 @@ export async function createExperiment(request: CreateExperimentRequest): Promis
 export async function getAnalysisResult(experimentId: string): Promise<AnalysisResult> {
   return callRpc<{ experimentId: string }, AnalysisResult>(
     ANALYSIS_URL, ANALYSIS_SVC, 'GetAnalysisResult', { experimentId },
+  );
+}
+
+export async function getNoveltyAnalysis(experimentId: string): Promise<NoveltyAnalysisResult> {
+  return callRpc<{ experimentId: string }, NoveltyAnalysisResult>(
+    ANALYSIS_URL, ANALYSIS_SVC, 'GetNoveltyAnalysis', { experimentId },
+  );
+}
+
+export async function getInterferenceAnalysis(experimentId: string): Promise<InterferenceAnalysisResult> {
+  return callRpc<{ experimentId: string }, InterferenceAnalysisResult>(
+    ANALYSIS_URL, ANALYSIS_SVC, 'GetInterferenceAnalysis', { experimentId },
+  );
+}
+
+export async function getInterleavingAnalysis(experimentId: string): Promise<InterleavingAnalysisResult> {
+  return callRpc<{ experimentId: string }, InterleavingAnalysisResult>(
+    ANALYSIS_URL, ANALYSIS_SVC, 'GetInterleavingAnalysis', { experimentId },
   );
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -137,3 +137,63 @@ export interface AnalysisResult {
   srmResult: SrmResult;
   computedAt: string;
 }
+
+// --- Novelty Analysis (M2.4) ---
+
+export interface NoveltyAnalysisResult {
+  experimentId: string;
+  metricId: string;
+  noveltyDetected: boolean;
+  rawTreatmentEffect: number;
+  projectedSteadyStateEffect: number;
+  noveltyAmplitude: number;
+  decayConstantDays: number;
+  isStabilized: boolean;
+  daysUntilProjectedStability: number;
+  computedAt: string;
+}
+
+// --- Interference Analysis (M2.5) ---
+
+export interface TitleSpillover {
+  contentId: string;
+  treatmentWatchRate: number;
+  controlWatchRate: number;
+  pValue: number;
+}
+
+export interface InterferenceAnalysisResult {
+  experimentId: string;
+  interferenceDetected: boolean;
+  jensenShannonDivergence: number;
+  jaccardSimilarityTop100: number;
+  treatmentGiniCoefficient: number;
+  controlGiniCoefficient: number;
+  treatmentCatalogCoverage: number;
+  controlCatalogCoverage: number;
+  spilloverTitles: TitleSpillover[];
+  computedAt: string;
+}
+
+// --- Interleaving Analysis (M2.6) ---
+
+export interface AlgorithmStrength {
+  algorithmId: string;
+  strength: number;
+  ciLower: number;
+  ciUpper: number;
+}
+
+export interface PositionAnalysis {
+  position: number;
+  algorithmEngagementRates: Record<string, number>;
+}
+
+export interface InterleavingAnalysisResult {
+  experimentId: string;
+  algorithmWinRates: Record<string, number>;
+  signTestPValue: number;
+  algorithmStrengths: AlgorithmStrength[];
+  positionAnalyses: PositionAnalysis[];
+  computedAt: string;
+}


### PR DESCRIPTION
## Summary

- Adds tabbed navigation to the results dashboard with **Overview**, **Novelty Effects**, **Content Interference**, and **Interleaving** tabs
- **Novelty tab**: exponential decay detection banner, current vs steady-state effect, decay constant, stability countdown
- **Interference tab**: Jensen-Shannon divergence, Jaccard similarity, Gini coefficient bars, spillover titles table with p-values
- **Interleaving tab**: sign test p-value, win rate bar chart (recharts), Bradley-Terry strength table, position engagement heatmap
- Adds MSW mock data and handlers for `GetNoveltyAnalysis`, `GetInterferenceAnalysis`, `GetInterleavingAnalysis` RPCs
- All data rendered from M4a Analysis service — no client-side statistical computation (bright line)

## What this unblocks

- Ready to integrate with Agent-4's live `AnalysisService` RPCs when M5 backend is available
- All three analysis tabs can swap from MSW mocks to real APIs with a single config change

## Test plan

- [x] 104 tests pass (16 new for analysis tabs)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] ESLint passes (`npx next lint`)
- [x] Tab navigation switches between all four views
- [x] Novelty tab shows detection banner, effect values, decay constant, stability status
- [x] Interference tab shows JSD, Jaccard, Gini bars, spillover titles
- [x] Interleaving tab shows sign test, win rates chart, Bradley-Terry table, position heatmap
- [x] Empty states render gracefully when analysis data is unavailable for an experiment

🤖 Generated with [Claude Code](https://claude.com/claude-code)