### PR TITLE
feat(m5): RBAC interceptor with role-based permissions (M4.4)

### DIFF
--- a/services/management/cmd/main.go
+++ b/services/management/cmd/main.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 	"syscall"
 
+	"connectrpc.com/connect"
+
 	"github.com/org/experimentation/gen/go/experimentation/assignment/v1/assignmentv1connect"
 	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
 
+	"github.com/org/experimentation-platform/services/management/internal/auth"
 	"github.com/org/experimentation-platform/services/management/internal/guardrail"
 	"github.com/org/experimentation-platform/services/management/internal/handlers"
 	"github.com/org/experimentation-platform/services/management/internal/sequential"
@@ -85,6 +88,20 @@ func main() {
 	}
 	streamSvc := handlers.NewConfigStreamService(experimentStore, notifier)
 
+	// Auth interceptors.
+	var handlerOpts []connect.HandlerOption
+	var streamOpts []connect.HandlerOption
+	if os.Getenv("DISABLE_AUTH") == "true" {
+		slog.Warn("auth disabled via DISABLE_AUTH=true")
+	} else {
+		handlerOpts = append(handlerOpts,
+			connect.WithInterceptors(auth.NewAuthInterceptor()),
+		)
+		streamOpts = append(streamOpts,
+			connect.WithInterceptors(auth.NewStreamAuthInterceptor()),
+		)
+	}
+
 	// Register ConnectRPC handlers on mux.
 	mux := http.NewServeMux()
 
@@ -94,10 +111,10 @@ func main() {
 		fmt.Fprint(w, "ok")
 	})
 
-	mgmtPath, mgmtHandler := managementv1connect.NewExperimentManagementServiceHandler(expSvc)
+	mgmtPath, mgmtHandler := managementv1connect.NewExperimentManagementServiceHandler(expSvc, handlerOpts...)
 	mux.Handle(mgmtPath, mgmtHandler)
 
