### PR TITLE
feat(m1): Team Draft Multileave — N-way interleaving (M2.7c)

### DIFF
--- a/crates/experimentation-assignment/benches/assignment_bench.rs
+++ b/crates/experimentation-assignment/benches/assignment_bench.rs
@@ -123,6 +123,48 @@ fn bench_optimized_interleave(c: &mut Criterion) {
     });
 }
 
+fn make_multileave_lists(n: usize) -> HashMap<String, RankedList> {
+    let mut m = HashMap::new();
+    for (i, algo) in ["algo_x", "algo_y", "algo_z"].iter().enumerate() {
+        m.insert(
+            algo.to_string(),
+            RankedList {
+                item_ids: (0..n).map(|j| format!("{algo}_item_{}_{j}", i)).collect(),
+            },
+        );
+    }
+    m
+}
+
+fn bench_multileave(c: &mut Criterion) {
+    let config = Config::from_json(DEV_CONFIG).unwrap();
+    let svc = AssignmentServiceImpl::from_config(Arc::new(config));
+
+    let lists_10 = make_multileave_lists(10);
+    c.bench_function("get_multileave_3_algos_10_items", |b| {
+        b.iter(|| {
+            svc.interleave(
+                black_box("exp_dev_007"),
+                black_box("user_42"),
+                black_box(&lists_10),
+            )
+            .unwrap()
+        })
+    });
+
+    let lists_50 = make_multileave_lists(50);
+    c.bench_function("get_multileave_3_algos_50_items", |b| {
+        b.iter(|| {
+            svc.interleave(
+                black_box("exp_dev_007"),
+                black_box("user_42"),
+                black_box(&lists_50),
+            )
+            .unwrap()
+        })
+    });
+}
+
 fn bench_bandit_assignment(c: &mut Criterion) {
     let config = Config::from_json(DEV_CONFIG).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
@@ -161,6 +203,7 @@ criterion_group!(
     bench_get_assignment,
     bench_get_interleaved_list,
     bench_optimized_interleave,
+    bench_multileave,
     bench_bandit_assignment,
 );
 criterion_main!(benches);

--- a/crates/experimentation-assignment/src/service.rs
+++ b/crates/experimentation-assignment/src/service.rs
@@ -183,7 +183,7 @@ impl AssignmentServiceImpl {
     /// Produce an interleaved list for a given experiment and user.
     ///
     /// Validates config, derives a deterministic RNG seed from (user_id, experiment_id),
-    /// then delegates to the Team Draft algorithm.
+    /// then dispatches to the appropriate interleaving algorithm.
     #[allow(clippy::result_large_err)]
     pub fn interleave(
         &self,
@@ -216,36 +216,7 @@ impl AssignmentServiceImpl {
             ))
         })?;
 
