### PR TITLE
feat(m1): UniFFI SDK LocalProviders for iOS/Android

### DIFF
--- a/scripts/generate_uniffi_bindings.sh
+++ b/scripts/generate_uniffi_bindings.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate UniFFI bindings for iOS (Swift) and Android (Kotlin).
+#
+# Uses `cargo rustc --crate-type cdylib` to build the hash crate as a dynamic
+# library without polluting the normal Cargo.toml (the crate is normally a lib).
+# Then runs uniffi-bindgen to generate Swift and Kotlin source files.
+#
+# Usage:
+#   ./scripts/generate_uniffi_bindings.sh
+#
+# Prerequisites:
+#   cargo install uniffi-bindgen-cli
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SWIFT_OUT="$REPO_ROOT/sdks/ios/Sources/Experimentation"
+KOTLIN_OUT="$REPO_ROOT/sdks/android/src/main/kotlin/com/experimentation/sdk"
+
+echo "==> Building experimentation-hash as cdylib with uniffi feature..."
+cargo rustc \
+  -p experimentation-hash \
+  --features uniffi \
+  --crate-type cdylib \
+  --manifest-path "$REPO_ROOT/crates/experimentation-hash/Cargo.toml"
+
+# Find the built dylib (macOS: .dylib, Linux: .so).
+DYLIB=$(find "$REPO_ROOT/target/debug" -maxdepth 1 \
+  \( -name "libexperimentation_hash.dylib" -o -name "libexperimentation_hash.so" \) \
+  -print -quit 2>/dev/null)
+
+if [[ -z "$DYLIB" ]]; then
+  echo "ERROR: Could not find libexperimentation_hash dylib in target/debug/" >&2
+  exit 1
+fi
+
+echo "==> Found dylib: $DYLIB"
+
+echo "==> Generating Swift bindings → $SWIFT_OUT"
+mkdir -p "$SWIFT_OUT"
+uniffi-bindgen generate \
+  --library "$DYLIB" \
+  --language swift \
+  --out-dir "$SWIFT_OUT"
+
+echo "==> Generating Kotlin bindings → $KOTLIN_OUT"
+mkdir -p "$KOTLIN_OUT"
+uniffi-bindgen generate \
+  --library "$DYLIB" \
+  --language kotlin \
+  --out-dir "$KOTLIN_OUT"
+
+echo "==> Done. Generated bindings:"
+find "$SWIFT_OUT" -name "*.swift" -newer "$DYLIB" -print 2>/dev/null || true
+find "$KOTLIN_OUT" -name "*.kt" -newer "$DYLIB" -print 2>/dev/null || true

