### PR TITLE
feat(m6): CATE lifecycle segment analysis tab

### DIFF
--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import {
   SEED_EXPERIMENTS, SEED_QUERY_LOG, SEED_ANALYSIS_RESULTS,
   SEED_NOVELTY_RESULTS, SEED_INTERFERENCE_RESULTS, SEED_INTERLEAVING_RESULTS,
-  SEED_BANDIT_RESULTS, SEED_HOLDOUT_RESULTS, SEED_GUARDRAIL_STATUS,
+  SEED_BANDIT_RESULTS, SEED_HOLDOUT_RESULTS, SEED_GUARDRAIL_STATUS, SEED_CATE_RESULTS,
 } from './seed-data';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
@@ -289,6 +289,19 @@ export const handlers = [
         breaches: [],
         isPaused: false,
       });
+    }
+    return HttpResponse.json(result);
+  }),
+
+  // GetCateAnalysis
+  http.post(`${ANALYSIS_SVC}/GetCateAnalysis`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_CATE_RESULTS[body.experimentId];
+    if (!result) {
+      return HttpResponse.json(
+        { error: `No CATE analysis for experiment ${body.experimentId}` },
+        { status: 404 },
+      );
     }
     return HttpResponse.json(result);
   }),

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -1,7 +1,7 @@
 import type {
   AnalysisResult, Experiment, QueryLogEntry,
   NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
-  BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult,
+  BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult, CateAnalysisResult,
 } from '@/lib/types';
 
 const INITIAL_EXPERIMENTS: Experiment[] = [
@@ -667,6 +667,87 @@ const INITIAL_GUARDRAIL_STATUS: Record<string, GuardrailStatusResult> = {
   },
 };
 
+/** CATE lifecycle segment analysis — homepage_recs_v2 shows heterogeneous effects. */
+const INITIAL_CATE_RESULTS: Record<string, CateAnalysisResult> = {
+  '11111111-1111-1111-1111-111111111111': {
+    experimentId: '11111111-1111-1111-1111-111111111111',
+    metricId: 'click_through_rate',
+    globalAte: 0.014,
+    globalSe: 0.0042,
+    globalCiLower: 0.006,
+    globalCiUpper: 0.022,
+    globalPValue: 0.001,
+    subgroupEffects: [
+      {
+        segment: 'TRIAL',
+        effect: 0.032,
+        se: 0.011,
+        ciLower: 0.010,
+        ciUpper: 0.054,
+        pValueRaw: 0.004,
+        pValueAdjusted: 0.012,
+        isSignificant: true,
+        nControl: 4200,
+        nTreatment: 4150,
+        controlMean: 0.108,
+        treatmentMean: 0.140,
+      },
+      {
+        segment: 'NEW',
+        effect: 0.021,
+        se: 0.008,
+        ciLower: 0.005,
+        ciUpper: 0.037,
+        pValueRaw: 0.009,
+        pValueAdjusted: 0.018,
+        isSignificant: true,
+        nControl: 8500,
+        nTreatment: 8400,
+        controlMean: 0.118,
+        treatmentMean: 0.139,
+      },
+      {
+        segment: 'ESTABLISHED',
+        effect: 0.008,
+        se: 0.005,
+        ciLower: -0.002,
+        ciUpper: 0.018,
+        pValueRaw: 0.11,
+        pValueAdjusted: 0.165,
+        isSignificant: false,
+        nControl: 18200,
+        nTreatment: 18100,
+        controlMean: 0.129,
+        treatmentMean: 0.137,
+      },
+      {
+        segment: 'MATURE',
+        effect: 0.004,
+        se: 0.006,
+        ciLower: -0.008,
+        ciUpper: 0.016,
+        pValueRaw: 0.51,
+        pValueAdjusted: 0.51,
+        isSignificant: false,
+        nControl: 15800,
+        nTreatment: 15900,
+        controlMean: 0.131,
+        treatmentMean: 0.135,
+      },
+    ],
+    heterogeneity: {
+      qStatistic: 12.4,
+      df: 3,
+      pValue: 0.006,
+      iSquared: 75.8,
+      heterogeneityDetected: true,
+    },
+    nSubgroups: 4,
+    fdrThreshold: 0.05,
+    computedAt: '2026-03-05T12:00:00Z',
+  },
+};
+
 /** Mutable copy of seed data — MSW handlers mutate this in-place. */
 export let SEED_EXPERIMENTS: Experiment[] = structuredClone(INITIAL_EXPERIMENTS);
 export let SEED_QUERY_LOG: Record<string, QueryLogEntry[]> = structuredClone(INITIAL_QUERY_LOG);
