### PR TITLE
feat(m1): live M4b bandit delegation with GrpcBanditClient

### DIFF
--- a/crates/experimentation-assignment/Cargo.toml
+++ b/crates/experimentation-assignment/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+anyhow = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/experimentation-assignment/benches/assignment_bench.rs
+++ b/crates/experimentation-assignment/benches/assignment_bench.rs
@@ -9,41 +9,74 @@ use experimentation_proto::experimentation::assignment::v1::RankedList;
 const DEV_CONFIG: &str = include_str!("../../../dev/config.json");
 
 fn bench_get_assignment(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let config = Config::from_json(DEV_CONFIG).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
     let no_attrs = HashMap::new();
 
     c.bench_function("get_assignment_single", |b| {
         b.iter(|| {
-            svc.assign(black_box("exp_dev_001"), black_box("user_42"), black_box(""), black_box(&no_attrs))
+            rt.block_on(async {
+                svc.assign(
+                    black_box("exp_dev_001"),
+                    black_box("user_42"),
+                    black_box(""),
+                    black_box(&no_attrs),
+                )
+                .await
                 .unwrap()
+            })
         })
     });
 
     c.bench_function("get_assignment_1000_users", |b| {
         b.iter(|| {
-            for i in 0..1000 {
-                let user_id = format!("user_{i}");
-                svc.assign(black_box("exp_dev_001"), black_box(&user_id), black_box(""), black_box(&no_attrs))
+            rt.block_on(async {
+                for i in 0..1000 {
+                    let user_id = format!("user_{i}");
+                    svc.assign(
+                        black_box("exp_dev_001"),
+                        black_box(&user_id),
+                        black_box(""),
+                        black_box(&no_attrs),
+                    )
+                    .await
                     .unwrap();
-            }
+                }
+            })
         })
     });
 
     c.bench_function("get_assignment_session_level", |b| {
         b.iter(|| {
-            svc.assign(black_box("exp_dev_003"), black_box("user_42"), black_box("session_42"), black_box(&no_attrs))
+            rt.block_on(async {
+                svc.assign(
+                    black_box("exp_dev_003"),
+                    black_box("user_42"),
+                    black_box("session_42"),
+                    black_box(&no_attrs),
+                )
+                .await
                 .unwrap()
+            })
         })
     });
 
     c.bench_function("get_assignment_session_1000", |b| {
         b.iter(|| {
-            for i in 0..1000 {
-                let session_id = format!("session_{i}");
-                svc.assign(black_box("exp_dev_003"), black_box("user_42"), black_box(&session_id), black_box(&no_attrs))
+            rt.block_on(async {
+                for i in 0..1000 {
+                    let session_id = format!("session_{i}");
+                    svc.assign(
+                        black_box("exp_dev_003"),
+                        black_box("user_42"),
+                        black_box(&session_id),
+                        black_box(&no_attrs),
+                    )
+                    .await
                     .unwrap();
-            }
+                }
+            })
         })
     });
 }
@@ -166,34 +199,41 @@ fn bench_multileave(c: &mut Criterion) {
 }
 
 fn bench_bandit_assignment(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let config = Config::from_json(DEV_CONFIG).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
     let no_attrs = HashMap::new();
 
     c.bench_function("get_assignment_mab_single", |b| {
         b.iter(|| {
-            svc.assign(
-                black_box("exp_dev_005"),
-                black_box("user_42"),
-                black_box(""),
-                black_box(&no_attrs),
-            )
-            .unwrap()
+            rt.block_on(async {
+                svc.assign(
+                    black_box("exp_dev_005"),
+                    black_box("user_42"),
+                    black_box(""),
+                    black_box(&no_attrs),
+                )
+                .await
+                .unwrap()
+            })
         })
     });
 
     c.bench_function("get_assignment_mab_1000_users", |b| {
         b.iter(|| {
-            for i in 0..1000 {
-                let user_id = format!("user_{i}");
-                svc.assign(
-                    black_box("exp_dev_005"),
-                    black_box(&user_id),
-                    black_box(""),
-                    black_box(&no_attrs),
-                )
-                .unwrap();
-            }
+            rt.block_on(async {
+                for i in 0..1000 {
+                    let user_id = format!("user_{i}");
+                    svc.assign(
+                        black_box("exp_dev_005"),
+                        black_box(&user_id),
+                        black_box(""),
+                        black_box(&no_attrs),
+                    )
+                    .await
+                    .unwrap();
+                }
+            })
         })
     });
 }

--- a/crates/experimentation-assignment/src/bandit_client.rs
+++ b/crates/experimentation-assignment/src/bandit_client.rs
@@ -1,14 +1,23 @@
 //! Bandit arm selection client.
 //!
-//! Until M4b delivers the BanditPolicyService, this module provides a mock
-//! implementation that selects arms uniformly at random with equal probability.
-//! The real implementation will call M4b's `SelectArm` gRPC RPC.
+//! Provides both a live gRPC client to M4b's `BanditPolicyService.SelectArm`
+//! and a mock uniform-random fallback used when M4b is unavailable or times out.
+//! Per onboarding pitfall #4: timeout at 10ms, fall back to uniform random.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use rand::Rng;
+use tonic::transport::Channel;
 
-use crate::config::BanditConfig;
+use crate::config::{BanditArmConfig, BanditConfig};
+
+use experimentation_proto::experimentation::bandit::v1::{
+    bandit_policy_service_client::BanditPolicyServiceClient, SelectArmRequest,
+};
+
+/// Default timeout for M4b SelectArm RPC (per onboarding pitfall #4).
+const BANDIT_TIMEOUT: Duration = Duration::from_millis(10);
 
 /// Result of selecting an arm from a bandit experiment.
 #[derive(Debug, Clone)]
@@ -21,6 +30,114 @@ pub struct ArmSelection {
     pub payload_json: String,
     /// All arm probabilities at selection time.
     pub all_arm_probabilities: HashMap<String, f64>,
+}
+
+/// gRPC client wrapper for M4b BanditPolicyService.
+///
+/// Calls `SelectArm` with a 10ms timeout. On timeout or error, the caller
+/// falls back to uniform random arm selection.
+#[derive(Clone)]
+pub struct GrpcBanditClient {
+    client: BanditPolicyServiceClient<Channel>,
+    timeout: Duration,
+}
+
+impl GrpcBanditClient {
+    /// Connect to M4b at the given address (e.g., "http://localhost:50054").
+    pub async fn connect(addr: &str) -> Result<Self, tonic::transport::Error> {
+        let channel = Channel::from_shared(addr.to_string())
+            .expect("valid URI")
+            .connect()
+            .await?;
+        Ok(Self {
+            client: BanditPolicyServiceClient::new(channel),
+            timeout: BANDIT_TIMEOUT,
+        })
+    }
+
+    /// Select an arm via M4b's SelectArm RPC.
+    ///
+    /// Returns `Err` on timeout (>10ms) or gRPC failure — caller should fall back
+    /// to uniform random.
+    pub async fn select_arm(
+        &self,
+        experiment_id: &str,
+        user_id: &str,
+        context_features: HashMap<String, f64>,
+    ) -> Result<ArmSelectionResult, BanditClientError> {
+        let req = SelectArmRequest {
+            experiment_id: experiment_id.to_string(),
+            user_id: user_id.to_string(),
+            context_features,
+        };
+
+        let mut client = self.client.clone();
+        let resp = tokio::time::timeout(self.timeout, client.select_arm(req))
+            .await
+            .map_err(|_| BanditClientError::Timeout)?
+            .map_err(BanditClientError::Grpc)?;
+
+        let arm = resp.into_inner();
+        Ok(ArmSelectionResult {
+            arm_id: arm.arm_id,
+            assignment_probability: arm.assignment_probability,
+            all_arm_probabilities: arm.all_arm_probabilities,
+        })
+    }
+}
+
+/// Raw result from M4b (no payload — that comes from local config).
+#[derive(Debug)]
+pub struct ArmSelectionResult {
+    pub arm_id: String,
+    pub assignment_probability: f64,
+    pub all_arm_probabilities: HashMap<String, f64>,
+}
+
+/// Errors from the bandit gRPC client.
+#[derive(Debug)]
+pub enum BanditClientError {
+    Timeout,
+    Grpc(tonic::Status),
+}
+
+impl std::fmt::Display for BanditClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "M4b SelectArm timed out (>10ms)"),
+            Self::Grpc(status) => write!(f, "M4b SelectArm gRPC error: {status}"),
+        }
+    }
+}
+
+/// Look up the payload_json for a given arm_id from local bandit config.
+///
+/// M4b only selects the arm — payload is stored in the local experiment config.
+pub fn lookup_arm_payload(arms: &[BanditArmConfig], arm_id: &str) -> String {
+    arms.iter()
+        .find(|a| a.arm_id == arm_id)
+        .map(|a| a.payload_json.clone())
+        .unwrap_or_default()
+}
+
+/// Extract context features from user attributes based on bandit config keys.
+///
+/// For CONTEXTUAL_BANDIT experiments, parses string attribute values to f64.
+/// Non-numeric values are silently skipped.
+pub fn extract_context_features(
+    bandit_config: &BanditConfig,
+    attributes: &HashMap<String, String>,
+) -> HashMap<String, f64> {
+    bandit_config
+        .context_feature_keys
+        .iter()
+        .filter_map(|key| {
+            attributes
+                .get(key)
+                .and_then(|v| v.parse::<f64>().ok())
+                .map(|v| (key.clone(), v))
+        })
+        .collect()
 }
 
 /// Select an arm using uniform random (mock for M4b).
@@ -149,5 +266,76 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0);
         let sel = select_arm_uniform(&config, &mut rng).unwrap();
         assert!(!sel.payload_json.is_empty());