--- a/sdks/android/src/main/kotlin/com/experimentation/sdk/LocalProvider.kt
+++ b/sdks/android/src/main/kotlin/com/experimentation/sdk/LocalProvider.kt
@@ -1,0 +1,123 @@
+/**
+ * LocalProvider — Android SDK
+ *
+ * Evaluates assignments locally using cached experiment config and UniFFI
+ * hash bindings. No network call required — ideal for offline / cold-start.
+ *
+ * The variant selection algorithm matches the Rust service exactly:
+ *   relative_bucket = bucket - start
+ *   cumulative = 0
+ *   for variant: cumulative += fraction * alloc_size; if relative < cumulative → return
+ *   fallthrough → last variant
+ */
+package com.experimentation.sdk
+
+// ---------------------------------------------------------------------------
+// Hash Provider Interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstracts hash computation so tests can inject a mock without native libs.
+ */
+interface HashProvider {
+    fun bucket(userId: String, salt: String, totalBuckets: Int): Int
+    fun isInAllocation(bucket: Int, startBucket: Int, endBucket: Int): Boolean
+}
+
+/**
+ * Production hash provider that delegates to the generated UniFFI bindings.
+ * Requires the UniFFI-generated native library to be loaded.
+ */
+class UniFFIHashProvider : HashProvider {
+    override fun bucket(userId: String, salt: String, totalBuckets: Int): Int =
+        uniffi.experimentation_hash.uniffiBucket(userId, salt, totalBuckets.toUInt()).toInt()
+
+    override fun isInAllocation(bucket: Int, startBucket: Int, endBucket: Int): Boolean =
+        uniffi.experimentation_hash.uniffiIsInAllocation(
+            bucket.toUInt(), startBucket.toUInt(), endBucket.toUInt()
+        )
+}
+
+// ---------------------------------------------------------------------------
+// LocalProvider
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluates assignments locally using hash-based bucketing.
+ *
+ * All assignments are returned with `fromCache = true` since they are computed
+ * client-side without a server round-trip.
+ */
+class LocalProvider(
+    private val hashProvider: HashProvider,
+    experiments: List<ExperimentConfig>,
+) : AssignmentProvider {
+
+    private val configs: Map<String, ExperimentConfig> =
+        experiments.associateBy { it.experimentId }
+
+    override suspend fun initialize() {
+        // No initialization needed for local provider.
+    }
+
+    override suspend fun getAssignment(
+        experimentId: String,
+        attributes: UserAttributes,
+    ): Assignment? {
+        val config = configs[experimentId] ?: return null
+        val userId = attributes.userId
+
+        val bucket = hashProvider.bucket(userId, config.hashSalt, config.totalBuckets)
+
+        if (!hashProvider.isInAllocation(bucket, config.allocationStart, config.allocationEnd)) {
+            return null
+        }
+
+        val variant = selectVariant(config, bucket) ?: return null
+
+        return Assignment(
+            experimentId = experimentId,
+            variantName = variant.name,
+            payload = variant.payload,
+            fromCache = true,
+        )
+    }
+
+    override suspend fun getAllAssignments(
+        attributes: UserAttributes,
+    ): Map<String, Assignment> {
+        val results = mutableMapOf<String, Assignment>()
+        for (experimentId in configs.keys) {
+            val assignment = getAssignment(experimentId, attributes)
+            if (assignment != null) {
+                results[experimentId] = assignment
+            }
+        }
+        return results
+    }
+
+    override suspend fun close() {
+        // No resources to release.
+    }
+
+    // -- Private --
+
+    /** Replicates the Rust select_variant algorithm exactly. */
+    private fun selectVariant(config: ExperimentConfig, bucket: Int): VariantConfig? {
+        if (config.variants.isEmpty()) return null
+
+        val allocSize = (config.allocationEnd - config.allocationStart + 1).toDouble()
+        val relativeBucket = (bucket - config.allocationStart).toDouble()
+
+        var cumulative = 0.0
+        for (variant in config.variants) {
+            cumulative += variant.trafficFraction * allocSize
+            if (relativeBucket < cumulative) {
+                return variant
+            }
+        }
+
+        // Fallthrough guard: assign to last variant (handles FP rounding edge cases).
+        return config.variants.last()
+    }
+}