-	streamPath, streamHandler := assignmentv1connect.NewAssignmentServiceHandler(streamSvc)
+	streamPath, streamHandler := assignmentv1connect.NewAssignmentServiceHandler(streamSvc, streamOpts...)
 	mux.Handle(streamPath, streamHandler)
 
 	srv := &http.Server{

--- a/services/management/internal/auth/auth_test.go
+++ b/services/management/internal/auth/auth_test.go
@@ -1,0 +1,259 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
+
+	"github.com/org/experimentation-platform/services/management/internal/auth"
+)
+
+func TestParseRole(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    auth.Role
+		wantErr bool
+	}{
+		{"viewer", auth.RoleViewer, false},
+		{"analyst", auth.RoleAnalyst, false},
+		{"experimenter", auth.RoleExperimenter, false},
+		{"admin", auth.RoleAdmin, false},
+		{"superadmin", "", true},
+		{"", "", true},
+		{"ADMIN", "", true}, // case-sensitive
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := auth.ParseRole(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRoleHasAtLeast(t *testing.T) {
+	tests := []struct {
+		role    auth.Role
+		min     auth.Role
+		allowed bool
+	}{
+		{auth.RoleAdmin, auth.RoleAdmin, true},
+		{auth.RoleAdmin, auth.RoleExperimenter, true},
+		{auth.RoleAdmin, auth.RoleAnalyst, true},
+		{auth.RoleAdmin, auth.RoleViewer, true},
+		{auth.RoleExperimenter, auth.RoleExperimenter, true},
+		{auth.RoleExperimenter, auth.RoleAnalyst, true},
+		{auth.RoleExperimenter, auth.RoleViewer, true},
+		{auth.RoleExperimenter, auth.RoleAdmin, false},
+		{auth.RoleAnalyst, auth.RoleAnalyst, true},
+		{auth.RoleAnalyst, auth.RoleViewer, true},
+		{auth.RoleAnalyst, auth.RoleExperimenter, false},
+		{auth.RoleAnalyst, auth.RoleAdmin, false},
+		{auth.RoleViewer, auth.RoleViewer, true},
+		{auth.RoleViewer, auth.RoleAnalyst, false},
+		{auth.RoleViewer, auth.RoleExperimenter, false},
+		{auth.RoleViewer, auth.RoleAdmin, false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.role)+">="+string(tt.min), func(t *testing.T) {
+			assert.Equal(t, tt.allowed, tt.role.HasAtLeast(tt.min))
+		})
+	}
+}
+
+func TestIdentityContext(t *testing.T) {
+	id := auth.Identity{Email: "alice@example.com", Role: auth.RoleExperimenter}
+	ctx := auth.WithIdentity(context.Background(), id)
+
+	got, err := auth.FromContext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, id, got)
+}
+
+func TestFromContextMissing(t *testing.T) {
+	_, err := auth.FromContext(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+// stubManagementService implements the management service interface with stubs.
+type stubManagementService struct {
+	managementv1connect.UnimplementedExperimentManagementServiceHandler
+	capturedCtx context.Context
+}
+
+func (s *stubManagementService) GetExperiment(ctx context.Context, _ *connect.Request[mgmtv1.GetExperimentRequest]) (*connect.Response[commonv1.Experiment], error) {
+	s.capturedCtx = ctx
+	return connect.NewResponse(&commonv1.Experiment{}), nil
+}
+
+func (s *stubManagementService) CreateExperiment(ctx context.Context, _ *connect.Request[mgmtv1.CreateExperimentRequest]) (*connect.Response[commonv1.Experiment], error) {
+	s.capturedCtx = ctx
+	return connect.NewResponse(&commonv1.Experiment{}), nil
+}
+
+func (s *stubManagementService) ArchiveExperiment(ctx context.Context, _ *connect.Request[mgmtv1.ArchiveExperimentRequest]) (*connect.Response[commonv1.Experiment], error) {
+	s.capturedCtx = ctx
+	return connect.NewResponse(&commonv1.Experiment{}), nil
+}
+
+// withAuthHeaders returns a client option that injects auth headers.
+func withAuthHeaders(email, role string) connect.ClientOption {
+	return connect.WithInterceptors(connect.UnaryInterceptorFunc(
+		func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				req.Header().Set(auth.HeaderUserEmail, email)
+				req.Header().Set(auth.HeaderUserRole, role)
+				return next(ctx, req)
+			}
+		},
+	))
+}
+
+func setupStubServer(t *testing.T) (*stubManagementService, string, func()) {
+	t.Helper()
+	stub := &stubManagementService{}
+	mux := http.NewServeMux()
+	path, handler := managementv1connect.NewExperimentManagementServiceHandler(stub,
+		connect.WithInterceptors(auth.NewAuthInterceptor()),
+	)
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	return stub, server.URL, server.Close
+}
+
+func TestInterceptor_ValidRequest(t *testing.T) {
+	stub, url, cleanup := setupStubServer(t)
+	defer cleanup()
+
+	client := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, url,
+		withAuthHeaders("alice@example.com", "viewer"),
+	)
+
+	_, err := client.GetExperiment(context.Background(), connect.NewRequest(&mgmtv1.GetExperimentRequest{
+		ExperimentId: "test-id",
+	}))
+	require.NoError(t, err)
+
+	id, err := auth.FromContext(stub.capturedCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", id.Email)
+	assert.Equal(t, auth.RoleViewer, id.Role)
+}
+
+func TestInterceptor_MissingEmail(t *testing.T) {
+	_, url, cleanup := setupStubServer(t)
+	defer cleanup()
+
+	client := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, url,
+		connect.WithInterceptors(connect.UnaryInterceptorFunc(
+			func(next connect.UnaryFunc) connect.UnaryFunc {
+				return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+					req.Header().Set(auth.HeaderUserRole, "viewer")
+					return next(ctx, req)
+				}
+			},
+		)),
+	)
+
+	_, err := client.GetExperiment(context.Background(), connect.NewRequest(&mgmtv1.GetExperimentRequest{
+		ExperimentId: "test-id",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestInterceptor_MissingRole(t *testing.T) {
+	_, url, cleanup := setupStubServer(t)
+	defer cleanup()
+
+	client := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, url,
+		connect.WithInterceptors(connect.UnaryInterceptorFunc(
+			func(next connect.UnaryFunc) connect.UnaryFunc {
+				return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+					req.Header().Set(auth.HeaderUserEmail, "alice@example.com")
+					return next(ctx, req)
+				}
+			},
+		)),
+	)
+
+	_, err := client.GetExperiment(context.Background(), connect.NewRequest(&mgmtv1.GetExperimentRequest{
+		ExperimentId: "test-id",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestInterceptor_InvalidRole(t *testing.T) {
+	_, url, cleanup := setupStubServer(t)
+	defer cleanup()
+
+	client := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, url,
+		withAuthHeaders("alice@example.com", "superadmin"),
+	)
+
+	_, err := client.GetExperiment(context.Background(), connect.NewRequest(&mgmtv1.GetExperimentRequest{
+		ExperimentId: "test-id",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestInterceptor_InsufficientRole(t *testing.T) {
+	_, url, cleanup := setupStubServer(t)
+	defer cleanup()
+
+	// Viewer trying to create (requires experimenter).
+	client := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, url,
+		withAuthHeaders("viewer@example.com", "viewer"),
+	)
+
+	_, err := client.CreateExperiment(context.Background(), connect.NewRequest(&mgmtv1.CreateExperimentRequest{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestInterceptor_AdminOnlyArchive(t *testing.T) {
+	_, url, cleanup := setupStubServer(t)
+	defer cleanup()
+
+	// Experimenter trying to archive (requires admin).
+	expClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, url,
+		withAuthHeaders("exp@example.com", "experimenter"),
+	)
+	_, err := expClient.ArchiveExperiment(context.Background(), connect.NewRequest(&mgmtv1.ArchiveExperimentRequest{
+		ExperimentId: "test-id",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// Admin should pass.
+	adminClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, url,
+		withAuthHeaders("admin@example.com", "admin"),
+	)
+	_, err = adminClient.ArchiveExperiment(context.Background(), connect.NewRequest(&mgmtv1.ArchiveExperimentRequest{
+		ExperimentId: "test-id",
+	}))
+	require.NoError(t, err)
+}

--- a/services/management/internal/auth/identity.go
+++ b/services/management/internal/auth/identity.go
@@ -1,0 +1,65 @@
+// Package auth provides identity extraction, role-based access control,
+// and ConnectRPC interceptors for the management service.
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+)
+
+// Role represents a user's authorization level.
+type Role string
+
+const (
+	RoleViewer       Role = "viewer"
+	RoleAnalyst      Role = "analyst"
+	RoleExperimenter Role = "experimenter"
+	RoleAdmin        Role = "admin"
+)
+
+// roleRank maps each role to a numeric rank for hierarchical comparison.
+var roleRank = map[Role]int{
+	RoleViewer:       0,
+	RoleAnalyst:      1,
+	RoleExperimenter: 2,
+	RoleAdmin:        3,
+}
+
+// ParseRole validates a role string and returns the corresponding Role.
+func ParseRole(s string) (Role, error) {
+	r := Role(s)
+	if _, ok := roleRank[r]; !ok {
+		return "", fmt.Errorf("invalid role %q: must be one of viewer, analyst, experimenter, admin", s)
+	}
+	return r, nil
+}
+
+// HasAtLeast returns true if this role meets or exceeds the minimum role.
+func (r Role) HasAtLeast(minimum Role) bool {
+	return roleRank[r] >= roleRank[minimum]
+}
+
+// Identity represents an authenticated user extracted from API gateway headers.
+type Identity struct {
+	Email string
+	Role  Role
+}
+
+type contextKey struct{}
+
+// WithIdentity stores an Identity in the context.
+func WithIdentity(ctx context.Context, id Identity) context.Context {
+	return context.WithValue(ctx, contextKey{}, id)
+}
+
+// FromContext retrieves the Identity from the context.
+// Returns a connect.CodeUnauthenticated error if no identity is present.
+func FromContext(ctx context.Context) (Identity, error) {
+	id, ok := ctx.Value(contextKey{}).(Identity)
+	if !ok {
+		return Identity{}, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("no identity in context"))
+	}
+	return id, nil
+}

--- a/services/management/internal/auth/interceptor.go
+++ b/services/management/internal/auth/interceptor.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"connectrpc.com/connect"
+
+	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
+)
+
+const (
+	// HeaderUserEmail is the HTTP header set by the API gateway containing the authenticated user's email.
+	HeaderUserEmail = "X-User-Email"
+	// HeaderUserRole is the HTTP header set by the API gateway containing the user's role.
+	HeaderUserRole = "X-User-Role"
+)
+
+// procedurePermissions maps each RPC procedure to the minimum role required.
+var procedurePermissions = map[string]Role{
+	// Read-only operations — viewer
+	managementv1connect.ExperimentManagementServiceGetExperimentProcedure:             RoleViewer,
+	managementv1connect.ExperimentManagementServiceListExperimentsProcedure:            RoleViewer,
+	managementv1connect.ExperimentManagementServiceGetMetricDefinitionProcedure:        RoleViewer,
+	managementv1connect.ExperimentManagementServiceListMetricDefinitionsProcedure:      RoleViewer,
+	managementv1connect.ExperimentManagementServiceGetLayerProcedure:                   RoleViewer,
+	managementv1connect.ExperimentManagementServiceGetLayerAllocationsProcedure:        RoleViewer,
+	managementv1connect.ExperimentManagementServiceListSurrogateModelsProcedure:        RoleViewer,
+	managementv1connect.ExperimentManagementServiceGetSurrogateCalibrationProcedure:    RoleViewer,
+
+	// Analyst operations
+	managementv1connect.ExperimentManagementServiceCreateMetricDefinitionProcedure:        RoleAnalyst,
+	managementv1connect.ExperimentManagementServiceCreateTargetingRuleProcedure:            RoleAnalyst,
+	managementv1connect.ExperimentManagementServiceCreateSurrogateModelProcedure:           RoleAnalyst,
+	managementv1connect.ExperimentManagementServiceTriggerSurrogateRecalibrationProcedure:  RoleAnalyst,
+
+	// Experimenter operations
+	managementv1connect.ExperimentManagementServiceCreateExperimentProcedure:   RoleExperimenter,
+	managementv1connect.ExperimentManagementServiceUpdateExperimentProcedure:   RoleExperimenter,
+	managementv1connect.ExperimentManagementServiceStartExperimentProcedure:    RoleExperimenter,
+	managementv1connect.ExperimentManagementServicePauseExperimentProcedure:    RoleExperimenter,
+	managementv1connect.ExperimentManagementServiceResumeExperimentProcedure:   RoleExperimenter,
+	managementv1connect.ExperimentManagementServiceConcludeExperimentProcedure: RoleExperimenter,
+
+	// Admin operations
+	managementv1connect.ExperimentManagementServiceArchiveExperimentProcedure: RoleAdmin,
+	managementv1connect.ExperimentManagementServiceCreateLayerProcedure:       RoleAdmin,
+}
+
+// NewAuthInterceptor returns a unary ConnectRPC interceptor that extracts identity
+// from API gateway headers and enforces role-based permissions.
+func NewAuthInterceptor() connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			email := req.Header().Get(HeaderUserEmail)
+			if email == "" {
+				return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("missing %s header", HeaderUserEmail))
+			}
+
+			roleStr := req.Header().Get(HeaderUserRole)
+			if roleStr == "" {
+				return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("missing %s header", HeaderUserRole))
+			}
+
+			role, err := ParseRole(roleStr)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeUnauthenticated, err)
+			}
+
+			// Determine required role for this procedure.
+			required, ok := procedurePermissions[req.Spec().Procedure]
+			if !ok {
+				// Unknown procedures default to admin.
+				required = RoleAdmin
+				slog.Warn("unknown procedure, defaulting to admin", "procedure", req.Spec().Procedure)
+			}
+
+			if !role.HasAtLeast(required) {
+				return nil, connect.NewError(connect.CodePermissionDenied,
+					fmt.Errorf("role %q insufficient for %s (requires %s)", role, req.Spec().Procedure, required))
+			}
+
+			ctx = WithIdentity(ctx, Identity{Email: email, Role: role})
+			return next(ctx, req)
+		}
+	}
+}

--- a/services/management/internal/auth/stream_interceptor.go
+++ b/services/management/internal/auth/stream_interceptor.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+
+	"connectrpc.com/connect"
+)
+
+// streamAuthInterceptor implements connect.Interceptor and extracts identity
+// from headers when present on streaming RPCs. It is permissive: requests
+// without identity headers (e.g., service-to-service calls like M1→M5
+// StreamConfigUpdates) are allowed through without an identity in context.
+//
+// For unary RPCs it is a no-op — use NewAuthInterceptor for unary enforcement.
+type streamAuthInterceptor struct{}
+
+// NewStreamAuthInterceptor returns a connect.Interceptor that permissively
+// extracts identity from streaming requests.
+func NewStreamAuthInterceptor() connect.Interceptor {
+	return &streamAuthInterceptor{}
+}
+
+func (s *streamAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return next
+}
+
+func (s *streamAuthInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (s *streamAuthInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
+		email := conn.RequestHeader().Get(HeaderUserEmail)
+		roleStr := conn.RequestHeader().Get(HeaderUserRole)
+
+		if email == "" || roleStr == "" {
+			slog.Debug("streaming request without identity headers",
+				"procedure", conn.Spec().Procedure,
+				"has_email", email != "",
+				"has_role", roleStr != "",
+			)
+			return next(ctx, conn)
+		}
+
+		role, err := ParseRole(roleStr)
+		if err != nil {
+			slog.Debug("streaming request with invalid role",
+				"procedure", conn.Spec().Procedure,
+				"role", roleStr,
+			)
+			return next(ctx, conn)
+		}
+
+		ctx = WithIdentity(ctx, Identity{Email: email, Role: role})
+		return next(ctx, conn)
+	}
+}

--- a/services/management/internal/handlers/auth_helpers.go
+++ b/services/management/internal/handlers/auth_helpers.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/org/experimentation-platform/services/management/internal/auth"
+)
+
+// actorFromContext extracts the authenticated user's email from the context.
+// Returns "system" if no identity is present (e.g., Kafka consumer paths
+// that bypass the RPC interceptor).
+func actorFromContext(ctx context.Context) string {
+	id, err := auth.FromContext(ctx)
+	if err != nil {
+		return "system"
+	}
+	return id.Email
+}

