### PR TITLE
feat(m5): surrogate recalibration trigger via Kafka

### DIFF
--- a/kafka/topic_configs.sh
+++ b/kafka/topic_configs.sh
@@ -76,12 +76,27 @@ kafka-topics.sh --create --topic guardrail_alerts \
   --config max.message.bytes=1048576 \
   --config min.insync.replicas=2
 
+# --- surrogate_recalibration_requests ---
+# Source: M5 Management Service (Go, on TriggerSurrogateRecalibration RPC)
+# Consumers: M3 Metric Engine (Go, triggers surrogate model recalibration)
+# Key: model_id (colocates all requests for one model on same partition)
+# Volume estimate: ~1 event/day (rare; manual or scheduled trigger)
+kafka-topics.sh --create --topic surrogate_recalibration_requests \
+  --partitions 4 \
+  --replication-factor 3 \
+  --config retention.ms=2592000000 \       # 30 days
+  --config cleanup.policy=delete \
+  --config segment.bytes=268435456 \       # 256 MB segments
+  --config max.message.bytes=1048576 \     # 1 MB max message
+  --config min.insync.replicas=2
+
 # ============================================================================
 # Consumer Groups
 # ============================================================================
 # metric-engine-spark       : M3 reads exposures, metric_events, qoe_events (batch)
 # bandit-policy-service     : M4b reads reward_events (real-time, committed offsets for crash recovery)
 # management-guardrail      : M5 reads guardrail_alerts (real-time, auto-pause trigger)
+# metric-engine-surrogate   : M3 reads surrogate_recalibration_requests (on-demand recalibration)
 # delta-lake-sink           : Kafka Connect writes all topics to Delta Lake
 
 # ============================================================================
@@ -95,3 +110,4 @@ kafka-topics.sh --create --topic guardrail_alerts \
 #   reward_events     -> experimentation.common.v1.RewardEvent
 #   qoe_events        -> experimentation.common.v1.QoEEvent
 #   guardrail_alerts  -> experimentation.common.v1.GuardrailAlert
+#   surrogate_recalibration_requests -> JSON (surrogate.RecalibrationRequest)

--- a/services/management/cmd/main.go
+++ b/services/management/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/org/experimentation-platform/services/management/internal/sequential"
 	"github.com/org/experimentation-platform/services/management/internal/store"
 	"github.com/org/experimentation-platform/services/management/internal/streaming"
+	"github.com/org/experimentation-platform/services/management/internal/surrogate"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
@@ -78,26 +79,40 @@ func main() {
 		slog.Info("M4b bandit client configured", "url", addr)
 	}
 
+	// Parse Kafka brokers once for both publisher and consumers.
+	var brokerList []string
+	if brokers := os.Getenv("KAFKA_BROKERS"); brokers != "" {
+		brokerList = strings.Split(brokers, ",")
+	}
+
+	// Surrogate recalibration publisher (Kafka → M3).
+	var surrogatePub *surrogate.KafkaPublisher
+	if len(brokerList) > 0 {
+		surrogatePub = surrogate.NewKafkaPublisher(brokerList)
+		serviceOpts = append(serviceOpts, handlers.WithSurrogatePublisher(surrogatePub))
+		slog.Info("surrogate recalibration publisher configured", "topic", surrogate.Topic)
+	}
+	defer surrogatePub.Close()
+
 	// Service handlers (created before consumers because sequential consumer uses expSvc as Concluder).
 	expSvc := handlers.NewExperimentService(experimentStore, auditStore, layerStore, metricStore, targetingStore, surrogateStore, notifier, serviceOpts...)
 
 	// Kafka consumers (guardrail auto-pause + sequential auto-conclude).