--- a/sdks/android/src/test/kotlin/com/experimentation/sdk/LocalProviderTest.kt
+++ b/sdks/android/src/test/kotlin/com/experimentation/sdk/LocalProviderTest.kt
@@ -1,0 +1,131 @@
+package com.experimentation.sdk
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+
+/**
+ * Mock hash provider for testing LocalProvider without native UniFFI library.
+ * Uses FNV-1a for deterministic hashing.
+ */
+class MockHashProvider : HashProvider {
+    override fun bucket(userId: String, salt: String, totalBuckets: Int): Int {
+        val key = "$userId\u0000$salt"
+        var hash = 0x811c9dc5.toInt()
+        for (byte in key.toByteArray(Charsets.UTF_8)) {
+            hash = hash xor byte.toInt()
+            hash = (hash.toLong() * 0x01000193L).toInt()
+        }
+        return (hash.toLong() and 0xFFFFFFFFL).toInt() % totalBuckets
+    }
+
+    override fun isInAllocation(bucket: Int, startBucket: Int, endBucket: Int): Boolean =
+        bucket in startBucket..endBucket
+}
+
+class LocalProviderTest {
+    private val hashProvider = MockHashProvider()
+
+    private fun makeExperiment(
+        id: String = "exp_1",
+        salt: String = "salt_1",
+        variants: List<VariantConfig> = listOf(
+            VariantConfig(name = "control", trafficFraction = 0.5, isControl = true),
+            VariantConfig(name = "treatment", trafficFraction = 0.5),
+        ),
+        allocationStart: Int = 0,
+        allocationEnd: Int = 9999,
+    ) = ExperimentConfig(
+        experimentId = id,
+        hashSalt = salt,
+        layerName = "layer_1",
+        variants = variants,
+        allocationStart = allocationStart,
+        allocationEnd = allocationEnd,
+        totalBuckets = 10_000,
+    )
+
+    @Test
+    fun deterministicAssignment() = runTest {
+        val exp = makeExperiment()
+        val provider = LocalProvider(hashProvider, listOf(exp))
+        val attrs = UserAttributes(userId = "user_42")
+
+        val a1 = provider.getAssignment("exp_1", attrs)
+        val a2 = provider.getAssignment("exp_1", attrs)
+
+        assertNotNull(a1)
+        assertEquals("Same user + salt must always get the same assignment", a1, a2)
+    }
+
+    @Test
+    fun outOfAllocationReturnsNull() = runTest {
+        val exp = makeExperiment(allocationStart = 0, allocationEnd = 0)
+        val provider = LocalProvider(hashProvider, listOf(exp))
+
+        var nullCount = 0
+        for (i in 0 until 100) {
+            val attrs = UserAttributes(userId = "out_of_alloc_user_$i")
+            if (provider.getAssignment("exp_1", attrs) == null) nullCount++
+        }
+        assertTrue("Most users should be outside 1-bucket allocation, got $nullCount nulls", nullCount > 90)
+    }
+
+    @Test
+    fun unknownExperimentReturnsNull() = runTest {
+        val exp = makeExperiment()
+        val provider = LocalProvider(hashProvider, listOf(exp))
+        val attrs = UserAttributes(userId = "user_1")
+
+        assertNull(provider.getAssignment("nonexistent", attrs))
+    }
+
+    @Test
+    fun getAllAssignments() = runTest {
+        val exp1 = makeExperiment(id = "exp_a", salt = "salt_a")
+        val exp2 = makeExperiment(id = "exp_b", salt = "salt_b")
+        val provider = LocalProvider(hashProvider, listOf(exp1, exp2))
+        val attrs = UserAttributes(userId = "user_1")
+
+        val all = provider.getAllAssignments(attrs)
+        assertEquals(2, all.size)
+        assertNotNull(all["exp_a"])
+        assertNotNull(all["exp_b"])
+    }
+
+    @Test
+    fun cumulativeFractionBoundary() = runTest {
+        val variants = listOf(
+            VariantConfig(name = "v1", trafficFraction = 0.1, isControl = true),
+            VariantConfig(name = "v2", trafficFraction = 0.8),
+            VariantConfig(name = "v3", trafficFraction = 0.1),
+        )
+        val exp = makeExperiment(variants = variants)
+        val provider = LocalProvider(hashProvider, listOf(exp))
+
+        val counts = mutableMapOf<String, Int>()
+        for (i in 0 until 1000) {
+            val attrs = UserAttributes(userId = "fraction_user_$i")
+            val assignment = provider.getAssignment("exp_1", attrs)
+            if (assignment != null) {
+                counts[assignment.variantName] = (counts[assignment.variantName] ?: 0) + 1
+            }
+        }
+
+        val v2Count = counts["v2"] ?: 0
+        val v2Fraction = v2Count / 1000.0
+        assertTrue("v2 (80% traffic) should get majority: got $v2Fraction", v2Fraction > 0.65)
+        assertTrue("v2 should not get everything: got $v2Fraction", v2Fraction < 0.95)
+    }
+
+    @Test
+    fun fromCacheFlag() = runTest {
+        val exp = makeExperiment()
+        val provider = LocalProvider(hashProvider, listOf(exp))
+        val attrs = UserAttributes(userId = "user_1")
+
+        val assignment = provider.getAssignment("exp_1", attrs)
+        assertNotNull(assignment)
+        assertTrue("LocalProvider assignments must have fromCache=true", assignment!!.fromCache)
+    }
+}

