### PR TITLE
test(m5): Phase 4 stress tests — concurrent state transitions + audit completeness

### DIFF
--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,6 +1,6 @@
 # Experimentation Platform — Coordination Status
 
-> **Last updated**: 2026-03-09 by Agent-3 (Phase 4 chaos/resilience tests — 20 tests across all M3 jobs)
+> **Last updated**: 2026-03-09 by Agent-5 (Phase 4 stress tests — concurrent state transitions, bucket reuse integrity, audit completeness)
 >
 > This file is the single source of truth for multi-agent execution state.
 > Update it each time a milestone merges to `main` or a blocker is identified.
@@ -17,7 +17,7 @@
 | Agent-2 | M2 Pipeline | 🟢 All Phases Complete | agent-2/feat/e2e-pipeline-tests | Service-layer tests + Producer trait extraction | — | Phase 1 (PRs #1, #8), Phase 2 (PR #23), Phase 3 (PR #40), Phase 4 (PRs #48, #59) all merged. 78 tests (36 pipeline + 42 ingest). Producer trait enables mock-based testing. |
 | Agent-3 | M3 Metrics | 🔵 Phase 4 In Progress | agent-3/test/chaos-resilience | 4.5 Chaos/resilience tests | — | Phase 1–3 done. Kafka publisher (PR #64). M3↔M5 contracts (PR #68). Phase 4: 20 chaos tests (PR #69) — FailingExecutor/Writer/Publisher inject Spark SQL, PG, Kafka failures across all job types. |
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 3 In Progress | agent-4/feat/m4b-grpc-wiring | M4b gRPC wiring | — | M1.14–1.19 merged. M2.1–2.6, M2.10 complete. M3.1 LinUCB merged (PR #54). M3.2 cold-start merged. M4.1 CATE in PR #70. M4b BanditPolicyService gRPC wiring: all 5 RPCs implemented (SelectArm, CreateColdStartBandit, ExportAffinityScores, GetPolicySnapshot, RollbackPolicy), 17 tests pass. |
-| Agent-5 | M5 Management | 🟢 Phase 3 Complete | agent-5/feat/cumulative-holdout | M3.6 Cumulative holdout complete | — | Phase 2 complete (PRs #50, #53). M3.6: cumulative holdout support — traffic 1-5% enforcement, sequential/guardrail bypass, holdout retirement audit, ListRunningHoldouts query. |
+| Agent-5 | M5 Management | 🔵 Phase 4 In Progress | agent-5/test/phase4-stress-tests | Phase 4 stress tests | — | Phase 3 complete (M3.6 PR #57). M4.4 RBAC interceptor (PR #71). Phase 4: 6 stress tests — 100-goroutine concurrent start, rapid lifecycle cycles, bucket reuse integrity, audit trail completeness. |
 | Agent-6 | M6 UI | 🔵 In Progress | agent-6/feat/live-api-integration | Live API integration with Agent-5 | — | M1.25–1.27, M2.8–2.9, analysis tabs (PR #56), bandit dashboard (PR #60). Live API integration: Next.js rewrites proxy, ConnectRPC error parsing, opt-in MSW, 24 contract tests. 139 tests pass. Ready to pair with Agent-5 backend. |
 | Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/phase4-benchmarks | Phase 4: Performance benchmarks + concurrency stress tests | — | M1.28–1.30 merged (PR #13). Phases 1–3 complete. Phase 4: EvaluateFlag p99 ~86μs (target <10ms ✅), hash Bucket ~64ns/op (target <1μs ✅), 50-writer concurrent update + 50r/10w mixed load pass with -race. |
 
@@ -115,8 +115,8 @@
 | 4.1 | CATE heterogeneous treatment effects | Agent-4 | 🔵 | Subgroup analysis + Cochran Q + BH-FDR. 22 tests (18 unit/proptest + 4 golden). |
 | 4.2 | Interference detection (content catalog spillover) | Agent-4 | ⚪ | — |
 | 4.3 | PGO-optimized builds for M1 + M4b | Agent-1/4 | ⚪ | — |
-| 4.4 | Full RBAC integration | Agent-5 | ⚪ | — |
-| 4.5 | End-to-end chaos testing passing | All | 🔵 | Production readiness | Agent-2: chaos scripts + crash-recovery tests merged. Agent-3: 20 resilience tests (PR #69) — Spark SQL, PG, Kafka failure injection across StandardJob, GuardrailJob, InterleavingJob, ContentConsumptionJob. Other agents pending. |
+| 4.4 | Full RBAC integration | Agent-5 | 🟢 | Agent-6 (role-aware UI controls) | PR #71 merged — ConnectRPC auth interceptor, 4-level role hierarchy, audit trail records real actor |
+| 4.5 | End-to-end chaos testing passing | All | 🔵 | Production readiness | Agent-2: chaos scripts + crash-recovery tests merged. Agent-3: 20 resilience tests (PR #69). Agent-5: 6 stress tests — 100-goroutine concurrent start, bucket reuse, audit completeness. Other agents pending. |
 
 ## Pair Integration Schedule
 

--- a/services/management/internal/handlers/stress_test.go
+++ b/services/management/internal/handlers/stress_test.go
@@ -1,0 +1,472 @@
+//go:build integration
+
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+)
+
+// --- Phase 4 Stress Tests ---
+// These tests validate that M5 handles high concurrency correctly:
+// - No partial state visible to concurrent readers
+// - No overlapping bucket allocations under contention
+// - Audit trail complete for every mutation
+
+// TestStress_ConcurrentStartExperiment_100 races 100 goroutines trying to
+// start the same DRAFT experiment. Exactly one must succeed; all others must
+// get FAILED_PRECONDITION. No partial state (e.g., stuck in STARTING) should
+// be visible after all goroutines finish.
+func TestStress_ConcurrentStartExperiment_100(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+	client := env.client
+	ctx := context.Background()
+
+	layer := createTestLayer(t, client, "stress-concurrent-start-"+t.Name(), 0)
+
+	created, err := client.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: newABExperimentInLayer("stress-start-100", layer.LayerId),
+	}))
+	require.NoError(t, err)
+	id := created.Msg.ExperimentId
+
+	const goroutines = 100
+	var successes atomic.Int32
+	var preconditionErrors atomic.Int32
+	var otherErrors atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := client.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+				ExperimentId: id,
+			}))
+			if err == nil {
+				successes.Add(1)
+			} else if connect.CodeOf(err) == connect.CodeFailedPrecondition {
+				preconditionErrors.Add(1)
+			} else {
+				otherErrors.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), successes.Load(),
+		"exactly 1 goroutine should succeed starting the experiment")
+	assert.Equal(t, int32(goroutines-1), preconditionErrors.Load(),
+		"all other goroutines should get FAILED_PRECONDITION")
+	assert.Equal(t, int32(0), otherErrors.Load(),
+		"no unexpected errors should occur")
+
+	// Verify final state is RUNNING (not stuck in STARTING or DRAFT).
+	got, err := client.GetExperiment(ctx, connect.NewRequest(&mgmtv1.GetExperimentRequest{
+		ExperimentId: id,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_RUNNING, got.Msg.State,
+		"experiment should be in RUNNING state after concurrent start attempts")
+}
+
+// TestStress_RapidCreateStartConcludeCycles creates and drives many experiments
+// through the full lifecycle on the same layer (with 10% traffic each), verifying
+// that allocations never overlap and all transitions succeed.
+func TestStress_RapidCreateStartConcludeCycles(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+	client := env.client
+	ctx := context.Background()
+
+	layer := createTestLayer(t, client, "stress-rapid-cycle-"+t.Name(), 0)
+
+	const cycles = 20
+	for i := 0; i < cycles; i++ {
+		// Create experiment.
+		exp, err := client.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+			Experiment: newABExperimentInLayer(fmt.Sprintf("rapid-cycle-%d", i), layer.LayerId),
+		}))
+		require.NoError(t, err, "create cycle %d", i)
+
+		// Set 10% traffic so multiple can coexist.
+		setTrafficPercentage(t, env.pool, exp.Msg.ExperimentId, 0.1)
+
+		// Start.
+		started, err := client.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+			ExperimentId: exp.Msg.ExperimentId,
+		}))
+		require.NoError(t, err, "start cycle %d", i)
+		assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_RUNNING, started.Msg.State)
+
+		// Conclude.
+		concluded, err := client.ConcludeExperiment(ctx, connect.NewRequest(&mgmtv1.ConcludeExperimentRequest{
+			ExperimentId: exp.Msg.ExperimentId,
+		}))
+		require.NoError(t, err, "conclude cycle %d", i)
+		assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_CONCLUDED, concluded.Msg.State)
+	}
+
+	// After all cycles, verify no active allocations remain (all released).
+	allocs, err := client.GetLayerAllocations(ctx, connect.NewRequest(&mgmtv1.GetLayerAllocationsRequest{
+		LayerId: layer.LayerId,
+	}))
+	require.NoError(t, err)
+
+	var activeCount int
+	for _, a := range allocs.Msg.Allocations {
+		if a.ReleasedAt == nil {
+			activeCount++
+		}
+	}
+	assert.Equal(t, 0, activeCount,
+		"all allocations should be released after conclude")
+}
+
+// TestStress_ConcurrentBucketAllocation_10Percent races 10 goroutines starting
+// 10% experiments on the same layer (100% capacity total). All should succeed
+// with non-overlapping ranges.
+func TestStress_ConcurrentBucketAllocation_10Percent(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+	client := env.client
+	ctx := context.Background()
+
+	layer := createTestLayer(t, client, "stress-alloc-10pct-"+t.Name(), 0)
+
+	const numExperiments = 10
+	ids := make([]string, numExperiments)
+	for i := 0; i < numExperiments; i++ {
+		exp, err := client.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+			Experiment: newABExperimentInLayer(fmt.Sprintf("alloc-10pct-%d", i), layer.LayerId),
+		}))
+		require.NoError(t, err)
+		ids[i] = exp.Msg.ExperimentId
+		setTrafficPercentage(t, env.pool, ids[i], 0.1)
+	}
+
+	// Start all concurrently.
+	var successes atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < numExperiments; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := client.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+				ExperimentId: ids[idx],
+			}))
+			if err == nil {
+				successes.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(numExperiments), successes.Load(),
+		"all 10 experiments should start (10%% each = 100%% capacity)")
+
+	// Verify no overlapping allocations.
+	allocs, err := client.GetLayerAllocations(ctx, connect.NewRequest(&mgmtv1.GetLayerAllocationsRequest{
+		LayerId: layer.LayerId,
+	}))
+	require.NoError(t, err)
+	require.Len(t, allocs.Msg.Allocations, numExperiments)
+
+	// Check pairwise non-overlap.
+	for i := 0; i < len(allocs.Msg.Allocations); i++ {
+		for j := i + 1; j < len(allocs.Msg.Allocations); j++ {
+			a := allocs.Msg.Allocations[i]
+			b := allocs.Msg.Allocations[j]
+			overlaps := a.StartBucket <= b.EndBucket && b.StartBucket <= a.EndBucket
+			assert.False(t, overlaps,
+				"allocations %d [%d-%d] and %d [%d-%d] overlap",
+				i, a.StartBucket, a.EndBucket, j, b.StartBucket, b.EndBucket)
+		}
+	}
+}
+
+// TestStress_AuditTrailCompleteness drives an experiment through the full
+// lifecycle (create → start → pause → resume → conclude → archive) and
+// verifies that every transition produces an audit trail entry.
+func TestStress_AuditTrailCompleteness(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+	client := env.client
+	pool := env.pool
+	ctx := context.Background()
+
+	layer := createTestLayer(t, client, "stress-audit-"+t.Name(), 0)
+
+	// 1. Create
+	created, err := client.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+		Experiment: newABExperimentInLayer("audit-completeness", layer.LayerId),
+	}))
+	require.NoError(t, err)
+	id := created.Msg.ExperimentId
+
+	// 2. Start (DRAFT → STARTING → RUNNING = 2 audit entries)
+	_, err = client.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+		ExperimentId: id,
+	}))
+	require.NoError(t, err)
+
+	// 3. Pause (RUNNING → RUNNING, audit only)
+	_, err = client.PauseExperiment(ctx, connect.NewRequest(&mgmtv1.PauseExperimentRequest{
+		ExperimentId: id,
+		Reason:       "stress test pause",
+	}))
+	require.NoError(t, err)
+
+	// 4. Resume (RUNNING → RUNNING, audit only)
+	_, err = client.ResumeExperiment(ctx, connect.NewRequest(&mgmtv1.ResumeExperimentRequest{
+		ExperimentId: id,
+	}))
+	require.NoError(t, err)
+
+	// 5. Conclude (RUNNING → CONCLUDING → CONCLUDED = 2 audit entries)
+	_, err = client.ConcludeExperiment(ctx, connect.NewRequest(&mgmtv1.ConcludeExperimentRequest{
+		ExperimentId: id,
+	}))
+	require.NoError(t, err)
+
+	// 6. Archive (CONCLUDED → ARCHIVED)
+	_, err = client.ArchiveExperiment(ctx, connect.NewRequest(&mgmtv1.ArchiveExperimentRequest{
+		ExperimentId: id,
+	}))
+	require.NoError(t, err)
+
+	// Query audit trail.
+	rows, err := pool.Query(ctx,
+		`SELECT action, previous_state, new_state, actor_email
+		 FROM audit_trail
+		 WHERE experiment_id = $1
+		 ORDER BY created_at ASC`, id)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type auditRow struct {
+		action    string
+		prevState *string
+		newState  *string
+		actor     string
+	}
+	var entries []auditRow
+	for rows.Next() {
+		var r auditRow
+		err := rows.Scan(&r.action, &r.prevState, &r.newState, &r.actor)
+		require.NoError(t, err)
+		entries = append(entries, r)
+	}
+	require.NoError(t, rows.Err())
+
+	// Expected transitions:
+	// 1. create: → DRAFT
+	// 2. start: DRAFT → STARTING
+	// 3. start: STARTING → RUNNING
+	// 4. pause: RUNNING → RUNNING
+	// 5. resume: RUNNING → RUNNING
+	// 6. conclude: RUNNING → CONCLUDING
+	// 7. conclude: CONCLUDING → CONCLUDED
+	// 8. archive: CONCLUDED → ARCHIVED
+	require.Len(t, entries, 8,
+		"expected 8 audit trail entries for full lifecycle (create + 2 start + pause + resume + 2 conclude + archive)")
+
+	// Verify each entry.
+	expected := []struct {
+		action   string
+		newState string
+	}{
+		{"create", "DRAFT"},
+		{"start", "STARTING"},
+		{"start", "RUNNING"},
+		{"pause", "RUNNING"},
+		{"resume", "RUNNING"},
+		{"conclude", "CONCLUDING"},
+		{"conclude", "CONCLUDED"},
+		{"archive", "ARCHIVED"},
+	}
+	for i, exp := range expected {
+		assert.Equal(t, exp.action, entries[i].action,
+			"entry %d: expected action %q, got %q", i, exp.action, entries[i].action)
+		if entries[i].newState != nil {
+			assert.Equal(t, exp.newState, *entries[i].newState,
+				"entry %d: expected new_state %q, got %q", i, exp.newState, *entries[i].newState)
+		}
+	}
+
+	// Verify no entries have "system" as actor (RBAC interceptor should inject real identity).
+	for i, e := range entries {
+		assert.NotEqual(t, "system", e.actor,
+			"entry %d (%s): actor should be the authenticated user, not 'system'", i, e.action)
+	}
+}
+
+// TestStress_BucketReuseIntegrity rapidly creates, starts, and concludes
+// experiments to verify bucket allocations maintain integrity through reuse.
+// Uses 0-second cooldown so buckets are immediately reusable.
+func TestStress_BucketReuseIntegrity(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+	client := env.client
+	ctx := context.Background()
+
+	// Layer with 0-second cooldown for immediate reuse.
+	layer := createTestLayer(t, client, "stress-reuse-"+t.Name(), 0)
+
+	const rounds = 10
+	for round := 0; round < rounds; round++ {
+		// Each round: create 5 experiments at 20% traffic, start all, conclude all.
+		const perRound = 5
+		ids := make([]string, perRound)
+		for i := 0; i < perRound; i++ {
+			exp, err := client.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+				Experiment: newABExperimentInLayer(
+					fmt.Sprintf("reuse-r%d-e%d", round, i), layer.LayerId),
+			}))
+			require.NoError(t, err)
+			ids[i] = exp.Msg.ExperimentId
+			setTrafficPercentage(t, env.pool, ids[i], 0.2)
+		}
+
+		// Start all.
+		for i, id := range ids {
+			_, err := client.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+				ExperimentId: id,
+			}))
+			require.NoError(t, err, "round %d, start experiment %d", round, i)
+		}
+
+		// Verify no overlapping allocations.
+		allocs, err := client.GetLayerAllocations(ctx, connect.NewRequest(&mgmtv1.GetLayerAllocationsRequest{
+			LayerId: layer.LayerId,
+		}))
+		require.NoError(t, err)
+
+		activeAllocs := filterActiveAllocations(allocs.Msg.Allocations)
+		require.Len(t, activeAllocs, perRound,
+			"round %d: expected %d active allocations", round, perRound)
+
+		for i := 0; i < len(activeAllocs); i++ {
+			for j := i + 1; j < len(activeAllocs); j++ {
+				a := activeAllocs[i]
+				b := activeAllocs[j]
+				overlaps := a.StartBucket <= b.EndBucket && b.StartBucket <= a.EndBucket
+				assert.False(t, overlaps,
+					"round %d: allocations [%d-%d] and [%d-%d] overlap",
+					round, a.StartBucket, a.EndBucket, b.StartBucket, b.EndBucket)
+			}
+		}
+
+		// Conclude all.
+		for i, id := range ids {
+			_, err := client.ConcludeExperiment(ctx, connect.NewRequest(&mgmtv1.ConcludeExperimentRequest{
+				ExperimentId: id,
+			}))
+			require.NoError(t, err, "round %d, conclude experiment %d", round, i)
+		}
+	}
+}
+
+// filterActiveAllocations returns allocations that haven't been released.
+func filterActiveAllocations(allocs []*commonv1.LayerAllocation) []*commonv1.LayerAllocation {
+	var active []*commonv1.LayerAllocation
+	for _, a := range allocs {
+		if a.ReleasedAt == nil {
+			active = append(active, a)
+		}
+	}
+	return active
+}
+
+// TestStress_ConcurrentLifecycleOperations fires mixed lifecycle operations
+// concurrently on different experiments to verify no cross-experiment interference.
+func TestStress_ConcurrentLifecycleOperations(t *testing.T) {
+	env, cleanup := setupTestServer(t)
+	defer cleanup()
+	client := env.client
+	ctx := context.Background()
+
+	const numExperiments = 20
+	layers := make([]string, numExperiments)
+	ids := make([]string, numExperiments)
+
+	// Each experiment gets its own layer to avoid allocation conflicts.
+	for i := 0; i < numExperiments; i++ {
+		layer := createTestLayer(t, client, fmt.Sprintf("stress-mixed-%d-%s", i, t.Name()), 0)
+		layers[i] = layer.LayerId
+
+		exp, err := client.CreateExperiment(ctx, connect.NewRequest(&mgmtv1.CreateExperimentRequest{
+			Experiment: newABExperimentInLayer(fmt.Sprintf("mixed-%d", i), layers[i]),
+		}))
+		require.NoError(t, err)
+		ids[i] = exp.Msg.ExperimentId
+	}
+
+	// Concurrently start all experiments.
+	var wg sync.WaitGroup
+	var startErrors atomic.Int32
+	for i := 0; i < numExperiments; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := client.StartExperiment(ctx, connect.NewRequest(&mgmtv1.StartExperimentRequest{
+				ExperimentId: ids[idx],
+			}))
+			if err != nil {
+				startErrors.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, int32(0), startErrors.Load(),
+		"all experiments should start (each in own layer)")
+
+	// Verify all are RUNNING.
+	for i, id := range ids {
+		got, err := client.GetExperiment(ctx, connect.NewRequest(&mgmtv1.GetExperimentRequest{
+			ExperimentId: id,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_RUNNING, got.Msg.State,
+			"experiment %d should be RUNNING", i)
+	}
+
+	// Concurrently conclude all experiments.
+	var concludeErrors atomic.Int32
+	for i := 0; i < numExperiments; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := client.ConcludeExperiment(ctx, connect.NewRequest(&mgmtv1.ConcludeExperimentRequest{
+				ExperimentId: ids[idx],
+			}))
+			if err != nil {
+				concludeErrors.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, int32(0), concludeErrors.Load(),
+		"all experiments should conclude")
+
+	// Verify all are CONCLUDED.
+	for i, id := range ids {
+		got, err := client.GetExperiment(ctx, connect.NewRequest(&mgmtv1.GetExperimentRequest{
+			ExperimentId: id,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, commonv1.ExperimentState_EXPERIMENT_STATE_CONCLUDED, got.Msg.State,
+			"experiment %d should be CONCLUDED", i)
+	}
+}


### PR DESCRIPTION
## Summary

- 6 integration stress tests validating M5 behavior under high concurrency and rapid lifecycle cycling
- Scales up existing concurrency tests (10 → 100 goroutines) and adds new stress scenarios
- Verifies audit trail completeness through full lifecycle (8 entries for create→start→pause→resume→conclude→archive)

## Tests

| Test | What it validates |
|------|------------------|
| `TestStress_ConcurrentStartExperiment_100` | 100 goroutines race to start same experiment — exactly 1 succeeds, 99 get FAILED_PRECONDITION, no partial state |
| `TestStress_ConcurrentBucketAllocation_10Percent` | 10 concurrent 10% experiments on same layer — all succeed, pairwise non-overlapping allocations |
| `TestStress_RapidCreateStartConcludeCycles` | 20 sequential create/start/conclude cycles on same layer — all allocations released |
| `TestStress_BucketReuseIntegrity` | 10 rounds x 5 experiments at 20% — bucket reuse with 0s cooldown, no overlaps per round |
| `TestStress_AuditTrailCompleteness` | Full lifecycle produces exactly 8 audit entries with correct action/state/actor |
| `TestStress_ConcurrentLifecycleOperations` | 20 experiments in isolated layers — concurrent start + concurrent conclude, all succeed |

## Test plan

- [x] `go vet ./services/management/...` — passes
- [x] `go build ./services/management/...` — passes
- [ ] `go test -tags integration -race -v -run TestStress ./services/management/internal/handlers/...` (requires `just dev`)

## What this unblocks

- Production readiness (M4.5 chaos testing) — Agent-5 stress testing contribution complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)