-	if brokers := os.Getenv("KAFKA_BROKERS"); brokers != "" {
-		brokerList := strings.Split(brokers, ",")
+	if len(brokerList) > 0 {
 
 		// Guardrail alert consumer (Kafka → auto-pause).
 		grProcessor := guardrail.NewProcessor(experimentStore, auditStore, notifier)
 		grConsumer := guardrail.NewConsumer(brokerList, grProcessor)
 		grConsumer.Start(ctx)
 		defer grConsumer.Stop()
-		slog.Info("guardrail consumer started", "brokers", brokers)
+		slog.Info("guardrail consumer started", "brokers", brokerList)
 
 		// Sequential boundary alert consumer (Kafka → auto-conclude).
 		seqProcessor := sequential.NewProcessor(experimentStore, auditStore, notifier, expSvc)
 		seqConsumer := sequential.NewConsumer(brokerList, seqProcessor)
 		seqConsumer.Start(ctx)
 		defer seqConsumer.Stop()
-		slog.Info("sequential consumer started", "brokers", brokers)
+		slog.Info("sequential consumer started", "brokers", brokerList)
 	} else {
 		slog.Info("kafka consumers disabled (KAFKA_BROKERS not set)")
 	}

--- a/services/management/internal/handlers/integration_test.go
+++ b/services/management/internal/handlers/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/org/experimentation-platform/services/management/internal/handlers"
 	"github.com/org/experimentation-platform/services/management/internal/sequential"
 	"github.com/org/experimentation-platform/services/management/internal/store"
+	"github.com/org/experimentation-platform/services/management/internal/surrogate"
 )
 
 type testEnv struct {
@@ -75,6 +76,40 @@ func setupTestServerWithAuth(t *testing.T, email, role string) (testEnv, func())
 	client := managementv1connect.NewExperimentManagementServiceClient(
 		http.DefaultClient, server.URL,
 		withAuth(email, role),
+	)
+
+	return testEnv{client: client, pool: pool}, func() {
+		server.Close()
+		pool.Close()
+	}
+}
+
+// setupTestServerWithOpts creates a test server with custom ServiceOptions (e.g., injecting a MemPublisher).
+func setupTestServerWithOpts(t *testing.T, opts ...handlers.ServiceOption) (testEnv, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	pool, err := store.NewPool(ctx)
+	require.NoError(t, err)
+
+	es := store.NewExperimentStore(pool)
+	as := store.NewAuditStore(pool)
+	ls := store.NewLayerStore(pool)
+	ms := store.NewMetricStore(pool)
+	ts := store.NewTargetingStore(pool)
+	ss := store.NewSurrogateStore(pool)
+	svc := handlers.NewExperimentService(es, as, ls, ms, ts, ss, nil, opts...)
+
+	mux := http.NewServeMux()
+	path, handler := managementv1connect.NewExperimentManagementServiceHandler(svc,
+		connect.WithInterceptors(auth.NewAuthInterceptor()),
+	)
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(mux)
+	client := managementv1connect.NewExperimentManagementServiceClient(
+		http.DefaultClient, server.URL,
+		withAuth("test@example.com", "admin"),
 	)
 
 	return testEnv{client: client, pool: pool}, func() {
@@ -1010,6 +1045,39 @@ func TestTriggerSurrogateRecalibration(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+func TestTriggerSurrogateRecalibration_PublishesEvent(t *testing.T) {
+	memPub := surrogate.NewMemPublisher()
+	env, cleanup := setupTestServerWithOpts(t, handlers.WithSurrogatePublisher(memPub))
+	defer cleanup()
+	client := env.client
+	ctx := context.Background()
+
+	// Create a model first.
+	created, err := client.CreateSurrogateModel(ctx, connect.NewRequest(&mgmtv1.CreateSurrogateModelRequest{
+		Model: newSurrogateModel(),
+	}))
+	require.NoError(t, err)
+	modelID := created.Msg.ModelId
+
+	// Trigger recalibration → should publish to MemPublisher.
+	_, err = client.TriggerSurrogateRecalibration(ctx, connect.NewRequest(&mgmtv1.TriggerSurrogateRecalibrationRequest{
+		ModelId: modelID,
+	}))
+	require.NoError(t, err)
+
+	// Verify published request.
+	reqs := memPub.Requests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, modelID, reqs[0].ModelID)
+	assert.Equal(t, "90_day_churn_rate", reqs[0].TargetMetricID)
+	assert.Equal(t, []string{"7d_watch_time", "7d_session_freq"}, reqs[0].InputMetricIDs)
+	assert.Equal(t, "LINEAR", reqs[0].ModelType)
+	assert.Equal(t, int32(7), reqs[0].ObservationWindowDays)
+	assert.Equal(t, int32(90), reqs[0].PredictionHorizonDays)
+	assert.Equal(t, "test@example.com", reqs[0].RequestedBy)
+	assert.NotEmpty(t, reqs[0].RequestedAt)
 }
 
 func TestCreateSurrogateModel_Validation(t *testing.T) {

--- a/services/management/internal/handlers/service.go
+++ b/services/management/internal/handlers/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/org/experimentation-platform/services/management/internal/store"
 	"github.com/org/experimentation-platform/services/management/internal/streaming"
+	"github.com/org/experimentation-platform/services/management/internal/surrogate"
 )
 
 // Compile-time check that ExperimentService implements the handler interface.
@@ -25,8 +26,9 @@ type ExperimentService struct {
 	notifier   *streaming.Notifier
 
 	// Optional external service clients (nil = graceful degradation).
-	analysisClient analysisv1connect.AnalysisServiceClient
-	banditClient   banditv1connect.BanditPolicyServiceClient
+	analysisClient     analysisv1connect.AnalysisServiceClient
+	banditClient       banditv1connect.BanditPolicyServiceClient
+	surrogatePublisher surrogate.Publisher
 }
 
 // ServiceOption configures optional dependencies on ExperimentService.
@@ -40,6 +42,11 @@ func WithAnalysisClient(c analysisv1connect.AnalysisServiceClient) ServiceOption
 // WithBanditClient sets the M4b bandit policy service client.
 func WithBanditClient(c banditv1connect.BanditPolicyServiceClient) ServiceOption {
 	return func(s *ExperimentService) { s.banditClient = c }
+}
+
+// WithSurrogatePublisher sets the Kafka publisher for surrogate recalibration requests.
+func WithSurrogatePublisher(p surrogate.Publisher) ServiceOption {
+	return func(s *ExperimentService) { s.surrogatePublisher = p }
 }
 
 // NewExperimentService creates a new handler with the given stores and notifier.

--- a/services/management/internal/handlers/surrogate.go
+++ b/services/management/internal/handlers/surrogate.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -12,6 +13,7 @@ import (
 	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
 
 	"github.com/org/experimentation-platform/services/management/internal/store"
+	surrogatepkg "github.com/org/experimentation-platform/services/management/internal/surrogate"
 	"github.com/org/experimentation-platform/services/management/internal/validation"
 )
 
@@ -93,16 +95,42 @@ func (s *ExperimentService) TriggerSurrogateRecalibration(
 		return nil, connect.NewError(connect.CodeInvalidArgument, nil)
 	}
 
-	// Verify model exists.
-	_, err := s.surrogates.GetByID(ctx, id)
+	// Verify model exists and capture row for the Kafka envelope.
+	model, err := s.surrogates.GetByID(ctx, id)
 	if err != nil {
 		return nil, wrapDBError(err, "surrogate_model", id)
 	}
 
-	// NOTE: audit_trail.experiment_id has a FK to experiments — surrogate model
-	// operations are logged via slog until the schema supports non-experiment auditing.
-	// TODO: Publish Kafka event or call Agent-3 to trigger actual recalibration.
-	slog.Info("surrogate recalibration triggered", "model_id", id)
+	actor := actorFromContext(ctx)
+	published := false
+
+	if s.surrogatePublisher != nil {
+		req := surrogatepkg.RecalibrationRequest{
+			ModelID:               model.ModelID,
+			TargetMetricID:        model.TargetMetricID,
+			InputMetricIDs:        model.InputMetricIDs,
+			ModelType:             model.ModelType,
+			ObservationWindowDays: model.ObservationWindowDays,
+			PredictionHorizonDays: model.PredictionHorizonDays,
+			RequestedBy:           actor,
+			RequestedAt:           time.Now().UTC().Format(time.RFC3339),
+		}
+		if pubErr := s.surrogatePublisher.Publish(ctx, req); pubErr != nil {
+			slog.Warn("surrogate recalibration publish failed (best-effort)",
+				"model_id", id, "error", pubErr)
+		} else {
+			published = true
+		}
+	} else {
+		slog.Warn("surrogate recalibration publisher not configured", "model_id", id)
+	}
+
+	slog.Info("surrogate recalibration triggered",
+		"model_id", model.ModelID,
+		"target_metric_id", model.TargetMetricID,
+		"model_type", model.ModelType,
+		"requested_by", actor,
+		"kafka_published", published)
 
 	return connect.NewResponse(&emptypb.Empty{}), nil
 }

--- a/services/management/internal/surrogate/publisher.go
+++ b/services/management/internal/surrogate/publisher.go
@@ -1,0 +1,105 @@
+// Package surrogate provides Kafka publishing for surrogate model recalibration requests.
+package surrogate
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+)
+
+// Topic is the Kafka topic for surrogate recalibration requests.
+const Topic = "surrogate_recalibration_requests"
+
+// RecalibrationRequest is the envelope published to Kafka so M3 can begin
+// recalibration without querying M5 back.
+type RecalibrationRequest struct {
+	ModelID               string   `json:"model_id"`
+	TargetMetricID        string   `json:"target_metric_id"`
+	InputMetricIDs        []string `json:"input_metric_ids"`
+	ModelType             string   `json:"model_type"`
+	ObservationWindowDays int32    `json:"observation_window_days"`
+	PredictionHorizonDays int32    `json:"prediction_horizon_days"`
+	RequestedBy           string   `json:"requested_by"`
+	RequestedAt           string   `json:"requested_at"`
+}
+
+// Publisher publishes surrogate recalibration requests.
+type Publisher interface {
+	Publish(ctx context.Context, req RecalibrationRequest) error
+}
+
+// KafkaPublisher publishes recalibration requests to Kafka.
+type KafkaPublisher struct {
+	writer *kafka.Writer
+}
+
+// NewKafkaPublisher creates a publisher targeting the surrogate_recalibration_requests topic.
+func NewKafkaPublisher(brokers []string) *KafkaPublisher {
+	w := &kafka.Writer{
+		Addr:         kafka.TCP(brokers...),
+		Topic:        Topic,
+		Balancer:     &kafka.Hash{},
+		RequiredAcks: kafka.RequireOne,
+		BatchTimeout: 10 * time.Millisecond,
+	}
+	return &KafkaPublisher{writer: w}
+}
+
+// Publish sends a recalibration request to Kafka, keyed by model_id.
+func (p *KafkaPublisher) Publish(ctx context.Context, req RecalibrationRequest) error {
+	value, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	return p.writer.WriteMessages(ctx, kafka.Message{
+		Key:   []byte(req.ModelID),
+		Value: value,
+	})
+}
+
+// Close closes the underlying Kafka writer.
+func (p *KafkaPublisher) Close() error {
+	if p == nil {
+		return nil
+	}
+	return p.writer.Close()
+}
+
+// MemPublisher is an in-memory publisher for testing.
+type MemPublisher struct {
+	mu       sync.Mutex
+	requests []RecalibrationRequest
+}
+
+// NewMemPublisher creates a new in-memory publisher.
+func NewMemPublisher() *MemPublisher {
+	return &MemPublisher{}
+}
+
+// Publish stores the request in memory.
+func (p *MemPublisher) Publish(_ context.Context, req RecalibrationRequest) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.requests = append(p.requests, req)
+	return nil
+}
+
+// Requests returns all published requests.
+func (p *MemPublisher) Requests() []RecalibrationRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]RecalibrationRequest, len(p.requests))
+	copy(out, p.requests)
+	return out
+}
+
+// Reset clears all published requests.
+func (p *MemPublisher) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.requests = nil
+}