--- a/sdks/ios/Sources/Experimentation/LocalProvider.swift
+++ b/sdks/ios/Sources/Experimentation/LocalProvider.swift
@@ -1,0 +1,175 @@
+//
+// LocalProvider.swift
+// Experimentation Platform — iOS SDK
+//
+// Evaluates assignments locally using cached experiment config and UniFFI
+// hash bindings. No network call required — ideal for offline / cold-start.
+//
+// The variant selection algorithm matches the Rust service exactly:
+//   relative_bucket = bucket - start
+//   cumulative = 0
+//   for variant: cumulative += fraction * alloc_size; if relative < cumulative → return
+//   fallthrough → last variant
+//
+
+import Foundation
+
+// MARK: - Hash Provider Protocol
+
+/// Abstracts hash computation so tests can inject a mock without native libs.
+public protocol HashProvider: Sendable {
+    func bucket(userId: String, salt: String, totalBuckets: UInt32) -> UInt32
+    func isInAllocation(bucket: UInt32, startBucket: UInt32, endBucket: UInt32) -> Bool
+}
+
+// MARK: - UniFFI Hash Provider
+
+/// Production hash provider that delegates to the generated UniFFI bindings.
+/// Requires the UniFFI-generated `experimentation_hashFFI` module to be linked.
+public struct UniFFIHashProvider: HashProvider {
+    public init() {}
+
+    public func bucket(userId: String, salt: String, totalBuckets: UInt32) -> UInt32 {
+        uniffi_bucket(userId: userId, salt: salt, totalBuckets: totalBuckets)
+    }
+
+    public func isInAllocation(bucket: UInt32, startBucket: UInt32, endBucket: UInt32) -> Bool {
+        uniffi_is_in_allocation(b: bucket, startBucket: startBucket, endBucket: endBucket)
+    }
+}
+
+// MARK: - Config Types
+
+/// Configuration for a single experiment (matches Rust ExperimentConfig).
+public struct LocalExperimentConfig: Sendable {
+    public let experimentId: String
+    public let hashSalt: String
+    public let layerId: String
+    public let variants: [LocalVariantConfig]
+    public let allocationStart: UInt32
+    public let allocationEnd: UInt32
+    public let totalBuckets: UInt32
+
+    public init(
+        experimentId: String,
+        hashSalt: String,
+        layerId: String,
+        variants: [LocalVariantConfig],
+        allocationStart: UInt32,
+        allocationEnd: UInt32,
+        totalBuckets: UInt32 = 10_000
+    ) {
+        self.experimentId = experimentId
+        self.hashSalt = hashSalt
+        self.layerId = layerId
+        self.variants = variants
+        self.allocationStart = allocationStart
+        self.allocationEnd = allocationEnd
+        self.totalBuckets = totalBuckets
+    }
+}
+
+/// Configuration for a single variant within an experiment.
+public struct LocalVariantConfig: Sendable {
+    public let name: String
+    public let trafficFraction: Double
+    public let isControl: Bool
+    public let payload: [String: String]
+
+    public init(name: String, trafficFraction: Double, isControl: Bool = false, payload: [String: String] = [:]) {
+        self.name = name
+        self.trafficFraction = trafficFraction
+        self.isControl = isControl
+        self.payload = payload
+    }
+}
+
+// MARK: - LocalProvider
+
+/// Evaluates assignments locally using hash-based bucketing.
+///
+/// All assignments are returned with `fromCache: true` since they are computed
+/// client-side without a server round-trip.
+public final class LocalProvider: AssignmentProvider, @unchecked Sendable {
+    private let hashProvider: HashProvider
+    private let configs: [String: LocalExperimentConfig]
+
+    public init(hashProvider: HashProvider, experiments: [LocalExperimentConfig]) {
+        self.hashProvider = hashProvider
+        var map: [String: LocalExperimentConfig] = [:]
+        for exp in experiments {
+            map[exp.experimentId] = exp
+        }
+        self.configs = map
+    }
+
+    public func initialize() async throws {
+        // No initialization needed for local provider.
+    }
+
+    public func getAssignment(experimentId: String, attributes: UserAttributes) async throws -> Assignment? {
+        guard let config = configs[experimentId] else {
+            return nil
+        }
+
+        let bucket = hashProvider.bucket(
+            userId: attributes.userId,
+            salt: config.hashSalt,
+            totalBuckets: config.totalBuckets
+        )
+
+        guard hashProvider.isInAllocation(
+            bucket: bucket,
+            startBucket: config.allocationStart,
+            endBucket: config.allocationEnd
+        ) else {
+            return nil
+        }
+
+        guard let variant = selectVariant(config: config, bucket: bucket) else {
+            return nil
+        }
+
+        return Assignment(
+            experimentId: experimentId,
+            variantName: variant.name,
+            payload: variant.payload,
+            fromCache: true
+        )
+    }
+
+    public func getAllAssignments(attributes: UserAttributes) async throws -> [String: Assignment] {
+        var results: [String: Assignment] = [:]
+        for experimentId in configs.keys {
+            if let assignment = try await getAssignment(experimentId: experimentId, attributes: attributes) {
+                results[experimentId] = assignment
+            }
+        }
+        return results
+    }
+
+    public func close() async {
+        // No resources to release.
+    }
+
+    // MARK: - Private
+
+    /// Replicates the Rust select_variant algorithm exactly.
+    private func selectVariant(config: LocalExperimentConfig, bucket: UInt32) -> LocalVariantConfig? {
+        guard !config.variants.isEmpty else { return nil }
+
+        let allocSize = Double(config.allocationEnd - config.allocationStart + 1)
+        let relativeBucket = Double(bucket - config.allocationStart)
+
+        var cumulative = 0.0
+        for variant in config.variants {
+            cumulative += variant.trafficFraction * allocSize
+            if relativeBucket < cumulative {
+                return variant
+            }
+        }
+
+        // Fallthrough guard: assign to last variant (handles FP rounding edge cases).
+        return config.variants.last
+    }
+}

