### PR TITLE
test(m7): chaos/crash-recovery tests for flags service (M4.5)

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,6 +1,6 @@
 # Experimentation Platform — Coordination Status
 
-> **Last updated**: 2026-03-09 by Agent-3 (Phase 4 chaos/resilience tests — 20 tests across all M3 jobs)
+> **Last updated**: 2026-03-09 by Agent-7 (M7 chaos/crash-recovery tests — 13 tests pass with -race)
 >
 > This file is the single source of truth for multi-agent execution state.
 > Update it each time a milestone merges to `main` or a blocker is identified.
@@ -19,7 +19,7 @@
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 3 In Progress | agent-4/feat/m4b-grpc-wiring | M4b gRPC wiring | — | M1.14–1.19 merged. M2.1–2.6, M2.10 complete. M3.1 LinUCB merged (PR #54). M3.2 cold-start merged. M4.1 CATE in PR #70. M4b BanditPolicyService gRPC wiring: all 5 RPCs implemented (SelectArm, CreateColdStartBandit, ExportAffinityScores, GetPolicySnapshot, RollbackPolicy), 17 tests pass. |
 | Agent-5 | M5 Management | 🟢 Phase 3 Complete | agent-5/feat/cumulative-holdout | M3.6 Cumulative holdout complete | — | Phase 2 complete (PRs #50, #53). M3.6: cumulative holdout support — traffic 1-5% enforcement, sequential/guardrail bypass, holdout retirement audit, ListRunningHoldouts query. |
 | Agent-6 | M6 UI | 🔵 In Progress | agent-6/feat/live-api-integration | Live API integration with Agent-5 | — | M1.25–1.27, M2.8–2.9, analysis tabs (PR #56), bandit dashboard (PR #60). Live API integration: Next.js rewrites proxy, ConnectRPC error parsing, opt-in MSW, 24 contract tests. 139 tests pass. Ready to pair with Agent-5 backend. |
-| Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/phase4-benchmarks | Phase 4: Performance benchmarks + concurrency stress tests | — | M1.28–1.30 merged (PR #13). Phases 1–3 complete. Phase 4: EvaluateFlag p99 ~86μs (target <10ms ✅), hash Bucket ~64ns/op (target <1μs ✅), 50-writer concurrent update + 50r/10w mixed load pass with -race. |
+| Agent-7 | M7 Flags | 🔵 In Progress | agent-7/test/chaos-crash-recovery | Phase 4.5: Chaos/crash-recovery tests | — | M1.28–1.30 merged (PR #13). Phases 1–4 complete. Phase 4.5: 13 chaos tests — ChaosStore failure injection, PromoteToExperiment atomicity, store recovery, 60-goroutine concurrent CRUD with random failures, audit isolation, context cancellation, server restart simulation. All pass with -race. |
 
 **Legend**: 🟢 Complete | 🔵 In Progress | 🟡 Not Started (unblocked) | ⚪ Waiting (blocked) | 🔴 Blocked (critical path)
 
@@ -116,7 +116,7 @@
 | 4.2 | Interference detection (content catalog spillover) | Agent-4 | ⚪ | — |
 | 4.3 | PGO-optimized builds for M1 + M4b | Agent-1/4 | ⚪ | — |
 | 4.4 | Full RBAC integration | Agent-5 | ⚪ | — |
-| 4.5 | End-to-end chaos testing passing | All | 🔵 | Production readiness | Agent-2: chaos scripts + crash-recovery tests merged. Agent-3: 20 resilience tests (PR #69) — Spark SQL, PG, Kafka failure injection across StandardJob, GuardrailJob, InterleavingJob, ContentConsumptionJob. Other agents pending. |
+| 4.5 | End-to-end chaos testing passing | All | 🔵 | Production readiness | Agent-2: chaos scripts + crash-recovery tests merged. Agent-3: 20 resilience tests (PR #69). Agent-7: 13 chaos tests — ChaosStore decorator, atomicity, concurrent CRUD, restart simulation. Other agents pending. |
 
 ## Pair Integration Schedule
 

--- a/services/flags/internal/handlers/chaos_test.go
+++ b/services/flags/internal/handlers/chaos_test.go
@@ -1,0 +1,563 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/org/experimentation-platform/services/flags/internal/store"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	flagsv1 "github.com/org/experimentation/gen/go/experimentation/flags/v1"
+	"github.com/org/experimentation/gen/go/experimentation/flags/v1/flagsv1connect"
+	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupChaosTest creates a test environment with a ChaosStore wrapping a MockStore.
+func setupChaosTest(t *testing.T) (flagsv1connect.FeatureFlagServiceClient, *store.ChaosStore, *store.MockStore) {
+	t.Helper()
+	mock := store.NewMockStore()
+	chaos := store.NewChaosStore(mock)
+	svc := NewFlagService(chaos)
+	mux := http.NewServeMux()
+	path, handler := flagsv1connect.NewFeatureFlagServiceHandler(svc)
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := flagsv1connect.NewFeatureFlagServiceClient(http.DefaultClient, server.URL)
+	return client, chaos, mock
+}
+
+// setupChaosTestWithAudit creates a test environment with ChaosStore + ChaosAuditStore.
+func setupChaosTestWithAudit(t *testing.T) (flagsv1connect.FeatureFlagServiceClient, *store.ChaosStore, *store.ChaosAuditStore, *store.MockStore) {
+	t.Helper()
+	mock := store.NewMockStore()
+	chaos := store.NewChaosStore(mock)
+	auditMock := store.NewMockAuditStore(mock)
+	chaosAudit := store.NewChaosAuditStore(auditMock)
+	svc := NewFlagServiceWithAudit(chaos, chaosAudit)
+	mux := http.NewServeMux()
+	path, handler := flagsv1connect.NewFeatureFlagServiceHandler(svc)
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := flagsv1connect.NewFeatureFlagServiceClient(http.DefaultClient, server.URL)
+	return client, chaos, chaosAudit, mock
+}
+
+// setupChaosTestWithM5 creates a test environment with ChaosStore + mock M5.
+func setupChaosTestWithM5(t *testing.T) (flagsv1connect.FeatureFlagServiceClient, *store.ChaosStore, *store.MockStore, *mockManagementHandler) {
+	t.Helper()
+
+	mgmtHandler := &mockManagementHandler{}
+	mgmtMux := http.NewServeMux()
+	mgmtPath, mgmtH := managementv1connect.NewExperimentManagementServiceHandler(mgmtHandler)
+	mgmtMux.Handle(mgmtPath, mgmtH)
+	mgmtServer := httptest.NewServer(mgmtMux)
+	t.Cleanup(mgmtServer.Close)
+
+	mgmtClient := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient,
+		mgmtServer.URL,
+	)
+
+	mock := store.NewMockStore()
+	chaos := store.NewChaosStore(mock)
+	svc := NewFlagServiceFull(chaos, nil, mgmtClient)
+	mux := http.NewServeMux()
+	path, handler := flagsv1connect.NewFeatureFlagServiceHandler(svc)
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := flagsv1connect.NewFeatureFlagServiceClient(http.DefaultClient, server.URL)
+	return client, chaos, mock, mgmtHandler
+}
+
+func createTestFlag(t *testing.T, client flagsv1connect.FeatureFlagServiceClient, name string) string {
+	t.Helper()
+	resp, err := client.CreateFlag(context.Background(), connect.NewRequest(&flagsv1.CreateFlagRequest{
+		Flag: &flagsv1.Flag{
+			Name:              name,
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			Enabled:           true,
+			RolloutPercentage: 0.5,
+		},
+	}))
+	require.NoError(t, err)
+	return resp.Msg.GetFlagId()
+}
+
+// ========================================================================
+// Scenario 1: Store failure injection
+// ========================================================================
+
+func TestChaos_CreateFlag_FailureNoPartialState(t *testing.T) {
+	client, chaos, mock := setupChaosTest(t)
+	ctx := context.Background()
+
+	// Inject failure on CreateFlag.
+	chaos.SetFailure("CreateFlag", store.ChaosConfig{Mode: store.FailAlways})
+
+	_, err := client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+		Flag: &flagsv1.Flag{
+			Name:              "should-not-exist",
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			RolloutPercentage: 0.5,
+		},
+	}))
+	assert.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+
+	// Verify no partial state — store should be empty.
+	flags, _, err := mock.ListFlags(ctx, 100, "")
+	require.NoError(t, err)
+	assert.Empty(t, flags)
+}
+
+func TestChaos_UpdateFlag_FailureOriginalUnchanged(t *testing.T) {
+	client, chaos, _ := setupChaosTest(t)
+	ctx := context.Background()
+
+	// Create a flag successfully.
+	flagID := createTestFlag(t, client, "update-chaos")
+
+	// Get original state.
+	original, err := client.GetFlag(ctx, connect.NewRequest(&flagsv1.GetFlagRequest{FlagId: flagID}))
+	require.NoError(t, err)
+	originalRollout := original.Msg.GetRolloutPercentage()
+
+	// Inject failure on UpdateFlag.
+	chaos.SetFailure("UpdateFlag", store.ChaosConfig{Mode: store.FailAlways})
+
+	_, err = client.UpdateFlag(ctx, connect.NewRequest(&flagsv1.UpdateFlagRequest{
+		Flag: &flagsv1.Flag{
+			FlagId:            flagID,
+			Name:              "update-chaos",
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			RolloutPercentage: 0.9,
+			Enabled:           true,
+		},
+	}))
+	assert.Error(t, err)
+
+	// Clear failure to verify original state.
+	chaos.ClearAllFailures()
+	after, err := client.GetFlag(ctx, connect.NewRequest(&flagsv1.GetFlagRequest{FlagId: flagID}))
+	require.NoError(t, err)
+	assert.Equal(t, originalRollout, after.Msg.GetRolloutPercentage(), "flag should be unchanged after failed update")
+}
+
+func TestChaos_EvaluateFlag_GetFlagFailure(t *testing.T) {
+	client, chaos, _ := setupChaosTest(t)
+	ctx := context.Background()
+
+	flagID := createTestFlag(t, client, "eval-chaos")
+
+	// Inject failure on GetFlag (used by EvaluateFlag).
+	chaos.SetFailure("GetFlag", store.ChaosConfig{Mode: store.FailAlways})
+
+	_, err := client.EvaluateFlag(ctx, connect.NewRequest(&flagsv1.EvaluateFlagRequest{
+		FlagId: flagID,
+		UserId: "user_123",
+	}))
+	assert.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+}
+
+func TestChaos_EvaluateFlags_GetAllEnabledFailure(t *testing.T) {
+	client, chaos, _ := setupChaosTest(t)
+	ctx := context.Background()
+
+	createTestFlag(t, client, "bulk-chaos")
+
+	// Inject failure on GetAllEnabledFlags (used by EvaluateFlags).
+	chaos.SetFailure("GetAllEnabledFlags", store.ChaosConfig{Mode: store.FailAlways})
+
+	_, err := client.EvaluateFlags(ctx, connect.NewRequest(&flagsv1.EvaluateFlagsRequest{
+		UserId: "user_123",
+	}))
+	assert.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+}
+
+// ========================================================================
+// Scenario 2: PromoteToExperiment atomicity
+// ========================================================================
+
+func TestChaos_Promote_M5Fails_FlagUnlinked(t *testing.T) {
+	client, _, mock, mgmtHandler := setupChaosTestWithM5(t)
+	ctx := context.Background()
+
+	flagID := createTestFlag(t, client, "promote-chaos")
+
+	// Configure M5 to fail.
+	mgmtHandler.returnErr = connect.NewError(connect.CodeUnavailable, fmt.Errorf("M5 down"))
+
+	_, err := client.PromoteToExperiment(ctx, connect.NewRequest(&flagsv1.PromoteToExperimentRequest{
+		FlagId:          flagID,
+		ExperimentType:  commonv1.ExperimentType_EXPERIMENT_TYPE_AB,
+		PrimaryMetricId: "ctr",
+	}))
+	assert.Error(t, err)
+
+	// Flag should be unchanged — not linked to any experiment (check via store directly).
+	f, err := mock.GetFlag(ctx, flagID)
+	require.NoError(t, err)
+	assert.Empty(t, f.PromotedExperimentID, "flag should not be linked after M5 failure")
+}
+
+func TestChaos_Promote_LinkFlagFails_NonFatal(t *testing.T) {
+	client, chaos, mock, _ := setupChaosTestWithM5(t)
+	ctx := context.Background()
+
+	flagID := createTestFlag(t, client, "link-chaos")
+
+	// Inject failure on LinkFlagToExperiment (called after M5 succeeds).
+	chaos.SetFailure("LinkFlagToExperiment", store.ChaosConfig{Mode: store.FailAlways})
+
+	// M5 succeeds, but link fails — should still return experiment (non-fatal).
+	resp, err := client.PromoteToExperiment(ctx, connect.NewRequest(&flagsv1.PromoteToExperimentRequest{
+		FlagId:          flagID,
+		ExperimentType:  commonv1.ExperimentType_EXPERIMENT_TYPE_AB,
+		PrimaryMetricId: "ctr",
+	}))
+	require.NoError(t, err, "promote should succeed even if linkage fails")
+	assert.NotEmpty(t, resp.Msg.GetExperimentId())
+
+	// Verify flag is NOT linked (check via store directly — linkage failed).
+	chaos.ClearAllFailures()
+	f, err := mock.GetFlag(ctx, flagID)
+	require.NoError(t, err)
+	assert.Empty(t, f.PromotedExperimentID, "linkage should be lost after LinkFlagToExperiment failure")
+}
+
+// ========================================================================
+// Scenario 3: Store recovery
+// ========================================================================
+
+func TestChaos_StoreRecovery_FailThenRecover(t *testing.T) {
+	client, chaos, _ := setupChaosTest(t)
+	ctx := context.Background()
+
+	// Phase 1: Create flags successfully.
+	id1 := createTestFlag(t, client, "recovery-1")
+	id2 := createTestFlag(t, client, "recovery-2")
+
+	// Phase 2: Inject failures — creates should fail.
+	chaos.SetFailure("CreateFlag", store.ChaosConfig{Mode: store.FailAlways})
+
+	_, err := client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+		Flag: &flagsv1.Flag{
+			Name:              "should-fail",
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			RolloutPercentage: 0.5,
+		},
+	}))
+	assert.Error(t, err)
+
+	// Phase 3: Clear failures — store recovers.
+	chaos.ClearAllFailures()
+
+	id3 := createTestFlag(t, client, "recovery-3")
+
+	// All successful flags should be retrievable.
+	for _, id := range []string{id1, id2, id3} {
+		resp, err := client.GetFlag(ctx, connect.NewRequest(&flagsv1.GetFlagRequest{FlagId: id}))
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Msg.GetName())
+	}
+
+	// Failed flag should not exist.
+	listResp, err := client.ListFlags(ctx, connect.NewRequest(&flagsv1.ListFlagsRequest{PageSize: 100}))
+	require.NoError(t, err)
+	assert.Len(t, listResp.Msg.GetFlags(), 3, "only 3 successfully created flags should exist")
+}
+
+// ========================================================================
+// Scenario 4: Concurrent CRUD with random failures
+// ========================================================================
+
+func TestChaos_ConcurrentCRUDWithRandomFailures(t *testing.T) {
+	client, chaos, _ := setupChaosTest(t)
+	ctx := context.Background()
+
+	// Pre-create some flags for update/evaluate targets.
+	var targetIDs []string
+	for i := 0; i < 5; i++ {
+		id := createTestFlag(t, client, fmt.Sprintf("concurrent-target-%d", i))
+		targetIDs = append(targetIDs, id)
+	}
+
+	// Inject 10% random failure on writes.
+	chaos.SetFailure("CreateFlag", store.ChaosConfig{Mode: store.FailRandom, Probability: 0.1})
+	chaos.SetFailure("UpdateFlag", store.ChaosConfig{Mode: store.FailRandom, Probability: 0.1})
+
+	var wg sync.WaitGroup
+	var createSuccesses, updateSuccesses, evalSuccesses atomic.Int64
+	var createFailures, updateFailures, evalFailures atomic.Int64
+
+	// 20 create goroutines.
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+				Flag: &flagsv1.Flag{
+					Name:              fmt.Sprintf("chaos-create-%d", idx),
+					Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+					DefaultValue:      "false",
+					Enabled:           true,
+					RolloutPercentage: 0.5,
+				},
+			}))
+			if err != nil {
+				createFailures.Add(1)
+			} else {
+				createSuccesses.Add(1)
+			}
+		}(i)
+	}
+
+	// 20 update goroutines.
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			targetID := targetIDs[idx%len(targetIDs)]
+			_, err := client.UpdateFlag(ctx, connect.NewRequest(&flagsv1.UpdateFlagRequest{
+				Flag: &flagsv1.Flag{
+					FlagId:            targetID,
+					Name:              fmt.Sprintf("concurrent-target-%d", idx%len(targetIDs)),
+					Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+					DefaultValue:      "false",
+					Enabled:           true,
+					RolloutPercentage: float64(idx%10) / 10.0,
+				},
+			}))
+			if err != nil {
+				updateFailures.Add(1)
+			} else {
+				updateSuccesses.Add(1)
+			}
+		}(i)
+	}
+
+	// 20 evaluate goroutines (no failure injection — reads should always work).
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			targetID := targetIDs[idx%len(targetIDs)]
+			_, err := client.EvaluateFlag(ctx, connect.NewRequest(&flagsv1.EvaluateFlagRequest{
+				FlagId: targetID,
+				UserId: fmt.Sprintf("user-%d", idx),
+			}))
+			if err != nil {
+				evalFailures.Add(1)
+			} else {
+				evalSuccesses.Add(1)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify: no panics, no races (enforced by -race flag).
+	t.Logf("creates: %d success / %d fail", createSuccesses.Load(), createFailures.Load())
+	t.Logf("updates: %d success / %d fail", updateSuccesses.Load(), updateFailures.Load())
+	t.Logf("evaluates: %d success / %d fail", evalSuccesses.Load(), evalFailures.Load())
+
+	assert.Greater(t, createSuccesses.Load(), int64(0), "some creates should succeed")
+	assert.Greater(t, updateSuccesses.Load(), int64(0), "some updates should succeed")
+	assert.Equal(t, int64(20), evalSuccesses.Load()+evalFailures.Load(), "all evaluate goroutines should complete")
+}
+
+// ========================================================================
+// Scenario 5: Audit store failure isolation
+// ========================================================================
+
+func TestChaos_AuditStoreFailure_CRUDStillWorks(t *testing.T) {
+	client, _, chaosAudit, _ := setupChaosTestWithAudit(t)
+	ctx := context.Background()
+
+	// Fail all audit writes.
+	chaosAudit.SetFailAll(fmt.Errorf("chaos: audit store down"))
+
+	// CRUD should still work — audit failures are logged, not propagated.
+	flagID := createTestFlag(t, client, "audit-chaos")
+
+	_, err := client.UpdateFlag(ctx, connect.NewRequest(&flagsv1.UpdateFlagRequest{
+		Flag: &flagsv1.Flag{
+			FlagId:            flagID,
+			Name:              "audit-chaos",
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			RolloutPercentage: 0.8,
+			Enabled:           true,
+		},
+	}))
+	require.NoError(t, err)
+
+	resp, err := client.GetFlag(ctx, connect.NewRequest(&flagsv1.GetFlagRequest{FlagId: flagID}))
+	require.NoError(t, err)
+	assert.Equal(t, 0.8, resp.Msg.GetRolloutPercentage())
+
+	eval, err := client.EvaluateFlag(ctx, connect.NewRequest(&flagsv1.EvaluateFlagRequest{
+		FlagId: flagID,
+		UserId: "user_456",
+	}))
+	require.NoError(t, err)
+	assert.NotEmpty(t, eval.Msg.GetValue())
+}
+
+// ========================================================================
+// Scenario 6: Context cancellation
+// ========================================================================
+
+func TestChaos_ContextCancellation_NoPartialState(t *testing.T) {
+	client, _, mock := setupChaosTest(t)
+
+	// Cancel the context before the call.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+		Flag: &flagsv1.Flag{
+			Name:              "cancelled-flag",
+			Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+			DefaultValue:      "false",
+			RolloutPercentage: 0.5,
+		},
+	}))
+	assert.Error(t, err, "canceled context should cause an error")
+
+	// Store should have no flags.
+	flags, _, err := mock.ListFlags(context.Background(), 100, "")
+	require.NoError(t, err)
+	assert.Empty(t, flags, "no flag should exist after canceled context")
+}
+
+func TestChaos_ContextCancellation_NoGoroutineLeak(t *testing.T) {
+	client, _, _ := setupChaosTest(t)
+
+	// Baseline goroutine count.
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	// Issue 20 requests with canceled contexts.
+	for i := 0; i < 20; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		client.CreateFlag(ctx, connect.NewRequest(&flagsv1.CreateFlagRequest{
+			Flag: &flagsv1.Flag{
+				Name:              fmt.Sprintf("leak-test-%d", i),
+				Type:              flagsv1.FlagType_FLAG_TYPE_BOOLEAN,
+				DefaultValue:      "false",
+				RolloutPercentage: 0.5,
+			},
+		}))
+	}
+
+	// Allow goroutines to settle.
+	runtime.GC()
+	runtime.Gosched()
+
+	current := runtime.NumGoroutine()
+	// Allow a generous margin (10 goroutines) for background activity.
+	assert.LessOrEqual(t, current, baseline+10,
+		"goroutine count should be stable after canceled requests (baseline=%d, current=%d)", baseline, current)
+}
+
+// ========================================================================
+// Scenario 7: Server restart simulation
+// ========================================================================
+
+func TestChaos_ServerRestart_StateSurvives(t *testing.T) {
+	mock := store.NewMockStore()
+	ctx := context.Background()
+
+	// Start server 1, create flags.
+	chaos1 := store.NewChaosStore(mock)
+	svc1 := NewFlagService(chaos1)
+	mux1 := http.NewServeMux()
+	path1, h1 := flagsv1connect.NewFeatureFlagServiceHandler(svc1)
+	mux1.Handle(path1, h1)
+	server1 := httptest.NewServer(mux1)
+	client1 := flagsv1connect.NewFeatureFlagServiceClient(http.DefaultClient, server1.URL)
+
+	id1 := createTestFlag(t, client1, "restart-1")
+	id2 := createTestFlag(t, client1, "restart-2")
+
+	// "Stop" server 1.
+	server1.Close()
+
+	// Start server 2 with same store.
+	chaos2 := store.NewChaosStore(mock)
+	svc2 := NewFlagService(chaos2)
+	mux2 := http.NewServeMux()
+	path2, h2 := flagsv1connect.NewFeatureFlagServiceHandler(svc2)
+	mux2.Handle(path2, h2)
+	server2 := httptest.NewServer(mux2)
+	t.Cleanup(server2.Close)
+	client2 := flagsv1connect.NewFeatureFlagServiceClient(http.DefaultClient, server2.URL)
+
+	// Flags should be accessible from new server.
+	for _, id := range []string{id1, id2} {
+		resp, err := client2.GetFlag(ctx, connect.NewRequest(&flagsv1.GetFlagRequest{FlagId: id}))
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.Msg.GetName())
+	}
+
+	// Can create new flags on new server.
+	id3 := createTestFlag(t, client2, "restart-3")
+	resp, err := client2.GetFlag(ctx, connect.NewRequest(&flagsv1.GetFlagRequest{FlagId: id3}))
+	require.NoError(t, err)
+	assert.Equal(t, "restart-3", resp.Msg.GetName())
+}
+
+func TestChaos_ServerRestart_MultiCycle(t *testing.T) {
+	mock := store.NewMockStore()
+	ctx := context.Background()
+
+	var allIDs []string
+
+	for cycle := 0; cycle < 3; cycle++ {
+		chaos := store.NewChaosStore(mock)
+		svc := NewFlagService(chaos)
+		mux := http.NewServeMux()
+		path, h := flagsv1connect.NewFeatureFlagServiceHandler(svc)
+		mux.Handle(path, h)
+		server := httptest.NewServer(mux)
+		client := flagsv1connect.NewFeatureFlagServiceClient(http.DefaultClient, server.URL)
+
+		// Create a flag in this cycle.
+		id := createTestFlag(t, client, fmt.Sprintf("cycle-%d-flag", cycle))
+		allIDs = append(allIDs, id)
+
+		// Verify all flags from previous cycles are accessible.
+		for _, prevID := range allIDs {
+			resp, err := client.GetFlag(ctx, connect.NewRequest(&flagsv1.GetFlagRequest{FlagId: prevID}))
+			require.NoError(t, err, "flag %s from previous cycle should be accessible", prevID)
+			assert.NotEmpty(t, resp.Msg.GetName())
+		}
+
+		// Verify total flag count.
+		list, err := client.ListFlags(ctx, connect.NewRequest(&flagsv1.ListFlagsRequest{PageSize: 100}))
+		require.NoError(t, err)
+		assert.Len(t, list.Msg.GetFlags(), cycle+1, "should have %d flags after cycle %d", cycle+1, cycle)
+
+		// "Restart" — close server.
+		server.Close()
+	}
+}