--- a/services/management/internal/surrogate/publisher_test.go
+++ b/services/management/internal/surrogate/publisher_test.go
@@ -1,0 +1,80 @@
+package surrogate
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemPublisher_Publish(t *testing.T) {
+	pub := NewMemPublisher()
+
+	req := RecalibrationRequest{
+		ModelID:               "model-1",
+		TargetMetricID:        "90_day_churn_rate",
+		InputMetricIDs:        []string{"7d_watch_time", "7d_session_freq"},
+		ModelType:             "LINEAR",
+		ObservationWindowDays: 7,
+		PredictionHorizonDays: 90,
+		RequestedBy:           "alice@example.com",
+		RequestedAt:           "2026-03-09T12:00:00Z",
+	}
+
+	err := pub.Publish(context.Background(), req)
+	require.NoError(t, err)
+
+	reqs := pub.Requests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "model-1", reqs[0].ModelID)
+	assert.Equal(t, "90_day_churn_rate", reqs[0].TargetMetricID)
+	assert.Equal(t, []string{"7d_watch_time", "7d_session_freq"}, reqs[0].InputMetricIDs)
+	assert.Equal(t, "LINEAR", reqs[0].ModelType)
+	assert.Equal(t, int32(7), reqs[0].ObservationWindowDays)
+	assert.Equal(t, int32(90), reqs[0].PredictionHorizonDays)
+	assert.Equal(t, "alice@example.com", reqs[0].RequestedBy)
+}
+
+func TestMemPublisher_Reset(t *testing.T) {
+	pub := NewMemPublisher()
+
+	err := pub.Publish(context.Background(), RecalibrationRequest{ModelID: "m1"})
+	require.NoError(t, err)
+	require.Len(t, pub.Requests(), 1)
+
+	pub.Reset()
+	assert.Empty(t, pub.Requests())
+}
+
+func TestRecalibrationRequest_JSONRoundTrip(t *testing.T) {
+	req := RecalibrationRequest{
+		ModelID:               "model-abc",
+		TargetMetricID:        "ltv_180d",
+		InputMetricIDs:        []string{"7d_revenue", "14d_sessions"},
+		ModelType:             "GRADIENT_BOOSTED",
+		ObservationWindowDays: 14,
+		PredictionHorizonDays: 180,
+		RequestedBy:           "bob@example.com",
+		RequestedAt:           "2026-03-09T15:30:00Z",
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	// Verify snake_case JSON field names.
+	raw := make(map[string]json.RawMessage)
+	require.NoError(t, json.Unmarshal(data, &raw))
+	expectedKeys := []string{
+		"model_id", "target_metric_id", "input_metric_ids", "model_type",
+		"observation_window_days", "prediction_horizon_days", "requested_by", "requested_at",
+	}
+	for _, key := range expectedKeys {
+		assert.Contains(t, raw, key, "missing expected JSON key: %s", key)
+	}
+
+	var decoded RecalibrationRequest
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, req, decoded)
+}


