### PR TITLE
feat(m2): fix loadtest + guardrail E2E harness + chaos framework

### DIFF
--- a/scripts/chaos_e2e_framework.sh
+++ b/scripts/chaos_e2e_framework.sh
@@ -1,0 +1,545 @@
+#!/usr/bin/env bash
+# =============================================================================
+# End-to-End Chaos Test Framework (Milestone 4.5)
+# =============================================================================
+# Multi-service chaos orchestrator with pluggable per-service hooks.
+#
+# Flow:
+#   1. Start Docker infra (Kafka, Postgres, Redis)
+#   2. Discover and start registered services
+#   3. Send sustained multi-event-type load
+#   4. Sequentially kill each service (kill -9), verify recovery < 2s
+#   5. Validate zero data loss (ingest counts match Kafka offsets)
+#   6. Generate unified report
+#
+# Pluggable hooks:
+#   Each agent adds a script at scripts/chaos_test_<service>.sh that exports:
+#     chaos_start_<service>   — Start the service, echo PID
+#     chaos_health_<service>  — Exit 0 if healthy
+#     chaos_verify_<service>  — Exit 0 if data integrity OK after recovery
+#
+# Built-in services (Agent-2):
+#   - pipeline (experimentation-pipeline binary)
+#
+# Prerequisites:
+#   - Docker Compose (kafka, zookeeper, postgres running)
+#   - Service binaries built (cargo build --release)
+#   - grpcurl installed
+#
+# Usage:
+#   ./scripts/chaos_e2e_framework.sh
+#   ./scripts/chaos_e2e_framework.sh --services pipeline --duration 20
+#   ./scripts/chaos_e2e_framework.sh --services pipeline,assignment --duration 30
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+LOAD_DURATION=${LOAD_DURATION:-15}
+KILL_AFTER_SECS=${KILL_AFTER_SECS:-8}
+RECOVERY_SLA_MS=${RECOVERY_SLA_MS:-2000}
+KAFKA_BROKERS=${KAFKA_BROKERS:-localhost:9092}
+KAFKA_INTERNAL=${KAFKA_INTERNAL:-kafka:29092}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORK_DIR=$(mktemp -d)
+SERVICES_ARG=""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log()     { echo -e "${BLUE}[chaos-e2e]${NC} $*"; }
+ok()      { echo -e "${GREEN}[  OK  ]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[ WARN ]${NC} $*"; }
+fail()    { echo -e "${RED}[ FAIL ]${NC} $*"; }
+section() { echo -e "\n${CYAN}${BOLD}=== $* ===${NC}"; }
+
+cleanup() {
+    log "Cleaning up..."
+    # Kill all tracked service PIDs
+    for pid_file in "$WORK_DIR"/pids/*; do
+        if [[ -f "$pid_file" ]]; then
+            local pid
+            pid=$(cat "$pid_file")
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+    # Kill any load generators
+    if [[ -f "$WORK_DIR/load_pid" ]]; then
+        kill "$(cat "$WORK_DIR/load_pid")" 2>/dev/null || true
+    fi
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --services)   SERVICES_ARG="$2"; shift 2 ;;
+        --duration)   LOAD_DURATION="$2"; shift 2 ;;
+        --kill-after) KILL_AFTER_SECS="$2"; shift 2 ;;
+        --recovery-sla) RECOVERY_SLA_MS="$2"; shift 2 ;;
+        --help|-h)
+            echo "Usage: $0 [--services svc1,svc2] [--duration SECS] [--kill-after SECS] [--recovery-sla MS]"
+            echo ""
+            echo "Options:"
+            echo "  --services     Comma-separated list of services to test (default: auto-discover)"
+            echo "  --duration     Total load duration in seconds (default: 15)"
+            echo "  --kill-after   Kill service after N seconds of load (default: 8)"
+            echo "  --recovery-sla Max recovery time in ms (default: 2000)"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+mkdir -p "$WORK_DIR"/{pids,results,logs}
+
+# ---------------------------------------------------------------------------
+# Built-in: Pipeline service hooks
+# ---------------------------------------------------------------------------
+PIPELINE_PORT=50061
+PIPELINE_METRICS_PORT=9091
+PIPELINE_BIN="$REPO_ROOT/target/release/experimentation-pipeline"
+PIPELINE_BUFFER_DIR="$WORK_DIR/pipeline-buffer"
+
+chaos_start_pipeline() {
+    mkdir -p "$PIPELINE_BUFFER_DIR"
+    BUFFER_DIR="$PIPELINE_BUFFER_DIR" \
+    PORT="$PIPELINE_PORT" \
+    METRICS_PORT="$PIPELINE_METRICS_PORT" \
+    KAFKA_BROKERS="$KAFKA_BROKERS" \
+    BLOOM_EXPECTED_DAILY=1000000 \
+    BLOOM_FP_RATE=0.001 \
+    BLOOM_ROTATION_SECS=3600 \
+    BUFFER_MAX_MB=50 \
+    RUST_LOG=warn \
+    "$PIPELINE_BIN" > "$WORK_DIR/logs/pipeline.log" 2>&1 &
+    echo $!
+}
+
+chaos_health_pipeline() {
+    grpcurl -plaintext "localhost:${PIPELINE_PORT}" list &>/dev/null 2>&1
+}
+
+chaos_verify_pipeline() {
+    # Verify pipeline is accepting events after recovery
+    local event_id="verify-pipeline-$(date +%s%N)"
+    local result
+    result=$(grpcurl -plaintext -d "{
+        \"event\": {
+            \"event_id\": \"$event_id\",
+            \"experiment_id\": \"chaos-verify\",
+            \"user_id\": \"chaos-verify-user\",
+            \"variant_id\": \"control\",
+            \"timestamp\": {\"seconds\": $(date +%s)}
+        }
+    }" "localhost:${PIPELINE_PORT}" \
+        experimentation.pipeline.v1.EventIngestionService/IngestExposure 2>&1) || return 1
+
+    echo "$result" | grep -q '"accepted": true'
+}
+
+# ---------------------------------------------------------------------------
+# Service discovery
+# ---------------------------------------------------------------------------
+declare -A SERVICE_PIDS
+declare -A SERVICE_RECOVERY_MS
+declare -A SERVICE_VERIFY_RESULT
+
+discover_services() {
+    local services=()
+
+    if [[ -n "$SERVICES_ARG" ]]; then
+        IFS=',' read -ra services <<< "$SERVICES_ARG"
+    else
+        # Auto-discover: check for built-in + pluggable hooks
+        if [[ -f "$PIPELINE_BIN" ]]; then
+            services+=("pipeline")
+        fi
+        # Discover pluggable hooks: scripts/chaos_test_<service>.sh
+        for hook in "$SCRIPT_DIR"/chaos_test_*.sh; do
+            if [[ -f "$hook" ]]; then
+                local svc_name
+                svc_name=$(basename "$hook" | sed 's/chaos_test_//;s/\.sh$//')
+                services+=("$svc_name")
+            fi
+        done
+    fi
+
+    if [[ ${#services[@]} -eq 0 ]]; then
+        fail "No services found. Build pipeline: cargo build --package experimentation-pipeline --release"
+        exit 1
+    fi
+
+    echo "${services[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Generic service lifecycle (built-in + pluggable hooks)
+# ---------------------------------------------------------------------------
+start_service() {
+    local svc="$1"
+    local pid
+
+    if declare -f "chaos_start_${svc}" > /dev/null 2>&1; then
+        pid=$(chaos_start_${svc})
+    elif [[ -f "$SCRIPT_DIR/chaos_test_${svc}.sh" ]]; then
+        # Source pluggable hook
+        # shellcheck source=/dev/null
+        source "$SCRIPT_DIR/chaos_test_${svc}.sh"
+        pid=$(chaos_start_${svc})
+    else
+        fail "No start hook for service '$svc'"
+        return 1
+    fi
+
+    echo "$pid" > "$WORK_DIR/pids/${svc}"
+    SERVICE_PIDS[$svc]=$pid
+    log "Started $svc (PID=$pid)"
+}
+
+wait_healthy() {
+    local svc="$1"
+    local max_wait=${2:-30}
+
+    for i in $(seq 1 "$max_wait"); do
+        if declare -f "chaos_health_${svc}" > /dev/null 2>&1; then
+            if chaos_health_${svc}; then
+                ok "$svc healthy after ${i}s"
+                return 0
+            fi
+        elif [[ -f "$SCRIPT_DIR/chaos_test_${svc}.sh" ]]; then
+            # shellcheck source=/dev/null
+            source "$SCRIPT_DIR/chaos_test_${svc}.sh"
+            if chaos_health_${svc}; then
+                ok "$svc healthy after ${i}s"
+                return 0
+            fi
+        fi
+        sleep 1
+    done
+
+    fail "$svc did not become healthy within ${max_wait}s"
+    return 1
+}
+
+kill_service() {
+    local svc="$1"
+    local pid="${SERVICE_PIDS[$svc]}"
+    log "Sending SIGKILL to $svc (PID=$pid)..."
+    kill -9 "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    ok "$svc killed"
+}
+
+restart_and_measure() {
+    local svc="$1"
+    local start_ns
+    start_ns=$(date +%s%N)
+
+    start_service "$svc"
+
+    # Wait for health with tight polling
+    local max_iters=200  # 200 * 100ms = 20s max
+    for i in $(seq 1 $max_iters); do
+        if declare -f "chaos_health_${svc}" > /dev/null 2>&1; then
+            if chaos_health_${svc}; then
+                local end_ns
+                end_ns=$(date +%s%N)
+                local recovery_ms=$(( (end_ns - start_ns) / 1000000 ))
+                SERVICE_RECOVERY_MS[$svc]=$recovery_ms
+                ok "$svc recovered in ${recovery_ms}ms"
+                return 0
+            fi
+        fi
+        sleep 0.1
+    done
+
+    fail "$svc did not recover within 20s"
+    SERVICE_RECOVERY_MS[$svc]=99999
+    return 1
+}
+
+verify_service() {
+    local svc="$1"
+
+    if declare -f "chaos_verify_${svc}" > /dev/null 2>&1; then
+        if chaos_verify_${svc}; then
+            SERVICE_VERIFY_RESULT[$svc]="PASS"
+            ok "$svc data integrity verified"
+        else
+            SERVICE_VERIFY_RESULT[$svc]="FAIL"
+            fail "$svc data integrity check failed"
+        fi
+    else
+        SERVICE_VERIFY_RESULT[$svc]="SKIP"
+        warn "$svc has no verify hook — skipping"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Load generator (multi-event-type)
+# ---------------------------------------------------------------------------
+send_load() {
+    local duration="$1"
+    local events_per_sec=${EVENTS_PER_SEC:-100}
+    local end_time=$(( $(date +%s) + duration ))
+    local sent=0
+
+    while [[ $(date +%s) -lt $end_time ]]; do
+        for _ in $(seq 1 "$events_per_sec"); do
+            local event_type=$((RANDOM % 4))
+            local event_id="chaos-e2e-$(date +%s%N)-$RANDOM"
+
+            case $event_type in
+                0)  # Exposure
+                    grpcurl -plaintext -d "{
+                        \"event\": {
+                            \"event_id\": \"$event_id\",
+                            \"experiment_id\": \"chaos-exp-$((RANDOM % 5))\",
+                            \"user_id\": \"chaos-user-$((RANDOM % 10000))\",
+                            \"variant_id\": \"control\",
+                            \"timestamp\": {\"seconds\": $(date +%s)}
+                        }
+                    }" "localhost:${PIPELINE_PORT}" \
+                        experimentation.pipeline.v1.EventIngestionService/IngestExposure \
+                        >/dev/null 2>&1 && sent=$((sent + 1)) &
+                    ;;
+                1)  # Metric
+                    grpcurl -plaintext -d "{
+                        \"event\": {
+                            \"event_id\": \"$event_id\",
+                            \"user_id\": \"chaos-user-$((RANDOM % 10000))\",
+                            \"event_type\": \"watch_time_minutes\",
+                            \"value\": $((RANDOM % 120)).$((RANDOM % 100)),
+                            \"content_id\": \"content_$((RANDOM % 200 + 1))\",
+                            \"session_id\": \"session-$((RANDOM % 50000))\",
+                            \"timestamp\": {\"seconds\": $(date +%s)}
+                        }
+                    }" "localhost:${PIPELINE_PORT}" \
+                        experimentation.pipeline.v1.EventIngestionService/IngestMetricEvent \
+                        >/dev/null 2>&1 && sent=$((sent + 1)) &
+                    ;;
+                2)  # QoE
+                    grpcurl -plaintext -d "{
+                        \"event\": {
+                            \"event_id\": \"$event_id\",
+                            \"session_id\": \"session-$((RANDOM % 50000))\",
+                            \"content_id\": \"content_$((RANDOM % 200 + 1))\",
+                            \"user_id\": \"chaos-user-$((RANDOM % 10000))\",
+                            \"metrics\": {
+                                \"time_to_first_frame_ms\": $((500 + RANDOM % 4000)),
+                                \"rebuffer_count\": $((RANDOM % 5)),
+                                \"rebuffer_ratio\": 0.0$((RANDOM % 99)),
+                                \"avg_bitrate_kbps\": $((2000 + RANDOM % 12000)),
+                                \"peak_resolution_height\": 1080,
+                                \"playback_duration_ms\": $((30000 + RANDOM % 7200000))
+                            },
+                            \"cdn_provider\": \"cloudfront\",
+                            \"timestamp\": {\"seconds\": $(date +%s)}
+                        }
+                    }" "localhost:${PIPELINE_PORT}" \
+                        experimentation.pipeline.v1.EventIngestionService/IngestQoEEvent \
+                        >/dev/null 2>&1 && sent=$((sent + 1)) &
+                    ;;
+                3)  # Reward
+                    grpcurl -plaintext -d "{
+                        \"event\": {
+                            \"event_id\": \"$event_id\",
+                            \"experiment_id\": \"content_cold_start_bandit\",
+                            \"user_id\": \"chaos-user-$((RANDOM % 10000))\",
+                            \"arm_id\": \"arm_$((RANDOM % 4))\",
+                            \"reward\": 0.$((RANDOM % 100)),
+                            \"timestamp\": {\"seconds\": $(date +%s)}
+                        }
+                    }" "localhost:${PIPELINE_PORT}" \
+                        experimentation.pipeline.v1.EventIngestionService/IngestRewardEvent \
+                        >/dev/null 2>&1 && sent=$((sent + 1)) &
+                    ;;
+            esac
+        done
+        wait 2>/dev/null || true
+        sleep 1
+    done
+
+    echo "$sent" > "$WORK_DIR/sent_count"
+}
+
+# ---------------------------------------------------------------------------
+# Kafka offset tracking
+# ---------------------------------------------------------------------------
+TOPICS="exposures metric_events qoe_events reward_events"
+
+record_offsets() {
+    local label="$1"
+    local total=0
+    for topic in $TOPICS; do
+        local offset
+        offset=$(docker compose exec -T kafka kafka-run-class kafka.tools.GetOffsetShell \
+            --broker-list "$KAFKA_INTERNAL" --topic "$topic" --time -1 2>/dev/null | \
+            awk -F: '{sum+=$3} END {print sum+0}') || offset=0
+        echo "$topic=$offset" >> "$WORK_DIR/offsets_${label}"
+        total=$((total + offset))
+    done
+    echo "$total"
+}
+
+# ===========================================================================
+# Main execution
+# ===========================================================================
+
+section "Pre-flight Checks"
+
+if ! command -v grpcurl &>/dev/null; then
+    fail "grpcurl not found. Install: brew install grpcurl"
+    exit 1
+fi
+
+if ! docker compose ps kafka 2>/dev/null | grep -q "running"; then
+    log "Starting Kafka via Docker Compose..."
+    (cd "$REPO_ROOT" && docker compose up -d kafka kafka-init)
+    log "Waiting for Kafka to be healthy..."
+    sleep 15
+fi
+
+# Discover services
+read -ra SERVICES <<< "$(discover_services)"
+log "Services to test: ${SERVICES[*]}"
+
+section "Phase 1: Start All Services"
+
+for svc in "${SERVICES[@]}"; do
+    start_service "$svc"
+done
+
+for svc in "${SERVICES[@]}"; do
+    wait_healthy "$svc" 30
+done
+
+section "Phase 2: Record Baseline Offsets"
+
+BASELINE_TOTAL=$(record_offsets "baseline")
+log "Baseline Kafka offset total: $BASELINE_TOTAL"
+
+section "Phase 3: Sustained Load (${LOAD_DURATION}s)"
+
+log "Sending multi-event-type load for ${LOAD_DURATION}s..."
+send_load "$LOAD_DURATION" &
+LOAD_PID=$!
+echo "$LOAD_PID" > "$WORK_DIR/load_pid"
+
+# Let load build up before chaos
+sleep "$KILL_AFTER_SECS"
+
+section "Phase 4: Sequential Kill + Recovery"
+
+OVERALL_RESULT="PASS"
+
+for svc in "${SERVICES[@]}"; do
+    echo ""
+    log "--- Testing $svc ---"
+
+    # Kill
+    kill_service "$svc"
+
+    # Brief pause to let in-flight events settle
+    sleep 1
+
+    # Restart and measure recovery time
+    if ! restart_and_measure "$svc"; then
+        OVERALL_RESULT="FAIL"
+        continue
+    fi
+
+    # Check recovery SLA
+    local_recovery_ms=${SERVICE_RECOVERY_MS[$svc]}
+    if [[ $local_recovery_ms -le $RECOVERY_SLA_MS ]]; then
+        ok "$svc recovery ${local_recovery_ms}ms <= ${RECOVERY_SLA_MS}ms SLA"
+    else
+        fail "$svc recovery ${local_recovery_ms}ms > ${RECOVERY_SLA_MS}ms SLA"
+        OVERALL_RESULT="FAIL"
+    fi
+
+    # Verify data integrity
+    sleep 2
+    verify_service "$svc"
+    if [[ "${SERVICE_VERIFY_RESULT[$svc]}" == "FAIL" ]]; then
+        OVERALL_RESULT="FAIL"
+    fi
+done
+
+# Wait for remaining load to finish
+wait "$LOAD_PID" 2>/dev/null || true
+
+section "Phase 5: Data Integrity Check"
+
+sleep 3  # Let Kafka replication settle
+
+FINAL_TOTAL=$(record_offsets "final")
+SENT_COUNT=$(cat "$WORK_DIR/sent_count" 2>/dev/null || echo 0)
+DELTA=$((FINAL_TOTAL - BASELINE_TOTAL))
+
+log "Events sent (confirmed ACK): $SENT_COUNT"
+log "Events on Kafka (offset delta): $DELTA"
+
+if [[ $DELTA -ge $SENT_COUNT ]] && [[ $SENT_COUNT -gt 0 ]]; then
+    ok "No data loss: $DELTA >= $SENT_COUNT"
+elif [[ $SENT_COUNT -eq 0 ]]; then
+    warn "No events were sent (service may have been down during load phase)"
+elif [[ $DELTA -ge $(( SENT_COUNT * 99 / 100 )) ]]; then
+    warn "Marginal: <1% loss ($DELTA / $SENT_COUNT) — within Bloom filter FPR tolerance"
+else
+    LOSS_PCT=$(( (SENT_COUNT - DELTA) * 100 / SENT_COUNT ))
+    fail "${LOSS_PCT}% data loss ($DELTA / $SENT_COUNT)"
+    OVERALL_RESULT="FAIL"
+fi
+
+# ===========================================================================
+# Report
+# ===========================================================================
+
+section "Chaos E2E Test Report"
+echo ""
+echo "  Load duration:       ${LOAD_DURATION}s"
+echo "  Kill after:          ${KILL_AFTER_SECS}s"
+echo "  Recovery SLA:        ${RECOVERY_SLA_MS}ms"
+echo "  Events sent (ACK):   ${SENT_COUNT}"
+echo "  Kafka offset delta:  ${DELTA}"
+echo ""
+printf "  %-20s %-15s %-15s\n" "SERVICE" "RECOVERY (ms)" "INTEGRITY"
+printf "  %-20s %-15s %-15s\n" "-------" "-------------" "---------"
+for svc in "${SERVICES[@]}"; do
+    local_recovery="${SERVICE_RECOVERY_MS[$svc]:-N/A}"
+    local_verify="${SERVICE_VERIFY_RESULT[$svc]:-N/A}"
+    printf "  %-20s %-15s %-15s\n" "$svc" "$local_recovery" "$local_verify"
+done
+echo ""
+
+if [[ "$OVERALL_RESULT" == "PASS" ]]; then
+    ok "OVERALL: PASS — all services recovered within SLA, no data loss"
+else
+    fail "OVERALL: FAIL — see details above"
+fi
+
+echo ""
+echo "  To add your service to this framework:"
+echo "    1. Create scripts/chaos_test_<service>.sh"
+echo "    2. Export: chaos_start_<service>, chaos_health_<service>, chaos_verify_<service>"
+echo "    3. Re-run: ./scripts/chaos_e2e_framework.sh"
+echo ""
+
+if [[ "$OVERALL_RESULT" == "FAIL" ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/generate_synthetic_events.py
+++ b/scripts/generate_synthetic_events.py
@@ -21,6 +21,9 @@ Usage:
     # Write to file
     python scripts/generate_synthetic_events.py --type metric --count 5000 --output events.jsonl
 
+    # Generate guardrail alert events (for M5 auto-pause testing)
+    python scripts/generate_synthetic_events.py --type guardrail_alert --count 10
+
     # All event types (for full pipeline testing)
     python scripts/generate_synthetic_events.py --type all --count 200
 """
@@ -91,6 +94,15 @@ CONTENT_IDS = [f"content_{i:04d}" for i in range(1, 201)]
 
 # Interleaving algorithms (for provenance maps)
 INTERLEAVING_ALGORITHMS = ["team_draft_a", "team_draft_b", "balanced_interleave"]
+
+# Guardrail metric IDs and thresholds
+GUARDRAIL_METRICS = {
+    "error_rate": {"threshold": 0.05, "breach_range": (0.06, 0.15)},
+    "crash_rate": {"threshold": 0.02, "breach_range": (0.025, 0.08)},
+    "rebuffer_ratio": {"threshold": 0.03, "breach_range": (0.035, 0.10)},
+    "latency_p99_ms": {"threshold": 5000, "breach_range": (5500, 15000)},
+    "revenue_per_user": {"threshold": 8.0, "breach_range": (4.0, 7.5)},
+}
 
 
 # ---------------------------------------------------------------------------
@@ -271,6 +283,35 @@ def generate_qoe(rng: random.Random) -> dict:
     }
 
 
+def generate_guardrail_alert(rng: random.Random) -> dict:
+    """Generate a realistic GuardrailAlert event.
+
+    Simulates M3 detecting a guardrail metric breach. Published to the
+    guardrail_alerts Kafka topic, consumed by M5 for auto-pause.
+    """
+    metric_id = rng.choice(list(GUARDRAIL_METRICS.keys()))
+    metric_config = GUARDRAIL_METRICS[metric_id]
+    threshold = metric_config["threshold"]
+    breach_lo, breach_hi = metric_config["breach_range"]
+    current_value = rng.uniform(breach_lo, breach_hi)
+
+    exp_id = rng.choice(EXPERIMENT_IDS)
+    variants = VARIANT_IDS.get(exp_id, ["control", "treatment"])
+    # Guardrail alerts are for non-control variants
+    non_control = [v for v in variants if v != "control"]
+    variant_id = rng.choice(non_control) if non_control else variants[-1]
+
+    return {
+        "experiment_id": exp_id,
+        "metric_id": metric_id,
+        "variant_id": variant_id,
+        "current_value": round(current_value, 6),
+        "threshold": threshold,
+        "consecutive_breach_count": rng.randint(1, 5),
+        "detected_at": make_timestamp(rng, jitter_hours=1),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Output formatters
 # ---------------------------------------------------------------------------
@@ -284,6 +325,10 @@ def format_grpcurl_cmd(event_type: str, event: dict, host: str = "localhost:5005
         "reward": "IngestRewardEvent",
         "qoe": "IngestQoEEvent",
     }
+    if event_type == "guardrail_alert":
+        # Guardrail alerts are not ingested via gRPC — output as JSON for kafka-console-producer
+        payload = json.dumps(event, separators=(",", ":"))
+        return f"echo '{payload}' | kafka-console-producer --broker-list localhost:9092 --topic guardrail_alerts"
     rpc = rpc_map[event_type]
     payload = json.dumps({"event": event}, separators=(",", ":"))
     return f"grpcurl -plaintext -d '{payload}' {host} {service}/{rpc}"
@@ -301,7 +346,7 @@ def main():
     )
     parser.add_argument(
         "--type", "-t",
-        choices=["exposure", "metric", "reward", "qoe", "all"],
+        choices=["exposure", "metric", "reward", "qoe", "guardrail_alert", "all"],
         default="exposure",
         help="Event type to generate (default: exposure)",
     )
@@ -321,6 +366,7 @@ def main():
         "metric": lambda: generate_metric(rng),
         "reward": lambda: generate_reward(rng),
         "qoe": lambda: generate_qoe(rng),
+        "guardrail_alert": lambda: generate_guardrail_alert(rng),
     }
 
     out = open(args.output, "w") if args.output else sys.stdout
@@ -329,7 +375,7 @@ def main():
         for i in range(args.count):
             if args.type == "all":
                 # Rotate through event types
-                event_types = ["exposure", "metric", "reward", "qoe"]
+                event_types = ["exposure", "metric", "reward", "qoe", "guardrail_alert"]
                 event_type = event_types[i % len(event_types)]
             else:
                 event_type = args.type

--- a/scripts/loadtest.js
+++ b/scripts/loadtest.js
@@ -7,10 +7,14 @@
 //   or: k6 run --vus 50 --duration 5m scripts/loadtest.js
 //
 // Scenarios:
-//   1. Assignment: High-frequency variant lookups (p99 < 50ms SLO)
-//   2. Exposure:   Event ingestion bursts
-//   3. Management: CRUD operations (lower frequency)
-//   4. Flags:      Flag evaluation lookups (p99 < 10ms SLO)
+//   1. Assignment:    High-frequency variant lookups (p99 < 50ms SLO)
+//   2. Exposure:      Event ingestion via IngestExposure RPC
+//   3. Metric Event:  Metric event ingestion via IngestMetricEvent RPC
+//   4. QoE Event:     QoE playback event ingestion via IngestQoEEvent RPC
+//   5. Reward Event:  Bandit reward ingestion via IngestRewardEvent RPC
+//   6. Batch:         Batch exposure ingestion via IngestExposureBatch RPC
+//   7. Management:    CRUD operations (lower frequency)
+//   8. Flags:         Flag evaluation lookups (p99 < 10ms SLO)
 // ==============================================================================
 
 import http from "k6/http";
@@ -25,6 +29,14 @@ const assignmentLatency = new Trend("assignment_latency", true);
 const assignmentErrors = new Rate("assignment_error_rate");
 const flagLatency = new Trend("flag_eval_latency", true);
 const exposuresSent = new Counter("exposures_sent");
+
+// Pipeline-specific metrics
+const pipelineIngestLatency = new Trend("pipeline_ingest_latency", true);
+const pipelineErrors = new Rate("pipeline_error_rate");
+const metricEventsSent = new Counter("metric_events_sent");
+const qoeEventsSent = new Counter("qoe_events_sent");
+const rewardEventsSent = new Counter("reward_events_sent");
+const batchEventsSent = new Counter("batch_events_sent");
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -41,6 +53,8 @@ const BASE_URLS = {
 const CONNECT_HEADERS = {
   "Content-Type": "application/json",
 };
+
+const PIPELINE_SERVICE = "experimentation.pipeline.v1.EventIngestionService";
 
 export const options = {
   scenarios: {
@@ -71,6 +85,51 @@ export const options = {
       startTime: "30s",
     },
 
+    // --- Metric events: sustained ingestion -----------------------------------
+    metric_event_load: {
+      executor: "constant-arrival-rate",
+      rate: 300,
+      timeUnit: "1s",
+      duration: "3m",
+      preAllocatedVUs: 20,
+      maxVUs: 40,
+      exec: "metricEventScenario",
+      startTime: "30s",
+    },
+
+    // --- QoE events: moderate ingestion ---------------------------------------
+    qoe_event_load: {
+      executor: "constant-arrival-rate",
+      rate: 100,
+      timeUnit: "1s",
+      duration: "3m",
+      preAllocatedVUs: 10,
+      maxVUs: 20,
+      exec: "qoeEventScenario",
+      startTime: "30s",
+    },
+
+    // --- Reward events: low-frequency bandit rewards --------------------------
+    reward_event_load: {
+      executor: "constant-arrival-rate",
+      rate: 50,
+      timeUnit: "1s",
+      duration: "3m",
+      preAllocatedVUs: 5,
+      maxVUs: 15,
+      exec: "rewardEventScenario",
+      startTime: "30s",
+    },
+
+    // --- Batch exposure: throughput comparison --------------------------------
+    batch_exposure: {
+      executor: "constant-vus",
+      vus: 10,
+      duration: "2m",
+      exec: "batchScenario",
+      startTime: "1m",
+    },
+
     // --- Management CRUD: low-frequency background ----------------------------
     management_crud: {
       executor: "per-vu-iterations",
@@ -92,12 +151,15 @@ export const options = {
 
   thresholds: {
     // Assignment SLO: p99 < 50ms
-    "assignment_latency":    ["p(99) < 50"],
-    "assignment_error_rate": ["rate < 0.001"],
+    "assignment_latency":       ["p(99) < 50"],
+    "assignment_error_rate":    ["rate < 0.001"],
     // Flag SLO: p99 < 10ms
-    "flag_eval_latency":     ["p(99) < 10"],
+    "flag_eval_latency":        ["p(99) < 10"],
+    // Pipeline SLO: p99 < 10ms for single-event ingestion
+    "pipeline_ingest_latency":  ["p(99) < 10"],
+    "pipeline_error_rate":      ["rate < 0.01"],
     // Overall HTTP errors
-    "http_req_failed":       ["rate < 0.01"],
+    "http_req_failed":          ["rate < 0.01"],
   },
 };
 
@@ -120,6 +182,19 @@ function randomExperimentId() {
     "onboarding_experiment",
   ];
   return experiments[Math.floor(Math.random() * experiments.length)];
+}
+
+function randomContentId() {
+  return `content_${String(Math.floor(Math.random() * 200) + 1).padStart(4, "0")}`;
+}
+
+function randomSessionId() {
+  return `session-${Math.floor(Math.random() * 100_000)}`;
+}
+
+function nowTimestamp() {
+  const now = Math.floor(Date.now() / 1000);
+  return { seconds: `${now}`, nanos: Math.floor(Math.random() * 999_999_999) };
 }
 
 function connectPost(baseUrl, service, method, body) {
@@ -158,30 +233,235 @@ export function assignmentScenario() {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario: Exposure Events
+// Scenario: Exposure Events (IngestExposure)
 // ---------------------------------------------------------------------------
 
 export function exposureScenario() {
-  group("Pipeline — TrackExposure", () => {
+  group("Pipeline — IngestExposure", () => {
     const res = connectPost(
       BASE_URLS.pipeline,
-      "experimentation.pipeline.v1.PipelineService",
-      "TrackExposure",
+      PIPELINE_SERVICE,
+      "IngestExposure",
       {
-        user_id: randomUserId(),
-        experiment_id: randomExperimentId(),
-        variant_name: Math.random() > 0.5 ? "control" : "treatment",
-        timestamp: new Date().toISOString(),
-        context: {
-          session_id: `session-${Math.floor(Math.random() * 100_000)}`,
+        event: {
+          event_id: `exp-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`,
+          experiment_id: randomExperimentId(),
+          user_id: randomUserId(),
+          variant_id: Math.random() > 0.5 ? "control" : "treatment",
+          timestamp: nowTimestamp(),
           platform: "web",
+          session_id: randomSessionId(),
         },
       }
     );
 
+    pipelineIngestLatency.add(res.timings.duration);
+    pipelineErrors.add(res.status !== 200);
     exposuresSent.add(1);
-    check(res, { "exposure: status 200": (r) => r.status === 200 });
+
+    check(res, {
+      "exposure: status 200": (r) => r.status === 200,
+      "exposure: accepted":   (r) => {
+        try { return JSON.parse(r.body).accepted === true; }
+        catch { return false; }
+      },
+    });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Metric Events (IngestMetricEvent)
+// ---------------------------------------------------------------------------
+
+export function metricEventScenario() {
+  const metricTypes = [
+    "watch_time_minutes",
+    "sessions_per_day",
+    "content_completion_rate",
+    "search_result_clicks",
+    "playback_start_rate",
+    "engagement_score",
+  ];
+
+  group("Pipeline — IngestMetricEvent", () => {
+    const metricType = metricTypes[Math.floor(Math.random() * metricTypes.length)];
+    const res = connectPost(
+      BASE_URLS.pipeline,
+      PIPELINE_SERVICE,
+      "IngestMetricEvent",
+      {
+        event: {
+          event_id: `met-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`,
+          user_id: randomUserId(),
+          event_type: metricType,
+          value: Math.random() * 100,
+          content_id: randomContentId(),
+          session_id: randomSessionId(),
+          timestamp: nowTimestamp(),
+          properties: { source: "k6_loadtest" },
+        },
+      }
+    );
+
+    pipelineIngestLatency.add(res.timings.duration);
+    pipelineErrors.add(res.status !== 200);
+    metricEventsSent.add(1);
+
+    check(res, {
+      "metric_event: status 200": (r) => r.status === 200,
+      "metric_event: accepted":   (r) => {
+        try { return JSON.parse(r.body).accepted === true; }
+        catch { return false; }
+      },
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: QoE Events (IngestQoEEvent)
+// ---------------------------------------------------------------------------
+
+export function qoeEventScenario() {
+  const cdnProviders = ["cloudfront", "akamai", "fastly", "cloudflare"];
+  const abrAlgorithms = ["buffer_based", "rate_based", "hybrid_abr", "low_latency"];
+  const encodingProfiles = ["h264_baseline", "h264_high", "h265_main", "av1_main"];
+
+  group("Pipeline — IngestQoEEvent", () => {
+    const avgBitrate = 2000 + Math.floor(Math.random() * 12000);
+    const rebufferCount = Math.floor(Math.random() * 5);
+    const playbackDurationMs = 30000 + Math.floor(Math.random() * 7200000);
+    const rebufferRatio = rebufferCount > 0
+      ? Math.min(1.0, (rebufferCount * (500 + Math.random() * 2500)) / playbackDurationMs)
+      : 0.0;
+
+    const res = connectPost(
+      BASE_URLS.pipeline,
+      PIPELINE_SERVICE,
+      "IngestQoEEvent",
+      {
+        event: {
+          event_id: `qoe-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`,
+          session_id: randomSessionId(),
+          content_id: randomContentId(),
+          user_id: randomUserId(),
+          metrics: {
+            time_to_first_frame_ms: `${500 + Math.floor(Math.random() * 4000)}`,
+            rebuffer_count: rebufferCount,
+            rebuffer_ratio: rebufferRatio,
+            avg_bitrate_kbps: avgBitrate,
+            resolution_switches: Math.floor(Math.random() * 10),
+            peak_resolution_height: avgBitrate > 8000 ? 1080 : 720,
+            startup_failure_rate: Math.random() < 0.02 ? 1.0 : 0.0,
+            playback_duration_ms: `${playbackDurationMs}`,
+          },
+          cdn_provider: cdnProviders[Math.floor(Math.random() * cdnProviders.length)],
+          abr_algorithm: abrAlgorithms[Math.floor(Math.random() * abrAlgorithms.length)],
+          encoding_profile: encodingProfiles[Math.floor(Math.random() * encodingProfiles.length)],
+          timestamp: nowTimestamp(),
+        },
+      }
+    );
+
+    pipelineIngestLatency.add(res.timings.duration);
+    pipelineErrors.add(res.status !== 200);
+    qoeEventsSent.add(1);
+
+    check(res, {
+      "qoe_event: status 200": (r) => r.status === 200,
+      "qoe_event: accepted":   (r) => {
+        try { return JSON.parse(r.body).accepted === true; }
+        catch { return false; }
+      },
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Reward Events (IngestRewardEvent)
+// ---------------------------------------------------------------------------
+
+export function rewardEventScenario() {
+  const banditArms = ["arm_0", "arm_1", "arm_2", "arm_3"];
+
+  group("Pipeline — IngestRewardEvent", () => {
+    // Binary reward (70%) or continuous [0,1] (30%)
+    const reward = Math.random() < 0.7
+      ? (Math.random() < 0.3 ? 1.0 : 0.0)
+      : Math.random();
+
+    const res = connectPost(
+      BASE_URLS.pipeline,
+      PIPELINE_SERVICE,
+      "IngestRewardEvent",
+      {
+        event: {
+          event_id: `rwd-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`,
+          experiment_id: "content_cold_start_bandit",
+          user_id: randomUserId(),
+          arm_id: banditArms[Math.floor(Math.random() * banditArms.length)],
+          reward: reward,
+          timestamp: nowTimestamp(),
+          context_json: JSON.stringify({ genre: "drama", hour: new Date().getHours() }),
+        },
+      }
+    );
+
+    pipelineIngestLatency.add(res.timings.duration);
+    pipelineErrors.add(res.status !== 200);
+    rewardEventsSent.add(1);
+
+    check(res, {
+      "reward_event: status 200": (r) => r.status === 200,
+      "reward_event: accepted":   (r) => {
+        try { return JSON.parse(r.body).accepted === true; }
+        catch { return false; }
+      },
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: Batch Exposure Ingestion (IngestExposureBatch)
+// ---------------------------------------------------------------------------
+
+export function batchScenario() {
+  const batchSize = 50;
+
+  group("Pipeline — IngestExposureBatch", () => {
+    const events = [];
+    for (let i = 0; i < batchSize; i++) {
+      events.push({
+        event_id: `batch-${Date.now()}-${__VU}-${__ITER}-${i}`,
+        experiment_id: randomExperimentId(),
+        user_id: randomUserId(),
+        variant_id: Math.random() > 0.5 ? "control" : "treatment",
+        timestamp: nowTimestamp(),
+        platform: "web",
+        session_id: randomSessionId(),
+      });
+    }
+
+    const res = connectPost(
+      BASE_URLS.pipeline,
+      PIPELINE_SERVICE,
+      "IngestExposureBatch",
+      { events: events }
+    );
+
+    pipelineIngestLatency.add(res.timings.duration);
+    pipelineErrors.add(res.status !== 200);
+    batchEventsSent.add(batchSize);
+
+    check(res, {
+      "batch: status 200": (r) => r.status === 200,
+      "batch: has accepted_count": (r) => {
+        try { return JSON.parse(r.body).accepted_count > 0; }
+        catch { return false; }
+      },
+    });
+  });
+
+  sleep(0.5);
 }
 
 // ---------------------------------------------------------------------------
@@ -259,14 +539,31 @@ export function handleSummary(data) {
   const get = (name, stat) => data.metrics[name]?.values?.[stat];
 
   console.log("\n=== Experimentation Platform Load Test Summary ===");
-  console.log(`Assignment p50:  ${get("assignment_latency", "p(50)")?.toFixed(2)} ms`);
-  console.log(`Assignment p99:  ${get("assignment_latency", "p(99)")?.toFixed(2)} ms  (SLO: <50ms)`);
-  console.log(`Assignment errs: ${(get("assignment_error_rate", "rate") * 100)?.toFixed(3)}%`);
-  console.log(`Flag eval p50:   ${get("flag_eval_latency", "p(50)")?.toFixed(2)} ms`);
-  console.log(`Flag eval p99:   ${get("flag_eval_latency", "p(99)")?.toFixed(2)} ms  (SLO: <10ms)`);
-  console.log(`Exposures sent:  ${get("exposures_sent", "count")}`);
-  console.log(`Total HTTP reqs: ${get("http_reqs", "count")}`);
-  console.log(`HTTP fail rate:  ${(get("http_req_failed", "rate") * 100)?.toFixed(3)}%`);
+  console.log("");
+  console.log("--- Assignment ---");
+  console.log(`  p50:  ${get("assignment_latency", "p(50)")?.toFixed(2)} ms`);
+  console.log(`  p99:  ${get("assignment_latency", "p(99)")?.toFixed(2)} ms  (SLO: <50ms)`);
+  console.log(`  errs: ${(get("assignment_error_rate", "rate") * 100)?.toFixed(3)}%`);
+  console.log("");
+  console.log("--- Pipeline (all event types) ---");
+  console.log(`  p50:  ${get("pipeline_ingest_latency", "p(50)")?.toFixed(2)} ms`);
+  console.log(`  p99:  ${get("pipeline_ingest_latency", "p(99)")?.toFixed(2)} ms  (SLO: <10ms)`);
+  console.log(`  errs: ${(get("pipeline_error_rate", "rate") * 100)?.toFixed(3)}%`);
+  console.log("");
+  console.log("--- Pipeline Event Counts ---");
+  console.log(`  Exposures (single): ${get("exposures_sent", "count")}`);
+  console.log(`  Metric events:      ${get("metric_events_sent", "count")}`);
+  console.log(`  QoE events:         ${get("qoe_events_sent", "count")}`);
+  console.log(`  Reward events:      ${get("reward_events_sent", "count")}`);
+  console.log(`  Batch events:       ${get("batch_events_sent", "count")}`);
+  console.log("");
+  console.log("--- Flag Evaluation ---");
+  console.log(`  p50:  ${get("flag_eval_latency", "p(50)")?.toFixed(2)} ms`);
+  console.log(`  p99:  ${get("flag_eval_latency", "p(99)")?.toFixed(2)} ms  (SLO: <10ms)`);
+  console.log("");
+  console.log("--- Overall ---");
+  console.log(`  Total HTTP reqs: ${get("http_reqs", "count")}`);
+  console.log(`  HTTP fail rate:  ${(get("http_req_failed", "rate") * 100)?.toFixed(3)}%`);
   console.log("===================================================\n");
 
   return { stdout: JSON.stringify(data.metrics, null, 2) };

--- a/scripts/test_guardrail_e2e.sh
+++ b/scripts/test_guardrail_e2e.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Guardrail Alert Integration Test Harness
+# =============================================================================
+# Tests the guardrail_alerts Kafka topic end-to-end:
+#   1. Verify topic exists with correct config
+#   2. Publish synthetic GuardrailAlert events (JSON-serialized)
+#   3. Consume and verify events arrive within expected window
+#   4. Check consumer group offset advancement
+#
+# This unblocks Agent-5 (management auto-pause) <-> Agent-3 (metric engine)
+# pair integration by validating the Kafka transport layer.
+#
+# Prerequisites:
+#   - Docker Compose running: docker compose up -d kafka kafka-init
+#   - Python 3.8+ (for synthetic event generator)
+#
+# Usage:
+#   ./scripts/test_guardrail_e2e.sh
+#   ./scripts/test_guardrail_e2e.sh --alerts 20 --timeout 30
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+NUM_ALERTS=${NUM_ALERTS:-10}
+CONSUME_TIMEOUT=${CONSUME_TIMEOUT:-15}
+KAFKA_BOOTSTRAP="localhost:9092"
+KAFKA_INTERNAL="kafka:29092"
+TOPIC="guardrail_alerts"
+CONSUMER_GROUP="guardrail-e2e-test-$$"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMP_DIR=$(mktemp -d)
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log()  { echo -e "${BLUE}[guardrail-e2e]${NC} $*"; }
+ok()   { echo -e "${GREEN}[  OK ]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN ]${NC} $*"; }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; }
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --alerts)   NUM_ALERTS="$2"; shift 2 ;;
+        --timeout)  CONSUME_TIMEOUT="$2"; shift 2 ;;
+        --help|-h)
+            echo "Usage: $0 [--alerts NUM] [--timeout SECS]"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+log "Guardrail Alert E2E Test: ${NUM_ALERTS} alerts, ${CONSUME_TIMEOUT}s timeout"
+
+if ! docker compose ps kafka 2>/dev/null | grep -q "running"; then
+    fail "Kafka is not running. Start with: docker compose up -d kafka kafka-init"
+    exit 1
+fi
+
+if ! command -v python3 &>/dev/null; then
+    fail "python3 not found"
+    exit 1
+fi
+
+RESULT="PASS"
+
+# ---------------------------------------------------------------------------
+# Step 1: Verify topic exists and inspect config
+# ---------------------------------------------------------------------------
+log "Step 1: Verifying '${TOPIC}' topic exists..."
+
+TOPIC_DESC=$(docker compose exec -T kafka kafka-topics \
+    --bootstrap-server "$KAFKA_INTERNAL" \
+    --describe --topic "$TOPIC" 2>/dev/null) || {
+    fail "Topic '${TOPIC}' does not exist. Run: docker compose up -d kafka-init"
+    exit 1
+}
+
+PARTITION_COUNT=$(echo "$TOPIC_DESC" | grep -c "Partition:" || echo 0)
+ok "Topic '${TOPIC}' exists with ${PARTITION_COUNT} partition(s)"
+echo "$TOPIC_DESC" | head -3
+
+# ---------------------------------------------------------------------------
+# Step 2: Record starting offset
+# ---------------------------------------------------------------------------
+log "Step 2: Recording starting offsets..."
+
+START_OFFSET=$(docker compose exec -T kafka kafka-run-class kafka.tools.GetOffsetShell \
+    --broker-list "$KAFKA_INTERNAL" --topic "$TOPIC" --time -1 2>/dev/null | \
+    awk -F: '{sum+=$3} END {print sum+0}') || START_OFFSET=0
+
+log "Starting offset: $START_OFFSET"
+
+# ---------------------------------------------------------------------------
+# Step 3: Generate and publish synthetic guardrail alerts
+# ---------------------------------------------------------------------------
+log "Step 3: Generating ${NUM_ALERTS} synthetic guardrail alerts..."
+
+python3 "$REPO_ROOT/scripts/generate_synthetic_events.py" \
+    --type guardrail_alert \
+    --count "$NUM_ALERTS" \
+    --seed 42 \
+    --compact \
+    --output "$TEMP_DIR/alerts.jsonl"
+
+ok "Generated ${NUM_ALERTS} alerts to $TEMP_DIR/alerts.jsonl"
+
+log "Publishing alerts to Kafka topic '${TOPIC}'..."
+PUBLISHED=0
+
+while IFS= read -r line; do
+    # Extract the event payload (strip the wrapper {"type": "guardrail_alert", "event": ...})
+    event_json=$(echo "$line" | python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps(d['event']))")
+
+    echo "$event_json" | docker compose exec -T kafka kafka-console-producer \
+        --broker-list "$KAFKA_INTERNAL" \
+        --topic "$TOPIC" 2>/dev/null && PUBLISHED=$((PUBLISHED + 1))
+done < "$TEMP_DIR/alerts.jsonl"
+
+ok "Published ${PUBLISHED}/${NUM_ALERTS} alerts to '${TOPIC}'"
+
+if [[ $PUBLISHED -ne $NUM_ALERTS ]]; then
+    warn "Not all alerts were published ($PUBLISHED / $NUM_ALERTS)"
+    RESULT="MARGINAL"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Consume events and verify arrival
+# ---------------------------------------------------------------------------
+log "Step 4: Consuming events (timeout: ${CONSUME_TIMEOUT}s)..."
+
+docker compose exec -T kafka kafka-console-consumer \
+    --bootstrap-server "$KAFKA_INTERNAL" \
+    --topic "$TOPIC" \
+    --from-beginning \
+    --max-messages "$NUM_ALERTS" \
+    --timeout-ms "$((CONSUME_TIMEOUT * 1000))" \
+    --group "$CONSUMER_GROUP" \
+    2>/dev/null > "$TEMP_DIR/consumed.jsonl" || true
+
+CONSUMED=$(wc -l < "$TEMP_DIR/consumed.jsonl" | tr -d ' ')
+log "Consumed: $CONSUMED events"
+
+if [[ $CONSUMED -ge $NUM_ALERTS ]]; then
+    ok "All ${NUM_ALERTS} alerts consumed successfully"
+else
+    fail "Only consumed $CONSUMED / $NUM_ALERTS alerts"
+    RESULT="FAIL"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: Verify offset advancement
+# ---------------------------------------------------------------------------
+log "Step 5: Verifying offset advancement..."
+
+END_OFFSET=$(docker compose exec -T kafka kafka-run-class kafka.tools.GetOffsetShell \
+    --broker-list "$KAFKA_INTERNAL" --topic "$TOPIC" --time -1 2>/dev/null | \
+    awk -F: '{sum+=$3} END {print sum+0}') || END_OFFSET=0
+
+DELTA=$((END_OFFSET - START_OFFSET))
+log "Offset delta: $DELTA (start=$START_OFFSET, end=$END_OFFSET)"
+
+if [[ $DELTA -ge $NUM_ALERTS ]]; then
+    ok "Offset advanced by $DELTA >= $NUM_ALERTS alerts published"
+else
+    fail "Offset delta $DELTA < $NUM_ALERTS expected"
+    RESULT="FAIL"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: Validate event content (spot check)
+# ---------------------------------------------------------------------------
+log "Step 6: Validating event content..."
+
+if [[ $CONSUMED -gt 0 ]]; then
+    FIRST_EVENT=$(head -1 "$TEMP_DIR/consumed.jsonl")
+
+    # Check for required fields
+    VALID=true
+    for field in experiment_id metric_id variant_id current_value threshold consecutive_breach_count; do
+        if ! echo "$FIRST_EVENT" | python3 -c "import sys,json; d=json.load(sys.stdin); assert '$field' in d" 2>/dev/null; then
+            warn "Missing field '$field' in consumed event"
+            VALID=false
+        fi
+    done
+
+    if $VALID; then
+        ok "Event content validated — all required fields present"
+        # Print a sample event
+        echo "$FIRST_EVENT" | python3 -m json.tool 2>/dev/null | head -15
+    else
+        warn "Some fields missing — events may use protobuf binary format"
+    fi
+else
+    warn "No events consumed, skipping content validation"
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+echo ""
+echo "============================================================="
+echo "  GUARDRAIL ALERT E2E TEST REPORT"
+echo "============================================================="
+echo "  Alerts generated:   $NUM_ALERTS"
+echo "  Alerts published:   $PUBLISHED"
+echo "  Alerts consumed:    $CONSUMED"
+echo "  Offset delta:       $DELTA"
+echo "  Consumer group:     $CONSUMER_GROUP"
+echo ""
+
+if [[ "$RESULT" == "PASS" ]]; then
+    ok "PASS: Guardrail alert pipeline working end-to-end"
+    echo ""
+    echo "  Agent-5 (management) can now consume from '${TOPIC}'"
+    echo "  Agent-3 (metrics) can now publish to '${TOPIC}'"
+elif [[ "$RESULT" == "MARGINAL" ]]; then
+    warn "MARGINAL: Partial success — investigate publish failures"
+else
+    fail "FAIL: Guardrail alert pipeline has issues"
+fi
+echo "============================================================="
+echo ""
+
+if [[ "$RESULT" == "FAIL" ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **Fix loadtest.js**: Corrected RPC names (`PipelineService/TrackExposure` → `EventIngestionService/IngestExposure`), fixed payload wrapping (`{event: {...}}`), added 4 new pipeline scenarios (metric, QoE, reward, batch), added `pipeline_ingest_latency` p99 <10ms SLO threshold
- **Guardrail alert test harness** (`test_guardrail_e2e.sh`): Verifies `guardrail_alerts` Kafka topic publish/consume end-to-end. Extends `generate_synthetic_events.py` with `--type guardrail_alert`. Unblocks Agent-5 ↔ Agent-3 pair integration (guardrail alerts → auto-pause)
- **E2E chaos framework** (`chaos_e2e_framework.sh`): Multi-service chaos orchestrator with pluggable per-service hooks. Sequential kill-9, recovery measurement (<2s SLA), data integrity validation via Kafka offset comparison. Pipeline is the first built-in plug-in; other agents add `chaos_test_<service>.sh` to participate

This unblocks Agent-3 (metric computation), Agent-5 (management auto-pause), and enables milestone 4.5 (end-to-end chaos testing).

## Test plan

- [x] `python3 scripts/generate_synthetic_events.py --type guardrail_alert --count 3` — generates valid alerts
- [x] `python3 scripts/generate_synthetic_events.py --type all --count 5` — rotates through all 5 event types
- [x] `bash -n scripts/test_guardrail_e2e.sh` — syntax valid
- [x] `bash -n scripts/chaos_e2e_framework.sh` — syntax valid
- [x] `cargo test -p experimentation-ingest -p experimentation-pipeline` — 36 tests pass
- [x] `cargo clippy -p experimentation-ingest -p experimentation-pipeline` — clean
- [ ] `k6 run --dry-run scripts/loadtest.js` — syntax OK (requires k6 installed)
- [ ] `./scripts/test_guardrail_e2e.sh` — full run against Docker Kafka
- [ ] `./scripts/chaos_e2e_framework.sh` — full run with pipeline binary + Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)