### PR TITLE
feat(m6): surrogate projections, holdout lift, guardrail breach panel

### DIFF
--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import {
   SEED_EXPERIMENTS, SEED_QUERY_LOG, SEED_ANALYSIS_RESULTS,
   SEED_NOVELTY_RESULTS, SEED_INTERFERENCE_RESULTS, SEED_INTERLEAVING_RESULTS,
-  SEED_BANDIT_RESULTS,
+  SEED_BANDIT_RESULTS, SEED_HOLDOUT_RESULTS, SEED_GUARDRAIL_STATUS,
 } from './seed-data';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
@@ -262,6 +262,33 @@ export const handlers = [
         { error: `No bandit dashboard for experiment ${body.experimentId}` },
         { status: 404 },
       );
+    }
+    return HttpResponse.json(result);
+  }),
+
+  // GetCumulativeHoldoutResult
+  http.post(`${ANALYSIS_SVC}/GetCumulativeHoldoutResult`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_HOLDOUT_RESULTS[body.experimentId];
+    if (!result) {
+      return HttpResponse.json(
+        { error: `No holdout result for experiment ${body.experimentId}` },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(result);
+  }),
+
+  // GetGuardrailStatus
+  http.post(`${MGMT_SVC}/GetGuardrailStatus`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_GUARDRAIL_STATUS[body.experimentId];
+    if (!result) {
+      return HttpResponse.json({
+        experimentId: body.experimentId,
+        breaches: [],
+        isPaused: false,
+      });
     }
     return HttpResponse.json(result);
   }),

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -1,7 +1,7 @@
 import type {
   AnalysisResult, Experiment, QueryLogEntry,
   NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
-  BanditDashboardResult,
+  BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult,
 } from '@/lib/types';
 
 const INITIAL_EXPERIMENTS: Experiment[] = [
@@ -45,6 +45,7 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
       plannedLooks: 0,
       overallAlpha: 0.05,
     },
+    surrogateModelId: 'surrogate-homepage-ltv',
     isCumulativeHoldout: false,
     createdAt: '2026-02-15T10:00:00Z',
     startedAt: '2026-02-16T08:00:00Z',
@@ -239,6 +240,46 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
     createdAt: '2026-02-10T09:00:00Z',
     startedAt: '2026-02-11T06:00:00Z',
   },
+  // Cumulative holdout experiment
+  {
+    experimentId: '77777777-7777-7777-7777-777777777777',
+    name: 'recommendation_holdout_q1',
+    description: 'Cumulative holdout measuring long-term impact of recommendation algorithm changes',
+    ownerEmail: 'alice@streamco.com',
+    type: 'CUMULATIVE_HOLDOUT',
+    state: 'RUNNING',
+    variants: [
+      {
+        variantId: 'v7-holdout',
+        name: 'holdout',
+        trafficFraction: 0.05,
+        isControl: true,
+        payloadJson: '{"algorithm": "collaborative_filter_v1"}',
+      },
+      {
+        variantId: 'v7-treatment',
+        name: 'all_changes',
+        trafficFraction: 0.95,
+        isControl: false,
+        payloadJson: '{"algorithm": "latest_production"}',
+      },
+    ],
+    layerId: 'layer-holdout',
+    hashSalt: 'salt-recommendation-holdout-q1',
+    primaryMetricId: 'monthly_active_days',
+    secondaryMetricIds: ['watch_hours_per_month', 'churn_rate'],
+    guardrailConfigs: [
+      {
+        metricId: 'churn_rate',
+        threshold: 0.08,
+        consecutiveBreachesRequired: 3,
+      },
+    ],
+    guardrailAction: 'ALERT_ONLY',
+    isCumulativeHoldout: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    startedAt: '2026-01-02T00:00:00Z',
+  },
 ];
 
 /** Mock query log entries for RUNNING experiments. */
@@ -370,6 +411,24 @@ const INITIAL_ANALYSIS_RESULTS: AnalysisResult[] = [
       observedCounts: { 'v1-control': 50102, 'v1-treatment': 49898 },
       expectedCounts: { 'v1-control': 50000, 'v1-treatment': 50000 },
     },