### PR DESCRIPTION
## Summary

- Replaces the TODO in `TriggerSurrogateRecalibration` handler with a Kafka publish to `surrogate_recalibration_requests`, enabling M3 to begin surrogate model recalibration asynchronously
- New `surrogate` package with `Publisher` interface, `KafkaPublisher` (hash balancer, keyed by `model_id`), and `MemPublisher` for tests
- Self-contained `RecalibrationRequest` envelope so M3 doesn't need to query M5 back
- Best-effort publishing: log warning on failure but don't fail the RPC
- Kafka topic config: 4 partitions, 30-day retention, RF=3, ISR=2

## Files changed

| File | Change |
|------|--------|
| `services/management/internal/surrogate/publisher.go` | New — Publisher interface + Kafka/Mem implementations |
| `services/management/internal/surrogate/publisher_test.go` | New — 3 unit tests |
| `services/management/internal/handlers/service.go` | Added `surrogatePublisher` field + `WithSurrogatePublisher` option |
| `services/management/internal/handlers/surrogate.go` | Replaced TODO with Kafka publish logic |
| `services/management/cmd/main.go` | Wired `KafkaPublisher` via `KAFKA_BROKERS` env |
| `kafka/topic_configs.sh` | Added `surrogate_recalibration_requests` topic |
| `services/management/internal/handlers/integration_test.go` | Added `setupTestServerWithOpts` + publish verification test |

## What this unblocks

- **Agent-3 (M3 Metrics)**: Can now consume `surrogate_recalibration_requests` to trigger model recalibration without polling M5

## Test plan

- [x] `go vet ./management/...` passes
- [x] `go build ./management/...` passes
- [x] `go test -race ./management/internal/surrogate/...` — 3 unit tests pass
- [ ] `go test -tags integration -run TestTriggerSurrogateRecalibration ./management/internal/handlers/...` (requires `just dev`)
- [ ] Existing `TestTriggerSurrogateRecalibration` covers nil-publisher graceful degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)