--- a/services/management/internal/handlers/experiment_crud.go
+++ b/services/management/internal/handlers/experiment_crud.go
@@ -61,7 +61,7 @@ func (s *ExperimentService) CreateExperiment(
 	if err := s.audit.Insert(ctx, tx, store.AuditEntry{
 		ExperimentID: created.ExperimentID,
 		Action:       "create",
-		ActorEmail:   created.OwnerEmail,
+		ActorEmail:   actorFromContext(ctx),
 		NewState:     "DRAFT",
 		DetailsJSON:  json.RawMessage(`{"source":"api"}`),
 	}); err != nil {
@@ -201,7 +201,7 @@ func (s *ExperimentService) UpdateExperiment(
 	if err := s.audit.Insert(ctx, tx, store.AuditEntry{
 		ExperimentID: updated.ExperimentID,
 		Action:       "config_update",
-		ActorEmail:   updated.OwnerEmail,
+		ActorEmail:   actorFromContext(ctx),
 		PreviousState: "DRAFT",
 		NewState:     "DRAFT",
 		DetailsJSON:  json.RawMessage(`{"source":"api"}`),

--- a/services/management/internal/handlers/integration_test.go
+++ b/services/management/internal/handlers/integration_test.go
@@ -21,6 +21,7 @@ import (
 	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
 	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
 
+	"github.com/org/experimentation-platform/services/management/internal/auth"
 	"github.com/org/experimentation-platform/services/management/internal/handlers"
 	"github.com/org/experimentation-platform/services/management/internal/sequential"
 	"github.com/org/experimentation-platform/services/management/internal/store"
@@ -31,7 +32,24 @@ type testEnv struct {
 	pool   *pgxpool.Pool
 }
 
+// withAuth returns a client option that injects auth headers into every request.
+func withAuth(email, role string) connect.ClientOption {
+	return connect.WithInterceptors(connect.UnaryInterceptorFunc(
+		func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				req.Header().Set(auth.HeaderUserEmail, email)
+				req.Header().Set(auth.HeaderUserRole, role)
+				return next(ctx, req)
+			}
+		},
+	))
+}
+
 func setupTestServer(t *testing.T) (testEnv, func()) {
+	return setupTestServerWithAuth(t, "test@example.com", "admin")
+}
+
+func setupTestServerWithAuth(t *testing.T, email, role string) (testEnv, func()) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -47,15 +65,48 @@ func setupTestServer(t *testing.T) (testEnv, func()) {
 	svc := handlers.NewExperimentService(es, as, ls, ms, ts, ss, nil)
 
 	mux := http.NewServeMux()
-	path, handler := managementv1connect.NewExperimentManagementServiceHandler(svc)
+	path, handler := managementv1connect.NewExperimentManagementServiceHandler(svc,
+		connect.WithInterceptors(auth.NewAuthInterceptor()),
+	)
 	mux.Handle(path, handler)
 
 	server := httptest.NewServer(mux)
 	client := managementv1connect.NewExperimentManagementServiceClient(
 		http.DefaultClient, server.URL,
+		withAuth(email, role),
 	)
 
 	return testEnv{client: client, pool: pool}, func() {
+		server.Close()
+		pool.Close()
+	}
+}
+
+// setupTestServerRaw returns a test server with auth interceptor but an unauthenticated client.
+func setupTestServerRaw(t *testing.T) (string, *pgxpool.Pool, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	pool, err := store.NewPool(ctx)
+	require.NoError(t, err)
+
+	es := store.NewExperimentStore(pool)
+	as := store.NewAuditStore(pool)
+	ls := store.NewLayerStore(pool)
+	ms := store.NewMetricStore(pool)
+	ts := store.NewTargetingStore(pool)
+	ss := store.NewSurrogateStore(pool)
+	svc := handlers.NewExperimentService(es, as, ls, ms, ts, ss, nil)
+
+	mux := http.NewServeMux()
+	path, handler := managementv1connect.NewExperimentManagementServiceHandler(svc,
+		connect.WithInterceptors(auth.NewAuthInterceptor()),
+	)
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(mux)
+
+	return server.URL, pool, func() {
 		server.Close()
 		pool.Close()
 	}
@@ -1253,4 +1304,148 @@ type mockConcludeCall struct {
 func (m *mockConcluder) ConcludeByID(_ context.Context, id, actor string, _ map[string]any) error {
 	m.calls = append(m.calls, mockConcludeCall{ID: id, Actor: actor})
 	return nil
+}
+
+// ─── RBAC integration tests ───────────────────────────────────────────────────
+
+func TestRBAC_ViewerCanRead(t *testing.T) {
+	serverURL, _, cleanup := setupTestServerRaw(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Admin creates experiment.
+	adminClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("admin@example.com", "admin"),
+	)
+	layer := createTestLayer(t, adminClient, "rbac-viewer-read-"+t.Name(), 0)
+	created, err := adminClient.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: newABExperimentInLayer("rbac-viewer-read", layer.LayerId),
+	}))
+	require.NoError(t, err)
+
+	// Viewer can read it.
+	viewerClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("viewer@example.com", "viewer"),
+	)
+	got, err := viewerClient.GetExperiment(ctx, connect.NewRequest(&mgmtv1.GetExperimentRequest{
+		ExperimentId: created.Msg.ExperimentId,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, created.Msg.ExperimentId, got.Msg.ExperimentId)
+}
+
+func TestRBAC_ViewerCannotCreate(t *testing.T) {
+	serverURL, _, cleanup := setupTestServerRaw(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	viewerClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("viewer@example.com", "viewer"),
+	)
+
+	_, err := viewerClient.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: newABExperiment("rbac-viewer-create"),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestRBAC_ExperimenterCanCreate(t *testing.T) {
+	serverURL, _, cleanup := setupTestServerRaw(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Admin creates the layer (layer creation is admin-only).
+	adminClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("admin@example.com", "admin"),
+	)
+	layer := createTestLayer(t, adminClient, "rbac-exp-create-"+t.Name(), 0)
+
+	// Experimenter creates the experiment.
+	expClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("experimenter@example.com", "experimenter"),
+	)
+	created, err := expClient.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: newABExperimentInLayer("rbac-exp-create", layer.LayerId),
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_DRAFT, created.Msg.State)
+}
+
+func TestRBAC_ExperimenterCannotArchive(t *testing.T) {
+	serverURL, _, cleanup := setupTestServerRaw(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Admin creates and drives experiment to CONCLUDED.
+	adminClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("admin@example.com", "admin"),
+	)
+	layer := createTestLayer(t, adminClient, "rbac-exp-archive-"+t.Name(), 0)
+	created, err := adminClient.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: newABExperimentInLayer("rbac-exp-archive", layer.LayerId),
+	}))
+	require.NoError(t, err)
+
+	_, err = adminClient.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+		ExperimentId: created.Msg.ExperimentId,
+	}))
+	require.NoError(t, err)
+
+	_, err = adminClient.ConcludeExperiment(ctx, connect.NewRequest(&mgmtv1.ConcludeExperimentRequest{
+		ExperimentId: created.Msg.ExperimentId,
+	}))
+	require.NoError(t, err)
+
+	// Experimenter tries to archive → denied.
+	expClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("experimenter@example.com", "experimenter"),
+	)
+	_, err = expClient.ArchiveExperiment(ctx, connect.NewRequest(&mgmtv1.ArchiveExperimentRequest{
+		ExperimentId: created.Msg.ExperimentId,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestRBAC_MissingHeaders(t *testing.T) {
+	serverURL, _, cleanup := setupTestServerRaw(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	noAuthClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL,
+	)
+
+	_, err := noAuthClient.ListExperiments(ctx, connect.NewRequest(&mgmtv1.ListExperimentsRequest{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestRBAC_AuditTrailRecordsRealActor(t *testing.T) {
+	serverURL, pool, cleanup := setupTestServerRaw(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Admin creates layer.
+	adminClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("admin@example.com", "admin"),
+	)
+	layer := createTestLayer(t, adminClient, "rbac-audit-"+t.Name(), 0)
+
+	// Experimenter creates experiment.
+	expClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, serverURL, withAuth("alice@corp.com", "experimenter"),
+	)
+	created, err := expClient.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: newABExperimentInLayer("rbac-audit-actor", layer.LayerId),
+	}))
+	require.NoError(t, err)
+
+	// Verify audit trail has real actor email (not "system").
+	var actorEmail string
+	err = pool.QueryRow(ctx, `SELECT actor_email FROM audit_trail WHERE experiment_id = $1 AND action = 'create'`,
+		created.Msg.ExperimentId).Scan(&actorEmail)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@corp.com", actorEmail)
 }

--- a/services/management/internal/handlers/lifecycle.go
+++ b/services/management/internal/handlers/lifecycle.go
@@ -71,7 +71,7 @@ func (s *ExperimentService) StartExperiment(
 	if err := s.audit.Insert(ctx, tx1, store.AuditEntry{
 		ExperimentID:  id,
 		Action:        "start",
-		ActorEmail:    "system",
+		ActorEmail:    actorFromContext(ctx),
 		PreviousState: "DRAFT",
 		NewState:      "STARTING",
 		DetailsJSON:   json.RawMessage(`{"phase":"validation_begin"}`),
@@ -183,7 +183,7 @@ func (s *ExperimentService) StartExperiment(
 	if err := s.audit.Insert(ctx, tx2, store.AuditEntry{
 		ExperimentID:  id,
 		Action:        "start",
-		ActorEmail:    "system",
+		ActorEmail:    actorFromContext(ctx),
 		PreviousState: "STARTING",
 		NewState:      "RUNNING",
 		DetailsJSON:   allocDetails,
@@ -229,7 +229,7 @@ func (s *ExperimentService) ConcludeExperiment(
 		extraDetails = map[string]any{"holdout_retirement": true}
 	}
 
-	exp, err := s.concludeByID(ctx, id, "system", extraDetails)
+	exp, err := s.concludeByID(ctx, id, actorFromContext(ctx), extraDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func (s *ExperimentService) ArchiveExperiment(
 	if err := s.audit.Insert(ctx, tx, store.AuditEntry{
 		ExperimentID:  id,
 		Action:        "archive",
-		ActorEmail:    "system",
+		ActorEmail:    actorFromContext(ctx),
 		PreviousState: "CONCLUDED",
 		NewState:      "ARCHIVED",
 	}); err != nil {
@@ -426,7 +426,7 @@ func (s *ExperimentService) PauseExperiment(
 	if err := s.audit.Insert(ctx, nil, store.AuditEntry{
 		ExperimentID:  id,
 		Action:        action,
-		ActorEmail:    "system",
+		ActorEmail:    actorFromContext(ctx),
 		PreviousState: "RUNNING",
 		NewState:      "RUNNING",
 		DetailsJSON:   details,
@@ -464,7 +464,7 @@ func (s *ExperimentService) ResumeExperiment(
 	if err := s.audit.Insert(ctx, nil, store.AuditEntry{
 		ExperimentID:  id,
 		Action:        "resume",
-		ActorEmail:    "system",
+		ActorEmail:    actorFromContext(ctx),
 		PreviousState: "RUNNING",
 		NewState:      "RUNNING",
 	}); err != nil {


### PR DESCRIPTION
## Summary

- Add `auth` package with `Identity`, `Role` types, hierarchical `HasAtLeast()` comparison, and context helpers
- Add ConnectRPC unary auth interceptor that extracts identity from API gateway headers (`X-User-Email`, `X-User-Role`) and enforces role-based permissions across all 20 RPCs
- Add permissive streaming interceptor for service-to-service calls (M1→M5 `StreamConfigUpdates`)
- Replace hardcoded `"system"` audit trail actors with real authenticated identity via `actorFromContext(ctx)`
- Wire interceptor in `main.go` with `DISABLE_AUTH=true` escape hatch for development

## Role hierarchy

`viewer` (read-only) < `analyst` (create metrics/targeting/surrogates) < `experimenter` (experiment CRUD + lifecycle) < `admin` (archive + create layers)

## Test plan

- [x] 10 unit tests in `auth` package — role parsing, hierarchy, context round-trip, interceptor enforcement (missing email, missing role, invalid role, insufficient role, admin-only archive)
- [ ] 6 RBAC integration tests (require `just dev`): viewer can read, viewer cannot create, experimenter can create, experimenter cannot archive, missing headers → unauthenticated, audit trail records real actor
- [ ] All existing integration tests updated with admin auth headers — no regressions

```bash
# Unit tests (no DB)
go test -v -race ./services/management/internal/auth/...

# Integration tests (requires just dev)
go test -tags integration -v -run TestRBAC ./services/management/internal/handlers/...
go test -tags integration -v ./services/management/internal/handlers/...
```

## What this unblocks

- Agent-6 (UI): can now send auth headers for role-aware UI controls
- Production readiness: API gateway can enforce authentication upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)