### PR TITLE
feat(m4a): wire remaining analysis RPCs (RunAnalysis, Interleaving, Novelty)

### DIFF
--- a/crates/experimentation-analysis/src/delta_reader.rs
+++ b/crates/experimentation-analysis/src/delta_reader.rs
@@ -1,14 +1,16 @@
-//! Delta Lake reader for content consumption data.
+//! Delta Lake readers for analysis service tables.
 //!
-//! Reads `content_consumption` tables from Delta Lake, filtered by experiment_id,
-//! and maps the result into `InterferenceInput` for the stats crate.
+//! Reads Delta Lake tables filtered by experiment_id and maps results into
+//! domain structs for the stats crate.
 
 use anyhow::{bail, Context};
-use deltalake::arrow::array::{Array, Float64Array, Int64Array, StringArray};
+use deltalake::arrow::array::{Array, Date32Array, Float64Array, Int64Array, MapArray, StringArray};
 use deltalake::arrow::record_batch::RecordBatch;
 use deltalake::DeltaTable;
 use experimentation_stats::interference::{ContentConsumption, InterferenceInput};
-use std::collections::HashMap;
+use experimentation_stats::interleaving::InterleavingScore;
+use experimentation_stats::novelty::DailyEffect;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 /// Row from the content_consumption Delta table.
@@ -208,11 +210,305 @@ fn build_interference_input(
     })
 }
 
+// ---------------------------------------------------------------------------
+// metric_summaries reader (for RunAnalysis / GetAnalysisResult)
+// ---------------------------------------------------------------------------
+
+/// Per-variant metric observations: Vec<(metric_value, Option<cuped_covariate>)>.
+type VariantObservations = Vec<(f64, Option<f64>)>;
+
+/// metric_id → variant_id → observations.
+type MetricsByVariant = HashMap<String, HashMap<String, VariantObservations>>;
+
+/// Grouped metric data for an experiment, ready for t-test / CUPED / SRM.
+#[derive(Debug)]
+pub struct ExperimentMetrics {
+    /// metric_id → variant_id → observations.
+    pub metrics: MetricsByVariant,
+    /// variant_id → count of distinct users (for SRM check).
+    pub variant_user_counts: HashMap<String, u64>,
+}
+
+/// Read metric_summaries from Delta Lake for a given experiment.
+pub async fn read_metric_summaries(
+    delta_path: &str,
+    experiment_id: &str,
+) -> anyhow::Result<ExperimentMetrics> {
+    let table_path = format!("{}/metric_summaries", delta_path);
+    let table = deltalake::open_table(&table_path)
+        .await
+        .context("metric_summaries table not found")?;
+
+    let batches = collect_batches(&table).await?;
+
+    let mut metrics: MetricsByVariant = HashMap::new();
+    let mut variant_users: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut found = false;
+
+    for batch in &batches {
+        let exp_arr = downcast_string(batch, "experiment_id")?;
+        let user_arr = downcast_string(batch, "user_id")?;
+        let variant_arr = downcast_string(batch, "variant_id")?;
+        let metric_arr = downcast_string(batch, "metric_id")?;
+        let value_arr = downcast_f64(batch, "metric_value")?;
+        let cov_col = batch
+            .column_by_name("cuped_covariate")
+            .context("missing cuped_covariate column")?;
+        let cov_arr = cov_col
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .context("cuped_covariate is not f64")?;
+
+        for i in 0..batch.num_rows() {
+            if exp_arr.is_null(i) || exp_arr.value(i) != experiment_id {
+                continue;
+            }
+            found = true;
+
+            let variant = variant_arr.value(i).to_string();
+            let metric = metric_arr.value(i).to_string();
+            let value = value_arr.value(i);
+            let covariate = if cov_arr.is_null(i) {
+                None
+            } else {
+                Some(cov_arr.value(i))
+            };
+
+            variant_users
+                .entry(variant.clone())
+                .or_default()
+                .insert(user_arr.value(i).to_string());
+
+            metrics
+                .entry(metric)
+                .or_default()
+                .entry(variant)
+                .or_default()
+                .push((value, covariate));
+        }
+    }
+
+    if !found {
+        bail!(
+            "no metric_summaries data found for experiment '{}'",
+            experiment_id
+        );
+    }
+
+    let variant_user_counts: HashMap<String, u64> = variant_users
+        .into_iter()
+        .map(|(k, v)| (k, v.len() as u64))
+        .collect();
+
+    Ok(ExperimentMetrics {
+        metrics,
+        variant_user_counts,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// interleaving_scores reader (for GetInterleavingAnalysis)
+// ---------------------------------------------------------------------------
+
+/// Read interleaving_scores from Delta Lake for a given experiment.
+pub async fn read_interleaving_scores(
+    delta_path: &str,
+    experiment_id: &str,
+) -> anyhow::Result<Vec<InterleavingScore>> {
+    let table_path = format!("{}/interleaving_scores", delta_path);
+    let table = deltalake::open_table(&table_path)
+        .await
+        .context("interleaving_scores table not found")?;
+
+    let batches = collect_batches(&table).await?;
+    let mut scores = Vec::new();
+
+    for batch in &batches {
+        let exp_arr = downcast_string(batch, "experiment_id")?;
+        let user_arr = downcast_string(batch, "user_id")?;
+        let map_col = batch
+            .column_by_name("algorithm_scores")
+            .context("missing algorithm_scores column")?;
+        let map_arr = map_col
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .context("algorithm_scores is not a MapArray")?;
+        let winner_col = batch
+            .column_by_name("winning_algorithm_id")
+            .context("missing winning_algorithm_id column")?;
+        let winner_arr = winner_col
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("winning_algorithm_id is not string")?;
+        let eng_arr = downcast_i64(batch, "total_engagements")?;
+
+        for i in 0..batch.num_rows() {
+            if exp_arr.is_null(i) || exp_arr.value(i) != experiment_id {
+                continue;
+            }
+
+            // Extract MAP<STRING, DOUBLE> entries for this row.
+            let entries = map_arr.value(i);
+            let keys = entries
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .context("map keys not string")?;
+            let values = entries
+                .column(1)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .context("map values not f64")?;
+
+            let mut algo_scores = HashMap::new();
+            for j in 0..entries.len() {
+                algo_scores.insert(keys.value(j).to_string(), values.value(j));
+            }
+
+            let winning = if winner_arr.is_null(i) {
+                None
+            } else {
+                Some(winner_arr.value(i).to_string())
+            };
+
+            scores.push(InterleavingScore {
+                user_id: user_arr.value(i).to_string(),
+                algorithm_scores: algo_scores,
+                winning_algorithm_id: winning,
+                total_engagements: eng_arr.value(i) as u32,
+            });
+        }
+    }
+
+    if scores.is_empty() {
+        bail!(
+            "no interleaving_scores data found for experiment '{}'",
+            experiment_id
+        );
+    }
+
+    Ok(scores)
+}
+
+// ---------------------------------------------------------------------------
+// daily_treatment_effects reader (for GetNoveltyAnalysis)
+// ---------------------------------------------------------------------------
+
+/// Read daily_treatment_effects from Delta Lake for a given experiment.
+///
+/// Returns `(metric_id, effects)` where `metric_id` is the metric with the
+/// most data points (when the request only has experiment_id, not metric_id).
+pub async fn read_daily_treatment_effects(
+    delta_path: &str,
+    experiment_id: &str,
+) -> anyhow::Result<(String, Vec<DailyEffect>)> {
+    let table_path = format!("{}/daily_treatment_effects", delta_path);
+    let table = deltalake::open_table(&table_path)
+        .await
+        .context("daily_treatment_effects table not found")?;
+
+    let batches = collect_batches(&table).await?;
+
+    // metric_id → Vec<(effect_date_i32, effect, sample_size)>
+    let mut by_metric: HashMap<String, Vec<(i32, f64, u64)>> = HashMap::new();
+
+    for batch in &batches {
+        let exp_arr = downcast_string(batch, "experiment_id")?;
+        let metric_arr = downcast_string(batch, "metric_id")?;
+        let date_col = batch
+            .column_by_name("effect_date")
+            .context("missing effect_date column")?;
+        let date_arr = date_col
+            .as_any()
+            .downcast_ref::<Date32Array>()
+            .context("effect_date is not Date32")?;
+        let effect_arr = downcast_f64(batch, "absolute_effect")?;
+        let size_arr = downcast_i64(batch, "sample_size")?;
+
+        for i in 0..batch.num_rows() {
+            if exp_arr.is_null(i) || exp_arr.value(i) != experiment_id {
+                continue;
+            }
+
+            let metric = metric_arr.value(i).to_string();
+            let date_val = date_arr.value(i); // days since epoch (i32)
+            let effect = effect_arr.value(i);
+            let sample_size = size_arr.value(i) as u64;
+
+            by_metric
+                .entry(metric)
+                .or_default()
+                .push((date_val, effect, sample_size));
+        }
+    }
+
+    if by_metric.is_empty() {
+        bail!(
+            "no daily_treatment_effects data found for experiment '{}'",
+            experiment_id
+        );
+    }
+
+    // Pick metric with most data points.
+    let (best_metric, mut rows) = by_metric
+        .into_iter()
+        .max_by_key(|(_, v)| v.len())
+        .unwrap();
+
+    // Sort by date, convert to sequential days from minimum.
+    rows.sort_by_key(|(date, _, _)| *date);
+    let min_date = rows[0].0;
+
+    let effects: Vec<DailyEffect> = rows
+        .iter()
+        .map(|&(date, effect, sample_size)| DailyEffect {
+            day: (date - min_date) as u32,
+            effect,
+            sample_size,
+        })
+        .collect();
+
+    Ok((best_metric, effects))
+}
+
+// ---------------------------------------------------------------------------
+// Shared column downcast helpers
+// ---------------------------------------------------------------------------
+
+fn downcast_string<'a>(batch: &'a RecordBatch, name: &str) -> anyhow::Result<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .context(format!("missing {name} column"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context(format!("{name} is not string"))
+}
+
+fn downcast_f64<'a>(batch: &'a RecordBatch, name: &str) -> anyhow::Result<&'a Float64Array> {
+    batch
+        .column_by_name(name)
+        .context(format!("missing {name} column"))?
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .context(format!("{name} is not f64"))
+}
+
+fn downcast_i64<'a>(batch: &'a RecordBatch, name: &str) -> anyhow::Result<&'a Int64Array> {
+    batch
+        .column_by_name(name)
+        .context(format!("missing {name} column"))?
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .context(format!("{name} is not i64"))
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use deltalake::arrow::array::{Float64Array, Int64Array, StringArray};
+    use deltalake::arrow::array::{
+        Date32Array, Float64Array, Int64Array, StringArray,
+        builder::{Float64Builder, MapBuilder, StringBuilder},
+    };
     use deltalake::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
     use deltalake::arrow::record_batch::RecordBatch;
     use deltalake::DeltaOps;
