### PR TITLE
feat(m6): bandit dashboard — arm allocation, reward curves, Thompson params (M3.3)

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -18,7 +18,7 @@
 | Agent-3 | M3 Metrics | 🔵 Integration Testing | agent-3/feat/m2-m3-integration-tests | Agent-2 ↔ Agent-3 integration tests | — | Phase 1 done. Phase 2: M2.10 (PR #35), M2.11 (PR #34) done. Integration tests: SQL template ↔ M2 schema alignment, PgWriter query_log, notebook export, guardrail alert contract. |
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 3 In Progress | agent-4/feat/linucb-contextual-bandit | M3.1 LinUCB Contextual Bandit | — | M1.14–1.19 merged. M2.1–2.6 complete (PRs #25, #29, #38). M2.10 (Agent-4 part) in progress. M3.1 LinUCB PR open. |
 | Agent-5 | M5 Management | 🔵 Phase 2 | agent-5/feat/surrogate-crud | Sequential auto-conclude (Phase 2) | — | Surrogate CRUD + sequential auto-conclude. Unblocks Agent-4 (boundary crossing → auto-conclude integration). |
-| Agent-6 | M6 UI | 🔵 In Progress | agent-6/feat/analysis-tabs | Analysis tabs (M2.4–2.6 UI) complete, PR #56 | — | M1.25–1.27 done, M2.8–2.9 done. Analysis tabs: novelty, interference, interleaving. 104 tests pass. Next: bandit dashboard (M3.3, blocked on M3.1) or live API integration. |
+| Agent-6 | M6 UI | 🔵 In Progress | agent-6/feat/bandit-dashboard | Bandit dashboard (M3.3) complete | — | M1.25–1.27, M2.8–2.9, analysis tabs (PR #56), bandit dashboard done. 115 tests pass. Next: live API integration (Agent-5 ↔ Agent-6). |
 | Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/flag-experiment-linkage | Phase 2+3: Flag-experiment linkage + dependency tracking | — | M1.28–1.30 merged (PR #13). PR #36: production wiring. Flag-experiment linkage: PromoteToExperiment records experiment ID, ResolvePromotedExperiment auto-updates flag when experiment concludes. Dependency tracking: query flags by targeting rule. |
 
 **Legend**: 🟢 Complete | 🔵 In Progress | 🟡 Not Started (unblocked) | ⚪ Waiting (blocked) | 🔴 Blocked (critical path)
@@ -102,7 +102,7 @@
 |---|-----------|-------|--------|----------|
 | 3.1 | LinUCB contextual bandit | Agent-4 | 🔵 | Agent-1 (contextual bandit arm selection via SelectArm RPC), Agent-6 (bandit dashboard) |
 | 3.2 | Content cold-start bandit | Agent-4 | ⚪ | — |
-| 3.3 | Bandit dashboard (arm allocation, reward curves) | Agent-6 | ⚪ | — |
+| 3.3 | Bandit dashboard (arm allocation, reward curves) | Agent-6 | 🔵 | PR pending — arm allocation chart, reward rates, Thompson Sampling params, reward history |
 | 3.4 | Session-level experiment support (full pipeline) | Agent-1/2/3 | 🟡 | — | Agent-2 part done (session_id keyed events). Agent-1/3 parts pending. |
 | 3.5 | Playback QoE experiment pipeline | Agent-2/3 | 🟡 | — | Agent-2 part done (QoE validation + ingestion PR #40). Agent-3 part pending (Spark SQL). |
 | 3.6 | Cumulative holdout support | Agent-5 | ⚪ | — |

--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -2,11 +2,13 @@ import { http, HttpResponse } from 'msw';
 import {
   SEED_EXPERIMENTS, SEED_QUERY_LOG, SEED_ANALYSIS_RESULTS,
   SEED_NOVELTY_RESULTS, SEED_INTERFERENCE_RESULTS, SEED_INTERLEAVING_RESULTS,
+  SEED_BANDIT_RESULTS,
 } from './seed-data';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
 const METRICS_SVC = '*/experimentation.metrics.v1.MetricComputationService';
 const ANALYSIS_SVC = '*/experimentation.analysis.v1.AnalysisService';
+const BANDIT_SVC = '*/experimentation.bandit.v1.BanditPolicyService';
 
 export const handlers = [
   // ListExperiments
@@ -245,6 +247,19 @@ export const handlers = [
     if (!result) {
       return HttpResponse.json(
         { error: `No interleaving analysis for experiment ${body.experimentId}` },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(result);
+  }),
+
+  // GetBanditDashboard
+  http.post(`${BANDIT_SVC}/GetBanditDashboard`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_BANDIT_RESULTS[body.experimentId];
+    if (!result) {
+      return HttpResponse.json(
+        { error: `No bandit dashboard for experiment ${body.experimentId}` },
         { status: 404 },
       );
     }

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -1,6 +1,7 @@
 import type {
   AnalysisResult, Experiment, QueryLogEntry,
   NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
+  BanditDashboardResult,
 } from '@/lib/types';
 
 const INITIAL_EXPERIMENTS: Experiment[] = [
@@ -520,6 +521,43 @@ const INITIAL_INTERLEAVING_RESULTS: Record<string, InterleavingAnalysisResult> =
   },
 };
 
+/** Bandit dashboard mock — cold_start_bandit with Thompson Sampling. */
+const INITIAL_BANDIT_RESULTS: Record<string, BanditDashboardResult> = {
+  '44444444-4444-4444-4444-444444444444': {
+    experimentId: '44444444-4444-4444-4444-444444444444',
+    algorithm: 'THOMPSON_SAMPLING',
+    totalRewardsProcessed: 3842,
+    snapshotAt: '2026-03-05T16:00:00Z',
+    arms: [
+      { armId: 'v4-arm1', name: 'top_carousel', selectionCount: 1200, rewardCount: 312, rewardRate: 0.26, assignmentProbability: 0.35, alpha: 313, beta: 889, expectedReward: 0.260 },
+      { armId: 'v4-arm2', name: 'genre_row', selectionCount: 980, rewardCount: 196, rewardRate: 0.20, assignmentProbability: 0.18, alpha: 197, beta: 785, expectedReward: 0.201 },
+      { armId: 'v4-arm3', name: 'trending_section', selectionCount: 860, rewardCount: 224, rewardRate: 0.26, assignmentProbability: 0.32, alpha: 225, beta: 637, expectedReward: 0.261 },
+      { armId: 'v4-arm4', name: 'personalized_row', selectionCount: 802, rewardCount: 144, rewardRate: 0.18, assignmentProbability: 0.15, alpha: 145, beta: 659, expectedReward: 0.180 },
+    ],
+    isWarmup: false,
+    warmupObservations: 1000,
+    minExplorationFraction: 0.1,
+    rewardHistory: [
+      { timestamp: '2026-03-02T00:00:00Z', armId: 'top_carousel', cumulativeReward: 45, cumulativeSelections: 180 },
+      { timestamp: '2026-03-02T00:00:00Z', armId: 'genre_row', cumulativeReward: 32, cumulativeSelections: 170 },
+      { timestamp: '2026-03-02T00:00:00Z', armId: 'trending_section', cumulativeReward: 38, cumulativeSelections: 160 },
+      { timestamp: '2026-03-02T00:00:00Z', armId: 'personalized_row', cumulativeReward: 28, cumulativeSelections: 165 },
+      { timestamp: '2026-03-03T00:00:00Z', armId: 'top_carousel', cumulativeReward: 105, cumulativeSelections: 400 },
+      { timestamp: '2026-03-03T00:00:00Z', armId: 'genre_row', cumulativeReward: 68, cumulativeSelections: 350 },
+      { timestamp: '2026-03-03T00:00:00Z', armId: 'trending_section', cumulativeReward: 82, cumulativeSelections: 340 },
+      { timestamp: '2026-03-03T00:00:00Z', armId: 'personalized_row', cumulativeReward: 55, cumulativeSelections: 330 },
+      { timestamp: '2026-03-04T00:00:00Z', armId: 'top_carousel', cumulativeReward: 190, cumulativeSelections: 720 },
+      { timestamp: '2026-03-04T00:00:00Z', armId: 'genre_row', cumulativeReward: 120, cumulativeSelections: 580 },
+      { timestamp: '2026-03-04T00:00:00Z', armId: 'trending_section', cumulativeReward: 155, cumulativeSelections: 560 },
+      { timestamp: '2026-03-04T00:00:00Z', armId: 'personalized_row', cumulativeReward: 88, cumulativeSelections: 520 },
+      { timestamp: '2026-03-05T00:00:00Z', armId: 'top_carousel', cumulativeReward: 312, cumulativeSelections: 1200 },
+      { timestamp: '2026-03-05T00:00:00Z', armId: 'genre_row', cumulativeReward: 196, cumulativeSelections: 980 },
+      { timestamp: '2026-03-05T00:00:00Z', armId: 'trending_section', cumulativeReward: 224, cumulativeSelections: 860 },
+      { timestamp: '2026-03-05T00:00:00Z', armId: 'personalized_row', cumulativeReward: 144, cumulativeSelections: 802 },
+    ],
+  },
+};
+
 /** Mutable copy of seed data — MSW handlers mutate this in-place. */
 export let SEED_EXPERIMENTS: Experiment[] = structuredClone(INITIAL_EXPERIMENTS);
 export let SEED_QUERY_LOG: Record<string, QueryLogEntry[]> = structuredClone(INITIAL_QUERY_LOG);
@@ -527,6 +565,7 @@ export let SEED_ANALYSIS_RESULTS: AnalysisResult[] = structuredClone(INITIAL_ANA
 export let SEED_NOVELTY_RESULTS: Record<string, NoveltyAnalysisResult> = structuredClone(INITIAL_NOVELTY_RESULTS);
 export let SEED_INTERFERENCE_RESULTS: Record<string, InterferenceAnalysisResult> = structuredClone(INITIAL_INTERFERENCE_RESULTS);
 export let SEED_INTERLEAVING_RESULTS: Record<string, InterleavingAnalysisResult> = structuredClone(INITIAL_INTERLEAVING_RESULTS);
+export let SEED_BANDIT_RESULTS: Record<string, BanditDashboardResult> = structuredClone(INITIAL_BANDIT_RESULTS);
 
 /** Reset seed data to initial state. Call in afterEach for test isolation. */
 export function resetSeedData(): void {
@@ -536,4 +575,5 @@ export function resetSeedData(): void {
   SEED_NOVELTY_RESULTS = structuredClone(INITIAL_NOVELTY_RESULTS);
   SEED_INTERFERENCE_RESULTS = structuredClone(INITIAL_INTERFERENCE_RESULTS);
   SEED_INTERLEAVING_RESULTS = structuredClone(INITIAL_INTERLEAVING_RESULTS);
+  SEED_BANDIT_RESULTS = structuredClone(INITIAL_BANDIT_RESULTS);
 }

--- a/ui/src/__tests__/bandit-dashboard.test.tsx
+++ b/ui/src/__tests__/bandit-dashboard.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import BanditDashboardPage from '@/app/experiments/[id]/bandit/page';
+
+let mockExperimentId = '44444444-4444-4444-4444-444444444444';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: mockExperimentId }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// Mock recharts
+vi.mock('recharts', async () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  );
+  const Noop = () => null;
+
+  return {
+    ResponsiveContainer: Passthrough,
+    BarChart: Passthrough,
+    Bar: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    Tooltip: Noop,
+    Cell: Noop,
+  };
+});
+
+describe('Bandit Dashboard - cold_start_bandit (experiment 444...)', () => {
+  beforeEach(() => {
+    mockExperimentId = '44444444-4444-4444-4444-444444444444';
+  });
+
+  it('shows loading then renders dashboard', async () => {
+    render(<BanditDashboardPage />);
+
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Bandit Dashboard' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows experiment name and algorithm in summary', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('cold_start_bandit')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('THOMPSON SAMPLING')).toBeInTheDocument();
+  });
+
+  it('shows total rewards processed', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('3,842')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Active status when not in warmup', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+  });
+
+  it('renders arm statistics table with all 4 arms', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Arm Statistics')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('top_carousel')).toBeInTheDocument();
+    expect(screen.getByText('genre_row')).toBeInTheDocument();
+    expect(screen.getByText('trending_section')).toBeInTheDocument();
+    expect(screen.getByText('personalized_row')).toBeInTheDocument();
+  });
+
+  it('shows selection counts and reward rates', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Arm Statistics')).toBeInTheDocument();
+    });
+
+    // top_carousel: 1200 selections, 26.0% reward rate
+    expect(screen.getAllByText('1,200').length).toBeGreaterThanOrEqual(1);
+    // All reward rate values visible
+    expect(screen.getAllByText('26.0%').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows Thompson Sampling alpha/beta columns', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    // top_carousel alpha=313
+    expect(screen.getByText('313')).toBeInTheDocument();
+    // top_carousel beta=889
+    expect(screen.getByText('889')).toBeInTheDocument();
+  });
+
+  it('renders allocation and reward rate chart sections', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Arm Allocation')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Reward Rates')).toBeInTheDocument();
+    expect(screen.getByText('Reward Rate Over Time')).toBeInTheDocument();
+    expect(screen.getAllByTestId('responsive-container').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows min exploration floor', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Min exploration floor: 10%/)).toBeInTheDocument();
+    });
+  });
+
+  it('breadcrumb links to correct URLs', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Bandit Dashboard' })).toBeInTheDocument();
+    });
+
+    const expLinks = screen.getAllByText('Experiments');
+    expect(expLinks[0].closest('a')).toHaveAttribute('href', '/');
+
+    const detailLinks = screen.getAllByText('Detail');
+    expect(detailLinks[0].closest('a')).toHaveAttribute('href', '/experiments/44444444-4444-4444-4444-444444444444');
+  });
+});
+
+describe('Bandit Dashboard - error state', () => {
+  it('shows error for non-bandit experiment', async () => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed/i)).toBeInTheDocument();
+    });
+  });
+});
+