@@ -677,6 +758,7 @@ export let SEED_INTERLEAVING_RESULTS: Record<string, InterleavingAnalysisResult>
 export let SEED_BANDIT_RESULTS: Record<string, BanditDashboardResult> = structuredClone(INITIAL_BANDIT_RESULTS);
 export let SEED_HOLDOUT_RESULTS: Record<string, CumulativeHoldoutResult> = structuredClone(INITIAL_HOLDOUT_RESULTS);
 export let SEED_GUARDRAIL_STATUS: Record<string, GuardrailStatusResult> = structuredClone(INITIAL_GUARDRAIL_STATUS);
+export let SEED_CATE_RESULTS: Record<string, CateAnalysisResult> = structuredClone(INITIAL_CATE_RESULTS);
 
 /** Reset seed data to initial state. Call in afterEach for test isolation. */
 export function resetSeedData(): void {
@@ -689,4 +771,5 @@ export function resetSeedData(): void {
   SEED_BANDIT_RESULTS = structuredClone(INITIAL_BANDIT_RESULTS);
   SEED_HOLDOUT_RESULTS = structuredClone(INITIAL_HOLDOUT_RESULTS);
   SEED_GUARDRAIL_STATUS = structuredClone(INITIAL_GUARDRAIL_STATUS);
+  SEED_CATE_RESULTS = structuredClone(INITIAL_CATE_RESULTS);
 }

--- a/ui/src/__tests__/cate-lifecycle.test.tsx
+++ b/ui/src/__tests__/cate-lifecycle.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ResultsPage from '@/app/experiments/[id]/results/page';
+
+let mockExperimentId = '11111111-1111-1111-1111-111111111111';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: mockExperimentId }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// Mock recharts
+vi.mock('recharts', async () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  );
+  const Noop = () => null;
+
+  return {
+    ResponsiveContainer: Passthrough,
+    ComposedChart: Passthrough,
+    BarChart: Passthrough,
+    Bar: Noop,
+    Scatter: Noop,
+    Line: Noop,
+    Area: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    ReferenceLine: Noop,
+    Tooltip: Noop,
+    ErrorBar: Noop,
+    Cell: Noop,
+  };
+});
+
+describe('Lifecycle Segments Tab - homepage_recs_v2', () => {
+  beforeEach(() => {
+    mockExperimentId = '11111111-1111-1111-1111-111111111111';
+  });
+
+  it('shows Lifecycle Segments tab for AB experiment', async () => {
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows heterogeneity detection banner with Cochran Q', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Lifecycle Segments' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Heterogeneous Treatment Effects Detected')).toBeInTheDocument();
+    });
+
+    // Cochran Q = 12.4
+    expect(screen.getByText(/Cochran Q = 12.4/)).toBeInTheDocument();
+    // I² = 75.8% appears in banner and summary card
+    expect(screen.getAllByText(/75.8%/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows global ATE summary', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Lifecycle Segments' }));
+
+    await waitFor(() => {
+      // Global ATE = +0.0140
+      expect(screen.getByText('+0.0140')).toBeInTheDocument();
+    });
+  });
+
+  it('shows subgroup effects table with segment names', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Lifecycle Segments' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Trial')).toBeInTheDocument();
+    });
+
+    // All 4 segments present
+    expect(screen.getByText('New (<30d)')).toBeInTheDocument();
+    expect(screen.getByText('Established (30-180d)')).toBeInTheDocument();
+    expect(screen.getByText('Mature (>180d)')).toBeInTheDocument();
+  });
+
+  it('shows significance badges for subgroups', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Lifecycle Segments' }));
+
+    await waitFor(() => {
+      // TRIAL and NEW are significant, ESTABLISHED and MATURE are not
+      const yesBadges = screen.getAllByText('Yes');
+      const noBadges = screen.getAllByText('No');
+      expect(yesBadges.length).toBe(2);
+      expect(noBadges.length).toBe(2);
+    });
+  });
+
+  it('shows BH FDR correction note', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Lifecycle Segments' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Benjamini-Hochberg FDR/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows forest plot section', async () => {
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Lifecycle Segments' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Lifecycle Segment Forest Plot')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Lifecycle Segments Tab - no data', () => {
+  it('shows empty state for experiment without CATE data', async () => {
+    mockExperimentId = '33333333-3333-3333-3333-333333333333';
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Results Dashboard' })).toBeInTheDocument();
+    });
+
+    // search_ranking_interleave is INTERLEAVING type — no lifecycle tab
+    expect(screen.queryByRole('tab', { name: 'Lifecycle Segments' })).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when CATE data not available for AB experiment', async () => {
+    // thumbnail_selection_v1 is AB but has no CATE seed data
+    mockExperimentId = '66666666-6666-6666-6666-666666666666';
+    const user = userEvent.setup();
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Lifecycle Segments' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Lifecycle Segments' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No lifecycle segment analysis available for this experiment.')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/app/experiments/[id]/results/page.tsx
+++ b/ui/src/app/experiments/[id]/results/page.tsx
@@ -17,8 +17,9 @@ import { InterleavingTab } from '@/components/interleaving-tab';
 import { SurrogateTab } from '@/components/surrogate-tab';
 import { HoldoutTab } from '@/components/holdout-tab';
 import { GuardrailTab } from '@/components/guardrail-tab';
+import { CateTab } from '@/components/cate-tab';
 
-type AnalysisTab = 'overview' | 'novelty' | 'interference' | 'interleaving' | 'surrogate' | 'holdout' | 'guardrails';
+type AnalysisTab = 'overview' | 'novelty' | 'interference' | 'interleaving' | 'surrogate' | 'holdout' | 'guardrails' | 'lifecycle';
 
 export default function ResultsPage() {
   const params = useParams<{ id: string }>();
@@ -81,6 +82,9 @@ export default function ResultsPage() {
     { key: 'interference', label: 'Content Interference' },
     { key: 'interleaving', label: 'Interleaving' },
   ];
+  if (experiment.type === 'AB' || experiment.type === 'MULTIVARIATE') {
+    tabs.push({ key: 'lifecycle', label: 'Lifecycle Segments' });
+  }
   if (hasSurrogateProjections) {
     tabs.push({ key: 'surrogate', label: 'Surrogate Projections' });
   }
@@ -172,6 +176,10 @@ export default function ResultsPage() {
 
       {activeTab === 'interleaving' && (
         <InterleavingTab experimentId={params.id} />
+      )}
+
+      {activeTab === 'lifecycle' && (
+        <CateTab experimentId={params.id} />
       )}
 
       {activeTab === 'surrogate' && analysisResult.surrogateProjections && (

--- a/ui/src/components/cate-tab.tsx
+++ b/ui/src/components/cate-tab.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  ComposedChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer, ReferenceLine, ErrorBar, Cell,
+} from 'recharts';
+import type { CateAnalysisResult } from '@/lib/types';
+import { getCateAnalysis } from '@/lib/api';
+import { formatPValue } from '@/lib/utils';
+
+interface CateTabProps {
+  experimentId: string;
+}
+
+const SEGMENT_LABELS: Record<string, string> = {
+  TRIAL: 'Trial',
+  NEW: 'New (<30d)',
+  ESTABLISHED: 'Established (30-180d)',
+  MATURE: 'Mature (>180d)',
+  AT_RISK: 'At Risk',
+  WINBACK: 'Winback',
+};
+
+export function CateTab({ experimentId }: CateTabProps) {
+  const [result, setResult] = useState<CateAnalysisResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getCateAnalysis(experimentId)
+      .then(setResult)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [experimentId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error || !result) {
+    return (
+      <div className="rounded-md bg-gray-50 p-4 text-sm text-gray-500">
+        No lifecycle segment analysis available for this experiment.
+      </div>
+    );
+  }
+
+  // Prepare chart data: per-segment effects with error bars
+  const chartData = result.subgroupEffects.map((sg) => ({
+    segment: SEGMENT_LABELS[sg.segment] || sg.segment,
+    effect: sg.effect,
+    errorX: [sg.effect - sg.ciLower, sg.ciUpper - sg.effect] as [number, number],
+    isSignificant: sg.isSignificant,
+  }));
+
+  return (
+    <div className="space-y-4">
+      {/* Heterogeneity banner */}
+      {result.heterogeneity.heterogeneityDetected ? (
+        <div className="rounded-md bg-amber-50 border border-amber-200 p-4">
+          <h4 className="text-sm font-semibold text-amber-800">Heterogeneous Treatment Effects Detected</h4>
+          <p className="mt-1 text-sm text-amber-700">
+            Cochran Q = {result.heterogeneity.qStatistic.toFixed(1)},
+            p = {formatPValue(result.heterogeneity.pValue)},
+            I&sup2; = {result.heterogeneity.iSquared.toFixed(1)}%.
+            Treatment effects vary significantly across lifecycle segments.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md bg-green-50 border border-green-200 p-4">
+          <h4 className="text-sm font-semibold text-green-800">Homogeneous Treatment Effects</h4>
+          <p className="mt-1 text-sm text-green-700">
+            Cochran Q = {result.heterogeneity.qStatistic.toFixed(1)},
+            p = {formatPValue(result.heterogeneity.pValue)}.
+            No significant variation in treatment effects across segments.
+          </p>
+        </div>
+      )}
+
+      {/* Global ATE summary */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">Global ATE</span>
+          <p className={`mt-1 text-lg font-semibold ${
+            result.globalAte > 0 ? 'text-green-700' : result.globalAte < 0 ? 'text-red-700' : 'text-gray-700'
+          }`}>
+            {result.globalAte > 0 ? '+' : ''}{result.globalAte.toFixed(4)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">95% CI</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            [{result.globalCiLower.toFixed(4)}, {result.globalCiUpper.toFixed(4)}]
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">p-value</span>
+          <p className="mt-1 text-lg font-semibold text-gray-900">
+            {formatPValue(result.globalPValue)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3">
+          <span className="text-xs font-medium uppercase text-gray-500">I&sup2;</span>
+          <p className={`mt-1 text-lg font-semibold ${
+            result.heterogeneity.iSquared > 50 ? 'text-amber-700' : 'text-gray-700'
+          }`}>
+            {result.heterogeneity.iSquared.toFixed(1)}%
+          </p>
+        </div>
+      </div>
+
+      {/* Forest plot */}
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <h4 className="mb-3 text-sm font-semibold text-gray-900">Lifecycle Segment Forest Plot</h4>
+        <div style={{ width: '100%', height: 40 + chartData.length * 50 }}>
+          <ResponsiveContainer>
+            <ComposedChart
+              layout="vertical"
+              data={chartData}
+              margin={{ top: 5, right: 30, bottom: 5, left: 120 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" horizontal={false} />
+              <XAxis type="number" tick={{ fontSize: 12 }} />
+              <YAxis
+                type="category"
+                dataKey="segment"
+                tick={{ fontSize: 12 }}
+                width={110}
+              />
+              <Tooltip
+                formatter={(value: number) => value.toFixed(4)}
+                labelFormatter={(label: string) => `Segment: ${label}`}
+              />
+              <ReferenceLine x={0} stroke="#9ca3af" strokeDasharray="3 3" />
+              <ReferenceLine
+                x={result.globalAte}
+                stroke="#6366f1"
+                strokeDasharray="5 5"
+                label={{ value: 'Global ATE', fill: '#6366f1', fontSize: 10 }}
+              />
+              <Bar dataKey="effect" barSize={12}>
+                <ErrorBar
+                  dataKey="errorX"
+                  width={4}
+                  strokeWidth={1.5}
+                  stroke="#374151"
+                  direction="x"
+                />
+                {chartData.map((entry, idx) => (
+                  <Cell
+                    key={idx}
+                    fill={entry.isSignificant ? '#16a34a' : '#9ca3af'}
+                  />
+                ))}
+              </Bar>
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Subgroup effects table */}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr className="bg-gray-50">
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase text-gray-500">Segment</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">N (ctrl/treat)</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Control Mean</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Treatment Mean</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">Effect</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">95% CI</th>
+              <th className="px-4 py-3 text-right text-xs font-medium uppercase text-gray-500">p (adj)</th>
+              <th className="px-4 py-3 text-center text-xs font-medium uppercase text-gray-500">Sig</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {result.subgroupEffects.map((sg) => (
+              <tr key={sg.segment}>
+                <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                  {SEGMENT_LABELS[sg.segment] || sg.segment}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-600">
+                  {sg.nControl.toLocaleString()} / {sg.nTreatment.toLocaleString()}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-mono text-gray-700">
+                  {sg.controlMean.toFixed(4)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-mono text-gray-700">
+                  {sg.treatmentMean.toFixed(4)}
+                </td>
+                <td className={`whitespace-nowrap px-4 py-3 text-right text-sm font-mono ${
+                  sg.effect > 0 ? 'text-green-700' : sg.effect < 0 ? 'text-red-700' : 'text-gray-700'
+                }`}>
+                  {sg.effect > 0 ? '+' : ''}{sg.effect.toFixed(4)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-mono text-gray-600">
+                  [{sg.ciLower.toFixed(4)}, {sg.ciUpper.toFixed(4)}]
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-right text-sm font-mono text-gray-700">
+                  {formatPValue(sg.pValueAdjusted)}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-center">
+                  {sg.isSignificant ? (
+                    <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
+                      Yes
+                    </span>
+                  ) : (
+                    <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+                      No
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* FDR note */}
+      <p className="text-xs text-gray-500">
+        p-values adjusted using Benjamini-Hochberg FDR correction (threshold: {result.fdrThreshold}).
+        Metric: {result.metricId}.
+      </p>
+    </div>
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,7 +1,7 @@
 import type {
   AnalysisResult, CreateExperimentRequest, Experiment, ListExperimentsResponse,
   QueryLogEntry, NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
-  BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult,
+  BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult, CateAnalysisResult,
 } from './types';
 import type { ExperimentState, ExperimentType } from './types';
 
@@ -191,5 +191,11 @@ export async function getCumulativeHoldoutResult(experimentId: string): Promise<
 export async function getGuardrailStatus(experimentId: string): Promise<GuardrailStatusResult> {
   return callRpc<{ experimentId: string }, GuardrailStatusResult>(
     MGMT_URL, MGMT_SVC, 'GetGuardrailStatus', { experimentId },
+  );
+}
+
+export async function getCateAnalysis(experimentId: string): Promise<CateAnalysisResult> {
+  return callRpc<{ experimentId: string }, CateAnalysisResult>(
+    ANALYSIS_URL, ANALYSIS_SVC, 'GetCateAnalysis', { experimentId },
   );
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -250,6 +250,54 @@ export interface GuardrailStatusResult {
   isPaused: boolean;
 }
 
+// --- CATE / Lifecycle Segments (M4.1) ---
+
+export type LifecycleSegment =
+  | 'TRIAL'
+  | 'NEW'
+  | 'ESTABLISHED'
+  | 'MATURE'
+  | 'AT_RISK'
+  | 'WINBACK';
+
+export interface SubgroupEffect {
+  segment: LifecycleSegment;
+  effect: number;
+  se: number;
+  ciLower: number;
+  ciUpper: number;
+  pValueRaw: number;
+  pValueAdjusted: number;
+  isSignificant: boolean;
+  nControl: number;
+  nTreatment: number;
+  controlMean: number;
+  treatmentMean: number;
+}
+
+export interface HeterogeneityTest {
+  qStatistic: number;
+  df: number;
+  pValue: number;
+  iSquared: number;
+  heterogeneityDetected: boolean;
+}
+
+export interface CateAnalysisResult {
+  experimentId: string;
+  metricId: string;
+  globalAte: number;
+  globalSe: number;
+  globalCiLower: number;
+  globalCiUpper: number;
+  globalPValue: number;
+  subgroupEffects: SubgroupEffect[];
+  heterogeneity: HeterogeneityTest;
+  nSubgroups: number;
+  fdrThreshold: number;
+  computedAt: string;
+}
+
 // --- Bandit Dashboard (M3.3) ---
 
 export type BanditAlgorithm = 'THOMPSON_SAMPLING' | 'LINEAR_UCB' | 'THOMPSON_LINEAR' | 'NEURAL_CONTEXTUAL';


### PR DESCRIPTION
## Summary
- **Lifecycle Segments tab**: per-segment treatment effects analysis with heterogeneity testing
- Horizontal forest plot showing per-segment effects with confidence interval error bars
- Cochran Q heterogeneity banner (detects if treatment effects vary across lifecycle segments)
- Subgroup effects table with BH-FDR corrected p-values and significance badges
- Global ATE summary with I² heterogeneity index
- Tab shown conditionally for AB and MULTIVARIATE experiments only

## Mock Data
homepage_recs_v2 (11111111...) with 4 lifecycle segments:
- **TRIAL**: +0.032 effect (significant) — new trial users benefit most
- **NEW**: +0.021 effect (significant) — new subscribers also benefit
- **ESTABLISHED**: +0.008 effect (not significant) — established users show minimal change
- **MATURE**: +0.004 effect (not significant) — mature users unaffected

Cochran Q = 12.4, I² = 75.8% — significant heterogeneity detected.

## Files changed
| File | Change |
|------|--------|
| `ui/src/lib/types.ts` | +LifecycleSegment, SubgroupEffect, HeterogeneityTest, CateAnalysisResult |
| `ui/src/lib/api.ts` | +getCateAnalysis API function |
| `ui/src/__mocks__/seed-data.ts` | +CATE results with 4 lifecycle segments |
| `ui/src/__mocks__/handlers.ts` | +GetCateAnalysis MSW handler |
| `ui/src/components/cate-tab.tsx` | New component — forest plot, heterogeneity banner, subgroup table |
| `ui/src/app/experiments/[id]/results/page.tsx` | Wire lifecycle tab (conditional on AB/MULTIVARIATE type) |
| `ui/src/__tests__/cate-lifecycle.test.tsx` | 9 new tests |

## Test plan
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `npx vitest run` — 158 tests pass (9 new)
- [ ] Browse `/experiments/11111111.../results` → Lifecycle Segments tab visible
- [ ] Click tab → heterogeneity banner with Cochran Q, forest plot, subgroup table
- [ ] TRIAL and NEW show green "Yes" significance badges
- [ ] ESTABLISHED and MATURE show gray "No" badges
- [ ] `/experiments/33333333.../results` → no Lifecycle Segments tab (INTERLEAVING type)
- [ ] `/experiments/66666666.../results` → Lifecycle Segments tab visible but shows empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)