@@ -230,15 +526,20 @@ mod tests {
         ]))
     }
 
-    /// Write a single-batch Delta table into a temp directory.
-    async fn write_test_table(dir: &std::path::Path, batch: RecordBatch) {
-        let table_path = dir.join("content_consumption");
+    /// Write a single-batch Delta table into a named subdirectory.
+    async fn write_named_test_table(dir: &std::path::Path, table_name: &str, batch: RecordBatch) {
+        let table_path = dir.join(table_name);
         std::fs::create_dir_all(&table_path).unwrap();
 
         let ops = DeltaOps::try_from_uri(table_path.to_str().unwrap())
             .await
             .unwrap();
         ops.write(vec![batch]).await.unwrap();
+    }
+
+    /// Write a single-batch Delta table into a temp directory.
+    async fn write_test_table(dir: &std::path::Path, batch: RecordBatch) {
+        write_named_test_table(dir, "content_consumption", batch).await;
     }
 
     fn make_batch(
@@ -383,5 +684,329 @@ mod tests {
         assert_eq!(input.treatment.len(), 1);
         assert_eq!(input.control[0].content_id, "movie-a");
         assert_eq!(input.treatment[0].content_id, "movie-b");
+    }
+
+    // -----------------------------------------------------------------------
+    // metric_summaries tests
+    // -----------------------------------------------------------------------
+
+    fn metric_summaries_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("user_id", DataType::Utf8, false),
+            Field::new("variant_id", DataType::Utf8, false),
+            Field::new("metric_id", DataType::Utf8, false),
+            Field::new("metric_value", DataType::Float64, false),
+            Field::new("cuped_covariate", DataType::Float64, true),
+        ]))
+    }
+
+    fn make_metric_batch(
+        experiment_ids: &[&str],
+        user_ids: &[&str],
+        variant_ids: &[&str],
+        metric_ids: &[&str],
+        metric_values: &[f64],
+        covariates: &[Option<f64>],
+    ) -> RecordBatch {
+        let schema = metric_summaries_schema();
+        let cov_arr: Float64Array = covariates.iter().copied().collect();
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(experiment_ids.to_vec())),
+                Arc::new(StringArray::from(user_ids.to_vec())),
+                Arc::new(StringArray::from(variant_ids.to_vec())),
+                Arc::new(StringArray::from(metric_ids.to_vec())),
+                Arc::new(Float64Array::from(metric_values.to_vec())),
+                Arc::new(cov_arr),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_metric_summaries_basic() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_metric_batch(
+            &["exp-1", "exp-1", "exp-1", "exp-1"],
+            &["u1", "u2", "u3", "u4"],
+            &["control", "control", "treatment", "treatment"],
+            &["ctr", "ctr", "ctr", "ctr"],
+            &[0.1, 0.2, 0.3, 0.4],
+            &[None, None, None, None],
+        );
+        write_named_test_table(tmp.path(), "metric_summaries", batch).await;
+
+        let result = read_metric_summaries(tmp.path().to_str().unwrap(), "exp-1")
+            .await
+            .unwrap();
+
+        assert_eq!(result.metrics.len(), 1);
+        let ctr = &result.metrics["ctr"];
+        assert_eq!(ctr["control"].len(), 2);
+        assert_eq!(ctr["treatment"].len(), 2);
+        assert_eq!(result.variant_user_counts["control"], 2);
+        assert_eq!(result.variant_user_counts["treatment"], 2);
+    }
+
+    #[tokio::test]
+    async fn test_read_metric_summaries_with_cuped() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_metric_batch(
+            &["exp-1", "exp-1", "exp-1", "exp-1"],
+            &["u1", "u2", "u3", "u4"],
+            &["control", "control", "treatment", "treatment"],
+            &["ctr", "ctr", "ctr", "ctr"],
+            &[0.1, 0.2, 0.3, 0.4],
+            &[Some(1.0), Some(2.0), Some(3.0), Some(4.0)],
+        );
+        write_named_test_table(tmp.path(), "metric_summaries", batch).await;
+
+        let result = read_metric_summaries(tmp.path().to_str().unwrap(), "exp-1")
+            .await
+            .unwrap();
+
+        let ctr = &result.metrics["ctr"];
+        // All covariates should be Some
+        for (_, cov) in &ctr["control"] {
+            assert!(cov.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_metric_summaries_empty() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_metric_batch(
+            &["exp-1"],
+            &["u1"],
+            &["control"],
+            &["ctr"],
+            &[0.1],
+            &[None],
+        );
+        write_named_test_table(tmp.path(), "metric_summaries", batch).await;
+
+        let result = read_metric_summaries(tmp.path().to_str().unwrap(), "exp-999").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no metric_summaries data"));
+    }
+
+    #[tokio::test]
+    async fn test_read_metric_summaries_multi_metric() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_metric_batch(
+            &["exp-1", "exp-1", "exp-1", "exp-1"],
+            &["u1", "u2", "u1", "u2"],
+            &["control", "treatment", "control", "treatment"],
+            &["ctr", "ctr", "revenue", "revenue"],
+            &[0.1, 0.3, 10.0, 15.0],
+            &[None, None, None, None],
+        );
+        write_named_test_table(tmp.path(), "metric_summaries", batch).await;
+
+        let result = read_metric_summaries(tmp.path().to_str().unwrap(), "exp-1")
+            .await
+            .unwrap();
+
+        assert_eq!(result.metrics.len(), 2);
+        assert!(result.metrics.contains_key("ctr"));
+        assert!(result.metrics.contains_key("revenue"));
+    }
+
+    // -----------------------------------------------------------------------
+    // interleaving_scores tests
+    // -----------------------------------------------------------------------
+
+    fn build_interleaving_batch(
+        experiment_ids: &[&str],
+        user_ids: &[&str],
+        algo_scores: &[Vec<(&str, f64)>],
+        winners: &[Option<&str>],
+        engagements: &[i64],
+    ) -> RecordBatch {
+        let mut map_builder =
+            MapBuilder::new(None, StringBuilder::new(), Float64Builder::new());
+
+        for row_scores in algo_scores {
+            for &(k, v) in row_scores {
+                map_builder.keys().append_value(k);
+                map_builder.values().append_value(v);
+            }
+            map_builder.append(true).unwrap();
+        }
+
+        let map_arr = map_builder.finish();
+        let winner_arr: StringArray = winners.iter().copied().collect();
+
+        // Build schema from the actual MapArray's data type to avoid field name mismatches.
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("user_id", DataType::Utf8, false),
+            Field::new("algorithm_scores", map_arr.data_type().clone(), false),
+            Field::new("winning_algorithm_id", DataType::Utf8, true),
+            Field::new("total_engagements", DataType::Int64, false),
+        ]));
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(experiment_ids.to_vec())),
+                Arc::new(StringArray::from(user_ids.to_vec())),
+                Arc::new(map_arr),
+                Arc::new(winner_arr),
+                Arc::new(Int64Array::from(engagements.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_interleaving_scores_basic() {
+        let tmp = TempDir::new().unwrap();
+        let batch = build_interleaving_batch(
+            &["exp-1", "exp-1", "exp-1"],
+            &["u1", "u2", "u3"],
+            &[
+                vec![("algo_a", 3.0), ("algo_b", 1.0)],
+                vec![("algo_a", 2.0), ("algo_b", 4.0)],
+                vec![("algo_a", 5.0), ("algo_b", 2.0)],
+            ],
+            &[Some("algo_a"), Some("algo_b"), Some("algo_a")],
+            &[4, 6, 7],
+        );
+        write_named_test_table(tmp.path(), "interleaving_scores", batch).await;
+
+        let scores = read_interleaving_scores(tmp.path().to_str().unwrap(), "exp-1")
+            .await
+            .unwrap();
+
+        assert_eq!(scores.len(), 3);
+        assert_eq!(scores[0].user_id, "u1");
+        assert_eq!(scores[0].algorithm_scores["algo_a"], 3.0);
+        assert_eq!(scores[0].algorithm_scores["algo_b"], 1.0);
+        assert_eq!(scores[0].winning_algorithm_id, Some("algo_a".to_string()));
+        assert_eq!(scores[0].total_engagements, 4);
+    }
+
+    #[tokio::test]
+    async fn test_read_interleaving_scores_empty() {
+        let tmp = TempDir::new().unwrap();
+        let batch = build_interleaving_batch(
+            &["exp-1"],
+            &["u1"],
+            &[vec![("algo_a", 3.0), ("algo_b", 1.0)]],
+            &[Some("algo_a")],
+            &[4],
+        );
+        write_named_test_table(tmp.path(), "interleaving_scores", batch).await;
+
+        let result = read_interleaving_scores(tmp.path().to_str().unwrap(), "exp-999").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no interleaving_scores data"));
+    }
+
+    // -----------------------------------------------------------------------
+    // daily_treatment_effects tests
+    // -----------------------------------------------------------------------
+
+    fn daily_effects_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("metric_id", DataType::Utf8, false),
+            Field::new("effect_date", DataType::Date32, false),
+            Field::new("absolute_effect", DataType::Float64, false),
+            Field::new("sample_size", DataType::Int64, false),
+        ]))
+    }
+
+    fn make_daily_effects_batch(
+        experiment_ids: &[&str],
+        metric_ids: &[&str],
+        dates: &[i32],
+        effects: &[f64],
+        sizes: &[i64],
+    ) -> RecordBatch {
+        let schema = daily_effects_schema();
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(experiment_ids.to_vec())),
+                Arc::new(StringArray::from(metric_ids.to_vec())),
+                Arc::new(Date32Array::from(dates.to_vec())),
+                Arc::new(Float64Array::from(effects.to_vec())),
+                Arc::new(Int64Array::from(sizes.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_daily_effects_basic() {
+        let tmp = TempDir::new().unwrap();
+        // 10 days of data for one metric (days since epoch: 19700+)
+        let base_date = 19700i32;
+        let dates: Vec<i32> = (0..10).map(|i| base_date + i).collect();
+        let effects: Vec<f64> = (0..10).map(|i| 5.0 + 3.0 * (-(i as f64) / 4.0).exp()).collect();
+        let sizes: Vec<i64> = vec![1000; 10];
+        let exp_ids: Vec<&str> = vec!["exp-1"; 10];
+        let metric_ids: Vec<&str> = vec!["ctr"; 10];
+
+        let batch = make_daily_effects_batch(&exp_ids, &metric_ids, &dates, &effects, &sizes);
+        write_named_test_table(tmp.path(), "daily_treatment_effects", batch).await;
+
+        let (metric_id, daily_effects) =
+            read_daily_treatment_effects(tmp.path().to_str().unwrap(), "exp-1")
+                .await
+                .unwrap();
+
+        assert_eq!(metric_id, "ctr");
+        assert_eq!(daily_effects.len(), 10);
+        // Days should be sequential from 0
+        assert_eq!(daily_effects[0].day, 0);
+        assert_eq!(daily_effects[9].day, 9);
+    }
+
+    #[tokio::test]
+    async fn test_read_daily_effects_multi_metric() {
+        let tmp = TempDir::new().unwrap();
+        // 10 rows for "ctr" + 5 rows for "revenue" → should pick "ctr"
+        let base = 19700i32;
+        let exp_ids = vec!["exp-1"; 15];
+        let mut metric_ids: Vec<&str> = vec!["ctr"; 10];
+        metric_ids.extend(vec!["revenue"; 5]);
+        let mut dates: Vec<i32> = (0..10).map(|i| base + i).collect();
+        dates.extend((0..5).map(|i| base + i));
+        let mut effects: Vec<f64> = (0..10).map(|i| 5.0 + 0.1 * i as f64).collect();
+        effects.extend((0..5).map(|i| 10.0 + 0.1 * i as f64));
+        let sizes = vec![1000i64; 15];
+
+        let batch = make_daily_effects_batch(&exp_ids, &metric_ids, &dates, &effects, &sizes);
+        write_named_test_table(tmp.path(), "daily_treatment_effects", batch).await;
+
+        let (metric_id, daily_effects) =
+            read_daily_treatment_effects(tmp.path().to_str().unwrap(), "exp-1")
+                .await
+                .unwrap();
+
+        assert_eq!(metric_id, "ctr"); // most data points
+        assert_eq!(daily_effects.len(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_read_daily_effects_empty() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_daily_effects_batch(
+            &["exp-1"],
+            &["ctr"],
+            &[19700],
+            &[5.0],
+            &[1000],
+        );
+        write_named_test_table(tmp.path(), "daily_treatment_effects", batch).await;
+
+        let result = read_daily_treatment_effects(tmp.path().to_str().unwrap(), "exp-999").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no daily_treatment_effects data"));
     }
 }

--- a/crates/experimentation-analysis/src/grpc.rs
+++ b/crates/experimentation-analysis/src/grpc.rs
@@ -1,7 +1,6 @@
 //! gRPC server for the AnalysisService (M4a).
 //!
-//! `GetInterferenceAnalysis` is fully wired through Delta Lake → experimentation-stats.
-//! Other RPCs return `Unimplemented` until their data pipelines are connected.
+//! All 5 RPCs are wired through Delta Lake → experimentation-stats → proto conversion.
 
 use crate::config::AnalysisConfig;
 use crate::delta_reader;
@@ -9,11 +8,14 @@ use experimentation_proto::experimentation::analysis::v1::analysis_service_serve
     AnalysisService, AnalysisServiceServer,
 };
 use experimentation_proto::experimentation::analysis::v1::{
-    AnalysisResult, GetAnalysisResultRequest, GetInterferenceAnalysisRequest,
-    GetInterleavingAnalysisRequest, GetNoveltyAnalysisRequest, InterferenceAnalysisResult,
-    InterleavingAnalysisResult, NoveltyAnalysisResult, RunAnalysisRequest, TitleSpillover,
+    AlgorithmStrength as ProtoAlgorithmStrength, AnalysisResult, GetAnalysisResultRequest,
+    GetInterferenceAnalysisRequest, GetInterleavingAnalysisRequest, GetNoveltyAnalysisRequest,
+    InterferenceAnalysisResult, InterleavingAnalysisResult, MetricResult, NoveltyAnalysisResult,
+    PositionAnalysis as ProtoPositionAnalysis, RunAnalysisRequest, SrmResult as ProtoSrmResult,
+    TitleSpillover,
 };
-use experimentation_stats::interference;
+use experimentation_stats::{cuped, interference, interleaving, novelty, srm, ttest};
+use std::collections::HashMap;
 use tonic::{Request, Response, Status};
 use tracing::info;
 
@@ -29,15 +31,46 @@ impl AnalysisServiceHandler {
     }
 }
 
-/// Convert a Rust `InterferenceAnalysisResult` to the proto equivalent.
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn now_timestamp() -> prost_types::Timestamp {
+    let now = chrono::Utc::now();
+    prost_types::Timestamp {
+        seconds: now.timestamp(),
+        nanos: now.timestamp_subsec_nanos() as i32,
+    }
+}
+
+fn map_reader_error(e: anyhow::Error) -> Status {
+    let msg = e.to_string();
+    if msg.contains("not found") || msg.contains("data found") {
+        Status::not_found(msg)
+    } else if msg.contains("only") && msg.contains("variant") {
+        Status::failed_precondition(msg)
+    } else {
+        Status::internal(msg)
+    }
+}
+
+fn map_stats_error(e: impl std::fmt::Display) -> Status {
+    let msg = e.to_string();
+    if msg.contains("must") || msg.contains("need at least") || msg.contains("alpha") {
+        Status::failed_precondition(msg)
+    } else {
+        Status::internal(format!("analysis failed: {msg}"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Proto converters
+// ---------------------------------------------------------------------------
+
 fn to_proto_interference_result(
     experiment_id: &str,
     result: &interference::InterferenceAnalysisResult,
 ) -> InterferenceAnalysisResult {
-    let now = chrono::Utc::now();
-    let seconds = now.timestamp();
-    let nanos = now.timestamp_subsec_nanos() as i32;
-
     InterferenceAnalysisResult {
         experiment_id: experiment_id.to_string(),
         interference_detected: result.interference_detected,
@@ -57,38 +90,297 @@ fn to_proto_interference_result(
                 p_value: s.p_value,
             })
             .collect(),
-        computed_at: Some(prost_types::Timestamp { seconds, nanos }),
+        computed_at: Some(now_timestamp()),
     }
 }
+
+fn to_proto_srm_result(srm: &srm::SrmResult) -> ProtoSrmResult {
+    let total: u64 = srm.observed.values().sum();
+    let total_f = total as f64;
+
+    ProtoSrmResult {
+        chi_squared: srm.chi_squared,
+        p_value: srm.p_value,
+        is_mismatch: srm.is_mismatch,
+        observed_counts: srm
+            .observed
+            .iter()
+            .map(|(k, &v)| (k.clone(), v as i64))
+            .collect(),
+        expected_counts: srm
+            .expected
+            .iter()
+            .map(|(k, &frac)| (k.clone(), (frac * total_f).round() as i64))
+            .collect(),
+    }
+}
+
+fn to_proto_interleaving_result(
+    experiment_id: &str,
+    result: &interleaving::InterleavingAnalysisResult,
+) -> InterleavingAnalysisResult {
+    InterleavingAnalysisResult {
+        experiment_id: experiment_id.to_string(),
+        algorithm_win_rates: result.algorithm_win_rates.clone(),
+        sign_test_p_value: result.sign_test_p_value,
+        algorithm_strengths: result
+            .algorithm_strengths
+            .iter()
+            .map(|s| ProtoAlgorithmStrength {
+                algorithm_id: s.algorithm_id.clone(),
+                strength: s.strength,
+                ci_lower: s.ci_lower,
+                ci_upper: s.ci_upper,
+            })
+            .collect(),
+        position_analyses: result
+            .position_analyses
+            .iter()
+            .map(|p| ProtoPositionAnalysis {
+                position: p.position as i32,
+                algorithm_engagement_rates: p.algorithm_engagement_rates.clone(),
+            })
+            .collect(),
+        computed_at: Some(now_timestamp()),
+    }
+}
+
+fn to_proto_novelty_result(
+    experiment_id: &str,
+    metric_id: &str,
+    result: &novelty::NoveltyAnalysisResult,
+) -> NoveltyAnalysisResult {
+    NoveltyAnalysisResult {
+        experiment_id: experiment_id.to_string(),
+        metric_id: metric_id.to_string(),
+        novelty_detected: result.novelty_detected,
+        raw_treatment_effect: result.raw_treatment_effect,
+        projected_steady_state_effect: result.projected_steady_state_effect,
+        novelty_amplitude: result.novelty_amplitude,
+        decay_constant_days: result.decay_constant_days,
+        is_stabilized: result.is_stabilized,
+        days_until_projected_stability: result.days_until_projected_stability,
+        computed_at: Some(now_timestamp()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core analysis computation (shared by run_analysis and get_analysis_result)
+// ---------------------------------------------------------------------------
+
+async fn compute_analysis(
+    config: &AnalysisConfig,
+    experiment_id: &str,
+) -> Result<AnalysisResult, Status> {
+    let data = delta_reader::read_metric_summaries(&config.delta_lake_path, experiment_id)
+        .await
+        .map_err(map_reader_error)?;
+
+    // Identify control variant: one named "control", or first alphabetically.
+    let control_variant = if data.variant_user_counts.contains_key("control") {
+        "control".to_string()
+    } else {
+        let mut variants: Vec<&String> = data.variant_user_counts.keys().collect();
+        variants.sort();
+        variants[0].clone()
+    };
+
+    // SRM check: uniform expected fractions.
+    let n_variants = data.variant_user_counts.len() as f64;
+    let expected_fractions: HashMap<String, f64> = data
+        .variant_user_counts
+        .keys()
+        .map(|k| (k.clone(), 1.0 / n_variants))
+        .collect();
+
+    let srm_result = srm::srm_check(&data.variant_user_counts, &expected_fractions, 0.001)
+        .map_err(map_stats_error)?;
+
+    let alpha = config.default_alpha;
+
+    // Per-metric, per-treatment-variant analysis.
+    let mut metric_results = Vec::new();
+
+    let mut metric_ids: Vec<&String> = data.metrics.keys().collect();
+    metric_ids.sort();
+
+    for metric_id in metric_ids {
+        let variant_data = &data.metrics[metric_id];
+
+        let control_tuples = match variant_data.get(&control_variant) {
+            Some(v) => v,
+            None => continue,
+        };
+
+        let control_values: Vec<f64> = control_tuples.iter().map(|(v, _)| *v).collect();
+
+        let mut variant_ids: Vec<&String> = variant_data.keys().collect();
+        variant_ids.sort();
+
+        for variant_id in variant_ids {
+            if *variant_id == control_variant {
+                continue;
+            }
+
+            let treatment_tuples = &variant_data[variant_id];
+            let treatment_values: Vec<f64> = treatment_tuples.iter().map(|(v, _)| *v).collect();
+
+            let ttest_result =
+                ttest::welch_ttest(&control_values, &treatment_values, alpha)
+                    .map_err(map_stats_error)?;
+
+            let relative_effect = if ttest_result.control_mean.abs() > 1e-10 {
+                ttest_result.effect / ttest_result.control_mean.abs()
+            } else {
+                0.0
+            };
+
+            // CUPED: only if all observations in both groups have non-null covariates.
+            let control_covs: Vec<f64> = control_tuples
+                .iter()
+                .filter_map(|(_, c)| *c)
+                .collect();
+            let treatment_covs: Vec<f64> = treatment_tuples
+                .iter()
+                .filter_map(|(_, c)| *c)
+                .collect();
+
+            let (cuped_effect, cuped_ci_lower, cuped_ci_upper, variance_reduction_pct) =
+                if control_covs.len() == control_values.len()
+                    && treatment_covs.len() == treatment_values.len()
+                    && control_covs.len() >= 2
+                    && treatment_covs.len() >= 2
+                {
+                    match cuped::cuped_adjust(
+                        &control_values,
+                        &treatment_values,
+                        &control_covs,
+                        &treatment_covs,
+                        alpha,
+                    ) {
+                        Ok(cr) => (
+                            cr.adjusted_effect,
+                            cr.ci_lower,
+                            cr.ci_upper,
+                            cr.variance_reduction * 100.0,
+                        ),
+                        Err(_) => (0.0, 0.0, 0.0, 0.0),
+                    }
+                } else {
+                    (0.0, 0.0, 0.0, 0.0)
+                };
+
+            metric_results.push(MetricResult {
+                metric_id: metric_id.clone(),
+                variant_id: variant_id.clone(),
+                control_mean: ttest_result.control_mean,
+                treatment_mean: ttest_result.treatment_mean,
+                absolute_effect: ttest_result.effect,
+                relative_effect,
+                ci_lower: ttest_result.ci_lower,
+                ci_upper: ttest_result.ci_upper,
+                p_value: ttest_result.p_value,
+                is_significant: ttest_result.is_significant,
+                cuped_adjusted_effect: cuped_effect,
+                cuped_ci_lower,
+                cuped_ci_upper,
+                variance_reduction_pct,
+                sequential_result: None,
+                segment_results: vec![],
+                session_level_result: None,
+            });
+        }
+    }
+
+    Ok(AnalysisResult {
+        experiment_id: experiment_id.to_string(),
+        metric_results,
+        srm_result: Some(to_proto_srm_result(&srm_result)),
+        surrogate_projections: vec![],
+        cochran_q_p_value: 0.0,
+        computed_at: Some(now_timestamp()),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// gRPC trait implementation
+// ---------------------------------------------------------------------------
 
 #[tonic::async_trait]
 impl AnalysisService for AnalysisServiceHandler {
     async fn run_analysis(
         &self,
-        _request: Request<RunAnalysisRequest>,
+        request: Request<RunAnalysisRequest>,
     ) -> Result<Response<AnalysisResult>, Status> {
-        Err(Status::unimplemented("not yet available"))
+        let experiment_id = request.into_inner().experiment_id;
+        if experiment_id.is_empty() {
+            return Err(Status::invalid_argument("experiment_id is required"));
+        }
+        let result = compute_analysis(&self.config, &experiment_id).await?;
+        Ok(Response::new(result))
     }
 
     async fn get_analysis_result(
         &self,
-        _request: Request<GetAnalysisResultRequest>,
+        request: Request<GetAnalysisResultRequest>,
     ) -> Result<Response<AnalysisResult>, Status> {
-        Err(Status::unimplemented("not yet available"))
+        let experiment_id = request.into_inner().experiment_id;
+        if experiment_id.is_empty() {
+            return Err(Status::invalid_argument("experiment_id is required"));
+        }
+        let result = compute_analysis(&self.config, &experiment_id).await?;
+        Ok(Response::new(result))
     }
 
     async fn get_interleaving_analysis(
         &self,
-        _request: Request<GetInterleavingAnalysisRequest>,
+        request: Request<GetInterleavingAnalysisRequest>,
     ) -> Result<Response<InterleavingAnalysisResult>, Status> {
-        Err(Status::unimplemented("not yet available"))
+        let experiment_id = request.into_inner().experiment_id;
+        if experiment_id.is_empty() {
+            return Err(Status::invalid_argument("experiment_id is required"));
+        }
+
+        let scores = delta_reader::read_interleaving_scores(
+            &self.config.delta_lake_path,
+            &experiment_id,
+        )
+        .await
+        .map_err(map_reader_error)?;
+
+        let result = interleaving::analyze_interleaving(&scores, self.config.default_alpha)
+            .map_err(map_stats_error)?;
+
+        Ok(Response::new(to_proto_interleaving_result(
+            &experiment_id,
+            &result,
+        )))
     }
 
     async fn get_novelty_analysis(
         &self,
-        _request: Request<GetNoveltyAnalysisRequest>,
+        request: Request<GetNoveltyAnalysisRequest>,
     ) -> Result<Response<NoveltyAnalysisResult>, Status> {
-        Err(Status::unimplemented("not yet available"))
+        let experiment_id = request.into_inner().experiment_id;
+        if experiment_id.is_empty() {
+            return Err(Status::invalid_argument("experiment_id is required"));
+        }
+
+        let (metric_id, effects) = delta_reader::read_daily_treatment_effects(
+            &self.config.delta_lake_path,
+            &experiment_id,
+        )
+        .await
+        .map_err(map_reader_error)?;
+
+        let result = novelty::analyze_novelty(&effects, self.config.default_alpha)
+            .map_err(map_stats_error)?;
+
+        Ok(Response::new(to_proto_novelty_result(
+            &experiment_id,
+            &metric_id,
+            &result,
+        )))
     }
 
     async fn get_interference_analysis(
@@ -105,16 +397,7 @@ impl AnalysisService for AnalysisServiceHandler {
             &experiment_id,
         )
         .await
-        .map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("no content_consumption data") {
-                Status::not_found(msg)
-            } else if msg.contains("only") && msg.contains("variant") {
-                Status::failed_precondition(msg)
-            } else {
-                Status::internal(msg)
-            }
-        })?;
+        .map_err(map_reader_error)?;
 
         let result = interference::analyze_interference(
             &input,
@@ -123,8 +406,10 @@ impl AnalysisService for AnalysisServiceHandler {
         )
         .map_err(|e| Status::internal(format!("analysis failed: {e}")))?;
 
-        let proto_result = to_proto_interference_result(&experiment_id, &result);
-        Ok(Response::new(proto_result))
+        Ok(Response::new(to_proto_interference_result(
+            &experiment_id,
+            &result,
+        )))
     }
 }
 
@@ -149,6 +434,139 @@ pub async fn serve_grpc(config: AnalysisConfig) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use deltalake::arrow::array::{
+        builder::{Float64Builder, MapBuilder, StringBuilder},
+        Array, Date32Array, Float64Array, Int64Array, StringArray,
+    };
+    use deltalake::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+    use deltalake::arrow::record_batch::RecordBatch;
+    use deltalake::DeltaOps;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    // -----------------------------------------------------------------------
+    // Test data helpers
+    // -----------------------------------------------------------------------
+
+    fn test_config(path: &str) -> AnalysisConfig {
+        AnalysisConfig {
+            grpc_addr: "[::1]:0".into(),
+            delta_lake_path: path.into(),
+            default_alpha: 0.05,
+            default_js_threshold: 0.05,
+        }
+    }
+
+    async fn write_table(dir: &std::path::Path, name: &str, batch: RecordBatch) {
+        let table_path = dir.join(name);
+        std::fs::create_dir_all(&table_path).unwrap();
+        let ops = DeltaOps::try_from_uri(table_path.to_str().unwrap())
+            .await
+            .unwrap();
+        ops.write(vec![batch]).await.unwrap();
+    }
+
+    fn metric_summaries_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("user_id", DataType::Utf8, false),
+            Field::new("variant_id", DataType::Utf8, false),
+            Field::new("metric_id", DataType::Utf8, false),
+            Field::new("metric_value", DataType::Float64, false),
+            Field::new("cuped_covariate", DataType::Float64, true),
+        ]))
+    }
+
+    fn make_analysis_data(
+        exp_ids: &[&str],
+        user_ids: &[&str],
+        variant_ids: &[&str],
+        metric_ids: &[&str],
+        values: &[f64],
+        covariates: &[Option<f64>],
+    ) -> RecordBatch {
+        let cov_arr: Float64Array = covariates.iter().copied().collect();
+        RecordBatch::try_new(
+            metric_summaries_schema(),
+            vec![
+                Arc::new(StringArray::from(exp_ids.to_vec())),
+                Arc::new(StringArray::from(user_ids.to_vec())),
+                Arc::new(StringArray::from(variant_ids.to_vec())),
+                Arc::new(StringArray::from(metric_ids.to_vec())),
+                Arc::new(Float64Array::from(values.to_vec())),
+                Arc::new(cov_arr),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn make_interleaving_data(
+        exp_ids: &[&str],
+        user_ids: &[&str],
+        algo_scores: &[Vec<(&str, f64)>],
+        winners: &[Option<&str>],
+        engagements: &[i64],
+    ) -> RecordBatch {
+        let mut map_builder = MapBuilder::new(None, StringBuilder::new(), Float64Builder::new());
+        for row_scores in algo_scores {
+            for &(k, v) in row_scores {
+                map_builder.keys().append_value(k);
+                map_builder.values().append_value(v);
+            }
+            map_builder.append(true).unwrap();
+        }
+        let map_arr = map_builder.finish();
+        let winner_arr: StringArray = winners.iter().copied().collect();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("user_id", DataType::Utf8, false),
+            Field::new("algorithm_scores", map_arr.data_type().clone(), false),
+            Field::new("winning_algorithm_id", DataType::Utf8, true),
+            Field::new("total_engagements", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(exp_ids.to_vec())),
+                Arc::new(StringArray::from(user_ids.to_vec())),
+                Arc::new(map_arr),
+                Arc::new(winner_arr),
+                Arc::new(Int64Array::from(engagements.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn make_daily_effects_data(
+        exp_ids: &[&str],
+        metric_ids: &[&str],
+        dates: &[i32],
+        effects: &[f64],
+        sizes: &[i64],
+    ) -> RecordBatch {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("metric_id", DataType::Utf8, false),
+            Field::new("effect_date", DataType::Date32, false),
+            Field::new("absolute_effect", DataType::Float64, false),
+            Field::new("sample_size", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(exp_ids.to_vec())),
+                Arc::new(StringArray::from(metric_ids.to_vec())),
+                Arc::new(Date32Array::from(dates.to_vec())),
+                Arc::new(Float64Array::from(effects.to_vec())),
+                Arc::new(Int64Array::from(sizes.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // Proto converter tests (kept from original)
+    // -----------------------------------------------------------------------
 
     fn sample_result_no_spillover() -> interference::InterferenceAnalysisResult {
         interference::InterferenceAnalysisResult {
@@ -193,7 +611,6 @@ mod tests {
     fn test_to_proto_interference_no_spillover() {
         let result = sample_result_no_spillover();
         let proto = to_proto_interference_result("exp-1", &result);
-
         assert_eq!(proto.experiment_id, "exp-1");
         assert!(!proto.interference_detected);
         assert!(proto.spillover_titles.is_empty());
@@ -204,7 +621,6 @@ mod tests {
     fn test_to_proto_interference_with_spillover() {
         let result = sample_result_with_spillover();
         let proto = to_proto_interference_result("exp-2", &result);
-
         assert!(proto.interference_detected);
         assert_eq!(proto.spillover_titles.len(), 2);
         assert_eq!(proto.spillover_titles[0].content_id, "movie-42");
@@ -215,101 +631,367 @@ mod tests {
     fn test_to_proto_all_fields_mapped() {
         let result = sample_result_with_spillover();
         let proto = to_proto_interference_result("exp-3", &result);
-
         assert_eq!(proto.jensen_shannon_divergence, 0.12);
         assert_eq!(proto.jaccard_similarity_top_100, 0.65);
         assert_eq!(proto.treatment_gini_coefficient, 0.45);
         assert_eq!(proto.control_gini_coefficient, 0.30);
         assert_eq!(proto.treatment_catalog_coverage, 0.70);
         assert_eq!(proto.control_catalog_coverage, 0.85);
-
         let spill = &proto.spillover_titles[0];
         assert_eq!(spill.treatment_watch_rate, 0.15);
         assert_eq!(spill.control_watch_rate, 0.05);
         assert_eq!(spill.p_value, 0.001);
     }
 
-    #[tokio::test]
-    async fn test_unimplemented_run_analysis() {
-        let handler = AnalysisServiceHandler::new(AnalysisConfig {
-            grpc_addr: "[::1]:0".into(),
-            delta_lake_path: "/tmp/nonexistent".into(),
-            default_alpha: 0.05,
-            default_js_threshold: 0.05,
-        });
+    // -----------------------------------------------------------------------
+    // RunAnalysis / GetAnalysisResult tests
+    // -----------------------------------------------------------------------
 
-        let err = handler
+    #[tokio::test]
+    async fn test_run_analysis_basic() {
+        let tmp = TempDir::new().unwrap();
+        // 5 control users + 5 treatment users, metric "ctr", clear effect
+        let n = 10;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<&str> = vec!["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10"];
+        let variant_ids: Vec<&str> = vec![
+            "control", "control", "control", "control", "control",
+            "treatment", "treatment", "treatment", "treatment", "treatment",
+        ];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 11.0, 12.0, 13.0, 14.0, 15.0];
+        let covariates: Vec<Option<f64>> = vec![None; n];
+
+        let batch = make_analysis_data(&exp_ids, &user_ids, &variant_ids, &metric_ids, &values, &covariates);
+        write_table(tmp.path(), "metric_summaries", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
             }))
             .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
+            .unwrap();
+
+        let result = resp.into_inner();
+        assert_eq!(result.experiment_id, "exp-1");
+        assert_eq!(result.metric_results.len(), 1);
+
+        let mr = &result.metric_results[0];
+        assert_eq!(mr.metric_id, "ctr");
+        assert_eq!(mr.variant_id, "treatment");
+        assert!((mr.control_mean - 3.0).abs() < 1e-10);
+        assert!((mr.treatment_mean - 13.0).abs() < 1e-10);
+        assert!((mr.absolute_effect - 10.0).abs() < 1e-10);
+        assert!(mr.is_significant); // large effect
+        assert!(mr.p_value < 0.05);
+        assert!(result.srm_result.is_some());
     }
 
     #[tokio::test]
-    async fn test_unimplemented_get_analysis_result() {
-        let handler = AnalysisServiceHandler::new(AnalysisConfig {
-            grpc_addr: "[::1]:0".into(),
-            delta_lake_path: "/tmp/nonexistent".into(),
-            default_alpha: 0.05,
-            default_js_threshold: 0.05,
-        });
+    async fn test_run_analysis_with_cuped() {
+        let tmp = TempDir::new().unwrap();
+        let n = 10;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<&str> = vec!["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10"];
+        let variant_ids: Vec<&str> = vec![
+            "control", "control", "control", "control", "control",
+            "treatment", "treatment", "treatment", "treatment", "treatment",
+        ];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        // Highly correlated covariate and outcome
+        let values: Vec<f64> = (0..10).map(|i| (i as f64) * 2.0 + if i >= 5 { 3.0 } else { 1.0 }).collect();
+        let covariates: Vec<Option<f64>> = (0..10).map(|i| Some(i as f64)).collect();
 
+        let batch = make_analysis_data(&exp_ids, &user_ids, &variant_ids, &metric_ids, &values, &covariates);
+        write_table(tmp.path(), "metric_summaries", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+            }))
+            .await
+            .unwrap();
+
+        let mr = &resp.into_inner().metric_results[0];
+        // CUPED should be populated since all covariates are present
+        assert!(mr.variance_reduction_pct > 0.0, "CUPED should reduce variance, got {}", mr.variance_reduction_pct);
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_srm() {
+        let tmp = TempDir::new().unwrap();
+        // 50/50 split → no SRM
+        let n = 10;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<&str> = vec!["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10"];
+        let variant_ids: Vec<&str> = vec![
+            "control", "control", "control", "control", "control",
+            "treatment", "treatment", "treatment", "treatment", "treatment",
+        ];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        let values: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 1.1, 2.1, 3.1, 4.1, 5.1];
+        let covariates: Vec<Option<f64>> = vec![None; n];
+
+        let batch = make_analysis_data(&exp_ids, &user_ids, &variant_ids, &metric_ids, &values, &covariates);
+        write_table(tmp.path(), "metric_summaries", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+            }))
+            .await
+            .unwrap();
+
+        let srm = resp.into_inner().srm_result.unwrap();
+        assert!(!srm.is_mismatch, "50/50 split should not trigger SRM");
+        assert_eq!(srm.observed_counts.len(), 2);
+        assert_eq!(srm.expected_counts.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_empty_id() {
+        let handler = AnalysisServiceHandler::new(test_config("/tmp/nonexistent"));
         let err = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_analysis_data(
+            &["exp-1"], &["u1"], &["control"], &["ctr"], &[1.0], &[None],
+        );
+        write_table(tmp.path(), "metric_summaries", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let err = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-999".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn test_get_analysis_result_delegates() {
+        let tmp = TempDir::new().unwrap();
+        let n = 10;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<&str> = vec!["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10"];
+        let variant_ids: Vec<&str> = vec![
+            "control", "control", "control", "control", "control",
+            "treatment", "treatment", "treatment", "treatment", "treatment",
+        ];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 11.0, 12.0, 13.0, 14.0, 15.0];
+        let covariates: Vec<Option<f64>> = vec![None; n];
+
+        let batch = make_analysis_data(&exp_ids, &user_ids, &variant_ids, &metric_ids, &values, &covariates);
+        write_table(tmp.path(), "metric_summaries", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let resp = handler
             .get_analysis_result(Request::new(GetAnalysisResultRequest {
                 experiment_id: "exp-1".into(),
             }))
             .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
+            .unwrap();
+
+        let result = resp.into_inner();
+        assert_eq!(result.experiment_id, "exp-1");
+        assert_eq!(result.metric_results.len(), 1);
+        assert!(result.srm_result.is_some());
     }
 
-    #[tokio::test]
-    async fn test_unimplemented_get_interleaving_analysis() {
-        let handler = AnalysisServiceHandler::new(AnalysisConfig {
-            grpc_addr: "[::1]:0".into(),
-            delta_lake_path: "/tmp/nonexistent".into(),
-            default_alpha: 0.05,
-            default_js_threshold: 0.05,
-        });
+    // -----------------------------------------------------------------------
+    // GetInterleavingAnalysis tests
+    // -----------------------------------------------------------------------
 
-        let err = handler
+    #[tokio::test]
+    async fn test_interleaving_basic() {
+        let tmp = TempDir::new().unwrap();
+        // 10 scores: 7 wins for algo_a, 3 for algo_b → sign test should detect
+        let n = 10;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<&str> = (0..n).map(|i| match i {
+            0 => "u0", 1 => "u1", 2 => "u2", 3 => "u3", 4 => "u4",
+            5 => "u5", 6 => "u6", 7 => "u7", 8 => "u8", _ => "u9",
+        }).collect();
+        let algo_scores: Vec<Vec<(&str, f64)>> = (0..n)
+            .map(|i| {
+                if i < 7 {
+                    vec![("algo_a", 3.0), ("algo_b", 1.0)]
+                } else {
+                    vec![("algo_a", 1.0), ("algo_b", 3.0)]
+                }
+            })
+            .collect();
+        let winners: Vec<Option<&str>> = (0..n)
+            .map(|i| if i < 7 { Some("algo_a") } else { Some("algo_b") })
+            .collect();
+        let engagements: Vec<i64> = vec![4; n];
+
+        let batch = make_interleaving_data(&exp_ids, &user_ids, &algo_scores, &winners, &engagements);
+        write_table(tmp.path(), "interleaving_scores", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let resp = handler
             .get_interleaving_analysis(Request::new(GetInterleavingAnalysisRequest {
                 experiment_id: "exp-1".into(),
             }))
             .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
+            .unwrap();
+
+        let result = resp.into_inner();
+        assert_eq!(result.experiment_id, "exp-1");
+        assert!(result.algorithm_win_rates.contains_key("algo_a"));
+        assert!(result.algorithm_win_rates.contains_key("algo_b"));
+        assert!(result.algorithm_win_rates["algo_a"] > result.algorithm_win_rates["algo_b"]);
+        assert!(!result.algorithm_strengths.is_empty());
+        assert!(!result.position_analyses.is_empty());
+        assert!(result.computed_at.is_some());
     }
 
     #[tokio::test]
-    async fn test_unimplemented_get_novelty_analysis() {
-        let handler = AnalysisServiceHandler::new(AnalysisConfig {
-            grpc_addr: "[::1]:0".into(),
-            delta_lake_path: "/tmp/nonexistent".into(),
-            default_alpha: 0.05,
-            default_js_threshold: 0.05,
-        });
+    async fn test_interleaving_empty_id() {
+        let handler = AnalysisServiceHandler::new(test_config("/tmp/nonexistent"));
+        let err = handler
+            .get_interleaving_analysis(Request::new(GetInterleavingAnalysisRequest {
+                experiment_id: "".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
 
+    #[tokio::test]
+    async fn test_interleaving_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_interleaving_data(
+            &["exp-1"],
+            &["u1"],
+            &[vec![("algo_a", 3.0), ("algo_b", 1.0)]],
+            &[Some("algo_a")],
+            &[4],
+        );
+        write_table(tmp.path(), "interleaving_scores", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let err = handler
+            .get_interleaving_analysis(Request::new(GetInterleavingAnalysisRequest {
+                experiment_id: "exp-999".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetNoveltyAnalysis tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_novelty_basic() {
+        let tmp = TempDir::new().unwrap();
+        // 15 days of decaying effect: s=5, a=3, d=4
+        let n = 15;
+        let base_date = 19700i32;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        let dates: Vec<i32> = (0..n as i32).map(|i| base_date + i).collect();
+        let effects: Vec<f64> = (0..n).map(|i| 5.0 + 3.0 * (-(i as f64) / 4.0).exp()).collect();
+        let sizes: Vec<i64> = vec![1000; n];
+
+        let batch = make_daily_effects_data(&exp_ids, &metric_ids, &dates, &effects, &sizes);
+        write_table(tmp.path(), "daily_treatment_effects", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let resp = handler
+            .get_novelty_analysis(Request::new(GetNoveltyAnalysisRequest {
+                experiment_id: "exp-1".into(),
+            }))
+            .await
+            .unwrap();
+
+        let result = resp.into_inner();
+        assert_eq!(result.experiment_id, "exp-1");
+        assert_eq!(result.metric_id, "ctr");
+        assert!(result.novelty_detected);
+        assert!(result.decay_constant_days > 0.0);
+        assert!(result.computed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_novelty_empty_id() {
+        let handler = AnalysisServiceHandler::new(test_config("/tmp/nonexistent"));
+        let err = handler
+            .get_novelty_analysis(Request::new(GetNoveltyAnalysisRequest {
+                experiment_id: "".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_novelty_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_daily_effects_data(
+            &["exp-1"], &["ctr"], &[19700], &[5.0], &[1000],
+        );
+        write_table(tmp.path(), "daily_treatment_effects", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
+        let err = handler
+            .get_novelty_analysis(Request::new(GetNoveltyAnalysisRequest {
+                experiment_id: "exp-999".into(),
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn test_novelty_insufficient_days() {
+        let tmp = TempDir::new().unwrap();
+        // Only 5 days → stats crate returns error (needs ≥ 7)
+        let n = 5;
+        let base_date = 19700i32;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        let dates: Vec<i32> = (0..n as i32).map(|i| base_date + i).collect();
+        let effects: Vec<f64> = vec![5.0; n];
+        let sizes: Vec<i64> = vec![1000; n];
+
+        let batch = make_daily_effects_data(&exp_ids, &metric_ids, &dates, &effects, &sizes);
+        write_table(tmp.path(), "daily_treatment_effects", batch).await;
+
+        let handler = AnalysisServiceHandler::new(test_config(tmp.path().to_str().unwrap()));
         let err = handler
             .get_novelty_analysis(Request::new(GetNoveltyAnalysisRequest {
                 experiment_id: "exp-1".into(),
             }))
             .await
             .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     }
+
+    // -----------------------------------------------------------------------
+    // GetInterferenceAnalysis tests (kept from original)
+    // -----------------------------------------------------------------------
 
     #[tokio::test]
     async fn test_interference_empty_experiment_id() {
-        let handler = AnalysisServiceHandler::new(AnalysisConfig {
-            grpc_addr: "[::1]:0".into(),
-            delta_lake_path: "/tmp/nonexistent".into(),
-            default_alpha: 0.05,
-            default_js_threshold: 0.05,
-        });
-
+        let handler = AnalysisServiceHandler::new(test_config("/tmp/nonexistent"));
         let err = handler
             .get_interference_analysis(Request::new(GetInterferenceAnalysisRequest {
                 experiment_id: "".into(),

--- a/docs/coordination/status.md
+++ b/docs/coordination/status.md
@@ -1,6 +1,6 @@
 # Experimentation Platform — Coordination Status
 
-> **Last updated**: 2026-03-09 by Agent-6 (RBAC-aware UI controls — role-based button disabling + auth context)
+> **Last updated**: 2026-03-10 by Agent-4 (Wire remaining analysis RPCs — RunAnalysis, GetInterleavingAnalysis, GetNoveltyAnalysis)
 >
 > This file is the single source of truth for multi-agent execution state.
 > Update it each time a milestone merges to `main` or a blocker is identified.
@@ -16,7 +16,7 @@
 | Agent-1 | M1 Assignment | 🔵 Phase 3 In Progress | agent-1/feat/live-bandit-delegation | Live M4b bandit delegation | — | M1.1–1.5 + M2.7 + M2.7b + M2.7c complete. Live bandit delegation: GrpcBanditClient with 10ms timeout, uniform random fallback, context feature extraction. 57 tests (54 integration + 3 gRPC mock). |
 | Agent-2 | M2 Pipeline | 🟢 All Phases Complete | agent-2/feat/e2e-pipeline-tests | Reward consumer integration tests (M2→M4b) | — | All phases merged (PRs #1, #8, #23, #40, #48, #59, #66, #78, #85). PR #99: 24 reward consumer integration tests (17 protobuf contract + 7 Kafka roundtrip) validating M2→M4b data path. 95 tests pass. |
 | Agent-3 | M3 Metrics | 🔵 Phase 4 In Progress | agent-3/perf/go-benchmarks | Go benchmarks (Phase 4 load testing) | — | Phase 1–3 done. Kafka publisher (PR #64). M3↔M5 contracts (PR #68). Chaos tests (PR #69). Coverage improvements (PR #77, #98). E2e pipeline tests (PR #79). Spark retry with exponential backoff (PR #86). Databricks notebook export (PR #87). CUSTOM metric (PR #91). PERCENTILE metric (PR #92). SQL template validation (PR #95). Go benchmarks: 51 benchmarks across 4 packages (PR #101). |
-| Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 4 In Progress | agent-4/feat/chaos-testing-m4a-m4b | Chaos testing (4.5) | — | M1.14–1.19 merged. M2.1–2.6, M2.10 complete. M3.1 LinUCB merged (PR #54). M3.2 cold-start merged. M4.1 CATE in PR #70. M4.2 analysis service (PR #93). Kafka reward consumer merged. Chaos testing: chaos_test_analysis.sh + chaos_test_policy.sh + 4 crash recovery integration tests (multi-experiment, offset verification, high-volume, recovery timing). 34 tests pass. |
+| Agent-4 | M4a Analysis + M4b Bandit | 🔵 Phase 4 In Progress | agent-4/feat/wire-remaining-analysis-rpcs | Wire remaining analysis RPCs | — | M1.14–1.19 merged. M2.1–2.6, M2.10 complete. M3.1 LinUCB merged (PR #54). M3.2 cold-start merged. M4.1 CATE in PR #70. M4.2 analysis service (PR #93). Chaos testing merged. **4/5 analysis RPCs wired**: RunAnalysis/GetAnalysisResult (t-test + SRM + CUPED), GetInterleavingAnalysis (sign test + Bradley-Terry), GetNoveltyAnalysis (decay fitting). 31 tests pass. |
 | Agent-5 | M5 Management | 🔵 Phase 4 In Progress | agent-5/feat/chaos-test-management | Chaos test script (4.5) | — | Phase 3 complete (M3.6 PR #57). M4.4 RBAC interceptor (PR #71). Phase 4: stress tests (PR #75). Guardrail override audit (PR #83). Type-specific conclude + QoE validation (PR #89). Chaos test script: crash recovery, state integrity, lifecycle verification (PR #96). |
 | Agent-6 | M6 UI | 🔵 Phase 4 In Progress | agent-6/feat/phase4-next | Phase 4 RBAC-aware UI controls | — | M1.25–1.27, M2.8–2.9, analysis tabs (PR #56), bandit dashboard (PR #60), live API integration. Phase 3 complete: surrogate/holdout/guardrail (PR #76), CATE lifecycle (PR #80), QoE/novelty/GST/Lorenz (PR #81). Phase 4: search/filter/sort (PR #90). RBAC UI: auth context, role-based button disabling, dev role switcher, permission denied handling. 218 tests pass. |
 | Agent-7 | M7 Flags | 🔵 In Progress | agent-7/feat/rbac-integration | Live M5 PromoteToExperiment wiring | — | M1.28–1.30 merged (PR #13). Phases 1–4.5 complete. Phase 4.4: RBAC interceptor. Live M5 wiring: layer_id, auth header forwarding, 10s client timeout, mock contract validation. |
@@ -115,7 +115,7 @@
 | # | Milestone | Owner | Status | Unblocks |
 |---|-----------|-------|--------|----------|
 | 4.1 | CATE heterogeneous treatment effects | Agent-4 | 🔵 | Subgroup analysis + Cochran Q + BH-FDR. 22 tests (18 unit/proptest + 4 golden). |
-| 4.2 | Interference detection (content catalog spillover) | Agent-4 | 🟢 | Agent-6 (interference panel from gRPC), M4a service pattern established | PR #93. M4a service scaffolded with GetInterferenceAnalysis RPC wired through Delta Lake → experimentation-stats. 13 tests. |
+| 4.2 | Analysis service — all RPCs wired | Agent-4 | 🟢 | Agent-6 (results dashboard, interleaving tab, novelty tab), Agent-5 (auto-conclude) | PR #93 scaffolded. All 5 RPCs now wired: RunAnalysis, GetAnalysisResult, GetInterleavingAnalysis, GetNoveltyAnalysis, GetInterferenceAnalysis. 31 tests. |
 | 4.3 | PGO-optimized builds for M1 + M4b | Agent-1/4 | ⚪ | — |
 | 4.4 | Full RBAC integration | Agent-5 | 🟢 | Agent-6 (role-aware UI controls) | PR #71 merged — ConnectRPC auth interceptor, 4-level role hierarchy, audit trail records real actor |
 | 4.4b | RBAC-aware UI controls | Agent-6 | 🔵 | — | Auth context + role-based button disabling + dev role switcher. Mirrors Agent-5 4-level hierarchy. 218 tests (23 new RBAC tests). |
@@ -135,7 +135,7 @@ Track integration test results between agent pairs.
 | 5 | Agent-5 ↔ Agent-3 (guardrail alerts → auto-pause) | 🟢 | M3 Kafka publisher (PR #64) + M5 consumer (PR #18). 3 schema contract tests (field symmetry, bidirectional deser, zero-value). Kafka roundtrip integration test. Agent-2 guardrail E2E harness (`test_guardrail_e2e.sh`, PR #78) validates topic publish/consume. |
 | 5 | Agent-2 ↔ Agent-4 (reward events: pipeline → bandit policy) | 🟢 | PR #99: 24 integration tests — 17 protobuf contract (encode/decode parity, context_json parsing, key contract) + 7 Kafka roundtrip (headers, partition determinism, consumer group offsets, ordering). |
 | 6 | Agent-1 ↔ Agent-4 (bandit delegation: assignment → SelectArm) | 🔵 | M1 GrpcBanditClient with 10ms timeout + uniform fallback. M4b SelectArm gRPC wired through LMAX core. 3 mock gRPC integration tests pass. Ready for live pairing (set M4B_ADDR env var). |
-| 6 | Agent-4 ↔ Agent-6 (analysis results → UI rendering) | 🔵 | M4a GetInterferenceAnalysis gRPC available. Agent-6 can now render interference panel from real responses. |
+| 6 | Agent-4 ↔ Agent-6 (analysis results → UI rendering) | 🔵 | All 5 M4a gRPC RPCs wired. Agent-6 can render results dashboard (t-test + SRM + CUPED), interleaving tab (sign test + Bradley-Terry), novelty tab (decay curves), and interference panel. |
 
 ## Contract Changes Log
 


### PR DESCRIPTION
## Summary

- Wire all 5 M4a analysis RPCs through Delta Lake → experimentation-stats → proto conversion → gRPC response (previously only GetInterferenceAnalysis was wired, the other 4 returned Unimplemented)
- Add 3 new Delta Lake reader functions: `read_metric_summaries` (with CUPED covariates + distinct user counting for SRM), `read_interleaving_scores` (MapArray extraction), `read_daily_treatment_effects` (Date32 handling, auto-selects metric with most data)
- Replace 4 `test_unimplemented_*` tests with 13 integration tests that write real Delta tables and validate end-to-end RPC responses

## RPCs Wired

| RPC | Delta Table | Stats Functions | Key Proto Fields |
|-----|------------|----------------|-----------------|
| `RunAnalysis` / `GetAnalysisResult` | metric_summaries | welch_ttest, srm_check, cuped_adjust | MetricResult, SrmResult |
| `GetInterleavingAnalysis` | interleaving_scores | analyze_interleaving | AlgorithmStrength, PositionAnalysis |
| `GetNoveltyAnalysis` | daily_treatment_effects | analyze_novelty | decay_constant_days, novelty_amplitude |

## Test plan

- [x] `cargo test -p experimentation-analysis` — 31 tests pass (14 delta_reader + 17 grpc)
- [x] `cargo clippy -p experimentation-analysis --all-features -- -D warnings` — clean
- [x] Rebased on latest `main`

**Unblocks:**
- Agent-6 (UI): results dashboard, interleaving tab, novelty tab
- Agent-5: auto-conclude for sequential experiments needs analysis results
- Pair integrations: Agent-4 ↔ Agent-6 advances toward 🟢

🤖 Generated with [Claude Code](https://claude.com/claude-code)