--- a/ui/src/app/experiments/[id]/bandit/page.tsx
+++ b/ui/src/app/experiments/[id]/bandit/page.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import type { Experiment, BanditDashboardResult } from '@/lib/types';
+import { getExperiment, getBanditDashboard } from '@/lib/api';
+import { formatDate } from '@/lib/utils';
+
+const ARM_COLORS = ['#4f46e5', '#0891b2', '#059669', '#d97706', '#dc2626', '#7c3aed'];
+
+export default function BanditDashboardPage() {
+  const params = useParams<{ id: string }>();
+  const [experiment, setExperiment] = useState<Experiment | null>(null);
+  const [dashboard, setDashboard] = useState<BanditDashboardResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!params.id) return;
+
+    Promise.all([getExperiment(params.id), getBanditDashboard(params.id)])
+      .then(([exp, bd]) => {
+        setExperiment(exp);
+        setDashboard(bd);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [params.id]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error || !experiment || !dashboard) {
+    return (
+      <div>
+        <nav className="mb-4 text-sm text-gray-500">
+          <Link href="/" className="hover:text-indigo-600">Experiments</Link>
+          <span className="mx-2">/</span>
+          <Link href={`/experiments/${params.id}`} className="hover:text-indigo-600">Detail</Link>
+          <span className="mx-2">/</span>
+          <span className="text-gray-900">Bandit</span>
+        </nav>
+        <div className="rounded-md bg-red-50 p-4">
+          <p className="text-sm text-red-700">
+            {error || 'No bandit dashboard available for this experiment.'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const allocationData = dashboard.arms.map((arm) => ({
+    name: arm.name,
+    probability: arm.assignmentProbability,
+  }));
+
+  const rewardRateData = dashboard.arms.map((arm) => ({
+    name: arm.name,
+    rewardRate: arm.rewardRate,
+  }));
+
+  // Build cumulative reward time series from rewardHistory
+  const uniqueTimestamps = [...new Set(dashboard.rewardHistory.map((p) => p.timestamp))].sort();
+  const rewardCurveData = uniqueTimestamps.map((ts) => {
+    const point: Record<string, unknown> = { date: formatDate(ts) };
+    for (const arm of dashboard.arms) {
+      const entry = dashboard.rewardHistory.find((p) => p.timestamp === ts && p.armId === arm.name);
+      if (entry) {
+        point[arm.name] = entry.cumulativeSelections > 0
+          ? entry.cumulativeReward / entry.cumulativeSelections
+          : 0;
+      }
+    }
+    return point;
+  });
+
+  const algorithmLabel = dashboard.algorithm.replace(/_/g, ' ');
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <nav className="mb-4 text-sm text-gray-500">
+        <Link href="/" className="hover:text-indigo-600">Experiments</Link>
+        <span className="mx-2">/</span>
+        <Link href={`/experiments/${params.id}`} className="hover:text-indigo-600">Detail</Link>
+        <span className="mx-2">/</span>
+        <span className="text-gray-900">Bandit</span>
+      </nav>
+
+      <h1 className="mb-6 text-2xl font-bold text-gray-900">Bandit Dashboard</h1>
+
+      {/* Summary bar */}
+      <div className="mb-6 flex items-center gap-6 rounded-lg border border-gray-200 bg-white px-4 py-3">
+        <div>
+          <span className="text-xs font-medium uppercase text-gray-500">Experiment</span>
+          <p className="text-sm font-medium text-gray-900">{experiment.name}</p>
+        </div>
+        <div>
+          <span className="text-xs font-medium uppercase text-gray-500">Algorithm</span>
+          <p className="text-sm text-gray-900">{algorithmLabel}</p>
+        </div>
+        <div>
+          <span className="text-xs font-medium uppercase text-gray-500">Rewards Processed</span>
+          <p className="text-sm text-gray-900">{dashboard.totalRewardsProcessed.toLocaleString()}</p>
+        </div>
+        <div>
+          <span className="text-xs font-medium uppercase text-gray-500">Last Snapshot</span>
+          <p className="text-sm text-gray-900">{formatDate(dashboard.snapshotAt)}</p>
+        </div>
+        <div>
+          <span className="text-xs font-medium uppercase text-gray-500">Status</span>
+          <p className="text-sm">
+            {dashboard.isWarmup ? (
+              <span className="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800">
+                Warmup ({dashboard.warmupObservations} obs)
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
+                Active
+              </span>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {/* Arm allocation chart */}
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-gray-900">Arm Allocation</h2>
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={allocationData} margin={{ left: 20, right: 20, top: 10, bottom: 10 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+              <YAxis domain={[0, 1]} tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`} />
+              <Tooltip formatter={(v: number) => `${(v * 100).toFixed(1)}%`} />
+              <Bar dataKey="probability" isAnimationActive={false}>
+                {allocationData.map((_, i) => (
+                  <Cell key={`alloc-${i}`} fill={ARM_COLORS[i % ARM_COLORS.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+          <p className="mt-2 text-xs text-gray-500">
+            Min exploration floor: {(dashboard.minExplorationFraction * 100).toFixed(0)}%
+          </p>
+        </div>
+      </section>
+
+      {/* Reward rates chart */}
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-gray-900">Reward Rates</h2>
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={rewardRateData} margin={{ left: 20, right: 20, top: 10, bottom: 10 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+              <YAxis domain={[0, 'auto']} tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`} />
+              <Tooltip formatter={(v: number) => `${(v * 100).toFixed(1)}%`} />
+              <Bar dataKey="rewardRate" isAnimationActive={false}>
+                {rewardRateData.map((_, i) => (
+                  <Cell key={`rr-${i}`} fill={ARM_COLORS[i % ARM_COLORS.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      {/* Reward curve over time */}
+      {rewardCurveData.length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-3 text-lg font-semibold text-gray-900">Reward Rate Over Time</h2>
+          <div className="rounded-lg border border-gray-200 bg-white p-4">
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={rewardCurveData} margin={{ left: 20, right: 20, top: 10, bottom: 10 }}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                <YAxis tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`} />
+                <Tooltip formatter={(v: number) => `${(v * 100).toFixed(1)}%`} />
+                {dashboard.arms.map((arm, i) => (
+                  <Bar key={arm.name} dataKey={arm.name} fill={ARM_COLORS[i % ARM_COLORS.length]} isAnimationActive={false} />
+                ))}
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+      )}
+
+      {/* Arm stats table */}
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-gray-900">Arm Statistics</h2>
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Arm</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Selections</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Rewards</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Reward Rate</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Allocation</th>
+                {dashboard.algorithm === 'THOMPSON_SAMPLING' && (
+                  <>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Alpha</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Beta</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {dashboard.arms.map((arm, i) => (
+                <tr key={arm.armId}>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                    <span className="mr-2 inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: ARM_COLORS[i % ARM_COLORS.length] }} />
+                    {arm.name}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{arm.selectionCount.toLocaleString()}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{arm.rewardCount.toLocaleString()}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{(arm.rewardRate * 100).toFixed(1)}%</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{(arm.assignmentProbability * 100).toFixed(1)}%</td>
+                  {dashboard.algorithm === 'THOMPSON_SAMPLING' && (
+                    <>
+                      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{arm.alpha?.toFixed(0)}</td>
+                      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">{arm.beta?.toFixed(0)}</td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -102,6 +102,14 @@ export default function ExperimentDetailPage() {
               View Results
             </Link>
           )}
+          {(experiment.type === 'MAB' || experiment.type === 'CONTEXTUAL_BANDIT') && experiment.state !== 'DRAFT' && (
+            <Link
+              href={`/experiments/${experiment.experimentId}/bandit`}
+              className="rounded-md bg-purple-600 px-3 py-2 text-sm font-medium text-white hover:bg-purple-700"
+            >
+              Bandit Dashboard
+            </Link>
+          )}
           <Link
             href={`/experiments/${experiment.experimentId}/sql`}
             className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   AnalysisResult, CreateExperimentRequest, Experiment, ListExperimentsResponse,
   QueryLogEntry, NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
+  BanditDashboardResult,
 } from './types';
 import type { ExperimentState, ExperimentType } from './types';
 
@@ -12,6 +13,9 @@ const METRICS_SVC = 'experimentation.metrics.v1.MetricComputationService';
 
 const ANALYSIS_URL = process.env.NEXT_PUBLIC_ANALYSIS_URL || 'http://localhost:50053';
 const ANALYSIS_SVC = 'experimentation.analysis.v1.AnalysisService';
+
+const BANDIT_URL = process.env.NEXT_PUBLIC_BANDIT_URL || 'http://localhost:50056';
+const BANDIT_SVC = 'experimentation.bandit.v1.BanditPolicyService';
 
 async function callRpc<Req, Res>(baseUrl: string, service: string, method: string, request: Req): Promise<Res> {
   const res = await fetch(`${baseUrl}/${service}/${method}`, {
@@ -154,5 +158,11 @@ export async function getInterferenceAnalysis(experimentId: string): Promise<Int
 export async function getInterleavingAnalysis(experimentId: string): Promise<InterleavingAnalysisResult> {
   return callRpc<{ experimentId: string }, InterleavingAnalysisResult>(
     ANALYSIS_URL, ANALYSIS_SVC, 'GetInterleavingAnalysis', { experimentId },
+  );
+}
+
+export async function getBanditDashboard(experimentId: string): Promise<BanditDashboardResult> {
+  return callRpc<{ experimentId: string }, BanditDashboardResult>(
+    BANDIT_URL, BANDIT_SVC, 'GetBanditDashboard', { experimentId },
   );
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -197,3 +197,38 @@ export interface InterleavingAnalysisResult {
   positionAnalyses: PositionAnalysis[];
   computedAt: string;
 }
+
+// --- Bandit Dashboard (M3.3) ---
+
+export type BanditAlgorithm = 'THOMPSON_SAMPLING' | 'LINEAR_UCB' | 'THOMPSON_LINEAR' | 'NEURAL_CONTEXTUAL';
+
+export interface BanditArmStats {
+  armId: string;
+  name: string;
+  selectionCount: number;
+  rewardCount: number;
+  rewardRate: number;
+  assignmentProbability: number;
+  alpha?: number;
+  beta?: number;
+  expectedReward?: number;
+}
+
+export interface RewardHistoryPoint {
+  timestamp: string;
+  armId: string;
+  cumulativeReward: number;
+  cumulativeSelections: number;
+}
+
+export interface BanditDashboardResult {
+  experimentId: string;
+  algorithm: BanditAlgorithm;
+  totalRewardsProcessed: number;
+  snapshotAt: string;
+  arms: BanditArmStats[];
+  isWarmup: boolean;
+  warmupObservations: number;
+  minExplorationFraction: number;
+  rewardHistory: RewardHistoryPoint[];
+}


### PR DESCRIPTION
## Summary

- Adds `/experiments/[id]/bandit` page for MAB and CONTEXTUAL_BANDIT experiments
- **Arm allocation chart**: bar chart showing current assignment probabilities per arm
- **Reward rates chart**: per-arm reward rate comparison
- **Reward rate over time**: cumulative reward history grouped by arm
- **Arm statistics table**: selections, rewards, reward rate, allocation, Thompson Sampling alpha/beta
- **Status indicator**: Warmup vs Active badge with observation count
- **Detail page link**: "Bandit Dashboard" button appears for bandit-type experiments (non-DRAFT)
- MSW mock for `cold_start_bandit` experiment (4 arms, Thompson Sampling, 3,842 rewards)

## What this unblocks

- M3.3 milestone complete — bandit visualization layer is ready
- Ready to integrate with Agent-4's live `BanditPolicyService.GetPolicySnapshot` RPC
- Cold-start affinity scores (via `ExportAffinityScores`) can be added in Phase 4

## Test plan

- [x] 115 tests pass (11 new for bandit dashboard)
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] Dashboard renders with all 4 arms from cold_start_bandit
- [x] Allocation chart, reward rate chart, and time series chart render
- [x] Thompson Sampling alpha/beta columns shown
- [x] Active/Warmup status badge displays correctly
- [x] Error state for non-bandit experiments
- [x] Breadcrumb links correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)