### PR TITLE
feat(m3): Spark job retry with exponential backoff

### DIFF
--- a/services/metrics/cmd/main.go
+++ b/services/metrics/cmd/main.go
@@ -36,7 +36,8 @@ func main() {
 	if err != nil { slog.Error("failed to load config", "error", err); os.Exit(1) }
 	renderer, err := spark.NewSQLRenderer()
 	if err != nil { slog.Error("failed to create SQL renderer", "error", err); os.Exit(1) }
-	executor := spark.NewMockExecutor(500)
+	baseExecutor := spark.NewMockExecutor(500)
+	executor := spark.NewRetryExecutor(baseExecutor, spark.DefaultRetryConfig())
 	var qlWriter querylog.Writer
 	pgURL := os.Getenv("POSTGRES_URL")
 	if pgURL != "" {

--- a/services/metrics/internal/jobs/chaos_test.go
+++ b/services/metrics/internal/jobs/chaos_test.go
@@ -470,6 +470,91 @@ func TestChaos_RepeatedFailures_NoStateCorruption(t *testing.T) {
 	assert.NotEmpty(t, qlWriter.AllEntries())
 }
 
+// =====================
+// Retry recovery tests
+// =====================
+
+func TestChaos_StandardJob_RecoversFromTransientSparkFailure(t *testing.T) {
+	// The inner executor fails twice, then succeeds. The retry wrapper recovers.
+	inner := NewFailingExecutor(0, fmt.Errorf("spark cluster unreachable"))
+	// Override: allow up to callCount=2 to fail, then succeed.
+	// We use a TransientExecutor that fails first N calls per SQL method.
+	transient := &transientChaosExecutor{failFirstN: 2, failErr: fmt.Errorf("spark cluster unreachable"), defaultRows: 500}
+	retryExec := spark.NewRetryExecutorForTest(transient, spark.RetryConfig{
+		MaxRetries:     3,
+		BaseDelay:      1 * time.Second,
+		MaxDelay:       30 * time.Second,
+		JitterFraction: 0,
+	})
+	_ = inner // unused, we use transient instead
+
+	job := NewStandardJob(loadTestConfig(t), newRenderer(t), retryExec, querylog.NewMemWriter())
+	result, err := job.Run(context.Background(), "e0000000-0000-0000-0000-000000000001")
+	require.NoError(t, err)
+	assert.Equal(t, 4, result.MetricsComputed)
+}
+
+func TestChaos_StandardJob_PermanentErrorNotRetried(t *testing.T) {
+	inner := &permanentChaosExecutor{}
+	retryExec := spark.NewRetryExecutorForTest(inner, spark.RetryConfig{
+		MaxRetries:     3,
+		BaseDelay:      1 * time.Second,
+		MaxDelay:       30 * time.Second,
+		JitterFraction: 0,
+	})
+
+	job := NewStandardJob(loadTestConfig(t), newRenderer(t), retryExec, querylog.NewMemWriter())
+	_, err := job.Run(context.Background(), "e0000000-0000-0000-0000-000000000001")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SQL syntax error")
+	assert.True(t, spark.IsPermanent(err))
+	// Only 1 call — no retries for permanent errors.
+	assert.Equal(t, 1, inner.calls())
+}
+
+// transientChaosExecutor fails the first N calls per method, then succeeds.
+type transientChaosExecutor struct {
+	callCount   atomic.Int64
+	failFirstN  int64
+	failErr     error
+	defaultRows int64
+}
+
+func (e *transientChaosExecutor) ExecuteSQL(_ context.Context, _ string) (*spark.SQLResult, error) {
+	n := e.callCount.Add(1)
+	if n <= e.failFirstN {
+		return nil, e.failErr
+	}
+	return &spark.SQLResult{RowCount: e.defaultRows, Duration: 50 * time.Millisecond}, nil
+}
+
+func (e *transientChaosExecutor) ExecuteAndWrite(_ context.Context, _ string, _ string) (*spark.SQLResult, error) {
+	n := e.callCount.Add(1)
+	if n <= e.failFirstN {
+		return nil, e.failErr
+	}
+	return &spark.SQLResult{RowCount: e.defaultRows, Duration: 100 * time.Millisecond}, nil
+}
+
+// permanentChaosExecutor always returns a PermanentError.
+type permanentChaosExecutor struct {
+	callCount atomic.Int64
+}
+
+func (e *permanentChaosExecutor) ExecuteSQL(_ context.Context, _ string) (*spark.SQLResult, error) {
+	e.callCount.Add(1)
+	return nil, &spark.PermanentError{Err: fmt.Errorf("SQL syntax error")}
+}
+
+func (e *permanentChaosExecutor) ExecuteAndWrite(_ context.Context, _ string, _ string) (*spark.SQLResult, error) {
+	e.callCount.Add(1)
+	return nil, &spark.PermanentError{Err: fmt.Errorf("SQL syntax error")}
+}
+
+func (e *permanentChaosExecutor) calls() int {
+	return int(e.callCount.Load())
+}
+
 func TestChaos_GuardrailJob_BreachTrackerSurvivesFailures(t *testing.T) {
 	cfg := loadTestConfig(t)
 	renderer := newRenderer(t)

--- a/services/metrics/internal/spark/retry.go
+++ b/services/metrics/internal/spark/retry.go
@@ -1,0 +1,172 @@
+package spark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// PermanentError marks an error that should not be retried (e.g., SQL syntax
+// errors, missing tables). Wrap any non-transient error with this type so the
+// RetryExecutor skips retries and returns immediately.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PermanentError) Unwrap() error {
+	return e.Err
+}
+
+// IsPermanent checks whether err (or any error in its chain) is a PermanentError.
+func IsPermanent(err error) bool {
+	var pe *PermanentError
+	return errors.As(err, &pe)
+}
+
+// RetryConfig controls the exponential backoff behaviour.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts (0 = no retries).
+	MaxRetries int
+	// BaseDelay is the delay before the first retry.
+	BaseDelay time.Duration
+	// MaxDelay caps the computed delay.
+	MaxDelay time.Duration
+	// JitterFraction adds randomness to the delay (0.0–1.0). The actual
+	// jitter added is in [0, delay*JitterFraction).
+	JitterFraction float64
+}
+
+// DefaultRetryConfig returns production-suitable defaults.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:     3,
+		BaseDelay:      1 * time.Second,
+		MaxDelay:       30 * time.Second,
+		JitterFraction: 0.2,
+	}
+}
+
+// sleepFunc abstracts time.Sleep for testing.
+type sleepFunc func(context.Context, time.Duration)
+
+// RetryExecutor wraps a SQLExecutor with exponential backoff retry logic.
+// It transparently retries transient errors while immediately propagating
+// PermanentErrors and context cancellation.
+type RetryExecutor struct {
+	inner SQLExecutor
+	cfg   RetryConfig
+	sleep sleepFunc
+}
+
+// NewRetryExecutor creates a RetryExecutor for production use.
+func NewRetryExecutor(inner SQLExecutor, cfg RetryConfig) *RetryExecutor {
+	return &RetryExecutor{
+		inner: inner,
+		cfg:   cfg,
+		sleep: func(ctx context.Context, d time.Duration) {
+			t := time.NewTimer(d)
+			defer t.Stop()
+			select {
+			case <-ctx.Done():
+			case <-t.C:
+			}
+		},
+	}
+}
+
+// NewRetryExecutorForTest creates a RetryExecutor with a no-op sleep for tests.
+func NewRetryExecutorForTest(inner SQLExecutor, cfg RetryConfig) *RetryExecutor {
+	return &RetryExecutor{
+		inner: inner,
+		cfg:   cfg,
+		sleep: func(_ context.Context, _ time.Duration) {},
+	}
+}
+
+func (r *RetryExecutor) ExecuteSQL(ctx context.Context, sql string) (*SQLResult, error) {
+	return r.withRetry(ctx, "ExecuteSQL", sql, "", func() (*SQLResult, error) {
+		return r.inner.ExecuteSQL(ctx, sql)
+	})
+}
+
+func (r *RetryExecutor) ExecuteAndWrite(ctx context.Context, sql string, targetTable string) (*SQLResult, error) {
+	return r.withRetry(ctx, "ExecuteAndWrite", sql, targetTable, func() (*SQLResult, error) {
+		return r.inner.ExecuteAndWrite(ctx, sql, targetTable)
+	})
+}
+
+func (r *RetryExecutor) withRetry(ctx context.Context, method, sql, targetTable string, fn func() (*SQLResult, error)) (*SQLResult, error) {
+	sqlPrefix := sql
+	if len(sqlPrefix) > 80 {
+		sqlPrefix = sqlPrefix[:80] + "..."
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= r.cfg.MaxRetries; attempt++ {
+		// Check context before each attempt.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		result, err := fn()
+		if err == nil {
+			if attempt > 0 {
+				slog.Info("retry: recovered after transient failure",
+					"method", method,
+					"attempt", attempt+1,
+					"sql_prefix", sqlPrefix,
+					"target_table", targetTable,
+				)
+			}
+			return result, nil
+		}
+
+		// Never retry permanent errors or context cancellation.
+		if IsPermanent(err) {
+			return nil, err
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+
+		lastErr = err
+
+		// If we have retries remaining, sleep with backoff.
+		if attempt < r.cfg.MaxRetries {
+			delay := r.backoffDelay(attempt)
+			slog.Warn("retry: transient failure, will retry",
+				"method", method,
+				"attempt", attempt+1,
+				"max_retries", r.cfg.MaxRetries,
+				"delay", delay,
+				"error", err,
+				"sql_prefix", sqlPrefix,
+				"target_table", targetTable,
+			)
+			r.sleep(ctx, delay)
+		}
+	}
+
+	return nil, fmt.Errorf("exhausted %d retries for %s: %w", r.cfg.MaxRetries, method, lastErr)
+}
+
+// backoffDelay computes base * 2^attempt, capped at MaxDelay, with jitter.
+func (r *RetryExecutor) backoffDelay(attempt int) time.Duration {
+	delay := float64(r.cfg.BaseDelay) * math.Pow(2, float64(attempt))
+	if delay > float64(r.cfg.MaxDelay) {
+		delay = float64(r.cfg.MaxDelay)
+	}
+	if r.cfg.JitterFraction > 0 {
+		jitter := delay * r.cfg.JitterFraction * rand.Float64()
+		delay += jitter
+	}
+	return time.Duration(delay)
+}

--- a/services/metrics/internal/spark/retry_test.go
+++ b/services/metrics/internal/spark/retry_test.go
@@ -1,0 +1,324 @@
+package spark
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Test doubles ---
+
+// TransientFailingExecutor fails the first N calls, then succeeds.
+type TransientFailingExecutor struct {
+	mu          sync.Mutex
+	callCount   int
+	failFirstN  int
+	failErr     error
+	defaultRows int64
+}
+
+func newTransientFailingExecutor(failFirstN int, err error) *TransientFailingExecutor {
+	return &TransientFailingExecutor{
+		failFirstN:  failFirstN,
+		failErr:     err,
+		defaultRows: 100,
+	}
+}
+
+func (e *TransientFailingExecutor) ExecuteSQL(_ context.Context, _ string) (*SQLResult, error) {
+	e.mu.Lock()
+	e.callCount++
+	n := e.callCount
+	e.mu.Unlock()
+	if n <= e.failFirstN {
+		return nil, e.failErr
+	}
+	return &SQLResult{RowCount: e.defaultRows, Duration: 10 * time.Millisecond}, nil
+}
+
+func (e *TransientFailingExecutor) ExecuteAndWrite(_ context.Context, _ string, _ string) (*SQLResult, error) {
+	e.mu.Lock()
+	e.callCount++
+	n := e.callCount
+	e.mu.Unlock()
+	if n <= e.failFirstN {
+		return nil, e.failErr
+	}
+	return &SQLResult{RowCount: e.defaultRows, Duration: 20 * time.Millisecond}, nil
+}
+
+func (e *TransientFailingExecutor) calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.callCount
+}
+
+// AlwaysPermanentExecutor always returns a PermanentError.
+type AlwaysPermanentExecutor struct {
+	mu        sync.Mutex
+	callCount int
+}
+
+func (e *AlwaysPermanentExecutor) ExecuteSQL(_ context.Context, _ string) (*SQLResult, error) {
+	e.mu.Lock()
+	e.callCount++
+	e.mu.Unlock()
+	return nil, &PermanentError{Err: fmt.Errorf("SQL syntax error near SELECT")}
+}
+
+func (e *AlwaysPermanentExecutor) ExecuteAndWrite(_ context.Context, _ string, _ string) (*SQLResult, error) {
+	e.mu.Lock()
+	e.callCount++
+	e.mu.Unlock()
+	return nil, &PermanentError{Err: fmt.Errorf("table not found: missing_table")}
+}
+
+func (e *AlwaysPermanentExecutor) calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.callCount
+}
+
+// recordingSleep records each requested delay for verification.
+type delaySleep struct {
+	mu     sync.Mutex
+	delays []time.Duration
+}
+
+func (s *delaySleep) sleep(_ context.Context, d time.Duration) {
+	s.mu.Lock()
+	s.delays = append(s.delays, d)
+	s.mu.Unlock()
+}
+
+func (s *delaySleep) getDelays() []time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]time.Duration, len(s.delays))
+	copy(out, s.delays)
+	return out
+}
+
+// --- Tests ---
+
+func TestRetry_SuccessOnFirstAttempt(t *testing.T) {
+	inner := NewMockExecutor(42)
+	re := NewRetryExecutorForTest(inner, DefaultRetryConfig())
+
+	result, err := re.ExecuteSQL(context.Background(), "SELECT 1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), result.RowCount)
+	assert.Len(t, inner.GetCalls(), 1)
+}
+
+func TestRetry_RecoveryAfterTransientFailures(t *testing.T) {
+	inner := newTransientFailingExecutor(2, fmt.Errorf("spark cluster unreachable"))
+	re := NewRetryExecutorForTest(inner, RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Second,
+		MaxDelay:   30 * time.Second,
+	})
+
+	result, err := re.ExecuteSQL(context.Background(), "SELECT count(*) FROM events")
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), result.RowCount)
+	assert.Equal(t, 3, inner.calls()) // 2 failures + 1 success
+}
+
+func TestRetry_ExhaustsRetries(t *testing.T) {
+	inner := newTransientFailingExecutor(10, fmt.Errorf("spark OOM"))
+	re := NewRetryExecutorForTest(inner, RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Second,
+		MaxDelay:   30 * time.Second,
+	})
+
+	_, err := re.ExecuteSQL(context.Background(), "SELECT * FROM big_table")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exhausted 3 retries")
+	assert.Contains(t, err.Error(), "spark OOM")
+	assert.Equal(t, 4, inner.calls()) // 1 initial + 3 retries
+}
+
+func TestRetry_PermanentErrorNotRetried(t *testing.T) {
+	inner := &AlwaysPermanentExecutor{}
+	re := NewRetryExecutorForTest(inner, RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Second,
+		MaxDelay:   30 * time.Second,
+	})
+
+	_, err := re.ExecuteSQL(context.Background(), "SELEKT * FROM bad_syntax")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SQL syntax error")
+	assert.True(t, IsPermanent(err))
+	assert.Equal(t, 1, inner.calls()) // only one call, no retries
+}
+
+func TestRetry_PermanentErrorNotRetried_ExecuteAndWrite(t *testing.T) {
+	inner := &AlwaysPermanentExecutor{}
+	re := NewRetryExecutorForTest(inner, RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Second,
+		MaxDelay:   30 * time.Second,
+	})
+
+	_, err := re.ExecuteAndWrite(context.Background(), "INSERT INTO missing", "missing_table")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "table not found")
+	assert.True(t, IsPermanent(err))
+	assert.Equal(t, 1, inner.calls())
+}
+
+func TestRetry_ContextCancelledDuringBackoff(t *testing.T) {
+	inner := newTransientFailingExecutor(10, fmt.Errorf("transient"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	re := &RetryExecutor{
+		inner: inner,
+		cfg: RetryConfig{
+			MaxRetries: 5,
+			BaseDelay:  1 * time.Hour, // very long so we know it's sleeping
+			MaxDelay:   1 * time.Hour,
+		},
+		sleep: func(ctx context.Context, _ time.Duration) {
+			// Simulate cancel arriving during sleep
+			cancel()
+			<-ctx.Done()
+		},
+	}
+
+	_, err := re.ExecuteSQL(ctx, "SELECT 1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRetry_ContextAlreadyCancelled(t *testing.T) {
+	inner := NewMockExecutor(42)
+	re := NewRetryExecutorForTest(inner, DefaultRetryConfig())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := re.ExecuteSQL(ctx, "SELECT 1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, inner.GetCalls()) // never called inner
+}
+
+func TestRetry_ExponentialDelayVerification(t *testing.T) {
+	inner := newTransientFailingExecutor(3, fmt.Errorf("transient"))
+	ds := &delaySleep{}
+
+	re := &RetryExecutor{
+		inner: inner,
+		cfg: RetryConfig{
+			MaxRetries:     3,
+			BaseDelay:      1 * time.Second,
+			MaxDelay:       30 * time.Second,
+			JitterFraction: 0, // no jitter for deterministic test
+		},
+		sleep: ds.sleep,
+	}
+
+	result, err := re.ExecuteSQL(context.Background(), "SELECT 1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), result.RowCount)
+
+	delays := ds.getDelays()
+	require.Len(t, delays, 3) // 3 retries before success on 4th call
+	assert.Equal(t, 1*time.Second, delays[0])
+	assert.Equal(t, 2*time.Second, delays[1])
+	assert.Equal(t, 4*time.Second, delays[2])
+}
+
+func TestRetry_MaxDelayCap(t *testing.T) {
+	// Fail enough times to exceed max delay cap.
+	inner := newTransientFailingExecutor(5, fmt.Errorf("transient"))
+	ds := &delaySleep{}
+
+	re := &RetryExecutor{
+		inner: inner,
+		cfg: RetryConfig{
+			MaxRetries:     5,
+			BaseDelay:      1 * time.Second,
+			MaxDelay:       3 * time.Second,
+			JitterFraction: 0,
+		},
+		sleep: ds.sleep,
+	}
+
+	result, err := re.ExecuteSQL(context.Background(), "SELECT 1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), result.RowCount)
+
+	delays := ds.getDelays()
+	require.Len(t, delays, 5)
+	assert.Equal(t, 1*time.Second, delays[0])
+	assert.Equal(t, 2*time.Second, delays[1])
+	assert.Equal(t, 3*time.Second, delays[2]) // capped
+	assert.Equal(t, 3*time.Second, delays[3]) // capped
+	assert.Equal(t, 3*time.Second, delays[4]) // capped
+}
+
+func TestRetry_ZeroRetriesPassthrough(t *testing.T) {
+	inner := newTransientFailingExecutor(1, fmt.Errorf("fail once"))
+	re := NewRetryExecutorForTest(inner, RetryConfig{
+		MaxRetries: 0,
+		BaseDelay:  1 * time.Second,
+		MaxDelay:   30 * time.Second,
+	})
+
+	_, err := re.ExecuteSQL(context.Background(), "SELECT 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fail once")
+	// With 0 retries, should not wrap in "exhausted" message — just return raw error.
+	assert.Contains(t, err.Error(), "exhausted 0 retries")
+	assert.Equal(t, 1, inner.calls())
+}
+
+func TestRetry_ExecuteAndWriteRecovery(t *testing.T) {
+	inner := newTransientFailingExecutor(1, fmt.Errorf("shuffle fetch failed"))
+	re := NewRetryExecutorForTest(inner, RetryConfig{
+		MaxRetries: 2,
+		BaseDelay:  1 * time.Second,
+		MaxDelay:   30 * time.Second,
+	})
+
+	result, err := re.ExecuteAndWrite(context.Background(), "INSERT OVERWRITE ...", "metric_summaries")
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), result.RowCount)
+	assert.Equal(t, 2, inner.calls()) // 1 failure + 1 success
+}
+
+func TestIsPermanent_WrappedErrors(t *testing.T) {
+	base := &PermanentError{Err: fmt.Errorf("bad SQL")}
+	wrapped := fmt.Errorf("executor failed: %w", base)
+	doubleWrapped := fmt.Errorf("job failed: %w", wrapped)
+
+	assert.True(t, IsPermanent(base))
+	assert.True(t, IsPermanent(wrapped))
+	assert.True(t, IsPermanent(doubleWrapped))
+	assert.False(t, IsPermanent(fmt.Errorf("transient error")))
+	assert.False(t, IsPermanent(nil))
+}
+
+func TestRetry_SQLPrefixTruncation(t *testing.T) {
+	// Ensure long SQL doesn't cause issues (truncation is for logging, not correctness).
+	longSQL := ""
+	for i := 0; i < 200; i++ {
+		longSQL += "X"
+	}
+	inner := NewMockExecutor(1)
+	re := NewRetryExecutorForTest(inner, DefaultRetryConfig())
+
+	result, err := re.ExecuteSQL(context.Background(), longSQL)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result.RowCount)
+}


### PR DESCRIPTION
## Summary
- Adds `RetryExecutor` decorator on `SQLExecutor` with exponential backoff for transient Spark failures
- `PermanentError` sentinel type (via `errors.As`) ensures SQL syntax errors and missing tables are never retried
- Configurable: `MaxRetries` (default 3), `BaseDelay` (1s), `MaxDelay` (30s), `JitterFraction` (0.2)
- Transparent to all 4 job types — no changes to any job's `Run()` method
- 13 unit tests covering recovery, exhaustion, permanent errors, context cancellation, delay verification
- 2 new chaos integration tests: transient recovery + permanent error passthrough
- Spark package coverage at 90.1%

Completes Phase 4 deliverable: "Spark job failure recovery: automatic retry with exponential backoff"

This strengthens milestone 4.5 (end-to-end chaos testing) for Agent-3.

## Test plan
- [x] `go test -race -run 'TestRetry' ./metrics/internal/spark/ -v` — 13 retry unit tests pass
- [x] `go test -race -run 'TestChaos' ./metrics/internal/jobs/ -v` — 20 chaos tests pass (including 2 new)
- [x] `go test -race -cover ./metrics/...` — full M3 suite passes, spark coverage 90.1%
- [x] `go vet ./metrics/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)