-        // 4. Request must contain exactly 2 algorithm lists (pairwise interleaving).
-        if algorithm_lists.len() != 2 {
-            return Err(Status::invalid_argument(format!(
-                "expected exactly 2 algorithm lists, got {}",
-                algorithm_lists.len(),
-            )));
-        }
-
-        // 5. Extract lists ordered by config algorithm_ids.
-        if il_config.algorithm_ids.len() != 2 {
-            return Err(Status::failed_precondition(format!(
-                "interleaving_config.algorithm_ids must have exactly 2 entries, got {}",
-                il_config.algorithm_ids.len(),
-            )));
-        }
-        let algo_a_id = &il_config.algorithm_ids[0];
-        let algo_b_id = &il_config.algorithm_ids[1];
-
-        let list_a = algorithm_lists.get(algo_a_id).ok_or_else(|| {
-            Status::invalid_argument(format!(
-                "missing algorithm list for '{algo_a_id}'",
-            ))
-        })?;
-        let list_b = algorithm_lists.get(algo_b_id).ok_or_else(|| {
-            Status::invalid_argument(format!(
-                "missing algorithm list for '{algo_b_id}'",
-            ))
-        })?;
-
-        // 6. Derive deterministic 64-bit seed from (user_id, experiment_id).
+        // 4. Derive deterministic 64-bit seed from (user_id, experiment_id).
         let seed_input = format!("{user_id}\x00{experiment_id}");
         let lo = experimentation_hash::murmur3::murmurhash3_x86_32(
             seed_input.as_bytes(),
@@ -258,29 +229,51 @@ impl AssignmentServiceImpl {
         let seed = (hi << 32) | lo;
         let mut rng = StdRng::seed_from_u64(seed);
 
-        // 7. Compute k = min(max_list_size, total available items).
-        let k = il_config
-            .max_list_size
-            .min(list_a.item_ids.len() + list_b.item_ids.len());
-
-        // 8. Delegate to interleaving algorithm based on method.
+        // 5. Dispatch by method.
         let result = match il_config.method.as_str() {
-            "TEAM_DRAFT" | "" => experimentation_interleaving::team_draft::team_draft(
-                &list_a.item_ids,
-                &list_b.item_ids,
-                algo_a_id,
-                algo_b_id,
-                k,
-                &mut rng,
-            ),
-            "OPTIMIZED" => experimentation_interleaving::optimized::optimized_interleave(
-                &list_a.item_ids,
-                &list_b.item_ids,
-                algo_a_id,
-                algo_b_id,
-                k,
-                &mut rng,
-            ),
+            "TEAM_DRAFT" | "" => {
+                let (algo_a_id, algo_b_id, list_a, list_b) =
+                    Self::extract_pairwise(il_config, algorithm_lists)?;
+                let k = il_config.max_list_size.min(list_a.len() + list_b.len());
+                experimentation_interleaving::team_draft::team_draft(
+                    list_a, list_b, algo_a_id, algo_b_id, k, &mut rng,
+                )
+            }
+            "OPTIMIZED" => {
+                let (algo_a_id, algo_b_id, list_a, list_b) =
+                    Self::extract_pairwise(il_config, algorithm_lists)?;
+                let k = il_config.max_list_size.min(list_a.len() + list_b.len());
+                experimentation_interleaving::optimized::optimized_interleave(
+                    list_a, list_b, algo_a_id, algo_b_id, k, &mut rng,
+                )
+            }
+            "MULTILEAVE" => {
+                // Require >= 3 algorithm_ids for multileave.
+                if il_config.algorithm_ids.len() < 3 {
+                    return Err(Status::failed_precondition(format!(
+                        "MULTILEAVE requires >= 3 algorithm_ids, got {}",
+                        il_config.algorithm_ids.len(),
+                    )));
+                }
+
+                // Build ordered (list, algo_id) vec from config order.
+                let mut ordered_lists: Vec<(&[String], &str)> = Vec::new();
+                let mut total_items = 0usize;
+                for algo_id in &il_config.algorithm_ids {
+                    let ranked = algorithm_lists.get(algo_id).ok_or_else(|| {
+                        Status::invalid_argument(format!(
+                            "missing algorithm list for '{algo_id}'",
+                        ))
+                    })?;
+                    total_items += ranked.item_ids.len();
+                    ordered_lists.push((&ranked.item_ids, algo_id.as_str()));
+                }
+
+                let k = il_config.max_list_size.min(total_items);
+                experimentation_interleaving::multileave::multileave(
+                    &ordered_lists, k, &mut rng,
+                )
+            }
             other => {
                 return Err(Status::invalid_argument(format!(
                     "unsupported interleaving method: {other}",
@@ -292,6 +285,39 @@ impl AssignmentServiceImpl {
             merged_list: result.merged_list,
             provenance: result.provenance,
         })
+    }
+
+    /// Validate and extract pairwise algorithm lists from a request.
+    ///
+    /// Enforces exactly 2 algorithm_ids in config and exactly 2 lists in request.
+    #[allow(clippy::result_large_err, clippy::type_complexity)]
+    fn extract_pairwise<'a>(
+        il_config: &'a crate::config::InterleavingConfig,
+        algorithm_lists: &'a HashMap<String, RankedList>,
+    ) -> Result<(&'a str, &'a str, &'a [String], &'a [String]), Status> {
+        if algorithm_lists.len() != 2 {
+            return Err(Status::invalid_argument(format!(
+                "expected exactly 2 algorithm lists, got {}",
+                algorithm_lists.len(),
+            )));
+        }
+        if il_config.algorithm_ids.len() != 2 {
+            return Err(Status::failed_precondition(format!(
+                "interleaving_config.algorithm_ids must have exactly 2 entries, got {}",
+                il_config.algorithm_ids.len(),
+            )));
+        }
+        let algo_a_id = il_config.algorithm_ids[0].as_str();
+        let algo_b_id = il_config.algorithm_ids[1].as_str();
+
+        let list_a = algorithm_lists.get(algo_a_id).ok_or_else(|| {
+            Status::invalid_argument(format!("missing algorithm list for '{algo_a_id}'"))
+        })?;
+        let list_b = algorithm_lists.get(algo_b_id).ok_or_else(|| {
+            Status::invalid_argument(format!("missing algorithm list for '{algo_b_id}'"))
+        })?;
+
+        Ok((algo_a_id, algo_b_id, &list_a.item_ids, &list_b.item_ids))
     }
 }
 

--- a/crates/experimentation-assignment/tests/assignment_test.rs
+++ b/crates/experimentation-assignment/tests/assignment_test.rs
@@ -637,6 +637,178 @@ fn unsupported_method_returns_error() {
     assert!(err.message().contains("unsupported interleaving method"));
 }
 
+// ── M3.x Tests (GetInterleavedList / Multileave) ──
+
+fn make_multi_algo_lists(items: &[(&str, &[&str])]) -> HashMap<String, RankedList> {
+    items
+        .iter()
+        .map(|(algo_id, item_ids)| {
+            (
+                algo_id.to_string(),
+                RankedList {
+                    item_ids: item_ids.iter().map(|s| s.to_string()).collect(),
+                },
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn multileave_basic_3_algorithms() {
+    let svc = make_service();
+    let lists = make_multi_algo_lists(&[
+        ("algo_x", &["i1", "i2", "i3", "i4", "i5"]),
+        ("algo_y", &["i6", "i7", "i8", "i9", "i10"]),
+        ("algo_z", &["i11", "i12", "i13", "i14", "i15"]),
+    ]);
+    let resp = svc.interleave("exp_dev_007", "user_1", &lists).unwrap();
+
+    assert!(!resp.merged_list.is_empty());
+    assert!(resp.merged_list.len() <= 15);
+    for item in &resp.merged_list {
+        assert!(resp.provenance.contains_key(item), "missing provenance for {item}");
+        let algo = &resp.provenance[item];
+        assert!(
+            ["algo_x", "algo_y", "algo_z"].contains(&algo.as_str()),
+            "unexpected provenance: {algo}"
+        );
+    }
+}
+
+#[test]
+fn multileave_deterministic() {
+    let svc = make_service();
+    let lists = make_multi_algo_lists(&[
+        ("algo_x", &["x1", "x2", "x3"]),
+        ("algo_y", &["y1", "y2", "y3"]),
+        ("algo_z", &["z1", "z2", "z3"]),
+    ]);
+    let r1 = svc.interleave("exp_dev_007", "user_42", &lists).unwrap();
+    let r2 = svc.interleave("exp_dev_007", "user_42", &lists).unwrap();
+    assert_eq!(r1.merged_list, r2.merged_list, "same inputs must produce same output");
+    assert_eq!(r1.provenance, r2.provenance);
+}
+
+#[test]
+fn multileave_balance_3_algorithms() {
+    let svc = make_service();
+    let mut counts: HashMap<String, u64> = HashMap::new();
+
+    for i in 0..1000 {
+        let user_id = format!("ml_balance_user_{i}");
+        let lists = make_multi_algo_lists(&[
+            ("algo_x", &["i1", "i2", "i3", "i4"]),
+            ("algo_y", &["i5", "i6", "i7", "i8"]),
+            ("algo_z", &["i9", "i10", "i11", "i12"]),
+        ]);
+        let resp = svc.interleave("exp_dev_007", &user_id, &lists).unwrap();
+        for algo in resp.provenance.values() {
+            *counts.entry(algo.clone()).or_insert(0) += 1;
+        }
+    }
+
+    let total: u64 = counts.values().sum();
+    for (algo, count) in &counts {
+        let frac = *count as f64 / total as f64;
+        assert!(
+            (0.25..=0.42).contains(&frac),
+            "algo {algo} fraction {frac:.3} outside [0.25, 0.42]"
+        );
+    }
+}
+
+#[test]
+fn multileave_dedup_across_3_lists() {
+    let svc = make_service();
+    let lists = make_multi_algo_lists(&[
+        ("algo_x", &["shared", "x_only"]),
+        ("algo_y", &["shared", "y_only"]),
+        ("algo_z", &["shared", "z_only"]),
+    ]);
+    let resp = svc.interleave("exp_dev_007", "user_1", &lists).unwrap();
+
+    let count_shared = resp.merged_list.iter().filter(|i| *i == "shared").count();
+    assert_eq!(count_shared, 1, "shared item should appear exactly once");
+    assert_eq!(resp.merged_list.len(), 4); // shared + x_only + y_only + z_only
+}
+
+#[test]
+fn multileave_respects_max_list_size() {
+    // exp_dev_007 has max_list_size=15. Provide 30 items total.
+    let svc = make_service();
+    let lists = make_multi_algo_lists(&[
+        ("algo_x", &["a0","a1","a2","a3","a4","a5","a6","a7","a8","a9"]),
+        ("algo_y", &["b0","b1","b2","b3","b4","b5","b6","b7","b8","b9"]),
+        ("algo_z", &["c0","c1","c2","c3","c4","c5","c6","c7","c8","c9"]),
+    ]);
+    let resp = svc.interleave("exp_dev_007", "user_1", &lists).unwrap();
+    assert!(
+        resp.merged_list.len() <= 15,
+        "merged list length {} exceeds max_list_size 15",
+        resp.merged_list.len(),
+    );
+}
+
+#[test]
+fn multileave_empty_lists() {
+    let svc = make_service();
+    let lists = make_multi_algo_lists(&[
+        ("algo_x", &[]),
+        ("algo_y", &[]),
+        ("algo_z", &[]),
+    ]);
+    let resp = svc.interleave("exp_dev_007", "user_1", &lists).unwrap();
+    assert!(resp.merged_list.is_empty());
+    assert!(resp.provenance.is_empty());
+}
+
+#[test]
+fn multileave_wrong_algo_count_for_multileave() {
+    // MULTILEAVE config with only 2 algorithm_ids → FailedPrecondition.
+    let json = r#"{
+        "experiments": [{
+            "experiment_id": "bad_multi",
+            "state": "RUNNING",
+            "type": "INTERLEAVING",
+            "hash_salt": "salt",
+            "layer_id": "layer_default",
+            "variants": [
+                { "variant_id": "a", "traffic_fraction": 0.5, "is_control": true, "payload_json": "{}" },
+                { "variant_id": "b", "traffic_fraction": 0.5, "is_control": false, "payload_json": "{}" }
+            ],
+            "allocation": { "start_bucket": 0, "end_bucket": 9999 },
+            "interleaving_config": {
+                "method": "MULTILEAVE",
+                "algorithm_ids": ["a", "b"],
+                "max_list_size": 10
+            }
+        }],
+        "layers": [{ "layer_id": "layer_default", "total_buckets": 10000 }]
+    }"#;
+
+    let config = Config::from_json(json).unwrap();
+    let svc = AssignmentServiceImpl::from_config(Arc::new(config));
+
+    let lists = make_algo_lists(&["x", "y"], &["z", "w"]);
+    let err = svc.interleave("bad_multi", "user_1", &lists).unwrap_err();
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    assert!(err.message().contains("MULTILEAVE requires >= 3"));
+}
+
+#[test]
+fn multileave_missing_algo_list_in_request() {
+    // Config has 3 algorithm_ids but request only provides 2 lists.
+    let svc = make_service();
+    let lists = make_multi_algo_lists(&[
+        ("algo_x", &["i1", "i2"]),
+        ("algo_y", &["i3", "i4"]),
+        // algo_z is missing
+    ]);
+    let err = svc.interleave("exp_dev_007", "user_1", &lists).unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("algo_z"));
+}
+
 // ── Bandit Delegation Tests (MAB / CONTEXTUAL_BANDIT) ──
 
 #[test]

--- a/crates/experimentation-interleaving/src/lib.rs
+++ b/crates/experimentation-interleaving/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements Team Draft (Phase 1), Optimized (Phase 2), and Multileave (Phase 3).
 
+pub mod multileave;
 pub mod optimized;
 pub mod team_draft;
 

--- a/crates/experimentation-interleaving/src/multileave.rs
+++ b/crates/experimentation-interleaving/src/multileave.rs
@@ -1,0 +1,286 @@
+//! Team Draft Multileave (Schuth et al., 2015).
+//!
+//! N-way generalization of Team Draft interleaving for comparing 3+
+//! ranking algorithms simultaneously. At each output position, the
+//! team with the fewest contributions picks next (ties broken uniformly
+//! at random). No floating-point computation.
+
+use super::InterleavedResult;
+use rand::Rng;
+use std::collections::{HashMap, HashSet};
+
+/// Produce an interleaved list using Team Draft Multileave.
+///
+/// # Arguments
+/// * `lists` - Slice of `(ranked_items, algorithm_id)` per algorithm
+/// * `k` - Maximum number of items in the merged list
+/// * `rng` - Random number generator (deterministic seed for reproducibility)
+pub fn multileave<R: Rng>(
+    lists: &[(&[String], &str)],
+    k: usize,
+    rng: &mut R,
+) -> InterleavedResult {
+    let n = lists.len();
+    let mut merged = Vec::with_capacity(k);
+    let mut provenance = HashMap::new();
+    let mut seen = HashSet::new();
+
+    // Per-team state: current pointer into ranked list and contribution count.
+    let mut pointers = vec![0usize; n];
+    let mut counts = vec![0usize; n];
+
+    while merged.len() < k {
+        // Advance each team's pointer past already-seen items.
+        for i in 0..n {
+            while pointers[i] < lists[i].0.len() && seen.contains(&lists[i].0[pointers[i]]) {
+                pointers[i] += 1;
+            }
+        }
+
+        // Find eligible teams (those with remaining unseen items).
+        let eligible: Vec<usize> = (0..n)
+            .filter(|&i| pointers[i] < lists[i].0.len())
+            .collect();
+
+        if eligible.is_empty() {
+            break;
+        }
+
+        // Among eligible teams, find the minimum contribution count.
+        let min_count = eligible.iter().map(|&i| counts[i]).min().unwrap();
+
+        // Collect teams tied at the minimum.
+        let candidates: Vec<usize> = eligible
+            .iter()
+            .filter(|&&i| counts[i] == min_count)
+            .copied()
+            .collect();
+
+        // Uniform random tie-breaking.
+        let chosen_team = candidates[rng.gen_range(0..candidates.len())];
+
+        let item = lists[chosen_team].0[pointers[chosen_team]].clone();
+        seen.insert(item.clone());
+        provenance.insert(item.clone(), lists[chosen_team].1.to_string());
+        merged.push(item);
+        counts[chosen_team] += 1;
+        pointers[chosen_team] += 1;
+    }
+
+    InterleavedResult {
+        merged_list: merged,
+        provenance,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_multileave_basic_3_lists() {
+        let l1 = s(&["a", "b", "c"]);
+        let l2 = s(&["d", "e", "f"]);
+        let l3 = s(&["g", "h", "i"]);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = multileave(
+            &[(&l1, "A"), (&l2, "B"), (&l3, "C")],
+            9,
+            &mut rng,
+        );
+
+        assert_eq!(result.merged_list.len(), 9);
+        for item in &result.merged_list {
+            assert!(result.provenance.contains_key(item));
+            let algo = &result.provenance[item];
+            assert!(["A", "B", "C"].contains(&algo.as_str()));
+        }
+    }
+
+    #[test]
+    fn test_multileave_deterministic() {
+        let l1 = s(&["a", "b", "c"]);
+        let l2 = s(&["d", "e", "f"]);
+        let l3 = s(&["g", "h", "i"]);
+
+        let mut rng1 = StdRng::seed_from_u64(12345);
+        let mut rng2 = StdRng::seed_from_u64(12345);
+
+        let r1 = multileave(&[(&l1, "A"), (&l2, "B"), (&l3, "C")], 9, &mut rng1);
+        let r2 = multileave(&[(&l1, "A"), (&l2, "B"), (&l3, "C")], 9, &mut rng2);
+
+        assert_eq!(r1.merged_list, r2.merged_list);
+        assert_eq!(r1.provenance, r2.provenance);
+    }
+
+    #[test]
+    fn test_multileave_balance_3_teams() {
+        let l1 = s(&["a1", "a2", "a3", "a4", "a5"]);
+        let l2 = s(&["b1", "b2", "b3", "b4", "b5"]);
+        let l3 = s(&["c1", "c2", "c3", "c4", "c5"]);
+
+        let mut totals = HashMap::new();
+
+        for seed in 0..1000u64 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let result = multileave(
+                &[(&l1, "A"), (&l2, "B"), (&l3, "C")],
+                15,
+                &mut rng,
+            );
+            for algo in result.provenance.values() {
+                *totals.entry(algo.clone()).or_insert(0u64) += 1;
+            }
+        }
+
+        let total: u64 = totals.values().sum();
+        for (algo, count) in &totals {
+            let frac = *count as f64 / total as f64;
+            assert!(
+                (0.25..=0.42).contains(&frac),
+                "algo {algo} fraction {frac:.3} outside [0.25, 0.42]"
+            );
+        }
+    }
+
+    #[test]
+    fn test_multileave_dedup_across_3() {
+        let l1 = s(&["shared", "a_only"]);
+        let l2 = s(&["shared", "b_only"]);
+        let l3 = s(&["shared", "c_only"]);
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let result = multileave(
+            &[(&l1, "A"), (&l2, "B"), (&l3, "C")],
+            10,
+            &mut rng,
+        );
+
+        let shared_count = result.merged_list.iter().filter(|i| *i == "shared").count();
+        assert_eq!(shared_count, 1, "shared item should appear exactly once");
+        assert_eq!(result.merged_list.len(), 4); // shared + a_only + b_only + c_only
+    }
+
+    #[test]
+    fn test_multileave_empty_lists() {
+        let l1: Vec<String> = vec![];
+        let l2: Vec<String> = vec![];
+        let l3: Vec<String> = vec![];
+        let mut rng = StdRng::seed_from_u64(0);
+
+        let result = multileave(
+            &[(&l1, "A"), (&l2, "B"), (&l3, "C")],
+            10,
+            &mut rng,
+        );
+
+        assert!(result.merged_list.is_empty());
+        assert!(result.provenance.is_empty());
+    }
+
+    #[test]
+    fn test_multileave_one_empty_among_three() {
+        let l1 = s(&["a", "b", "c"]);
+        let l2: Vec<String> = vec![];
+        let l3 = s(&["d", "e", "f"]);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = multileave(
+            &[(&l1, "A"), (&l2, "B"), (&l3, "C")],
+            10,
+            &mut rng,
+        );
+
+        assert_eq!(result.merged_list.len(), 6);
+        // Only A and C should have provenance.
+        for algo in result.provenance.values() {
+            assert!(algo == "A" || algo == "C", "unexpected algo: {algo}");
+        }
+    }
+
+    #[test]
+    fn test_multileave_k_smaller_than_total() {
+        let l1 = s(&["a", "b", "c", "d", "e"]);
+        let l2 = s(&["f", "g", "h", "i", "j"]);
+        let l3 = s(&["k", "l", "m", "n", "o"]);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = multileave(
+            &[(&l1, "A"), (&l2, "B"), (&l3, "C")],
+            5,
+            &mut rng,
+        );
+
+        assert_eq!(result.merged_list.len(), 5);
+    }
+
+    #[test]
+    fn test_multileave_4_algorithms() {
+        let l1 = s(&["a1", "a2", "a3"]);
+        let l2 = s(&["b1", "b2", "b3"]);
+        let l3 = s(&["c1", "c2", "c3"]);
+        let l4 = s(&["d1", "d2", "d3"]);
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let result = multileave(
+            &[(&l1, "A"), (&l2, "B"), (&l3, "C"), (&l4, "D")],
+            12,
+            &mut rng,
+        );
+
+        assert_eq!(result.merged_list.len(), 12);
+        let algos: HashSet<_> = result.provenance.values().collect();
+        assert_eq!(algos.len(), 4, "all 4 algorithms should contribute");
+    }
+
+    #[test]
+    fn test_multileave_5_algorithms_large() {
+        let lists: Vec<Vec<String>> = (0..5)
+            .map(|team| (0..20).map(|i| format!("t{team}_item_{i}")).collect())
+            .collect();
+        let mut rng = StdRng::seed_from_u64(42);
+
+        let refs: Vec<(&[String], &str)> = vec![
+            (&lists[0], "A"),
+            (&lists[1], "B"),
+            (&lists[2], "C"),
+            (&lists[3], "D"),
+            (&lists[4], "E"),
+        ];
+
+        let result = multileave(&refs, 50, &mut rng);
+
+        assert_eq!(result.merged_list.len(), 50); // 5 × 20 = 100 items, k=50
+        let unique: HashSet<_> = result.merged_list.iter().collect();
+        assert_eq!(unique.len(), 50, "no duplicates in merged list");
+
+        let algos: HashSet<_> = result.provenance.values().collect();
+        assert_eq!(algos.len(), 5, "all 5 algorithms should contribute");
+    }
+
+    #[test]
+    fn test_multileave_single_item_lists() {
+        let l1 = s(&["only_a"]);
+        let l2 = s(&["only_b"]);
+        let l3 = s(&["only_c"]);
+        let mut rng = StdRng::seed_from_u64(99);
+
+        let result = multileave(
+            &[(&l1, "A"), (&l2, "B"), (&l3, "C")],
+            10,
+            &mut rng,
+        );
+
+        assert_eq!(result.merged_list.len(), 3);
+        assert!(result.merged_list.contains(&"only_a".to_string()));
+        assert!(result.merged_list.contains(&"only_b".to_string()));
+        assert!(result.merged_list.contains(&"only_c".to_string()));
+    }
+}

--- a/dev/config.json
+++ b/dev/config.json
@@ -117,6 +117,25 @@
         "algorithm_ids": ["algo_a", "algo_b"],
         "max_list_size": 10
       }
+    },
+    {
+      "experiment_id": "exp_dev_007",
+      "name": "Multileave 3-Algorithm Ranker Test",
+      "state": "RUNNING",
+      "type": "INTERLEAVING",
+      "hash_salt": "dev_salt_007",
+      "layer_id": "layer_interleave_multi",
+      "variants": [
+        { "variant_id": "algo_x", "traffic_fraction": 0.34, "is_control": true, "payload_json": "{}" },
+        { "variant_id": "algo_y", "traffic_fraction": 0.33, "is_control": false, "payload_json": "{}" },
+        { "variant_id": "algo_z", "traffic_fraction": 0.33, "is_control": false, "payload_json": "{}" }
+      ],
+      "allocation": { "start_bucket": 0, "end_bucket": 9999 },
+      "interleaving_config": {
+        "method": "MULTILEAVE",
+        "algorithm_ids": ["algo_x", "algo_y", "algo_z"],
+        "max_list_size": 15
+      }
     }
   ],
   "layers": [
@@ -124,6 +143,7 @@
     { "layer_id": "layer_session", "total_buckets": 10000 },
     { "layer_id": "layer_interleave", "total_buckets": 10000 },
     { "layer_id": "layer_bandit", "total_buckets": 10000 },
-    { "layer_id": "layer_interleave_opt", "total_buckets": 10000 }
+    { "layer_id": "layer_interleave_opt", "total_buckets": 10000 },
+    { "layer_id": "layer_interleave_multi", "total_buckets": 10000 }
   ]
 }

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -13,7 +13,7 @@
 
 | Agent | Module | Status | Current Branch | Current Milestone | Blocked By | Notes |
 |-------|--------|--------|----------------|-------------------|------------|-------|
-| Agent-1 | M1 Assignment | 🔵 Phase 2 In Progress | agent-1/feat/interleaved-list-rpc | Optimized Interleaving (M2.7b) | — | M1.1–1.5 + M2.7 + Bandit delegation complete. M2.7b: Optimized Interleaving (greedy softmax) with method dispatch. |
+| Agent-1 | M1 Assignment | 🔵 Phase 2 In Progress | agent-1/feat/multileave-interleaving | Multileave (M2.7c) | — | M1.1–1.5 + M2.7 + M2.7b + Bandit delegation complete. M2.7c: Team Draft Multileave (3+ algorithms). |
 | Agent-2 | M2 Pipeline | 🟢 All Phases Complete | agent-2/feat/e2e-pipeline-tests | Service-layer tests + Producer trait extraction | — | Phase 1 (PRs #1, #8), Phase 2 (PR #23), Phase 3 (PR #40), Phase 4 (PRs #48, #59) all merged. 78 tests (36 pipeline + 42 ingest). Producer trait enables mock-based testing. |
 | Agent-3 | M3 Metrics | 🔵 Contract Testing | agent-3/test/m3-m4-integration-contract | M3 ↔ M4a data contract tests | — | Phase 1 done. Phase 2 done (M2.10 PR #35, M2.11 PR #34). M2↔M3 integration tests merged (PR #51). M3↔M4a contract tests: 33 tests verify SQL template output columns match Delta Lake schemas M4a reads. CI optimization (PR #58): skip Rust jobs on non-Rust changes. |
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 3 In Progress | agent-4/feat/cold-start-bandit | M3.2 Content Cold-Start Bandit | — | M1.14–1.19 merged. M2.1–2.6, M2.10 complete. M3.1 LinUCB merged (PR #54). M3.2 cold-start bandit in progress. |
@@ -91,6 +91,7 @@
 | 2.6 | Interleaving analysis (Team Draft scoring) | Agent-4 | 🟢 | Agent-6 (interleaving tab) | PR #38 — Sign test, Bradley-Terry MM, position analysis |
 | 2.7 | GetInterleavedList RPC (Team Draft) | Agent-1 | 🟢 | Agent-4 (interleaving analysis) |
 | 2.7b | Optimized Interleaving (softmax method) | Agent-1 | 🟢 | Agent-4 (interleaving analysis — sensitivity comparison) |
+| 2.7c | Multileave Interleaving (Team Draft N-way) | Agent-1 | 🟢 | Agent-4 (N-way ranking comparison) |
 | 2.8 | Results dashboard (treatment effects, CI chart, sequential boundary) | Agent-6 | 🟢 | Stakeholder demo |
 | 2.9 | Notebook export (.ipynb from query log) | Agent-6 | 🟢 | — |
 | 2.10 | Surrogate metric framework (M3 + M4a) | Agent-3/4 | 🟢 | Agent-3 part: PR #35. Agent-4 part: PR #43. Both merged. |


### PR DESCRIPTION
## Summary

- **Team Draft Multileave** (Schuth et al., 2015): N-way generalization of Team Draft for comparing 3+ ranking algorithms simultaneously
- Refactored `interleave()` into method-based dispatch (`TEAM_DRAFT`, `OPTIMIZED`, `MULTILEAVE`) with extracted `extract_pairwise()` helper
- `MULTILEAVE` validates `>= 3` algorithm_ids in config and matches request lists to config order
- Added `exp_dev_007` (3-algorithm MULTILEAVE experiment) to dev config
- Purely integer-based algorithm — no floating-point computation, no `assert_finite!` needed

## Files Changed

| File | Action |
|------|--------|
| `crates/experimentation-interleaving/src/multileave.rs` | **New** — Core algorithm (~70 lines) + 10 unit tests |
| `crates/experimentation-interleaving/src/lib.rs` | Added `pub mod multileave` |
| `crates/experimentation-assignment/src/service.rs` | Refactored dispatch + `MULTILEAVE` branch |
| `dev/config.json` | `exp_dev_007` + `layer_interleave_multi` |
| `crates/experimentation-assignment/tests/assignment_test.rs` | 8 integration tests |
| `crates/experimentation-assignment/benches/assignment_bench.rs` | 2 benchmarks (3 algos × 10/50 items) |
| `docs/coordination/status.md` | M2.7c milestone marked 🟢 |

## Test Results

- `experimentation-interleaving`: 29 tests pass (10 new + 19 existing)
- `experimentation-assignment`: 82 tests pass (8 new + 74 existing)
- `clippy --all-features -- -D warnings`: zero warnings
- Backward compatible: TEAM_DRAFT and OPTIMIZED paths unchanged

## Unblocks

- Agent-4: Multi-algorithm interleaving analysis (extending Team Draft scoring to N-way)

## Test plan

- [x] `cargo test --package experimentation-interleaving` — 29 pass
- [x] `cargo test --package experimentation-assignment` — 82 pass
- [x] `cargo clippy` — zero warnings
- [x] Determinism: same (user_id, experiment_id) → same interleaved list
- [x] Balance: each of 3 algorithms contributes ~33% (±8%) over 1000 users
- [x] Error paths: MULTILEAVE with 2 algos → FailedPrecondition; missing list → InvalidArgument

🤖 Generated with [Claude Code](https://claude.com/claude-code)