+    surrogateProjections: [
+      {
+        metricId: 'monthly_retention_rate',
+        surrogateMetricId: 'click_through_rate',
+        projectedEffect: 0.008,
+        projectionCiLower: 0.002,
+        projectionCiUpper: 0.014,
+        calibrationRSquared: 0.78,
+      },
+      {
+        metricId: 'lifetime_value',
+        surrogateMetricId: 'watch_time_per_session',
+        projectedEffect: 2.45,
+        projectionCiLower: -0.50,
+        projectionCiUpper: 5.40,
+        calibrationRSquared: 0.52,
+      },
+    ],
     computedAt: '2026-03-05T12:00:00Z',
   },
   {
@@ -558,6 +617,56 @@ const INITIAL_BANDIT_RESULTS: Record<string, BanditDashboardResult> = {
   },
 };
 
+/** Cumulative holdout results — recommendation_holdout_q1 running since Jan 2026. */
+const INITIAL_HOLDOUT_RESULTS: Record<string, CumulativeHoldoutResult> = {
+  '77777777-7777-7777-7777-777777777777': {
+    experimentId: '77777777-7777-7777-7777-777777777777',
+    metricId: 'monthly_active_days',
+    currentCumulativeLift: 1.8,
+    currentCiLower: 0.4,
+    currentCiUpper: 3.2,
+    isSignificant: true,
+    timeSeries: [
+      { date: '2026-01-15', cumulativeLift: 0.3, ciLower: -2.1, ciUpper: 2.7, sampleSize: 12000 },
+      { date: '2026-01-31', cumulativeLift: 0.8, ciLower: -1.0, ciUpper: 2.6, sampleSize: 24000 },
+      { date: '2026-02-15', cumulativeLift: 1.2, ciLower: -0.2, ciUpper: 2.6, sampleSize: 36000 },
+      { date: '2026-02-28', cumulativeLift: 1.5, ciLower: 0.1, ciUpper: 2.9, sampleSize: 48000 },
+      { date: '2026-03-05', cumulativeLift: 1.8, ciLower: 0.4, ciUpper: 3.2, sampleSize: 55000 },
+    ],
+    computedAt: '2026-03-05T18:00:00Z',
+  },
+};
+
+/** Guardrail breach history — homepage_recs_v2 had a brief crash_rate spike. */
+const INITIAL_GUARDRAIL_STATUS: Record<string, GuardrailStatusResult> = {
+  '11111111-1111-1111-1111-111111111111': {
+    experimentId: '11111111-1111-1111-1111-111111111111',
+    breaches: [
+      {
+        experimentId: '11111111-1111-1111-1111-111111111111',
+        metricId: 'crash_rate',
+        variantId: 'v1-treatment',
+        currentValue: 0.012,
+        threshold: 0.01,
+        consecutiveBreachCount: 1,
+        action: 'ALERT',
+        detectedAt: '2026-02-28T03:15:00Z',
+      },
+      {
+        experimentId: '11111111-1111-1111-1111-111111111111',
+        metricId: 'crash_rate',
+        variantId: 'v1-treatment',
+        currentValue: 0.014,
+        threshold: 0.01,
+        consecutiveBreachCount: 2,
+        action: 'AUTO_PAUSE',
+        detectedAt: '2026-02-28T06:30:00Z',
+      },
+    ],
+    isPaused: false,
+  },
+};
+
 /** Mutable copy of seed data — MSW handlers mutate this in-place. */
 export let SEED_EXPERIMENTS: Experiment[] = structuredClone(INITIAL_EXPERIMENTS);
 export let SEED_QUERY_LOG: Record<string, QueryLogEntry[]> = structuredClone(INITIAL_QUERY_LOG);
@@ -566,6 +675,8 @@ export let SEED_NOVELTY_RESULTS: Record<string, NoveltyAnalysisResult> = structu
 export let SEED_INTERFERENCE_RESULTS: Record<string, InterferenceAnalysisResult> = structuredClone(INITIAL_INTERFERENCE_RESULTS);
 export let SEED_INTERLEAVING_RESULTS: Record<string, InterleavingAnalysisResult> = structuredClone(INITIAL_INTERLEAVING_RESULTS);
 export let SEED_BANDIT_RESULTS: Record<string, BanditDashboardResult> = structuredClone(INITIAL_BANDIT_RESULTS);