--- a/sdks/ios/Tests/ExperimentationTests/LocalProviderTests.swift
+++ b/sdks/ios/Tests/ExperimentationTests/LocalProviderTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import Experimentation
+
+/// Mock hash provider for testing LocalProvider without native UniFFI library.
+struct MockHashProvider: HashProvider {
+    /// Deterministic bucket: hash(userId + salt) mod totalBuckets.
+    /// Uses a simple FNV-1a hash for test determinism.
+    func bucket(userId: String, salt: String, totalBuckets: UInt32) -> UInt32 {
+        let key = "\(userId)\0\(salt)"
+        var hash: UInt32 = 0x811c9dc5
+        for byte in key.utf8 {
+            hash ^= UInt32(byte)
+            hash &*= 0x01000193
+        }
+        return hash % totalBuckets
+    }
+
+    func isInAllocation(bucket: UInt32, startBucket: UInt32, endBucket: UInt32) -> Bool {
+        bucket >= startBucket && bucket <= endBucket
+    }
+}
+
+final class LocalProviderTests: XCTestCase {
+    private let hashProvider = MockHashProvider()
+
+    private func makeExperiment(
+        id: String = "exp_1",
+        salt: String = "salt_1",
+        variants: [LocalVariantConfig] = [
+            LocalVariantConfig(name: "control", trafficFraction: 0.5, isControl: true),
+            LocalVariantConfig(name: "treatment", trafficFraction: 0.5)
+        ],
+        allocationStart: UInt32 = 0,
+        allocationEnd: UInt32 = 9999
+    ) -> LocalExperimentConfig {
+        LocalExperimentConfig(
+            experimentId: id,
+            hashSalt: salt,
+            layerId: "layer_1",
+            variants: variants,
+            allocationStart: allocationStart,
+            allocationEnd: allocationEnd,
+            totalBuckets: 10_000
+        )
+    }
+
+    // MARK: - Deterministic assignment
+
+    func testDeterministicAssignment() async throws {
+        let exp = makeExperiment()
+        let provider = LocalProvider(hashProvider: hashProvider, experiments: [exp])
+        let attrs = UserAttributes(userId: "user_42")
+
+        let a1 = try await provider.getAssignment(experimentId: "exp_1", attributes: attrs)
+        let a2 = try await provider.getAssignment(experimentId: "exp_1", attributes: attrs)
+
+        XCTAssertNotNil(a1)
+        XCTAssertEqual(a1, a2, "Same user + salt must always get the same assignment")
+    }
+
+    // MARK: - Out of allocation returns nil
+
+    func testOutOfAllocationReturnsNil() async throws {
+        // Allocation covers only buckets 0–0 (1 bucket out of 10000).
+        // Most users will be outside this range.
+        let exp = makeExperiment(allocationStart: 0, allocationEnd: 0)
+        let provider = LocalProvider(hashProvider: hashProvider, experiments: [exp])
+
+        // Try many users — most should be nil.
+        var nilCount = 0
+        for i in 0..<100 {
+            let attrs = UserAttributes(userId: "out_of_alloc_user_\(i)")
+            let result = try await provider.getAssignment(experimentId: "exp_1", attributes: attrs)
+            if result == nil { nilCount += 1 }
+        }
+        XCTAssertGreaterThan(nilCount, 90, "Most users should be outside 1-bucket allocation")
+    }
+
+    // MARK: - Unknown experiment returns nil
+
+    func testUnknownExperimentReturnsNil() async throws {
+        let exp = makeExperiment()
+        let provider = LocalProvider(hashProvider: hashProvider, experiments: [exp])
+        let attrs = UserAttributes(userId: "user_1")
+
+        let result = try await provider.getAssignment(experimentId: "nonexistent", attributes: attrs)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - getAllAssignments
+
+    func testGetAllAssignments() async throws {
+        let exp1 = makeExperiment(id: "exp_a", salt: "salt_a")
+        let exp2 = makeExperiment(id: "exp_b", salt: "salt_b")
+        let provider = LocalProvider(hashProvider: hashProvider, experiments: [exp1, exp2])
+        let attrs = UserAttributes(userId: "user_1")
+
+        let all = try await provider.getAllAssignments(attributes: attrs)
+        XCTAssertEqual(all.count, 2)
+        XCTAssertNotNil(all["exp_a"])
+        XCTAssertNotNil(all["exp_b"])
+    }
+
+    // MARK: - Cumulative fraction boundary
+
+    func testCumulativeFractionBoundary() async throws {
+        // 3 variants: 10%, 80%, 10%.
+        let variants = [
+            LocalVariantConfig(name: "v1", trafficFraction: 0.1, isControl: true),
+            LocalVariantConfig(name: "v2", trafficFraction: 0.8),
+            LocalVariantConfig(name: "v3", trafficFraction: 0.1),
+        ]
+        let exp = makeExperiment(variants: variants)
+        let provider = LocalProvider(hashProvider: hashProvider, experiments: [exp])
+
+        // Run many users and verify the middle variant gets ~80% of traffic.
+        var counts: [String: Int] = [:]
+        for i in 0..<1000 {
+            let attrs = UserAttributes(userId: "fraction_user_\(i)")
+            if let assignment = try await provider.getAssignment(experimentId: "exp_1", attributes: attrs) {
+                counts[assignment.variantName, default: 0] += 1
+            }
+        }
+
+        let v2Count = counts["v2"] ?? 0
+        let v2Fraction = Double(v2Count) / 1000.0
+        XCTAssertGreaterThan(v2Fraction, 0.65, "v2 (80% traffic) should get majority: got \(v2Fraction)")
+        XCTAssertLessThan(v2Fraction, 0.95, "v2 should not get everything: got \(v2Fraction)")
+    }
+
+    // MARK: - fromCache flag
+
+    func testFromCacheFlag() async throws {
+        let exp = makeExperiment()
+        let provider = LocalProvider(hashProvider: hashProvider, experiments: [exp])
+        let attrs = UserAttributes(userId: "user_1")
+
+        let assignment = try await provider.getAssignment(experimentId: "exp_1", attributes: attrs)
+        XCTAssertNotNil(assignment)
+        XCTAssertTrue(assignment!.fromCache, "LocalProvider assignments must have fromCache=true")
+    }
+}


### PR DESCRIPTION
## Summary

- **UniFFI binding generation script** (`scripts/generate_uniffi_bindings.sh`): builds the hash crate as a cdylib and generates Swift + Kotlin source files via `uniffi-bindgen`
- **iOS `LocalProvider`**: implements `AssignmentProvider` with offline hash-based assignment using `HashProvider` protocol for mock injection
- **Android `LocalProvider`**: same pattern using `HashProvider` interface, reuses existing `ExperimentConfig`/`VariantConfig` types
- **12 tests total** (6 per platform): determinism, out-of-allocation, unknown experiment, getAllAssignments, cumulative fraction boundary, fromCache flag

The variant selection algorithm exactly replicates the Rust `select_variant()` logic:
```
relative_bucket = bucket - start
cumulative = 0
for variant: cumulative += fraction * alloc_size; if relative < cumulative → return
fallthrough → last variant
```

## Unblocks

- Mobile SDKs can now evaluate assignments offline without network round-trips
- Agent-7 can consume UniFFI bindings for native hash parity

## Test plan

- [x] `bash -n scripts/generate_uniffi_bindings.sh` — syntax OK
- [x] `cargo test -p experimentation-hash --features uniffi` — 4 UniFFI Rust tests pass
- [ ] iOS LocalProviderTests — 6 tests with MockHashProvider (no native lib required)
- [ ] Android LocalProviderTest — 6 tests with MockHashProvider (no native lib required)
- [x] No proto changes, no shared crate changes — zero cross-agent impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)