+    }
+
+    #[test]
+    fn test_lookup_arm_payload_found() {
+        let arms = vec![
+            BanditArmConfig {
+                arm_id: "a".to_string(),
+                name: "A".to_string(),
+                payload_json: r#"{"x":1}"#.to_string(),
+            },
+            BanditArmConfig {
+                arm_id: "b".to_string(),
+                name: "B".to_string(),
+                payload_json: r#"{"x":2}"#.to_string(),
+            },
+        ];
+        assert_eq!(lookup_arm_payload(&arms, "b"), r#"{"x":2}"#);
+    }
+
+    #[test]
+    fn test_lookup_arm_payload_not_found() {
+        let arms = vec![BanditArmConfig {
+            arm_id: "a".to_string(),
+            name: "A".to_string(),
+            payload_json: "{}".to_string(),
+        }];
+        assert_eq!(lookup_arm_payload(&arms, "missing"), "");
+    }
+
+    #[test]
+    fn test_extract_context_features() {
+        let config = BanditConfig {
+            algorithm: "LINEAR_UCB".to_string(),
+            arms: vec![],
+            reward_metric_id: "clicks".to_string(),
+            context_feature_keys: vec![
+                "age".to_string(),
+                "tenure".to_string(),
+                "missing".to_string(),
+            ],
+            min_exploration_fraction: 0.1,
+            warmup_observations: 1000,
+        };
+        let mut attrs = HashMap::new();
+        attrs.insert("age".to_string(), "25.0".to_string());
+        attrs.insert("tenure".to_string(), "3.5".to_string());
+        attrs.insert("country".to_string(), "US".to_string()); // not in context_feature_keys
+
+        let features = extract_context_features(&config, &attrs);
+        assert_eq!(features.len(), 2);
+        assert!((features["age"] - 25.0).abs() < f64::EPSILON);
+        assert!((features["tenure"] - 3.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_extract_context_features_non_numeric_skipped() {
+        let config = BanditConfig {
+            algorithm: "LINEAR_UCB".to_string(),
+            arms: vec![],
+            reward_metric_id: "clicks".to_string(),
+            context_feature_keys: vec!["age".to_string(), "country".to_string()],
+            min_exploration_fraction: 0.1,
+            warmup_observations: 1000,
+        };
+        let mut attrs = HashMap::new();
+        attrs.insert("age".to_string(), "25".to_string());
+        attrs.insert("country".to_string(), "US".to_string()); // not parseable as f64
+
+        let features = extract_context_features(&config, &attrs);
+        assert_eq!(features.len(), 1);
+        assert!((features["age"] - 25.0).abs() < f64::EPSILON);
     }
 }

--- a/crates/experimentation-assignment/src/config.rs
+++ b/crates/experimentation-assignment/src/config.rs
@@ -180,10 +180,13 @@ impl Config {
         // Validate traffic fractions and build indexes.
         for exp in &config.experiments {
             for v in &exp.variants {
-                assert_finite(v.traffic_fraction, &format!(
-                    "variant {}.traffic_fraction in experiment {}",
-                    v.variant_id, exp.experiment_id,
-                ));
+                assert_finite(
+                    v.traffic_fraction,
+                    &format!(
+                        "variant {}.traffic_fraction in experiment {}",
+                        v.variant_id, exp.experiment_id,
+                    ),
+                );
             }
         }
 

--- a/crates/experimentation-assignment/src/config_cache.rs
+++ b/crates/experimentation-assignment/src/config_cache.rs
@@ -9,9 +9,7 @@ use std::sync::Arc;
 use experimentation_core::error::assert_finite;
 use tokio::sync::watch;
 
-use crate::config::{
-    AllocationConfig, Config, ExperimentConfig, LayerConfig, VariantConfig,
-};
+use crate::config::{AllocationConfig, Config, ExperimentConfig, LayerConfig, VariantConfig};
 
 use experimentation_proto::experimentation::common::v1::{
     Experiment, ExperimentState, ExperimentType, Variant,
@@ -151,19 +149,13 @@ pub fn experiment_from_proto(
         })
         .unwrap_or_else(|_| "UNSPECIFIED".to_string());
 
-    let variants: Vec<VariantConfig> = proto
-        .variants
-        .iter()
-        .map(variant_from_proto)
-        .collect();
+    let variants: Vec<VariantConfig> = proto.variants.iter().map(variant_from_proto).collect();
 
     // Preserve allocation from existing config, or default to full range.
-    let allocation = existing
-        .map(|e| e.allocation)
-        .unwrap_or(AllocationConfig {
-            start_bucket: 0,
-            end_bucket: 9999,
-        });
+    let allocation = existing.map(|e| e.allocation).unwrap_or(AllocationConfig {
+        start_bucket: 0,
+        end_bucket: 9999,
+    });
 
     // Preserve targeting rule from existing config (stream has only targeting_rule_id).
     let targeting_rule = existing.and_then(|e| e.targeting_rule.clone());

--- a/crates/experimentation-assignment/src/main.rs
+++ b/crates/experimentation-assignment/src/main.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use tokio_util::sync::CancellationToken;
 
+use experimentation_assignment::bandit_client::GrpcBanditClient;
 use experimentation_assignment::config::Config;
 use experimentation_assignment::config_cache::ConfigCache;
 use experimentation_assignment::service::AssignmentServiceImpl;
@@ -40,7 +41,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::warn!("M5_ADDR not set, running with static local config");
     }
 
-    let svc = AssignmentServiceImpl::new(handle);
+    // Connect to M4b BanditPolicyService for live arm selection.
+    let bandit_client = if let Ok(m4b_addr) = std::env::var("M4B_ADDR") {
+        match GrpcBanditClient::connect(&m4b_addr).await {
+            Ok(client) => {
+                tracing::info!(m4b_addr = %m4b_addr, "M4b bandit client connected");
+                Some(client)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    m4b_addr = %m4b_addr,
+                    error = %e,
+                    "M4b connect failed, bandit experiments use uniform random fallback",
+                );
+                None
+            }
+        }
+    } else {
+        tracing::warn!("M4B_ADDR not set, bandit experiments use uniform random");
+        None
+    };
+
+    let svc = AssignmentServiceImpl::new(handle, bandit_client);
 
     tracing::info!(%grpc_addr, "starting gRPC server");
     tonic::transport::Server::builder()

--- a/crates/experimentation-assignment/src/service.rs
+++ b/crates/experimentation-assignment/src/service.rs
@@ -14,10 +14,10 @@ use tonic::{Request, Response, Status};
 use experimentation_proto::experimentation::assignment::v1::{
     assignment_service_server::AssignmentService, ConfigUpdate, GetAssignmentRequest,
     GetAssignmentResponse, GetAssignmentsRequest, GetAssignmentsResponse,
-    GetInterleavedListRequest, GetInterleavedListResponse, RankedList,
-    StreamConfigUpdatesRequest,
+    GetInterleavedListRequest, GetInterleavedListResponse, RankedList, StreamConfigUpdatesRequest,
 };
 
+use crate::bandit_client::{self, GrpcBanditClient};
 use crate::config::{Config, ExperimentConfig};
 use crate::config_cache::ConfigCacheHandle;
 use crate::targeting;
@@ -25,25 +25,33 @@ use crate::targeting;
 /// gRPC service implementation backed by a live config cache.
 pub struct AssignmentServiceImpl {
     config: ConfigCacheHandle,
+    bandit_client: Option<GrpcBanditClient>,
 }
 
 impl AssignmentServiceImpl {
-    pub fn new(config: ConfigCacheHandle) -> Self {
-        Self { config }
-    }
-
-    /// Wrap a static `Arc<Config>` for tests and backward compatibility.
-    pub fn from_config(config: Arc<Config>) -> Self {
+    pub fn new(config: ConfigCacheHandle, bandit_client: Option<GrpcBanditClient>) -> Self {
         Self {
-            config: ConfigCacheHandle::from_static(config),
+            config,
+            bandit_client,
         }
     }
 
-    /// Core assignment logic — pure CPU, no async needed.
+    /// Wrap a static `Arc<Config>` for tests and backward compatibility.
+    ///
+    /// Uses no bandit client (uniform random fallback for bandit experiments).
+    pub fn from_config(config: Arc<Config>) -> Self {
+        Self {
+            config: ConfigCacheHandle::from_static(config),
+            bandit_client: None,
+        }
+    }
+
+    /// Core assignment logic.
     ///
     /// Returns `Ok(response)` on success, `Err(Status)` on lookup failure.
+    /// Async because bandit experiments may call M4b SelectArm gRPC.
     #[allow(clippy::result_large_err)]
-    pub fn assign(
+    pub async fn assign(
         &self,
         experiment_id: &str,
         user_id: &str,
@@ -56,9 +64,7 @@ impl AssignmentServiceImpl {
         let exp = config
             .experiments_by_id
             .get(experiment_id)
-            .ok_or_else(|| {
-                Status::not_found(format!("experiment not found: {experiment_id}"))
-            })?;
+            .ok_or_else(|| Status::not_found(format!("experiment not found: {experiment_id}")))?;
 
         // 2. Check experiment state — only RUNNING serves assignments.
         if exp.state != "RUNNING" {
@@ -84,13 +90,13 @@ impl AssignmentServiceImpl {
         let layer = config
             .layers_by_id
             .get(&exp.layer_id)
-            .ok_or_else(|| {
-                Status::internal(format!("layer not found: {}", exp.layer_id))
-            })?;
+            .ok_or_else(|| Status::internal(format!("layer not found: {}", exp.layer_id)))?;
 
         // 5. Bandit delegation: MAB / CONTEXTUAL_BANDIT use arm selection, not bucketing.
         if exp.r#type == "MAB" || exp.r#type == "CONTEXTUAL_BANDIT" {
-            return self.assign_bandit(exp, user_id, experiment_id);
+            return self
+                .assign_bandit(exp, user_id, experiment_id, attributes)
+                .await;
         }
 
         // 6. Hash entity into a bucket (user_id for AB, session_id for SESSION_LEVEL).
@@ -104,8 +110,7 @@ impl AssignmentServiceImpl {
         } else {
             user_id
         };
-        let bucket =
-            experimentation_hash::bucket(hash_input, &exp.hash_salt, layer.total_buckets);
+        let bucket = experimentation_hash::bucket(hash_input, &exp.hash_salt, layer.total_buckets);
 
         // 7. Check allocation range.
         if !experimentation_hash::is_in_allocation(
@@ -134,15 +139,19 @@ impl AssignmentServiceImpl {
 
     /// Bandit arm selection for MAB / CONTEXTUAL_BANDIT experiments.
     ///
-    /// Derives a deterministic RNG seed from (user_id, experiment_id),
-    /// then delegates to the bandit client (currently mock uniform random).
-    /// When M4b is live, this will call `SelectArm` gRPC instead.
+    /// If a gRPC bandit client is configured, calls M4b `SelectArm` with a 10ms
+    /// timeout. On success, the arm payload is looked up from local config (M4b
+    /// only selects the arm, not the payload). On timeout or error, falls back
+    /// to uniform random selection.
+    ///
+    /// If no bandit client is configured, always uses uniform random.
     #[allow(clippy::result_large_err)]
-    fn assign_bandit(
+    async fn assign_bandit(
         &self,
         exp: &ExperimentConfig,
         user_id: &str,
         experiment_id: &str,
+        attributes: &HashMap<String, String>,
     ) -> Result<GetAssignmentResponse, Status> {
         let bandit_config = exp.bandit_config.as_ref().ok_or_else(|| {
             Status::failed_precondition(format!(
@@ -150,22 +159,46 @@ impl AssignmentServiceImpl {
             ))
         })?;
 
-        // Deterministic seed from (user_id, experiment_id).
+        // Try live M4b client first.
+        if let Some(ref client) = self.bandit_client {
+            let context_features =
+                bandit_client::extract_context_features(bandit_config, attributes);
+
+            match client
+                .select_arm(experiment_id, user_id, context_features)
+                .await
+            {
+                Ok(result) => {
+                    let payload =
+                        bandit_client::lookup_arm_payload(&bandit_config.arms, &result.arm_id);
+                    return Ok(GetAssignmentResponse {
+                        experiment_id: experiment_id.to_string(),
+                        variant_id: result.arm_id,
+                        payload_json: payload,
+                        assignment_probability: result.assignment_probability,
+                        is_active: true,
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        experiment_id,
+                        error = %e,
+                        "M4b SelectArm failed, falling back to uniform random",
+                    );
+                    // Fall through to uniform random below.
+                }
+            }
+        }
+
+        // Fallback: deterministic uniform random arm selection.
         let seed_input = format!("{user_id}\x00{experiment_id}");
-        let lo = experimentation_hash::murmur3::murmurhash3_x86_32(
-            seed_input.as_bytes(),
-            0,
-        ) as u64;
-        let hi = experimentation_hash::murmur3::murmurhash3_x86_32(
-            seed_input.as_bytes(),
-            1,
-        ) as u64;
+        let lo = experimentation_hash::murmur3::murmurhash3_x86_32(seed_input.as_bytes(), 0) as u64;
+        let hi = experimentation_hash::murmur3::murmurhash3_x86_32(seed_input.as_bytes(), 1) as u64;
         let seed = (hi << 32) | lo;
         let mut rng = StdRng::seed_from_u64(seed);
 
-        // TODO(m4b): Replace with gRPC call to M4b SelectArm when available.
-        let selection = crate::bandit_client::select_arm_uniform(bandit_config, &mut rng)
-            .ok_or_else(|| {
+        let selection =
+            bandit_client::select_arm_uniform(bandit_config, &mut rng).ok_or_else(|| {
                 Status::failed_precondition(format!(
                     "experiment {experiment_id} bandit_config has no arms",
                 ))
@@ -197,9 +230,7 @@ impl AssignmentServiceImpl {
         let exp = config
             .experiments_by_id
             .get(experiment_id)
-            .ok_or_else(|| {
-                Status::not_found(format!("experiment not found: {experiment_id}"))
-            })?;
+            .ok_or_else(|| Status::not_found(format!("experiment not found: {experiment_id}")))?;
 
         // 2. Experiment must be RUNNING.
         if exp.state != "RUNNING" {
@@ -218,14 +249,8 @@ impl AssignmentServiceImpl {
 
         // 4. Derive deterministic 64-bit seed from (user_id, experiment_id).
         let seed_input = format!("{user_id}\x00{experiment_id}");
-        let lo = experimentation_hash::murmur3::murmurhash3_x86_32(
-            seed_input.as_bytes(),
-            0,
-        ) as u64;
-        let hi = experimentation_hash::murmur3::murmurhash3_x86_32(
-            seed_input.as_bytes(),
-            1,
-        ) as u64;
+        let lo = experimentation_hash::murmur3::murmurhash3_x86_32(seed_input.as_bytes(), 0) as u64;
+        let hi = experimentation_hash::murmur3::murmurhash3_x86_32(seed_input.as_bytes(), 1) as u64;
         let seed = (hi << 32) | lo;
         let mut rng = StdRng::seed_from_u64(seed);
 
@@ -261,18 +286,14 @@ impl AssignmentServiceImpl {
                 let mut total_items = 0usize;
                 for algo_id in &il_config.algorithm_ids {
                     let ranked = algorithm_lists.get(algo_id).ok_or_else(|| {
-                        Status::invalid_argument(format!(
-                            "missing algorithm list for '{algo_id}'",
-                        ))
+                        Status::invalid_argument(format!("missing algorithm list for '{algo_id}'",))
                     })?;
                     total_items += ranked.item_ids.len();
                     ordered_lists.push((&ranked.item_ids, algo_id.as_str()));
                 }
 
                 let k = il_config.max_list_size.min(total_items);
-                experimentation_interleaving::multileave::multileave(
-                    &ordered_lists, k, &mut rng,
-                )
+                experimentation_interleaving::multileave::multileave(&ordered_lists, k, &mut rng)
             }
             other => {
                 return Err(Status::invalid_argument(format!(
@@ -325,12 +346,8 @@ impl AssignmentServiceImpl {
 ///
 /// Uses traffic_fraction to partition the allocation range. Falls through to the
 /// last variant if floating-point rounding causes no match (total function).
-fn select_variant(
-    exp: &ExperimentConfig,
-    bucket: u32,
-) -> &crate::config::VariantConfig {
-    let alloc_size =
-        (exp.allocation.end_bucket - exp.allocation.start_bucket + 1) as f64;
+fn select_variant(exp: &ExperimentConfig, bucket: u32) -> &crate::config::VariantConfig {
+    let alloc_size = (exp.allocation.end_bucket - exp.allocation.start_bucket + 1) as f64;
     let relative_bucket = (bucket - exp.allocation.start_bucket) as f64;
 
     let mut cumulative = 0.0_f64;
@@ -342,7 +359,9 @@ fn select_variant(
     }
 
     // Fallthrough guard: assign to last variant (handles FP rounding edge cases).
-    exp.variants.last().expect("experiment must have at least one variant")
+    exp.variants
+        .last()
+        .expect("experiment must have at least one variant")
 }
 
 #[tonic::async_trait]
@@ -352,7 +371,14 @@ impl AssignmentService for AssignmentServiceImpl {
         request: Request<GetAssignmentRequest>,
     ) -> Result<Response<GetAssignmentResponse>, Status> {
         let req = request.into_inner();
-        let resp = self.assign(&req.experiment_id, &req.user_id, &req.session_id, &req.attributes)?;
+        let resp = self
+            .assign(
+                &req.experiment_id,
+                &req.user_id,
+                &req.session_id,
+                &req.attributes,
+            )
+            .await?;
         Ok(Response::new(resp))
     }
 
@@ -366,7 +392,15 @@ impl AssignmentService for AssignmentServiceImpl {
 
         for exp in &config.experiments {
             // Best-effort: skip experiments that fail assignment.
-            if let Ok(resp) = self.assign(&exp.experiment_id, &req.user_id, &req.session_id, &req.attributes) {
+            if let Ok(resp) = self
+                .assign(
+                    &exp.experiment_id,
+                    &req.user_id,
+                    &req.session_id,
+                    &req.attributes,
+                )
+                .await
+            {
                 assignments.push(resp);
             }
         }
@@ -383,8 +417,7 @@ impl AssignmentService for AssignmentServiceImpl {
         Ok(Response::new(resp))
     }
 
-    type StreamConfigUpdatesStream =
-        ReceiverStream<Result<ConfigUpdate, Status>>;
+    type StreamConfigUpdatesStream = ReceiverStream<Result<ConfigUpdate, Status>>;
 
     async fn stream_config_updates(
         &self,

--- a/crates/experimentation-assignment/src/stream_client.rs
+++ b/crates/experimentation-assignment/src/stream_client.rs
@@ -26,10 +26,7 @@ pub struct StreamClient {
 
 impl StreamClient {
     pub fn new(m5_endpoint: String, cache: ConfigCache) -> Self {
-        Self {
-            m5_endpoint,
-            cache,
-        }
+        Self { m5_endpoint, cache }
     }
 
     /// Run the stream loop until `shutdown` is cancelled.
@@ -96,10 +93,7 @@ impl StreamClient {
             last_known_version: self.cache.last_version(),
         };
 
-        let mut stream = client
-            .stream_config_updates(request)
-            .await?
-            .into_inner();
+        let mut stream = client.stream_config_updates(request).await?.into_inner();
 
         // Reset backoff on successful connection.
         // (Caller manages backoff state, but we signal success by processing updates.)

--- a/crates/experimentation-assignment/src/targeting.rs
+++ b/crates/experimentation-assignment/src/targeting.rs
@@ -33,10 +33,7 @@ fn evaluate_group(group: &TargetingGroup, attributes: &HashMap<String, String>) 
 
 /// Evaluate a single predicate against the attribute map.
 /// Missing attribute → false (safe default, fail-closed).
-fn evaluate_predicate(
-    pred: &TargetingPredicate,
-    attributes: &HashMap<String, String>,
-) -> bool {
+fn evaluate_predicate(pred: &TargetingPredicate, attributes: &HashMap<String, String>) -> bool {
     let attr_value = match attributes.get(&pred.attribute_key) {
         Some(v) => v,
         None => return false, // Missing attribute → no match.
@@ -47,7 +44,10 @@ fn evaluate_predicate(
         "NOT_EQUALS" => pred.values.first().is_some_and(|v| v != attr_value),
         "IN" => pred.values.iter().any(|v| v == attr_value),
         "NOT_IN" => !pred.values.iter().any(|v| v == attr_value),
-        "CONTAINS" => pred.values.first().is_some_and(|v| attr_value.contains(v.as_str())),
+        "CONTAINS" => pred
+            .values
+            .first()
+            .is_some_and(|v| attr_value.contains(v.as_str())),
         "GT" | "GREATER_THAN" => compare_numeric(attr_value, &pred.values, |a, b| a > b),
         "LT" | "LESS_THAN" => compare_numeric(attr_value, &pred.values, |a, b| a < b),
         "GTE" => compare_numeric(attr_value, &pred.values, |a, b| a >= b),

--- a/crates/experimentation-assignment/tests/assignment_test.rs
+++ b/crates/experimentation-assignment/tests/assignment_test.rs
@@ -1,9 +1,20 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use experimentation_assignment::config::Config;
 use experimentation_assignment::service::AssignmentServiceImpl;
 use experimentation_proto::experimentation::assignment::v1::RankedList;
+use experimentation_proto::experimentation::bandit::v1::bandit_policy_service_server::{
+    BanditPolicyService, BanditPolicyServiceServer,
+};
+use experimentation_proto::experimentation::bandit::v1::{
+    CreateColdStartBanditRequest, CreateColdStartBanditResponse, ExportAffinityScoresRequest,
+    ExportAffinityScoresResponse, GetPolicySnapshotRequest, RollbackPolicyRequest,
+    SelectArmRequest,
+};
+use experimentation_proto::experimentation::common::v1::{ArmSelection, PolicySnapshot};
 
 /// Compile-time embed of dev config — avoids path issues in tests.
 const DEV_CONFIG: &str = include_str!("../../../dev/config.json");
@@ -18,29 +29,44 @@ fn no_attrs() -> HashMap<String, String> {
 }
 
 fn attrs(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-    pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
 }
 
 // ── M1.2 Tests (static bucketing) ──
 
-#[test]
-fn determinism_same_user_same_variant() {
+#[tokio::test]
+async fn determinism_same_user_same_variant() {
     let svc = make_service();
-    let r1 = svc.assign("exp_dev_001", "user_42", "", &no_attrs()).unwrap();
-    let r2 = svc.assign("exp_dev_001", "user_42", "", &no_attrs()).unwrap();
-    assert_eq!(r1.variant_id, r2.variant_id, "same user must get same variant");
+    let r1 = svc
+        .assign("exp_dev_001", "user_42", "", &no_attrs())
+        .await
+        .unwrap();
+    let r2 = svc
+        .assign("exp_dev_001", "user_42", "", &no_attrs())
+        .await
+        .unwrap();
+    assert_eq!(
+        r1.variant_id, r2.variant_id,
+        "same user must get same variant"
+    );
     assert_eq!(r1.payload_json, r2.payload_json);
     assert!(r1.is_active);
 }
 
-#[test]
-fn balance_50_50_chi_squared() {
+#[tokio::test]
+async fn balance_50_50_chi_squared() {
     let svc = make_service();
     let mut counts = std::collections::HashMap::new();
 
     for i in 0..10_000 {
         let user_id = format!("balance_user_{i}");
-        let resp = svc.assign("exp_dev_001", &user_id, "", &no_attrs()).unwrap();
+        let resp = svc
+            .assign("exp_dev_001", &user_id, "", &no_attrs())
+            .await
+            .unwrap();
         *counts.entry(resp.variant_id).or_insert(0u64) += 1;
     }
 
@@ -61,15 +87,18 @@ fn balance_50_50_chi_squared() {
     );
 }
 
-#[test]
-fn not_found_unknown_experiment() {
+#[tokio::test]
+async fn not_found_unknown_experiment() {
     let svc = make_service();
-    let err = svc.assign("nonexistent_exp", "user_1", "", &no_attrs()).unwrap_err();
+    let err = svc
+        .assign("nonexistent_exp", "user_1", "", &no_attrs())
+        .await
+        .unwrap_err();
     assert_eq!(err.code(), tonic::Code::NotFound);
 }
 
-#[test]
-fn empty_assignment_outside_allocation() {
+#[tokio::test]
+async fn empty_assignment_outside_allocation() {
     let json = r#"{
         "experiments": [{
             "experiment_id": "narrow_exp",
@@ -89,9 +118,15 @@ fn empty_assignment_outside_allocation() {
 
     let mut outside_count = 0;
     for i in 0..1000 {
-        let resp = svc.assign("narrow_exp", &format!("user_{i}"), "", &no_attrs()).unwrap();
+        let resp = svc
+            .assign("narrow_exp", &format!("user_{i}"), "", &no_attrs())
+            .await
+            .unwrap();
         if resp.variant_id.is_empty() {
-            assert!(resp.is_active, "outside allocation should still be is_active=true");
+            assert!(
+                resp.is_active,
+                "outside allocation should still be is_active=true"
+            );
             outside_count += 1;
         }
     }
@@ -102,8 +137,8 @@ fn empty_assignment_outside_allocation() {
     );
 }
 
-#[test]
-fn inactive_experiment_returns_is_active_false() {
+#[tokio::test]
+async fn inactive_experiment_returns_is_active_false() {
     let json = r#"{
         "experiments": [{
             "experiment_id": "draft_exp",
@@ -121,42 +156,74 @@ fn inactive_experiment_returns_is_active_false() {
     let config = Config::from_json(json).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
-    let resp = svc.assign("draft_exp", "user_1", "", &no_attrs()).unwrap();
-    assert!(!resp.is_active, "DRAFT experiment must return is_active=false");
-    assert!(resp.variant_id.is_empty(), "DRAFT experiment must not assign a variant");
+    let resp = svc
+        .assign("draft_exp", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
+    assert!(
+        !resp.is_active,
+        "DRAFT experiment must return is_active=false"
+    );
+    assert!(
+        resp.variant_id.is_empty(),
+        "DRAFT experiment must not assign a variant"
+    );
 }
 
 // ── M1.4 Tests (targeting rules) ──
 
-#[test]
-fn targeting_country_in_match() {
+#[tokio::test]
+async fn targeting_country_in_match() {
     let svc = make_service();
     // exp_dev_002 targets country IN [US, UK] AND tier IN [premium, platinum]
-    let resp = svc.assign("exp_dev_002", "user_1", "", &attrs(&[("country", "US"), ("tier", "premium")])).unwrap();
+    let resp = svc
+        .assign(
+            "exp_dev_002",
+            "user_1",
+            "",
+            &attrs(&[("country", "US"), ("tier", "premium")]),
+        )
+        .await
+        .unwrap();
     assert!(resp.is_active);
-    assert!(!resp.variant_id.is_empty(), "targeted user should get a variant");
+    assert!(
+        !resp.variant_id.is_empty(),
+        "targeted user should get a variant"
+    );
 }
 
-#[test]
-fn targeting_empty_rule_matches_all() {
+#[tokio::test]
+async fn targeting_empty_rule_matches_all() {
     let svc = make_service();
     // exp_dev_001 has no targeting rule — all users match
-    let resp = svc.assign("exp_dev_001", "user_1", "", &no_attrs()).unwrap();
+    let resp = svc
+        .assign("exp_dev_001", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
     assert!(resp.is_active);
     assert!(!resp.variant_id.is_empty());
 }
 
-#[test]
-fn targeting_missing_attribute_no_match() {
+#[tokio::test]
+async fn targeting_missing_attribute_no_match() {
     let svc = make_service();
     // exp_dev_002 requires country + tier, but we provide neither
-    let resp = svc.assign("exp_dev_002", "user_1", "", &no_attrs()).unwrap();
-    assert!(resp.is_active, "targeting miss should still be is_active=true");
-    assert!(resp.variant_id.is_empty(), "targeting miss should return empty variant");
+    let resp = svc
+        .assign("exp_dev_002", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
+    assert!(
+        resp.is_active,
+        "targeting miss should still be is_active=true"
+    );
+    assert!(
+        resp.variant_id.is_empty(),
+        "targeting miss should return empty variant"
+    );
 }
 
-#[test]
-fn targeting_no_rule_matches_all() {
+#[tokio::test]
+async fn targeting_no_rule_matches_all() {
     // Experiment without targeting_rule field at all
     let json = r#"{
         "experiments": [{
@@ -175,25 +242,50 @@ fn targeting_no_rule_matches_all() {
     let config = Config::from_json(json).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
-    let resp = svc.assign("no_target_exp", "user_1", "", &no_attrs()).unwrap();
+    let resp = svc
+        .assign("no_target_exp", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
     assert!(resp.is_active);
-    assert!(!resp.variant_id.is_empty(), "no targeting rule → all users match");
+    assert!(
+        !resp.variant_id.is_empty(),
+        "no targeting rule → all users match"
+    );
 }
 
-#[test]
-fn targeting_compound_and_across_groups() {
+#[tokio::test]
+async fn targeting_compound_and_across_groups() {
     let svc = make_service();
     // Correct country but wrong tier → AND fails
-    let resp = svc.assign("exp_dev_002", "user_1", "", &attrs(&[("country", "US"), ("tier", "free")])).unwrap();
+    let resp = svc
+        .assign(
+            "exp_dev_002",
+            "user_1",
+            "",
+            &attrs(&[("country", "US"), ("tier", "free")]),
+        )
+        .await
+        .unwrap();
     assert!(resp.variant_id.is_empty(), "wrong tier should not match");
 
     // Correct tier but wrong country → AND fails
-    let resp2 = svc.assign("exp_dev_002", "user_2", "", &attrs(&[("country", "FR"), ("tier", "premium")])).unwrap();
-    assert!(resp2.variant_id.is_empty(), "wrong country should not match");
+    let resp2 = svc
+        .assign(
+            "exp_dev_002",
+            "user_2",
+            "",
+            &attrs(&[("country", "FR"), ("tier", "premium")]),
+        )
+        .await
+        .unwrap();
+    assert!(
+        resp2.variant_id.is_empty(),
+        "wrong country should not match"
+    );
 }
 
-#[test]
-fn targeting_gt_numeric() {
+#[tokio::test]
+async fn targeting_gt_numeric() {
     let json = r#"{
         "experiments": [{
             "experiment_id": "age_exp",
@@ -216,33 +308,51 @@ fn targeting_gt_numeric() {
     let config = Config::from_json(json).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
-    let resp = svc.assign("age_exp", "user_1", "", &attrs(&[("age", "25")])).unwrap();
+    let resp = svc
+        .assign("age_exp", "user_1", "", &attrs(&[("age", "25")]))
+        .await
+        .unwrap();
     assert!(!resp.variant_id.is_empty(), "age 25 > 18 should match");
 
-    let resp2 = svc.assign("age_exp", "user_2", "", &attrs(&[("age", "15")])).unwrap();
+    let resp2 = svc
+        .assign("age_exp", "user_2", "", &attrs(&[("age", "15")]))
+        .await
+        .unwrap();
     assert!(resp2.variant_id.is_empty(), "age 15 <= 18 should not match");
 }
 
 // ── M1.5 Tests (session-level + layer-aware assignment) ──
 
-#[test]
-fn session_level_determinism() {
+#[tokio::test]
+async fn session_level_determinism() {
     let svc = make_service();
-    let r1 = svc.assign("exp_dev_003", "user_1", "session_abc", &no_attrs()).unwrap();
-    let r2 = svc.assign("exp_dev_003", "user_1", "session_abc", &no_attrs()).unwrap();
-    assert_eq!(r1.variant_id, r2.variant_id, "same session_id must get same variant");
+    let r1 = svc
+        .assign("exp_dev_003", "user_1", "session_abc", &no_attrs())
+        .await
+        .unwrap();
+    let r2 = svc
+        .assign("exp_dev_003", "user_1", "session_abc", &no_attrs())
+        .await
+        .unwrap();
+    assert_eq!(
+        r1.variant_id, r2.variant_id,
+        "same session_id must get same variant"
+    );
     assert!(r1.is_active);
     assert!(!r1.variant_id.is_empty());
 }
 
-#[test]
-fn session_level_cross_session_variation() {
+#[tokio::test]
+async fn session_level_cross_session_variation() {
     let svc = make_service();
     // Collect variants across many sessions — should see both variants.
     let mut variants = std::collections::HashSet::new();
     for i in 0..200 {
         let session = format!("session_{i}");
-        let resp = svc.assign("exp_dev_003", "user_1", &session, &no_attrs()).unwrap();
+        let resp = svc
+            .assign("exp_dev_003", "user_1", &session, &no_attrs())
+            .await
+            .unwrap();
         variants.insert(resp.variant_id);
     }
     assert!(
@@ -251,10 +361,13 @@ fn session_level_cross_session_variation() {
     );
 }
 
-#[test]
-fn session_level_missing_session_id() {
+#[tokio::test]
+async fn session_level_missing_session_id() {
     let svc = make_service();
-    let err = svc.assign("exp_dev_003", "user_1", "", &no_attrs()).unwrap_err();
+    let err = svc
+        .assign("exp_dev_003", "user_1", "", &no_attrs())
+        .await
+        .unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
     assert!(
         err.message().contains("session_id"),
@@ -263,11 +376,17 @@ fn session_level_missing_session_id() {
     );
 }
 
-#[test]
-fn session_level_same_user_different_sessions() {
+#[tokio::test]
+async fn session_level_same_user_different_sessions() {
     let svc = make_service();
-    let r1 = svc.assign("exp_dev_003", "user_42", "sess_A", &no_attrs()).unwrap();
-    let r2 = svc.assign("exp_dev_003", "user_42", "sess_B", &no_attrs()).unwrap();
+    let r1 = svc
+        .assign("exp_dev_003", "user_42", "sess_A", &no_attrs())
+        .await
+        .unwrap();
+    let r2 = svc
+        .assign("exp_dev_003", "user_42", "sess_B", &no_attrs())
+        .await
+        .unwrap();
     // Different sessions may get different buckets (hash depends on session_id, not user_id).
     // We can't guarantee different variants, but we verify both succeed.
     assert!(r1.is_active);
@@ -276,20 +395,32 @@ fn session_level_same_user_different_sessions() {
     assert!(!r2.variant_id.is_empty());
 }
 
-#[test]
-fn layer_orthogonality() {
+#[tokio::test]
+async fn layer_orthogonality() {
     // User gets assignment in both default layer (AB) and session layer (SESSION_LEVEL).
     let svc = make_service();
-    let ab_resp = svc.assign("exp_dev_001", "user_1", "", &no_attrs()).unwrap();
-    let session_resp = svc.assign("exp_dev_003", "user_1", "session_1", &no_attrs()).unwrap();
+    let ab_resp = svc
+        .assign("exp_dev_001", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
+    let session_resp = svc
+        .assign("exp_dev_003", "user_1", "session_1", &no_attrs())
+        .await
+        .unwrap();
     assert!(ab_resp.is_active);
     assert!(session_resp.is_active);
-    assert!(!ab_resp.variant_id.is_empty(), "AB experiment should assign");
-    assert!(!session_resp.variant_id.is_empty(), "session experiment should assign");
+    assert!(
+        !ab_resp.variant_id.is_empty(),
+        "AB experiment should assign"
+    );
+    assert!(
+        !session_resp.variant_id.is_empty(),
+        "session experiment should assign"
+    );
 }
 
-#[test]
-fn layer_exclusive_allocation() {
+#[tokio::test]
+async fn layer_exclusive_allocation() {
     // Two experiments in the same layer with non-overlapping allocations.
     // A user should match at most one.
     let json = r#"{
@@ -323,8 +454,8 @@ fn layer_exclusive_allocation() {
 
     for i in 0..500 {
         let user = format!("excl_user_{i}");
-        let a = svc.assign("exp_a", &user, "", &no_attrs()).unwrap();
-        let b = svc.assign("exp_b", &user, "", &no_attrs()).unwrap();
+        let a = svc.assign("exp_a", &user, "", &no_attrs()).await.unwrap();
+        let b = svc.assign("exp_b", &user, "", &no_attrs()).await.unwrap();
 
         // With same salt and same layer, user hashes to one bucket.
         // That bucket is in exactly one allocation range.
@@ -347,11 +478,15 @@ fn make_algo_lists(a_items: &[&str], b_items: &[&str]) -> HashMap<String, Ranked
     let mut m = HashMap::new();
     m.insert(
         "algo_a".to_string(),
-        RankedList { item_ids: a_items.iter().map(|s| s.to_string()).collect() },
+        RankedList {
+            item_ids: a_items.iter().map(|s| s.to_string()).collect(),
+        },
     );
     m.insert(
         "algo_b".to_string(),
-        RankedList { item_ids: b_items.iter().map(|s| s.to_string()).collect() },
+        RankedList {
+            item_ids: b_items.iter().map(|s| s.to_string()).collect(),
+        },
     );
     m
 }
@@ -365,8 +500,14 @@ fn interleaving_basic() {
     );
     let resp = svc.interleave("exp_dev_004", "user_1", &lists).unwrap();
 
-    assert!(!resp.merged_list.is_empty(), "merged list should not be empty");
-    assert!(resp.merged_list.len() <= 10, "should not exceed max_list_size");
+    assert!(
+        !resp.merged_list.is_empty(),
+        "merged list should not be empty"
+    );
+    assert!(
+        resp.merged_list.len() <= 10,
+        "should not exceed max_list_size"
+    );
     // Every item has provenance.
     for item in &resp.merged_list {
         assert!(
@@ -384,13 +525,13 @@ fn interleaving_basic() {
 #[test]
 fn interleaving_deterministic() {
     let svc = make_service();
-    let lists = make_algo_lists(
-        &["x1", "x2", "x3", "x4"],
-        &["y1", "y2", "y3", "y4"],
-    );
+    let lists = make_algo_lists(&["x1", "x2", "x3", "x4"], &["y1", "y2", "y3", "y4"]);
     let r1 = svc.interleave("exp_dev_004", "user_42", &lists).unwrap();
     let r2 = svc.interleave("exp_dev_004", "user_42", &lists).unwrap();
-    assert_eq!(r1.merged_list, r2.merged_list, "same inputs must produce same output");
+    assert_eq!(
+        r1.merged_list, r2.merged_list,
+        "same inputs must produce same output"
+    );
     assert_eq!(r1.provenance, r2.provenance);
 }
 
@@ -398,8 +539,12 @@ fn interleaving_deterministic() {
 fn interleaving_respects_max_list_size() {
     // exp_dev_004 has max_list_size=10. Provide 20 items total.
     let svc = make_service();
-    let a: Vec<&str> = (0..10).map(|i| ["a0","a1","a2","a3","a4","a5","a6","a7","a8","a9"][i]).collect();
-    let b: Vec<&str> = (0..10).map(|i| ["b0","b1","b2","b3","b4","b5","b6","b7","b8","b9"][i]).collect();
+    let a: Vec<&str> = (0..10)
+        .map(|i| ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"][i])
+        .collect();
+    let b: Vec<&str> = (0..10)
+        .map(|i| ["b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9"][i])
+        .collect();
     let lists = make_algo_lists(&a, &b);
     let resp = svc.interleave("exp_dev_004", "user_1", &lists).unwrap();
     assert!(
@@ -413,7 +558,9 @@ fn interleaving_respects_max_list_size() {
 fn interleaving_unknown_experiment() {
     let svc = make_service();
     let lists = make_algo_lists(&["a"], &["b"]);
-    let err = svc.interleave("nonexistent_exp", "user_1", &lists).unwrap_err();
+    let err = svc
+        .interleave("nonexistent_exp", "user_1", &lists)
+        .unwrap_err();
     assert_eq!(err.code(), tonic::Code::NotFound);
 }
 
@@ -432,15 +579,35 @@ fn interleaving_wrong_algo_count() {
 
     // 1 algorithm
     let mut one = HashMap::new();
-    one.insert("algo_a".to_string(), RankedList { item_ids: vec!["x".to_string()] });
+    one.insert(
+        "algo_a".to_string(),
+        RankedList {
+            item_ids: vec!["x".to_string()],
+        },
+    );
     let err = svc.interleave("exp_dev_004", "user_1", &one).unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
 
     // 3 algorithms
     let mut three = HashMap::new();
-    three.insert("algo_a".to_string(), RankedList { item_ids: vec!["x".to_string()] });
-    three.insert("algo_b".to_string(), RankedList { item_ids: vec!["y".to_string()] });
-    three.insert("algo_c".to_string(), RankedList { item_ids: vec!["z".to_string()] });
+    three.insert(
+        "algo_a".to_string(),
+        RankedList {
+            item_ids: vec!["x".to_string()],
+        },
+    );
+    three.insert(
+        "algo_b".to_string(),
+        RankedList {
+            item_ids: vec!["y".to_string()],
+        },
+    );
+    three.insert(
+        "algo_c".to_string(),
+        RankedList {
+            item_ids: vec!["z".to_string()],
+        },
+    );
     let err = svc.interleave("exp_dev_004", "user_1", &three).unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
 }
@@ -460,7 +627,11 @@ fn interleaving_disjoint_lists() {
     let lists = make_algo_lists(&["a", "b", "c"], &["d", "e", "f"]);
     let resp = svc.interleave("exp_dev_004", "user_1", &lists).unwrap();
     // All 6 items should appear.
-    assert_eq!(resp.merged_list.len(), 6, "all disjoint items should appear");
+    assert_eq!(
+        resp.merged_list.len(),
+        6,
+        "all disjoint items should appear"
+    );
     let set: std::collections::HashSet<_> = resp.merged_list.iter().collect();
     for item in &["a", "b", "c", "d", "e", "f"] {
         assert!(set.contains(&item.to_string()), "missing item {item}");
@@ -492,10 +663,7 @@ fn interleaving_balance() {
 
     for i in 0..1000 {
         let user_id = format!("balance_user_{i}");
-        let lists = make_algo_lists(
-            &["i1", "i2", "i3", "i4"],
-            &["i5", "i6", "i7", "i8"],
-        );
+        let lists = make_algo_lists(&["i1", "i2", "i3", "i4"], &["i5", "i6", "i7", "i8"]);
         let resp = svc.interleave("exp_dev_004", &user_id, &lists).unwrap();
         for algo in resp.provenance.values() {
             match algo.as_str() {
@@ -547,8 +715,12 @@ fn optimized_interleaving_deterministic() {
 #[test]
 fn optimized_interleaving_respects_max_list_size() {
     let svc = make_service();
-    let a: Vec<&str> = (0..10).map(|i| ["a0","a1","a2","a3","a4","a5","a6","a7","a8","a9"][i]).collect();
-    let b: Vec<&str> = (0..10).map(|i| ["b0","b1","b2","b3","b4","b5","b6","b7","b8","b9"][i]).collect();
+    let a: Vec<&str> = (0..10)
+        .map(|i| ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"][i])
+        .collect();
+    let b: Vec<&str> = (0..10)
+        .map(|i| ["b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9"][i])
+        .collect();
     let lists = make_algo_lists(&a, &b);
     let resp = svc.interleave("exp_dev_006", "user_1", &lists).unwrap();
     assert!(
@@ -632,7 +804,9 @@ fn unsupported_method_returns_error() {
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
     let lists = make_algo_lists(&["a", "b"], &["c", "d"]);
-    let err = svc.interleave("bad_method_exp", "user_1", &lists).unwrap_err();
+    let err = svc
+        .interleave("bad_method_exp", "user_1", &lists)
+        .unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
     assert!(err.message().contains("unsupported interleaving method"));
 }
@@ -666,7 +840,10 @@ fn multileave_basic_3_algorithms() {
     assert!(!resp.merged_list.is_empty());
     assert!(resp.merged_list.len() <= 15);
     for item in &resp.merged_list {
-        assert!(resp.provenance.contains_key(item), "missing provenance for {item}");
+        assert!(
+            resp.provenance.contains_key(item),
+            "missing provenance for {item}"
+        );
         let algo = &resp.provenance[item];
         assert!(
             ["algo_x", "algo_y", "algo_z"].contains(&algo.as_str()),
@@ -685,7 +862,10 @@ fn multileave_deterministic() {
     ]);
     let r1 = svc.interleave("exp_dev_007", "user_42", &lists).unwrap();
     let r2 = svc.interleave("exp_dev_007", "user_42", &lists).unwrap();
-    assert_eq!(r1.merged_list, r2.merged_list, "same inputs must produce same output");
+    assert_eq!(
+        r1.merged_list, r2.merged_list,
+        "same inputs must produce same output"
+    );
     assert_eq!(r1.provenance, r2.provenance);
 }
 
@@ -737,9 +917,18 @@ fn multileave_respects_max_list_size() {
     // exp_dev_007 has max_list_size=15. Provide 30 items total.
     let svc = make_service();
     let lists = make_multi_algo_lists(&[
-        ("algo_x", &["a0","a1","a2","a3","a4","a5","a6","a7","a8","a9"]),
-        ("algo_y", &["b0","b1","b2","b3","b4","b5","b6","b7","b8","b9"]),
-        ("algo_z", &["c0","c1","c2","c3","c4","c5","c6","c7","c8","c9"]),
+        (
+            "algo_x",
+            &["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"],
+        ),
+        (
+            "algo_y",
+            &["b0", "b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8", "b9"],
+        ),
+        (
+            "algo_z",
+            &["c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9"],
+        ),
     ]);
     let resp = svc.interleave("exp_dev_007", "user_1", &lists).unwrap();
     assert!(
@@ -752,11 +941,7 @@ fn multileave_respects_max_list_size() {
 #[test]
 fn multileave_empty_lists() {
     let svc = make_service();
-    let lists = make_multi_algo_lists(&[
-        ("algo_x", &[]),
-        ("algo_y", &[]),
-        ("algo_z", &[]),
-    ]);
+    let lists = make_multi_algo_lists(&[("algo_x", &[]), ("algo_y", &[]), ("algo_z", &[])]);
     let resp = svc.interleave("exp_dev_007", "user_1", &lists).unwrap();
     assert!(resp.merged_list.is_empty());
     assert!(resp.provenance.is_empty());
@@ -811,12 +996,18 @@ fn multileave_missing_algo_list_in_request() {
 
 // ── Bandit Delegation Tests (MAB / CONTEXTUAL_BANDIT) ──
 
-#[test]
-fn bandit_mab_basic_assignment() {
+#[tokio::test]
+async fn bandit_mab_basic_assignment() {
     let svc = make_service();
-    let resp = svc.assign("exp_dev_005", "user_1", "", &no_attrs()).unwrap();
+    let resp = svc
+        .assign("exp_dev_005", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
     assert!(resp.is_active);
-    assert!(!resp.variant_id.is_empty(), "MAB experiment should assign an arm");
+    assert!(
+        !resp.variant_id.is_empty(),
+        "MAB experiment should assign an arm"
+    );
     // Arm should be one of the configured arms.
     assert!(
         ["arm_hero", "arm_carousel", "arm_spotlight"].contains(&resp.variant_id.as_str()),
@@ -831,25 +1022,32 @@ fn bandit_mab_basic_assignment() {
     );
 }
 
-#[test]
-fn bandit_mab_deterministic() {
+#[tokio::test]
+async fn bandit_mab_deterministic() {
     let svc = make_service();
-    let r1 = svc.assign("exp_dev_005", "user_42", "", &no_attrs()).unwrap();
-    let r2 = svc.assign("exp_dev_005", "user_42", "", &no_attrs()).unwrap();
+    let r1 = svc
+        .assign("exp_dev_005", "user_42", "", &no_attrs())
+        .await
+        .unwrap();
+    let r2 = svc
+        .assign("exp_dev_005", "user_42", "", &no_attrs())
+        .await
+        .unwrap();
     assert_eq!(r1.variant_id, r2.variant_id, "same user must get same arm");
-    assert!(
-        (r1.assignment_probability - r2.assignment_probability).abs() < f64::EPSILON
-    );
+    assert!((r1.assignment_probability - r2.assignment_probability).abs() < f64::EPSILON);
 }
 
-#[test]
-fn bandit_mab_balance() {
+#[tokio::test]
+async fn bandit_mab_balance() {
     let svc = make_service();
     let mut counts: HashMap<String, u64> = HashMap::new();
 
     for i in 0..3000 {
         let user = format!("bandit_user_{i}");
-        let resp = svc.assign("exp_dev_005", &user, "", &no_attrs()).unwrap();
+        let resp = svc
+            .assign("exp_dev_005", &user, "", &no_attrs())
+            .await
+            .unwrap();
         *counts.entry(resp.variant_id).or_insert(0) += 1;
     }
 
@@ -864,10 +1062,13 @@ fn bandit_mab_balance() {
     }
 }
 
-#[test]
-fn bandit_mab_payload_propagated() {
+#[tokio::test]
+async fn bandit_mab_payload_propagated() {
     let svc = make_service();
-    let resp = svc.assign("exp_dev_005", "user_1", "", &no_attrs()).unwrap();
+    let resp = svc
+        .assign("exp_dev_005", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
     // Payload should contain the arm's payload_json from bandit_config.
     assert!(
         resp.payload_json.contains("placement"),
@@ -876,8 +1077,8 @@ fn bandit_mab_payload_propagated() {
     );
 }
 
-#[test]
-fn bandit_missing_config_fails() {
+#[tokio::test]
+async fn bandit_missing_config_fails() {
     // AB experiment used as MAB type — no bandit_config.
     let json = r#"{
         "experiments": [{
@@ -897,13 +1098,16 @@ fn bandit_missing_config_fails() {
     let config = Config::from_json(json).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
-    let err = svc.assign("bad_mab", "user_1", "", &no_attrs()).unwrap_err();
+    let err = svc
+        .assign("bad_mab", "user_1", "", &no_attrs())
+        .await
+        .unwrap_err();
     assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     assert!(err.message().contains("bandit_config"));
 }
 
-#[test]
-fn bandit_empty_arms_fails() {
+#[tokio::test]
+async fn bandit_empty_arms_fails() {
     let json = r#"{
         "experiments": [{
             "experiment_id": "empty_arms_mab",
@@ -927,13 +1131,16 @@ fn bandit_empty_arms_fails() {
     let config = Config::from_json(json).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
-    let err = svc.assign("empty_arms_mab", "user_1", "", &no_attrs()).unwrap_err();
+    let err = svc
+        .assign("empty_arms_mab", "user_1", "", &no_attrs())
+        .await
+        .unwrap_err();
     assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     assert!(err.message().contains("no arms"));
 }
 
-#[test]
-fn bandit_contextual_type_also_delegates() {
+#[tokio::test]
+async fn bandit_contextual_type_also_delegates() {
     let json = r#"{
         "experiments": [{
             "experiment_id": "ctx_bandit",
@@ -962,7 +1169,10 @@ fn bandit_contextual_type_also_delegates() {
     let config = Config::from_json(json).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
-    let resp = svc.assign("ctx_bandit", "user_1", "", &no_attrs()).unwrap();
+    let resp = svc
+        .assign("ctx_bandit", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
     assert!(resp.is_active);
     assert!(
         resp.variant_id == "arm_a" || resp.variant_id == "arm_b",
@@ -977,8 +1187,8 @@ fn bandit_contextual_type_also_delegates() {
     );
 }
 
-#[test]
-fn bandit_not_running_returns_inactive() {
+#[tokio::test]
+async fn bandit_not_running_returns_inactive() {
     let json = r#"{
         "experiments": [{
             "experiment_id": "draft_mab",
@@ -1002,13 +1212,16 @@ fn bandit_not_running_returns_inactive() {
     let config = Config::from_json(json).unwrap();
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
-    let resp = svc.assign("draft_mab", "user_1", "", &no_attrs()).unwrap();
+    let resp = svc
+        .assign("draft_mab", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
     assert!(!resp.is_active, "DRAFT MAB should return is_active=false");
     assert!(resp.variant_id.is_empty());
 }
 
-#[test]
-fn bandit_targeting_still_applies() {
+#[tokio::test]
+async fn bandit_targeting_still_applies() {
     let json = r#"{
         "experiments": [{
             "experiment_id": "targeted_mab",
@@ -1039,10 +1252,288 @@ fn bandit_targeting_still_applies() {
     let svc = AssignmentServiceImpl::from_config(Arc::new(config));
 
     // User with US country → should get arm
-    let resp = svc.assign("targeted_mab", "user_1", "", &attrs(&[("country", "US")])).unwrap();
+    let resp = svc
+        .assign("targeted_mab", "user_1", "", &attrs(&[("country", "US")]))
+        .await
+        .unwrap();
     assert!(!resp.variant_id.is_empty(), "US user should get an arm");
 
     // User with FR country → targeting miss
-    let resp2 = svc.assign("targeted_mab", "user_2", "", &attrs(&[("country", "FR")])).unwrap();
-    assert!(resp2.variant_id.is_empty(), "FR user should not match targeting");
+    let resp2 = svc
+        .assign("targeted_mab", "user_2", "", &attrs(&[("country", "FR")]))
+        .await
+        .unwrap();
+    assert!(
+        resp2.variant_id.is_empty(),
+        "FR user should not match targeting"
+    );
+}
+
+// ── Live Bandit gRPC Integration Tests ──
+
+/// Mock M4b BanditPolicyService that returns a fixed arm selection.
+struct MockBanditService {
+    /// If Some, sleep this long before responding (to test timeout).
+    delay: Option<Duration>,
+    /// The arm_id to return.
+    arm_id: String,
+    /// The probability to return.
+    probability: f64,
+    /// Captured context features (for verification in tests).
+    captured_features: Arc<tokio::sync::Mutex<Option<HashMap<String, f64>>>>,
+}
+
+#[tonic::async_trait]
+impl BanditPolicyService for MockBanditService {
+    async fn select_arm(
+        &self,
+        request: tonic::Request<SelectArmRequest>,
+    ) -> Result<tonic::Response<ArmSelection>, tonic::Status> {
+        let req = request.into_inner();
+
+        // Capture context features for test verification.
+        *self.captured_features.lock().await = Some(req.context_features.clone());
+
+        if let Some(delay) = self.delay {
+            tokio::time::sleep(delay).await;
+        }
+
+        let mut all_probs = HashMap::new();
+        all_probs.insert(self.arm_id.clone(), self.probability);
+
+        Ok(tonic::Response::new(ArmSelection {
+            arm_id: self.arm_id.clone(),
+            assignment_probability: self.probability,
+            all_arm_probabilities: all_probs,
+        }))
+    }
+
+    async fn create_cold_start_bandit(
+        &self,
+        _request: tonic::Request<CreateColdStartBanditRequest>,
+    ) -> Result<tonic::Response<CreateColdStartBanditResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("not needed for test"))
+    }
+
+    async fn export_affinity_scores(
+        &self,
+        _request: tonic::Request<ExportAffinityScoresRequest>,
+    ) -> Result<tonic::Response<ExportAffinityScoresResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("not needed for test"))
+    }
+
+    async fn get_policy_snapshot(
+        &self,
+        _request: tonic::Request<GetPolicySnapshotRequest>,
+    ) -> Result<tonic::Response<PolicySnapshot>, tonic::Status> {
+        Err(tonic::Status::unimplemented("not needed for test"))
+    }
+
+    async fn rollback_policy(
+        &self,
+        _request: tonic::Request<RollbackPolicyRequest>,
+    ) -> Result<tonic::Response<PolicySnapshot>, tonic::Status> {
+        Err(tonic::Status::unimplemented("not needed for test"))
+    }
+}
+
+/// Start a mock M4b server on a random port, return the address.
+async fn start_mock_m4b(
+    delay: Option<Duration>,
+    arm_id: &str,
+    probability: f64,
+) -> (
+    SocketAddr,
+    Arc<tokio::sync::Mutex<Option<HashMap<String, f64>>>>,
+) {
+    let captured = Arc::new(tokio::sync::Mutex::new(None));
+    let svc = MockBanditService {
+        delay,
+        arm_id: arm_id.to_string(),
+        probability,
+        captured_features: captured.clone(),
+    };
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(BanditPolicyServiceServer::new(svc))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+
+    // Give server a moment to start.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    (addr, captured)
+}
+
+#[tokio::test]
+async fn bandit_grpc_client_success() {
+    // Start mock M4b that returns arm_hero with 0.7 probability.
+    let (addr, _captured) = start_mock_m4b(None, "arm_hero", 0.7).await;
+
+    let client = experimentation_assignment::bandit_client::GrpcBanditClient::connect(&format!(
+        "http://{addr}"
+    ))
+    .await
+    .unwrap();
+
+    // Build service with MAB experiment config that has arm_hero.
+    let json = r#"{
+        "experiments": [{
+            "experiment_id": "live_mab",
+            "state": "RUNNING",
+            "type": "MAB",
+            "hash_salt": "salt",
+            "layer_id": "layer_default",
+            "variants": [],
+            "allocation": { "start_bucket": 0, "end_bucket": 9999 },
+            "bandit_config": {
+                "algorithm": "THOMPSON_SAMPLING",
+                "arms": [
+                    { "arm_id": "arm_hero", "name": "Hero", "payload_json": "{\"placement\":\"hero\"}" },
+                    { "arm_id": "arm_carousel", "name": "Carousel", "payload_json": "{\"placement\":\"carousel\"}" }
+                ],
+                "reward_metric_id": "clicks"
+            }
+        }],
+        "layers": [{ "layer_id": "layer_default", "total_buckets": 10000 }]
+    }"#;
+
+    let config = Config::from_json(json).unwrap();
+    let svc = AssignmentServiceImpl::new(
+        experimentation_assignment::config_cache::ConfigCacheHandle::from_static(Arc::new(config)),
+        Some(client),
+    );
+
+    let resp = svc
+        .assign("live_mab", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
+    assert!(resp.is_active);
+    assert_eq!(resp.variant_id, "arm_hero");
+    assert!((resp.assignment_probability - 0.7).abs() < 1e-9);
+    // Payload comes from local config, not M4b.
+    assert_eq!(resp.payload_json, r#"{"placement":"hero"}"#);
+}
+
+#[tokio::test]
+async fn bandit_grpc_timeout_falls_back() {
+    // Start mock M4b that sleeps 50ms (>> 10ms timeout).
+    let (addr, _captured) = start_mock_m4b(Some(Duration::from_millis(50)), "arm_hero", 0.7).await;
+
+    let client = experimentation_assignment::bandit_client::GrpcBanditClient::connect(&format!(
+        "http://{addr}"
+    ))
+    .await
+    .unwrap();
+
+    let json = r#"{
+        "experiments": [{
+            "experiment_id": "timeout_mab",
+            "state": "RUNNING",
+            "type": "MAB",
+            "hash_salt": "salt",
+            "layer_id": "layer_default",
+            "variants": [],
+            "allocation": { "start_bucket": 0, "end_bucket": 9999 },
+            "bandit_config": {
+                "algorithm": "THOMPSON_SAMPLING",
+                "arms": [
+                    { "arm_id": "arm_a", "name": "A", "payload_json": "{\"a\":1}" },
+                    { "arm_id": "arm_b", "name": "B", "payload_json": "{\"b\":2}" }
+                ],
+                "reward_metric_id": "clicks"
+            }
+        }],
+        "layers": [{ "layer_id": "layer_default", "total_buckets": 10000 }]
+    }"#;
+
+    let config = Config::from_json(json).unwrap();
+    let svc = AssignmentServiceImpl::new(
+        experimentation_assignment::config_cache::ConfigCacheHandle::from_static(Arc::new(config)),
+        Some(client),
+    );
+
+    // Should fall back to uniform random (not fail).
+    let resp = svc
+        .assign("timeout_mab", "user_1", "", &no_attrs())
+        .await
+        .unwrap();
+    assert!(resp.is_active);
+    assert!(
+        resp.variant_id == "arm_a" || resp.variant_id == "arm_b",
+        "fallback should return one of the arms, got: {}",
+        resp.variant_id
+    );
+    // Uniform probability: 1/2 = 0.5.
+    assert!(
+        (resp.assignment_probability - 0.5).abs() < 1e-9,
+        "fallback should use uniform probability, got {}",
+        resp.assignment_probability
+    );
+}
+
+#[tokio::test]
+async fn bandit_contextual_features_forwarded() {
+    // Start mock M4b that captures context features.
+    let (addr, captured) = start_mock_m4b(None, "arm_a", 0.6).await;
+
+    let client = experimentation_assignment::bandit_client::GrpcBanditClient::connect(&format!(
+        "http://{addr}"
+    ))
+    .await
+    .unwrap();
+
+    let json = r#"{
+        "experiments": [{
+            "experiment_id": "ctx_mab",
+            "state": "RUNNING",
+            "type": "CONTEXTUAL_BANDIT",
+            "hash_salt": "salt",
+            "layer_id": "layer_default",
+            "variants": [],
+            "allocation": { "start_bucket": 0, "end_bucket": 9999 },
+            "bandit_config": {
+                "algorithm": "LINEAR_UCB",
+                "arms": [
+                    { "arm_id": "arm_a", "name": "A", "payload_json": "{}" },
+                    { "arm_id": "arm_b", "name": "B", "payload_json": "{}" }
+                ],
+                "reward_metric_id": "engagement",
+                "context_feature_keys": ["age", "tenure"]
+            }
+        }],
+        "layers": [{ "layer_id": "layer_default", "total_buckets": 10000 }]
+    }"#;
+
+    let config = Config::from_json(json).unwrap();
+    let svc = AssignmentServiceImpl::new(
+        experimentation_assignment::config_cache::ConfigCacheHandle::from_static(Arc::new(config)),
+        Some(client),
+    );
+
+    let user_attrs = attrs(&[("age", "30"), ("tenure", "2.5"), ("country", "US")]);
+    let resp = svc
+        .assign("ctx_mab", "user_1", "", &user_attrs)
+        .await
+        .unwrap();
+    assert!(resp.is_active);
+    assert_eq!(resp.variant_id, "arm_a");
+
+    // Verify context features were forwarded to M4b.
+    let features = captured.lock().await.take().unwrap();
+    assert_eq!(
+        features.len(),
+        2,
+        "should forward 2 context features (age, tenure)"
+    );
+    assert!((features["age"] - 30.0).abs() < f64::EPSILON);
+    assert!((features["tenure"] - 2.5).abs() < f64::EPSILON);
+    // "country" should NOT be in features (not in context_feature_keys).
+    assert!(!features.contains_key("country"));
 }

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,6 +1,6 @@
 # Experimentation Platform — Coordination Status
 
-> **Last updated**: 2026-03-09 by Agent-7 (M7 chaos/crash-recovery tests — 13 tests pass with -race)
+> **Last updated**: 2026-03-09 by Agent-1 (Live M4b bandit delegation — GrpcBanditClient with 10ms timeout + fallback)
 >
 > This file is the single source of truth for multi-agent execution state.
 > Update it each time a milestone merges to `main` or a blocker is identified.
@@ -13,7 +13,7 @@
 
 | Agent | Module | Status | Current Branch | Current Milestone | Blocked By | Notes |
 |-------|--------|--------|----------------|-------------------|------------|-------|
-| Agent-1 | M1 Assignment | 🔵 Phase 2 In Progress | agent-1/feat/multileave-interleaving | Multileave (M2.7c) | — | M1.1–1.5 + M2.7 + M2.7b + Bandit delegation complete. M2.7c: Team Draft Multileave (3+ algorithms). |
+| Agent-1 | M1 Assignment | 🔵 Phase 3 In Progress | agent-1/feat/live-bandit-delegation | Live M4b bandit delegation | — | M1.1–1.5 + M2.7 + M2.7b + M2.7c complete. Live bandit delegation: GrpcBanditClient with 10ms timeout, uniform random fallback, context feature extraction. 57 tests (54 integration + 3 gRPC mock). |
 | Agent-2 | M2 Pipeline | 🟢 All Phases Complete | agent-2/feat/e2e-pipeline-tests | Service-layer tests + Producer trait extraction | — | Phase 1 (PRs #1, #8), Phase 2 (PR #23), Phase 3 (PR #40), Phase 4 (PRs #48, #59) all merged. 78 tests (36 pipeline + 42 ingest). Producer trait enables mock-based testing. |
 | Agent-3 | M3 Metrics | 🔵 Phase 4 In Progress | agent-3/test/e2e-pipeline-3.4-3.5 | 3.4/3.5 e2e pipeline tests | — | Phase 1–3 done. Kafka publisher (PR #64). M3↔M5 contracts (PR #68). Chaos tests (PR #69). Coverage improvements (PR #77). E2e pipeline tests for session-level, QoE, lifecycle, correlation paths (PR #79). |
 | Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 3 In Progress | agent-4/feat/m4b-grpc-wiring | M4b gRPC wiring | — | M1.14–1.19 merged. M2.1–2.6, M2.10 complete. M3.1 LinUCB merged (PR #54). M3.2 cold-start merged. M4.1 CATE in PR #70. M4b BanditPolicyService gRPC wiring: all 5 RPCs implemented (SelectArm, CreateColdStartBandit, ExportAffinityScores, GetPolicySnapshot, RollbackPolicy), 17 tests pass. |
@@ -130,7 +130,7 @@ Track integration test results between agent pairs.
 | 4 | Agent-1 ↔ Agent-7 (hash parity via CGo) | 🟢 | CGo bridge parity confirmed — 10K vectors. Justfile target: `test-flags-cgo`. |
 | 5 | Agent-3 ↔ Agent-4 (metric summaries → analysis) | 🔵 | 33 contract tests verify M3 SQL output columns match Delta Lake schemas M4a reads. Covers all 4 output tables + ratio delta method variance components. |
 | 5 | Agent-5 ↔ Agent-3 (guardrail alerts → auto-pause) | 🟢 | M3 Kafka publisher (PR #64) + M5 consumer (PR #18). 3 schema contract tests (field symmetry, bidirectional deser, zero-value). Kafka roundtrip integration test. |
-| 6 | Agent-1 ↔ Agent-4 (bandit delegation: assignment → SelectArm) | 🔵 | M1 bandit delegation with mock uniform selection ready. M4b SelectArm gRPC now implemented with all 5 RPCs wired through LMAX core. Ready for live integration testing. |
+| 6 | Agent-1 ↔ Agent-4 (bandit delegation: assignment → SelectArm) | 🔵 | M1 GrpcBanditClient with 10ms timeout + uniform fallback. M4b SelectArm gRPC wired through LMAX core. 3 mock gRPC integration tests pass. Ready for live pairing (set M4B_ADDR env var). |
 | 6 | Agent-4 ↔ Agent-6 (analysis results → UI rendering) | ⚪ | — |
 
 ## Contract Changes Log


### PR DESCRIPTION
## Summary

- **GrpcBanditClient** calls M4b `SelectArm` RPC with 10ms timeout; falls back to deterministic uniform random on timeout or gRPC error (per onboarding pitfall #4)
- `assign()` / `assign_bandit()` are now `async` — needed because bandit experiments call M4b over gRPC
- Context feature extraction for `CONTEXTUAL_BANDIT` experiments: parses numeric attributes matching `bandit_config.context_feature_keys` into `HashMap<String, f64>` and forwards to M4b
- `lookup_arm_payload()` resolves payload from local config (M4b only selects the arm, not the payload)
- `main.rs` reads `M4B_ADDR` env var at startup; if unset or connection fails, all bandit experiments use uniform fallback

## Unblocks

- **Agent-4**: Live Agent-1 ↔ Agent-4 integration testing (set `M4B_ADDR` env var pointing to M4b)

## Test plan

- [x] `cargo test --package experimentation-assignment` — 89 tests pass (26 lib + 54 integration + 9 config cache)
- [x] `cargo clippy --package experimentation-assignment -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] **bandit_grpc_client_success** — mock M4b returns arm_hero with 0.7 probability, verify arm + probability + local payload lookup
- [x] **bandit_grpc_timeout_falls_back** — mock server sleeps 50ms (>> 10ms timeout), verify fallback to uniform random
- [x] **bandit_contextual_features_forwarded** — CONTEXTUAL_BANDIT with context_feature_keys, verify features extracted from attributes and sent to M4b
- [x] All 36 existing bandit/assignment tests pass unchanged (from_config provides None → uniform fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)