+export let SEED_HOLDOUT_RESULTS: Record<string, CumulativeHoldoutResult> = structuredClone(INITIAL_HOLDOUT_RESULTS);
+export let SEED_GUARDRAIL_STATUS: Record<string, GuardrailStatusResult> = structuredClone(INITIAL_GUARDRAIL_STATUS);
 
 /** Reset seed data to initial state. Call in afterEach for test isolation. */
 export function resetSeedData(): void {
@@ -576,4 +687,6 @@ export function resetSeedData(): void {
   SEED_INTERFERENCE_RESULTS = structuredClone(INITIAL_INTERFERENCE_RESULTS);
   SEED_INTERLEAVING_RESULTS = structuredClone(INITIAL_INTERLEAVING_RESULTS);
   SEED_BANDIT_RESULTS = structuredClone(INITIAL_BANDIT_RESULTS);
+  SEED_HOLDOUT_RESULTS = structuredClone(INITIAL_HOLDOUT_RESULTS);
+  SEED_GUARDRAIL_STATUS = structuredClone(INITIAL_GUARDRAIL_STATUS);
 }

--- a/ui/src/__tests__/experiment-list.test.tsx
+++ b/ui/src/__tests__/experiment-list.test.tsx
@@ -56,7 +56,7 @@ describe('Experiment List Page', () => {
     render(<ExperimentListPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('alice@streamco.com')).toBeInTheDocument();
+      expect(screen.getAllByText('alice@streamco.com').length).toBeGreaterThanOrEqual(1);
     });
 
     expect(screen.getByText('bob@streamco.com')).toBeInTheDocument();

--- a/ui/src/__tests__/svod-views.test.tsx
+++ b/ui/src/__tests__/svod-views.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ResultsPage from '@/app/experiments/[id]/results/page';
+
+let mockExperimentId = '11111111-1111-1111-1111-111111111111';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: mockExperimentId }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// Mock recharts to avoid SVG rendering issues in jsdom
+vi.mock('recharts', async () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  );
+  const Noop = () => null;
+
+  return {
+    ResponsiveContainer: Passthrough,
+    ComposedChart: Passthrough,
+    BarChart: Passthrough,
+    Bar: Noop,
+    Scatter: Noop,
+    Line: Noop,
+    Area: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    ReferenceLine: Noop,
+    Tooltip: Noop,
+    ErrorBar: Noop,
+    Cell: Noop,
+  };
+});
+
+describe('Surrogate Tab - homepage_recs_v2', () => {
+  beforeEach(() => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+  });
+
+  it('shows Surrogate Projections tab for experiment with surrogate data', async () => {
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Surrogate Projections' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows surrogate projection table with R² badges', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Surrogate Projections' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Surrogate Projections' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('monthly_retention_rate')).toBeInTheDocument();
+    });
+
+    // Surrogate metric name
+    expect(screen.getByText('click_through_rate')).toBeInTheDocument();
+    // R² = 0.78 -> High badge
+    expect(screen.getByText('High')).toBeInTheDocument();
+    // R² = 0.52 -> Medium badge
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+  });
+
+  it('shows projected effects for long-term metrics', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Surrogate Projections' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Surrogate Projections' }));
+
+    await waitFor(() => {
+      // monthly_retention_rate projected effect = 0.008
+      expect(screen.getByText('+0.0080')).toBeInTheDocument();
+    });
+
+    // lifetime_value projected effect = 2.45
+    expect(screen.getByText('+2.4500')).toBeInTheDocument();
+  });
+
+  it('shows calibration guide with color legend', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Surrogate Projections' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Surrogate Projections' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Calibration Guide')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Surrogate Tab - no surrogate data', () => {
+  it('does not show Surrogate Projections tab for experiment without surrogates', async () => {
+    mockExperimentId = '33333333-3333-3333-3333-333333333333';
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Results Dashboard' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('tab', { name: 'Surrogate Projections' })).not.toBeInTheDocument();
+  });
+});
+
+describe('Guardrails Tab - homepage_recs_v2', () => {
+  beforeEach(() => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+  });
+
+  it('shows Guardrails tab for experiment with guardrail configs', async () => {
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Guardrails' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows breach history table with actions', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Guardrails' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Guardrails' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('crash_rate').length).toBe(2);
+    });
+
+    // Breach values
+    expect(screen.getByText('0.0120')).toBeInTheDocument();
+    expect(screen.getByText('0.0140')).toBeInTheDocument();
+
+    // Action badges
+    expect(screen.getByText('Alert')).toBeInTheDocument();
+    expect(screen.getByText('Auto-Pause')).toBeInTheDocument();
+  });
+
+  it('shows breach count and variant', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Guardrails' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Guardrails' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('v1-treatment').length).toBe(2);
+    });
+  });
+});
+
+describe('Guardrails Tab - no guardrails', () => {
+  it('does not show Guardrails tab for experiment without guardrail configs', async () => {
+    mockExperimentId = '33333333-3333-3333-3333-333333333333';
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Results Dashboard' })).toBeInTheDocument();
+    });
+
+    // search_ranking_interleave has empty guardrailConfigs
+    expect(screen.queryByRole('tab', { name: 'Guardrails' })).not.toBeInTheDocument();
+  });
+});
+
+describe('Holdout Tab - no holdout data', () => {
+  it('does not show Holdout Lift tab for non-holdout experiment', async () => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Results Dashboard' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('tab', { name: 'Holdout Lift' })).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/app/experiments/[id]/results/page.tsx
+++ b/ui/src/app/experiments/[id]/results/page.tsx
@@ -14,15 +14,11 @@ import { SequentialBoundaryPlot } from '@/components/charts/sequential-boundary-
 import { NoveltyTab } from '@/components/novelty-tab';
 import { InterferenceTab } from '@/components/interference-tab';
 import { InterleavingTab } from '@/components/interleaving-tab';
+import { SurrogateTab } from '@/components/surrogate-tab';
+import { HoldoutTab } from '@/components/holdout-tab';
+import { GuardrailTab } from '@/components/guardrail-tab';
 
-type AnalysisTab = 'overview' | 'novelty' | 'interference' | 'interleaving';
-
-const TABS: { key: AnalysisTab; label: string }[] = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'novelty', label: 'Novelty Effects' },
-  { key: 'interference', label: 'Content Interference' },
-  { key: 'interleaving', label: 'Interleaving' },
-];
+type AnalysisTab = 'overview' | 'novelty' | 'interference' | 'interleaving' | 'surrogate' | 'holdout' | 'guardrails';
 
 export default function ResultsPage() {
   const params = useParams<{ id: string }>();
@@ -74,7 +70,26 @@ export default function ResultsPage() {
 
   const hasCupedData = analysisResult.metricResults.some((m) => m.varianceReductionPct > 0);
   const maxVarianceReduction = Math.max(...analysisResult.metricResults.map((m) => m.varianceReductionPct));
-  const isInterleaving = experiment.type === 'INTERLEAVING';
+  const hasSurrogateProjections = (analysisResult.surrogateProjections?.length ?? 0) > 0;
+  const isHoldout = experiment.type === 'CUMULATIVE_HOLDOUT';
+  const hasGuardrails = experiment.guardrailConfigs.length > 0;
+
+  // Build tabs dynamically based on experiment features
+  const tabs: { key: AnalysisTab; label: string }[] = [
+    { key: 'overview', label: 'Overview' },
+    { key: 'novelty', label: 'Novelty Effects' },
+    { key: 'interference', label: 'Content Interference' },
+    { key: 'interleaving', label: 'Interleaving' },
+  ];
+  if (hasSurrogateProjections) {
+    tabs.push({ key: 'surrogate', label: 'Surrogate Projections' });
+  }
+  if (isHoldout) {
+    tabs.push({ key: 'holdout', label: 'Holdout Lift' });
+  }
+  if (hasGuardrails) {
+    tabs.push({ key: 'guardrails', label: 'Guardrails' });
+  }
 
   return (
     <div>
@@ -98,7 +113,7 @@ export default function ResultsPage() {
       {/* Tab navigation */}
       <div className="mb-6 border-b border-gray-200">
         <nav className="-mb-px flex space-x-6" aria-label="Analysis tabs">
-          {TABS.map((tab) => (
+          {tabs.map((tab) => (
             <button
               key={tab.key}
               onClick={() => setActiveTab(tab.key)}
@@ -157,6 +172,18 @@ export default function ResultsPage() {
 
       {activeTab === 'interleaving' && (
         <InterleavingTab experimentId={params.id} />
+      )}
+
+      {activeTab === 'surrogate' && analysisResult.surrogateProjections && (
+        <SurrogateTab projections={analysisResult.surrogateProjections} />
+      )}
+
+      {activeTab === 'holdout' && (
+        <HoldoutTab experimentId={params.id} />
+      )}
+
+      {activeTab === 'guardrails' && (
+        <GuardrailTab experimentId={params.id} />
       )}
     </div>
   );

--- a/ui/src/components/guardrail-tab.tsx
+++ b/ui/src/components/guardrail-tab.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { GuardrailStatusResult } from '@/lib/types';
+import { getGuardrailStatus } from '@/lib/api';
+import { formatDate } from '@/lib/utils';
+
+interface GuardrailTabProps {
+  experimentId: string;
+}
+
+export function GuardrailTab({ experimentId }: GuardrailTabProps) {
+  const [result, setResult] = useState<GuardrailStatusResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getGuardrailStatus(experimentId)
+      .then(setResult)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [experimentId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Failed to load guardrail status: {error}
+      </div>
+    );
+  }
+
+  if (!result || result.breaches.length === 0) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-md bg-green-50 border border-green-200 p-4">
+          <h4 className="text-sm font-semibold text-green-800">No Guardrail Breaches</h4>
+          <p className="mt-1 text-sm text-green-700">
+            All guardrail metrics are within acceptable thresholds.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const hasPause = result.breaches.some((b) => b.action === 'AUTO_PAUSE');
+
+  return (
+    <div className="space-y-4">
+      {/* Status banner */}
+      {result.isPaused ? (
+        <div className="rounded-md bg-red-50 border border-red-200 p-4">
+          <h4 className="text-sm font-semibold text-red-800">Experiment Auto-Paused</h4>
+          <p className="mt-1 text-sm text-red-700">
+            This experiment was automatically paused due to guardrail breaches.
+          </p>
+        </div>
+      ) : hasPause ? (
+        <div className="rounded-md bg-amber-50 border border-amber-200 p-4">
+          <h4 className="text-sm font-semibold text-amber-800">Guardrail Breaches Detected</h4>
+          <p className="mt-1 text-sm text-amber-700">
+            {result.breaches.length} breach{result.breaches.length !== 1 ? 'es' : ''} recorded.
+            Auto-pause was triggered but the experiment has since been resumed.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md bg-amber-50 border border-amber-200 p-4">
+          <h4 className="text-sm font-semibold text-amber-800">Guardrail Alerts</h4>
+          <p className="mt-1 text-sm text-amber-700">
+            {result.breaches.length} alert{result.breaches.length !== 1 ? 's' : ''} recorded.
+            No auto-pause was triggered.
+          </p>
+        </div>
+      )}
+
+      {/* Breach history table */}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr className="bg-gray-50">
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Time</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Metric</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Variant</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Value</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Threshold</th>
+              <th className="px-4 py-3 text-center text-xs font-medium uppercase text-gray-500">Consecutive</th>
+              <th className="px-4 py-3 text-center text-xs font-medium uppercase text-gray-500">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {result.breaches.map((breach, idx) => (
+              <tr key={`${breach.metricId}-${breach.detectedAt}-${idx}`}>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                  {formatDate(breach.detectedAt)}
+                  <span className="ml-1 text-xs text-gray-400">
+                    {new Date(breach.detectedAt).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                  {breach.metricId}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                  {breach.variantId}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-mono text-red-700">
+                  {breach.currentValue.toFixed(4)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-mono text-gray-600">
+                  {breach.threshold.toFixed(4)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-center text-sm text-gray-700">
+                  {breach.consecutiveBreachCount}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-center">
+                  <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                    breach.action === 'AUTO_PAUSE'
+                      ? 'bg-red-100 text-red-800'
+                      : 'bg-yellow-100 text-yellow-800'
+                  }`}>
+                    {breach.action === 'AUTO_PAUSE' ? 'Auto-Pause' : 'Alert'}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/holdout-tab.tsx
+++ b/ui/src/components/holdout-tab.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Line, XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer, ReferenceLine, Area, ComposedChart,
+} from 'recharts';
+import type { CumulativeHoldoutResult } from '@/lib/types';
+import { getCumulativeHoldoutResult } from '@/lib/api';
+
+interface HoldoutTabProps {
+  experimentId: string;
+}
+
+export function HoldoutTab({ experimentId }: HoldoutTabProps) {
+  const [result, setResult] = useState<CumulativeHoldoutResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getCumulativeHoldoutResult(experimentId)
+      .then(setResult)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [experimentId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error || !result) {
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+        No cumulative holdout data available for this experiment.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Status banner */}
+      <div className={`rounded-md border p-4 ${
+        result.isSignificant
+          ? 'bg-green-50 border-green-200'
+          : 'bg-gray-50 border-gray-200'
+      }`}>
+        <h4 className={`text-sm font-semibold ${
+          result.isSignificant ? 'text-green-800' : 'text-gray-800'
+        }`}>
+          Cumulative Holdout — {result.metricId}
+        </h4>
+        <p className={`mt-1 text-sm ${
+          result.isSignificant ? 'text-green-700' : 'text-gray-700'
+        }`}>
+          {result.isSignificant
+            ? 'The cumulative lift is statistically significant. Production changes are delivering measurable impact.'
+            : 'The cumulative lift is not yet statistically significant. Continue monitoring.'
+          }
+        </p>
+      </div>
+
+      {/* Key metrics */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Cumulative Lift</span>
+          <p className={`mt-1 text-lg font-semibold ${
+            result.currentCumulativeLift > 0 ? 'text-green-700' : 'text-red-700'
+          }`}>
+            {result.currentCumulativeLift > 0 ? '+' : ''}{result.currentCumulativeLift.toFixed(2)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">95% CI</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            [{result.currentCiLower.toFixed(2)}, {result.currentCiUpper.toFixed(2)}]
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Latest Sample</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {result.timeSeries.length > 0
+              ? result.timeSeries[result.timeSeries.length - 1].sampleSize.toLocaleString()
+              : '—'
+            }
+          </p>
+        </div>
+      </div>
+
+      {/* Time series chart */}
+      {result.timeSeries.length > 0 && (
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <h4 className="mb-3 text-sm font-semibold text-gray-900">Cumulative Lift Over Time</h4>
+          <div style={{ width: '100%', height: 300 }}>
+            <ResponsiveContainer>
+              <ComposedChart data={result.timeSeries} margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={(d: string) => new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                  tick={{ fontSize: 12 }}
+                />
+                <YAxis tick={{ fontSize: 12 }} />
+                <Tooltip
+                  labelFormatter={(d: string) => new Date(d).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                  formatter={(value: number, name: string) => [value.toFixed(2), name]}
+                />
+                <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="3 3" />
+                <Area
+                  dataKey="ciUpper"
+                  stroke="none"
+                  fill="#bbf7d0"
+                  fillOpacity={0.4}
+                  name="CI Upper"
+                />
+                <Area
+                  dataKey="ciLower"
+                  stroke="none"
+                  fill="#ffffff"
+                  fillOpacity={1}
+                  name="CI Lower"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="cumulativeLift"
+                  stroke="#16a34a"
+                  strokeWidth={2}
+                  dot={{ fill: '#16a34a', r: 3 }}
+                  name="Cumulative Lift"
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/surrogate-tab.tsx
+++ b/ui/src/components/surrogate-tab.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import type { SurrogateProjection } from '@/lib/types';
+
+interface SurrogateTabProps {
+  projections: SurrogateProjection[];
+}
+
+function rSquaredBadge(r2: number): { label: string; bg: string; text: string } {
+  if (r2 >= 0.7) return { label: 'High', bg: 'bg-green-100', text: 'text-green-800' };
+  if (r2 >= 0.5) return { label: 'Medium', bg: 'bg-yellow-100', text: 'text-yellow-800' };
+  return { label: 'Low', bg: 'bg-red-100', text: 'text-red-800' };
+}
+
+export function SurrogateTab({ projections }: SurrogateTabProps) {
+  if (projections.length === 0) {
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+        No surrogate projections available for this experiment.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md bg-blue-50 border border-blue-200 p-4">
+        <h4 className="text-sm font-semibold text-blue-800">Surrogate Projections</h4>
+        <p className="mt-1 text-sm text-blue-700">
+          Long-term metric effects projected from short-term surrogate metrics.
+          Confidence depends on model calibration (R&sup2;).
+        </p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr className="bg-gray-50">
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Long-Term Metric</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Surrogate Metric</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Projected Effect</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">95% CI</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">R&sup2;</th>
+              <th className="px-4 py-3 text-center text-xs font-medium uppercase text-gray-500">Confidence</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {projections.map((proj) => {
+              const badge = rSquaredBadge(proj.calibrationRSquared);
+              const ciIncludes0 = proj.projectionCiLower <= 0 && proj.projectionCiUpper >= 0;
+              return (
+                <tr key={`${proj.metricId}-${proj.surrogateMetricId}`}>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                    {proj.metricId}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                    {proj.surrogateMetricId}
+                  </td>
+                  <td className={`whitespace-nowrap px-4 py-3 text-right text-sm font-mono ${
+                    proj.projectedEffect > 0 ? 'text-green-700' : proj.projectedEffect < 0 ? 'text-red-700' : 'text-gray-700'
+                  }`}>
+                    {proj.projectedEffect > 0 ? '+' : ''}{proj.projectedEffect.toFixed(4)}
+                  </td>
+                  <td className={`whitespace-nowrap px-4 py-3 text-right text-sm font-mono ${
+                    ciIncludes0 ? 'text-gray-500' : 'text-gray-700'
+                  }`}>
+                    [{proj.projectionCiLower.toFixed(4)}, {proj.projectionCiUpper.toFixed(4)}]
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-mono text-gray-700">
+                    {proj.calibrationRSquared.toFixed(2)}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-center">
+                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${badge.bg} ${badge.text}`}>
+                      {badge.label}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <h4 className="text-sm font-semibold text-gray-900">Calibration Guide</h4>
+        <div className="mt-2 flex items-center gap-6 text-xs text-gray-600">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2.5 w-2.5 rounded-full bg-green-500" />
+            High (R&sup2; &ge; 0.7)
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2.5 w-2.5 rounded-full bg-yellow-500" />
+            Medium (0.5 &le; R&sup2; &lt; 0.7)
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block h-2.5 w-2.5 rounded-full bg-red-500" />
+            Low (R&sup2; &lt; 0.5)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,7 +1,7 @@
 import type {
   AnalysisResult, CreateExperimentRequest, Experiment, ListExperimentsResponse,
   QueryLogEntry, NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
-  BanditDashboardResult,
+  BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult,
 } from './types';
 import type { ExperimentState, ExperimentType } from './types';
 
@@ -179,5 +179,17 @@ export async function getInterleavingAnalysis(experimentId: string): Promise<Int
 export async function getBanditDashboard(experimentId: string): Promise<BanditDashboardResult> {
   return callRpc<{ experimentId: string }, BanditDashboardResult>(
     BANDIT_URL, BANDIT_SVC, 'GetBanditDashboard', { experimentId },
+  );
+}
+
+export async function getCumulativeHoldoutResult(experimentId: string): Promise<CumulativeHoldoutResult> {
+  return callRpc<{ experimentId: string }, CumulativeHoldoutResult>(
+    ANALYSIS_URL, ANALYSIS_SVC, 'GetCumulativeHoldoutResult', { experimentId },
+  );
+}
+
+export async function getGuardrailStatus(experimentId: string): Promise<GuardrailStatusResult> {
+  return callRpc<{ experimentId: string }, GuardrailStatusResult>(
+    MGMT_URL, MGMT_SVC, 'GetGuardrailStatus', { experimentId },
   );
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -135,6 +135,7 @@ export interface AnalysisResult {
   experimentId: string;
   metricResults: MetricResult[];
   srmResult: SrmResult;
+  surrogateProjections?: SurrogateProjection[];
   computedAt: string;
 }
 
@@ -196,6 +197,57 @@ export interface InterleavingAnalysisResult {
   algorithmStrengths: AlgorithmStrength[];
   positionAnalyses: PositionAnalysis[];
   computedAt: string;
+}
+
+// --- Surrogate Projections (M2.10) ---
+
+export interface SurrogateProjection {
+  metricId: string;
+  surrogateMetricId: string;
+  projectedEffect: number;
+  projectionCiLower: number;
+  projectionCiUpper: number;
+  calibrationRSquared: number;
+}
+
+// --- Cumulative Holdout (M2.10) ---
+
+export interface HoldoutTimeSeriesPoint {
+  date: string;
+  cumulativeLift: number;
+  ciLower: number;
+  ciUpper: number;
+  sampleSize: number;
+}
+
+export interface CumulativeHoldoutResult {
+  experimentId: string;
+  metricId: string;
+  currentCumulativeLift: number;
+  currentCiLower: number;
+  currentCiUpper: number;
+  isSignificant: boolean;
+  timeSeries: HoldoutTimeSeriesPoint[];
+  computedAt: string;
+}
+
+// --- Guardrail Breach History (M2.10) ---
+
+export interface GuardrailBreachEvent {
+  experimentId: string;
+  metricId: string;
+  variantId: string;
+  currentValue: number;
+  threshold: number;
+  consecutiveBreachCount: number;
+  action: 'ALERT' | 'AUTO_PAUSE';
+  detectedAt: string;
+}
+
+export interface GuardrailStatusResult {
+  experimentId: string;
+  breaches: GuardrailBreachEvent[];
+  isPaused: boolean;
 }
 
 // --- Bandit Dashboard (M3.3) ---


### PR DESCRIPTION
## Summary
- **Surrogate Projections tab**: projected long-term metric effects from short-term surrogates with R² calibration confidence badges (High ≥0.7, Medium ≥0.5, Low <0.5)
- **Cumulative Holdout tab**: time-series chart of cumulative lift over time with CI band, significance status, and sample size — for `CUMULATIVE_HOLDOUT` experiments
- **Guardrails tab**: breach history table showing metric, variant, current value vs threshold, consecutive breach count, and action badges (Alert / Auto-Pause)
- Tabs appear conditionally based on experiment type and data availability
- New holdout seed experiment (`77777777...`), surrogate projections on `homepage_recs_v2`, guardrail breach history for crash_rate

## Files changed
| File | Change |
|------|--------|
| `ui/src/lib/types.ts` | +6 new types: SurrogateProjection, HoldoutTimeSeriesPoint, CumulativeHoldoutResult, GuardrailBreachEvent, GuardrailStatusResult, AnalysisResult.surrogateProjections |
| `ui/src/lib/api.ts` | +2 API functions: getCumulativeHoldoutResult, getGuardrailStatus |
| `ui/src/__mocks__/seed-data.ts` | +holdout experiment, surrogate projections, guardrail breaches |
| `ui/src/__mocks__/handlers.ts` | +2 MSW handlers: GetCumulativeHoldoutResult, GetGuardrailStatus |
| `ui/src/components/surrogate-tab.tsx` | New component |
| `ui/src/components/holdout-tab.tsx` | New component |
| `ui/src/components/guardrail-tab.tsx` | New component |
| `ui/src/app/experiments/[id]/results/page.tsx` | Dynamic tabs, wire 3 new views |
| `ui/src/__tests__/svod-views.test.tsx` | 10 new tests |

## Test plan
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `npx vitest run` — 149 tests pass (10 new)
- [ ] Browse `/experiments/11111111.../results` → Surrogate Projections + Guardrails tabs visible
- [ ] Surrogate tab shows R² badges (High green, Medium yellow)
- [ ] Guardrails tab shows 2 breach rows with Alert and Auto-Pause badges
- [ ] Browse `/experiments/77777777.../results` → Holdout Lift tab visible with time-series chart
- [ ] `/experiments/33333333.../results` → no Surrogate or Guardrails tabs (correct conditional hiding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)