--- a/services/flags/internal/store/chaos.go
+++ b/services/flags/internal/store/chaos.go
@@ -1,0 +1,242 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// FailureMode controls how a ChaosStore method fails.
+type FailureMode int
+
+const (
+	FailNone    FailureMode = iota // No failure injection.
+	FailAlways                     // Every call fails.
+	FailAfterN                     // Fail after N successful calls.
+	FailRandom                     // Fail with given probability per call.
+)
+
+// ChaosConfig configures failure injection for a single store method.
+type ChaosConfig struct {
+	Mode        FailureMode
+	Err         error   // Error to return. Defaults to errChaosDefault.
+	AfterN      int     // For FailAfterN: succeed first N calls, then fail.
+	Probability float64 // For FailRandom: probability [0,1] of failure per call.
+}
+
+var errChaosDefault = fmt.Errorf("chaos: simulated store failure")
+
+// ChaosStore wraps a Store and injects configurable failures per-method.
+// Thread-safe for use with -race.
+type ChaosStore struct {
+	inner    Store
+	mu       sync.RWMutex
+	configs  map[string]ChaosConfig
+	counters map[string]*atomic.Int64
+	rng      *rand.Rand
+	rngMu    sync.Mutex
+}
+
+// NewChaosStore wraps the given store with chaos injection capabilities.
+func NewChaosStore(inner Store) *ChaosStore {
+	return &ChaosStore{
+		inner:    inner,
+		configs:  make(map[string]ChaosConfig),
+		counters: make(map[string]*atomic.Int64),
+		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// SetFailure configures failure injection for a named method.
+func (c *ChaosStore) SetFailure(method string, cfg ChaosConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.configs[method] = cfg
+	if _, ok := c.counters[method]; !ok {
+		c.counters[method] = &atomic.Int64{}
+	}
+}
+
+// ClearAllFailures removes all failure injection configs.
+func (c *ChaosStore) ClearAllFailures() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.configs = make(map[string]ChaosConfig)
+}
+
+// CallCount returns the number of times a method has been invoked.
+func (c *ChaosStore) CallCount(method string) int64 {
+	c.mu.RLock()
+	counter, ok := c.counters[method]
+	c.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+	return counter.Load()
+}
+
+// shouldFail checks if the given method should fail on this call.
+func (c *ChaosStore) shouldFail(method string) error {
+	c.mu.RLock()
+	cfg, ok := c.configs[method]
+	counter := c.counters[method]
+	c.mu.RUnlock()
+
+	if !ok {
+		return nil
+	}
+
+	if counter != nil {
+		counter.Add(1)
+	}
+
+	errToReturn := cfg.Err
+	if errToReturn == nil {
+		errToReturn = errChaosDefault
+	}
+
+	switch cfg.Mode {
+	case FailNone:
+		return nil
+	case FailAlways:
+		return errToReturn
+	case FailAfterN:
+		if counter != nil && counter.Load() > int64(cfg.AfterN) {
+			return errToReturn
+		}
+		return nil
+	case FailRandom:
+		c.rngMu.Lock()
+		r := c.rng.Float64()
+		c.rngMu.Unlock()
+		if r < cfg.Probability {
+			return errToReturn
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// Inner returns the underlying store (for test assertions).
+func (c *ChaosStore) Inner() Store {
+	return c.inner
+}
+
+func (c *ChaosStore) CreateFlag(ctx context.Context, f *Flag) (*Flag, error) {
+	if err := c.shouldFail("CreateFlag"); err != nil {
+		return nil, err
+	}
+	return c.inner.CreateFlag(ctx, f)
+}
+
+func (c *ChaosStore) GetFlag(ctx context.Context, flagID string) (*Flag, error) {
+	if err := c.shouldFail("GetFlag"); err != nil {
+		return nil, err
+	}
+	return c.inner.GetFlag(ctx, flagID)
+}
+
+func (c *ChaosStore) UpdateFlag(ctx context.Context, f *Flag) (*Flag, error) {
+	if err := c.shouldFail("UpdateFlag"); err != nil {
+		return nil, err
+	}
+	return c.inner.UpdateFlag(ctx, f)
+}
+
+func (c *ChaosStore) DeleteFlag(ctx context.Context, flagID string) error {
+	if err := c.shouldFail("DeleteFlag"); err != nil {
+		return err
+	}
+	return c.inner.DeleteFlag(ctx, flagID)
+}
+
+func (c *ChaosStore) ListFlags(ctx context.Context, pageSize int, pageToken string) ([]*Flag, string, error) {
+	if err := c.shouldFail("ListFlags"); err != nil {
+		return nil, "", err
+	}
+	return c.inner.ListFlags(ctx, pageSize, pageToken)
+}
+
+func (c *ChaosStore) GetAllEnabledFlags(ctx context.Context) ([]*Flag, error) {
+	if err := c.shouldFail("GetAllEnabledFlags"); err != nil {
+		return nil, err
+	}
+	return c.inner.GetAllEnabledFlags(ctx)
+}
+
+func (c *ChaosStore) LinkFlagToExperiment(ctx context.Context, flagID, experimentID string) error {
+	if err := c.shouldFail("LinkFlagToExperiment"); err != nil {
+		return err
+	}
+	return c.inner.LinkFlagToExperiment(ctx, flagID, experimentID)
+}
+
+func (c *ChaosStore) GetFlagByExperiment(ctx context.Context, experimentID string) (*Flag, error) {
+	if err := c.shouldFail("GetFlagByExperiment"); err != nil {
+		return nil, err
+	}
+	return c.inner.GetFlagByExperiment(ctx, experimentID)
+}
+
+func (c *ChaosStore) GetFlagsByTargetingRule(ctx context.Context, targetingRuleID string) ([]*Flag, error) {
+	if err := c.shouldFail("GetFlagsByTargetingRule"); err != nil {
+		return nil, err
+	}
+	return c.inner.GetFlagsByTargetingRule(ctx, targetingRuleID)
+}
+
+func (c *ChaosStore) GetPromotedFlags(ctx context.Context) ([]*Flag, error) {
+	if err := c.shouldFail("GetPromotedFlags"); err != nil {
+		return nil, err
+	}
+	return c.inner.GetPromotedFlags(ctx)
+}
+
+// ChaosAuditStore wraps an AuditStore and injects failures on RecordAudit.
+// Read methods pass through unchanged.
+type ChaosAuditStore struct {
+	inner   AuditStore
+	mu      sync.RWMutex
+	failErr error
+}
+
+// NewChaosAuditStore wraps the given audit store with chaos injection.
+func NewChaosAuditStore(inner AuditStore) *ChaosAuditStore {
+	return &ChaosAuditStore{inner: inner}
+}
+
+// SetFailAll configures RecordAudit to always return the given error.
+func (c *ChaosAuditStore) SetFailAll(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failErr = err
+}
+
+// ClearFailure removes the failure injection.
+func (c *ChaosAuditStore) ClearFailure() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.failErr = nil
+}
+
+func (c *ChaosAuditStore) RecordAudit(ctx context.Context, entry *AuditEntry) error {
+	c.mu.RLock()
+	err := c.failErr
+	c.mu.RUnlock()
+	if err != nil {
+		return err
+	}
+	return c.inner.RecordAudit(ctx, entry)
+}
+
+func (c *ChaosAuditStore) GetFlagAuditLog(ctx context.Context, flagID string, limit int) ([]*AuditEntry, error) {
+	return c.inner.GetFlagAuditLog(ctx, flagID, limit)
+}
+
+func (c *ChaosAuditStore) GetStaleFlags(ctx context.Context, staleThreshold time.Duration) ([]*StaleFlagEntry, error) {
+	return c.inner.GetStaleFlags(ctx, staleThreshold)
+}


### PR DESCRIPTION
## Summary
- Add `ChaosStore` and `ChaosAuditStore` decorators (`store/chaos.go`) that wrap any Store/AuditStore with configurable failure injection (FailAlways, FailAfterN, FailRandom) — thread-safe with RWMutex + atomic counters
- Add 13 chaos tests across 7 scenarios (`handlers/chaos_test.go`): store failure injection (4), PromoteToExperiment atomicity (2), store recovery (1), 60-goroutine concurrent CRUD with 10% random write failures (1), audit store failure isolation (1), context cancellation (2), server restart simulation (2)
- Update `docs/coordination/status.md` to reflect Agent-7 chaos testing milestone (4.5)

## Test plan
- [x] `go test -race -v -run='TestChaos' ./flags/internal/handlers/` — all 13 pass
- [x] `go test -race ./flags/...` — full flags suite passes
- [x] `go vet ./flags/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)