### PR TITLE
test(m4a): validate GST boundaries against scipy to 4+ decimal places

### DIFF
--- a/crates/experimentation-stats/tests/golden/gst_evaluate_obf_4_look1_cross.json
+++ b/crates/experimentation-stats/tests/golden/gst_evaluate_obf_4_look1_cross.json
@@ -1,0 +1,16 @@
+{
+  "test_name": "gst_evaluate_obf_4_look1_cross",
+  "description": "OBF K=4, z=4.5 at look 1 \u2014 exceeds early OBF boundary (~3.92), rare early stopping",
+  "z_stat": 4.5,
+  "current_look": 1,
+  "planned_looks": 4,
+  "overall_alpha": 0.05,
+  "spending_function": "OBrienFleming",
+  "prev_alpha_spent": 0.0,
+  "expected": {
+    "boundary_crossed": true,
+    "critical_value": 3.919927969080382,
+    "alpha_spent": 8.857543832130332e-05,
+    "alpha_remaining": 0.0499114245616787
+  }
+}

--- a/crates/experimentation-stats/tests/golden/gst_evaluate_obf_4_look1_no_cross.json
+++ b/crates/experimentation-stats/tests/golden/gst_evaluate_obf_4_look1_no_cross.json
@@ -1,0 +1,16 @@
+{
+  "test_name": "gst_evaluate_obf_4_look1_no_cross",
+  "description": "OBF K=4, z=2.0 at look 1 \u2014 well below OBF boundary (~3.92), no crossing",
+  "z_stat": 2.0,
+  "current_look": 1,
+  "planned_looks": 4,
+  "overall_alpha": 0.05,
+  "spending_function": "OBrienFleming",
+  "prev_alpha_spent": 0.0,
+  "expected": {
+    "boundary_crossed": false,
+    "critical_value": 3.919927969080382,
+    "alpha_spent": 8.857543832130332e-05,
+    "alpha_remaining": 0.0499114245616787
+  }
+}

--- a/crates/experimentation-stats/tests/golden/gst_evaluate_obf_4_look4_cross.json
+++ b/crates/experimentation-stats/tests/golden/gst_evaluate_obf_4_look4_cross.json
@@ -1,0 +1,16 @@
+{
+  "test_name": "gst_evaluate_obf_4_look4_cross",
+  "description": "OBF K=4, z=3.0 at final look \u2014 exceeds boundary (~2.04), crossing",
+  "z_stat": 3.0,
+  "current_look": 4,
+  "planned_looks": 4,
+  "overall_alpha": 0.05,
+  "spending_function": "OBrienFleming",
+  "prev_alpha_spent": 0.023625121317601305,
+  "expected": {
+    "boundary_crossed": true,
+    "critical_value": 2.042638485279184,
+    "alpha_spent": 0.05,
+    "alpha_remaining": 0.0
+  }
+}

--- a/crates/experimentation-stats/tests/golden/gst_evaluate_pocock_3_look2_cross.json
+++ b/crates/experimentation-stats/tests/golden/gst_evaluate_pocock_3_look2_cross.json
@@ -1,0 +1,16 @@
+{
+  "test_name": "gst_evaluate_pocock_3_look2_cross",
+  "description": "Pocock K=3, z=2.5 at look 2 \u2014 exceeds Pocock boundary (~2.29), crossing",
+  "z_stat": 2.5,
+  "current_look": 2,
+  "planned_looks": 3,
+  "overall_alpha": 0.05,
+  "spending_function": "Pocock",
+  "prev_alpha_spent": 0.022641621263197066,
+  "expected": {
+    "boundary_crossed": true,
+    "critical_value": 2.294911132376029,
+    "alpha_spent": 0.03816912576950707,
+    "alpha_remaining": 0.011830874230492935
+  }
+}

--- a/crates/experimentation-stats/tests/golden/gst_evaluate_pocock_3_look3_no_cross.json
+++ b/crates/experimentation-stats/tests/golden/gst_evaluate_pocock_3_look3_no_cross.json
@@ -1,0 +1,16 @@
+{
+  "test_name": "gst_evaluate_pocock_3_look3_no_cross",
+  "description": "Pocock K=3, z=1.5 at final look \u2014 below boundary (~2.30), no crossing",
+  "z_stat": 1.5,
+  "current_look": 3,
+  "planned_looks": 3,
+  "overall_alpha": 0.05,
+  "spending_function": "Pocock",
+  "prev_alpha_spent": 0.03816912576950707,
+  "expected": {
+    "boundary_crossed": false,
+    "critical_value": 2.2959383587158584,
+    "alpha_spent": 0.05,
+    "alpha_remaining": 0.0
+  }
+}

--- a/crates/experimentation-stats/tests/golden/gst_obf_2_looks.json
+++ b/crates/experimentation-stats/tests/golden/gst_obf_2_looks.json
@@ -3,7 +3,7 @@
   "spending_function": "OBrienFleming",
   "planned_looks": 2,
   "overall_alpha": 0.05,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=2, test.type=2, alpha=0.05, sfu=sfLDOF)",
   "boundaries": [
     {
@@ -18,7 +18,7 @@
       "information_fraction": 1.0,
       "cumulative_alpha": 0.05,
       "incremental_alpha": 0.0444254033192157,
-      "critical_value": 1.9793113426784357
+      "critical_value": 1.979311342678642
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_obf_3_looks_alpha01.json
+++ b/crates/experimentation-stats/tests/golden/gst_obf_3_looks_alpha01.json
@@ -3,7 +3,7 @@
   "spending_function": "OBrienFleming",
   "planned_looks": 3,
   "overall_alpha": 0.01,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=3, test.type=2, alpha=0.01, sfu=sfLDOF)",
   "boundaries": [
     {
@@ -18,14 +18,14 @@
       "information_fraction": 0.6666666666666666,
       "cumulative_alpha": 0.0016064464568816827,
       "incremental_alpha": 0.0015983064171658512,
-      "critical_value": 3.155356892907035
+      "critical_value": 3.155356892907008
     },
     {
       "look": 3,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.01,
       "incremental_alpha": 0.008393553543118317,
-      "critical_value": 2.597245677573483
+      "critical_value": 2.5972456775733406
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_obf_4_looks.json
+++ b/crates/experimentation-stats/tests/golden/gst_obf_4_looks.json
@@ -3,7 +3,7 @@
   "spending_function": "OBrienFleming",
   "planned_looks": 4,
   "overall_alpha": 0.05,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=4, test.type=2, alpha=0.05, sfu=sfLDOF)",
   "boundaries": [
     {
@@ -18,21 +18,21 @@
       "information_fraction": 0.5,
       "cumulative_alpha": 0.005574596680784305,
       "incremental_alpha": 0.005486021242463002,
-      "critical_value": 2.7739525452438825
+      "critical_value": 2.7739525452435316
     },
     {
       "look": 3,
       "information_fraction": 0.75,
       "cumulative_alpha": 0.023625121317601305,
       "incremental_alpha": 0.018050524636817,
-      "critical_value": 2.298242500688246
+      "critical_value": 2.2982425006879055
     },
     {
       "look": 4,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.05,
       "incremental_alpha": 0.026374878682398697,
-      "critical_value": 2.042638485279324
+      "critical_value": 2.042638485279184
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_obf_5_looks_alpha10.json
+++ b/crates/experimentation-stats/tests/golden/gst_obf_5_looks_alpha10.json
@@ -3,7 +3,7 @@
   "spending_function": "OBrienFleming",
   "planned_looks": 5,
   "overall_alpha": 0.1,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=5, test.type=2, alpha=0.1, sfu=sfLDOF)",
   "boundaries": [
     {
@@ -18,28 +18,28 @@
       "information_fraction": 0.4,
       "cumulative_alpha": 0.009302239997693196,
       "incremental_alpha": 0.00906717420510783,
-      "critical_value": 2.604312056774928
+      "critical_value": 2.6043120567752283
     },
     {
       "look": 3,
       "information_fraction": 0.6,
       "cumulative_alpha": 0.033712234877398384,
       "incremental_alpha": 0.024409994879705188,
-      "critical_value": 2.166850450025514
+      "critical_value": 2.1668504500258052
     },
     {
       "look": 4,
       "information_fraction": 0.8,
       "cumulative_alpha": 0.06591485344808312,
       "incremental_alpha": 0.03220261857068474,
-      "critical_value": 1.9346160767660747
+      "critical_value": 1.934616076765991
     },
     {
       "look": 5,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.1,
       "incremental_alpha": 0.034085146551916884,
-      "critical_value": 1.7900592314667776
+      "critical_value": 1.7900592314666426
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_obf_6_looks.json
+++ b/crates/experimentation-stats/tests/golden/gst_obf_6_looks.json
@@ -3,7 +3,7 @@
   "spending_function": "OBrienFleming",
   "planned_looks": 6,
   "overall_alpha": 0.05,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=6, test.type=2, alpha=0.05, sfu=sfLDOF)",
   "boundaries": [
     {
@@ -18,35 +18,35 @@
       "information_fraction": 0.3333333333333333,
       "cumulative_alpha": 0.0006868948682239306,
       "incremental_alpha": 0.0006853154189836452,
-      "critical_value": 3.3950251887194516
+      "critical_value": 3.3950251887191314
     },
     {
       "look": 3,
       "information_fraction": 0.5,
       "cumulative_alpha": 0.005574596680784305,
       "incremental_alpha": 0.004887701812560374,
-      "critical_value": 2.7872873926478414
+      "critical_value": 2.787287392647528
     },
     {
       "look": 4,
       "information_fraction": 0.6666666666666666,
       "cumulative_alpha": 0.016374666450048148,
       "incremental_alpha": 0.010800069769263843,
-      "critical_value": 2.4489195421587713
+      "critical_value": 2.448919542158336
     },
     {
       "look": 5,
       "information_fraction": 0.8333333333333334,
       "cumulative_alpha": 0.0317906567189612,
       "incremental_alpha": 0.015415990268913049,
-      "critical_value": 2.2319551356489726
+      "critical_value": 2.2319551356492013
     },
     {
       "look": 6,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.05,
       "incremental_alpha": 0.018209343281038806,
-      "critical_value": 2.0799106634136364
+      "critical_value": 2.0799106634132443
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_pocock_2_looks.json
+++ b/crates/experimentation-stats/tests/golden/gst_pocock_2_looks.json
@@ -3,7 +3,7 @@
   "spending_function": "Pocock",
   "planned_looks": 2,
   "overall_alpha": 0.05,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=2, test.type=2, alpha=0.05, sfu=sfLDPocock)",
   "boundaries": [
     {
@@ -18,7 +18,7 @@
       "information_fraction": 1.0,
       "cumulative_alpha": 0.05,
       "incremental_alpha": 0.018994274652086127,
-      "critical_value": 2.2009769552113063
+      "critical_value": 2.2009769552110754
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_pocock_3_looks.json
+++ b/crates/experimentation-stats/tests/golden/gst_pocock_3_looks.json
@@ -3,7 +3,7 @@
   "spending_function": "Pocock",
   "planned_looks": 3,
   "overall_alpha": 0.05,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=3, test.type=2, alpha=0.05, sfu=sfLDPocock)",
   "boundaries": [
     {
@@ -18,14 +18,14 @@
       "information_fraction": 0.6666666666666666,
       "cumulative_alpha": 0.03816912576950707,
       "incremental_alpha": 0.015527504506310002,
-      "critical_value": 2.294911132375699
+      "critical_value": 2.294911132376029
     },
     {
       "look": 3,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.05,
       "incremental_alpha": 0.011830874230492935,
-      "critical_value": 2.2959383587160236
+      "critical_value": 2.2959383587158584
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_pocock_4_looks.json
+++ b/crates/experimentation-stats/tests/golden/gst_pocock_4_looks.json
@@ -3,7 +3,7 @@
   "spending_function": "Pocock",
   "planned_looks": 4,
   "overall_alpha": 0.05,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=4, test.type=2, alpha=0.05, sfu=sfLDPocock)",
   "boundaries": [
     {
@@ -18,21 +18,21 @@
       "information_fraction": 0.5,
       "cumulative_alpha": 0.031005725347913876,
       "incremental_alpha": 0.013137024372474455,
-      "critical_value": 2.3675242946634434
+      "critical_value": 2.367524294663525
     },
     {
       "look": 3,
       "information_fraction": 0.75,
       "cumulative_alpha": 0.04139944696214349,
       "incremental_alpha": 0.010393721614229613,
-      "critical_value": 2.3581677349904093
+      "critical_value": 2.3581677349901327
     },
     {
       "look": 4,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.05,
       "incremental_alpha": 0.008600553037856513,
-      "critical_value": 2.3500295372908657
+      "critical_value": 2.350029537291249
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_pocock_5_looks_alpha10.json
+++ b/crates/experimentation-stats/tests/golden/gst_pocock_5_looks_alpha10.json
@@ -3,7 +3,7 @@
   "spending_function": "Pocock",
   "planned_looks": 5,
   "overall_alpha": 0.1,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=5, test.type=2, alpha=0.1, sfu=sfLDPocock)",
   "boundaries": [
     {
@@ -18,28 +18,28 @@
       "information_fraction": 0.4,
       "cumulative_alpha": 0.05231371636115855,
       "incremental_alpha": 0.022774263449123786,
-      "critical_value": 2.1437476982527337
+      "critical_value": 2.1437476982527244
     },
     {
       "look": 3,
       "information_fraction": 0.6,
       "cumulative_alpha": 0.0708513066862315,
       "incremental_alpha": 0.018537590325072954,
-      "critical_value": 2.113281163617071
+      "critical_value": 2.1132811636170175
     },
     {
       "look": 4,
       "information_fraction": 0.8,
       "cumulative_alpha": 0.08648397251631904,
       "incremental_alpha": 0.01563266583008753,
-      "critical_value": 2.0895655324923914
+      "critical_value": 2.0895655324924007
     },
     {
       "look": 5,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.1,
       "incremental_alpha": 0.01351602748368097,
-      "critical_value": 2.0708940552508546
+      "critical_value": 2.070894055251273
     }
   ]
 }

--- a/crates/experimentation-stats/tests/golden/gst_pocock_6_looks.json
+++ b/crates/experimentation-stats/tests/golden/gst_pocock_6_looks.json
@@ -3,7 +3,7 @@
   "spending_function": "Pocock",
   "planned_looks": 6,
   "overall_alpha": 0.05,
-  "source": "recursive_integration_python",
+  "source": "scipy_gauss_legendre_201_nodes",
   "r_command": "gsDesign(k=6, test.type=2, alpha=0.05, sfu=sfLDPocock)",
   "boundaries": [
     {
@@ -18,35 +18,35 @@
       "information_fraction": 0.3333333333333333,
       "cumulative_alpha": 0.022641621263197066,
       "incremental_alpha": 0.010050005815306937,
-      "critical_value": 2.4769066736252405
+      "critical_value": 2.476906673625507
     },
     {
       "look": 3,
       "information_fraction": 0.5,
       "cumulative_alpha": 0.031005725347913876,
       "incremental_alpha": 0.00836410408471681,
-      "critical_value": 2.4549636966926305
+      "critical_value": 2.454963696692431
     },
     {
       "look": 4,
       "information_fraction": 0.6666666666666666,
       "cumulative_alpha": 0.03816912576950707,
       "incremental_alpha": 0.007163400421593191,
-      "critical_value": 2.437261643020132
+      "critical_value": 2.437261643019923
     },
     {
       "look": 5,
       "information_fraction": 0.8333333333333334,
       "cumulative_alpha": 0.04443367356954783,
       "incremental_alpha": 0.006264547800040765,
-      "critical_value": 2.423276163182444
+      "critical_value": 2.423276163182237
     },
     {
       "look": 6,
       "information_fraction": 1.0,
       "cumulative_alpha": 0.05,
       "incremental_alpha": 0.00556632643045217,
-      "critical_value": 2.4120586953581205
+      "critical_value": 2.41205869535807
     }
   ]
 }

--- a/crates/experimentation-stats/tests/sequential_golden.rs
+++ b/crates/experimentation-stats/tests/sequential_golden.rs
@@ -7,7 +7,7 @@
 //! Update: UPDATE_GOLDEN=1 cargo test -p experimentation-stats --test sequential_golden
 
 use experimentation_stats::sequential::{
-    gst_boundaries, msprt_normal, spending_function_alpha, SpendingFunction,
+    gst_boundaries, gst_evaluate, msprt_normal, spending_function_alpha, SpendingFunction,
 };
 use std::path::PathBuf;
 
@@ -166,6 +166,80 @@ fn run_gst_golden(filename: &str) {
     }
 }
 
+// ----- GST evaluate golden types + runner -----
+
+#[derive(serde::Deserialize)]
+struct GoldenGstEvaluate {
+    test_name: String,
+    z_stat: f64,
+    current_look: u32,
+    planned_looks: u32,
+    overall_alpha: f64,
+    spending_function: String,
+    prev_alpha_spent: f64,
+    expected: GstEvaluateExpected,
+}
+
+#[derive(serde::Deserialize)]
+struct GstEvaluateExpected {
+    boundary_crossed: bool,
+    critical_value: f64,
+    alpha_spent: f64,
+    alpha_remaining: f64,
+}
+
+fn load_gst_evaluate(filename: &str) -> GoldenGstEvaluate {
+    let path = golden_dir().join(filename);
+    let data = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read golden file {}: {e}", path.display()));
+    serde_json::from_str(&data)
+        .unwrap_or_else(|e| panic!("Failed to parse golden file {}: {e}", path.display()))
+}
+
+fn run_gst_evaluate_golden(filename: &str) {
+    let golden = load_gst_evaluate(filename);
+    let spending = match golden.spending_function.as_str() {
+        "OBrienFleming" => SpendingFunction::OBrienFleming,
+        "Pocock" => SpendingFunction::Pocock,
+        other => panic!("Unknown spending function: {other}"),
+    };
+
+    let result = gst_evaluate(
+        golden.z_stat,
+        golden.current_look,
+        golden.planned_looks,
+        golden.overall_alpha,
+        spending,
+        golden.prev_alpha_spent,
+    )
+    .unwrap_or_else(|e| panic!("[{}] gst_evaluate failed: {e}", golden.test_name));
+
+    let name = &golden.test_name;
+    assert_eq!(
+        result.boundary_crossed, golden.expected.boundary_crossed,
+        "[{name}] boundary_crossed mismatch: expected {}, got {}",
+        golden.expected.boundary_crossed, result.boundary_crossed
+    );
+    assert_close(
+        result.critical_value,
+        golden.expected.critical_value,
+        "critical_value",
+        name,
+    );
+    assert_close(
+        result.alpha_spent,
+        golden.expected.alpha_spent,
+        "alpha_spent",
+        name,
+    );
+    assert_close(
+        result.alpha_remaining,
+        golden.expected.alpha_remaining,
+        "alpha_remaining",
+        name,
+    );
+}
+
 // ----- mSPRT golden tests -----
 
 #[test]
@@ -285,4 +359,31 @@ fn obf_boundaries_decreasing() {
             bounds[i - 1]
         );
     }
+}
+
+// ----- GST evaluate golden tests -----
+
+#[test]
+fn golden_gst_evaluate_obf_4_look1_no_cross() {
+    run_gst_evaluate_golden("gst_evaluate_obf_4_look1_no_cross.json");
+}
+
+#[test]
+fn golden_gst_evaluate_obf_4_look1_cross() {
+    run_gst_evaluate_golden("gst_evaluate_obf_4_look1_cross.json");
+}
+
+#[test]
+fn golden_gst_evaluate_obf_4_look4_cross() {
+    run_gst_evaluate_golden("gst_evaluate_obf_4_look4_cross.json");
+}
+
+#[test]
+fn golden_gst_evaluate_pocock_3_look2_cross() {
+    run_gst_evaluate_golden("gst_evaluate_pocock_3_look2_cross.json");
+}
+
+#[test]
+fn golden_gst_evaluate_pocock_3_look3_no_cross() {
+    run_gst_evaluate_golden("gst_evaluate_pocock_3_look3_no_cross.json");
 }

--- a/scripts/generate_gst_golden.py
+++ b/scripts/generate_gst_golden.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Generate GST boundary golden files using Armitage-McPherson-Rowe recursive
+integration with Gauss-Legendre quadrature — the same algorithm R's gsDesign
+package and our Rust implementation use.
+
+Mathematical formulation:
+  - Lan-DeMets alpha spending: OBF and Pocock
+  - Recursive GL quadrature for multivariate normal continuation probabilities
+  - Correlation structure: Corr(Z_i, Z_j) = sqrt(t_i / t_j) for i < j
+  - Transition density: Z_k | Z_{k-1}=w ~ N(w·sqrt(t_{k-1}/t_k), 1 - t_{k-1}/t_k)
+
+Usage:
+    python3 scripts/generate_gst_golden.py              # compare with existing
+    python3 scripts/generate_gst_golden.py --update      # overwrite golden files
+
+Reference:
+    R: gsDesign(k=K, test.type=2, alpha=α, sfu=sfLDOF|sfLDPocock)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+from scipy import stats
+
+GOLDEN_DIR = Path(__file__).parent.parent / "crates" / "experimentation-stats" / "tests" / "golden"
+
+# Number of Gauss-Legendre quadrature nodes
+N_NODES = 201
+
+
+def obf_spending(t: float, alpha: float) -> float:
+    """Lan-DeMets O'Brien-Fleming: α*(t) = 2·[1 - Φ(z_{α/2}/√t)]"""
+    if t <= 0:
+        return 0.0
+    if t >= 1:
+        return alpha
+    z = stats.norm.ppf(1 - alpha / 2)
+    return float(min(alpha, 2.0 * (1.0 - stats.norm.cdf(z / np.sqrt(t)))))
+
+
+def pocock_spending(t: float, alpha: float) -> float:
+    """Lan-DeMets Pocock: α*(t) = α·ln(1 + (e-1)·t)"""
+    if t <= 0:
+        return 0.0
+    if t >= 1:
+        return alpha
+    return float(min(alpha, alpha * np.log(1.0 + (np.e - 1.0) * t)))
+
+
+def gl_on_interval(nodes_ref, weights_ref, lo, hi):
+    """Map GL nodes from [-1,1] to [lo, hi]."""
+    half_len = (hi - lo) / 2.0
+    mid = (hi + lo) / 2.0
+    return half_len * nodes_ref + mid, half_len * weights_ref
+
+
+def gst_boundaries_reference(planned_looks, overall_alpha, spending_fn):
+    """Compute GST boundaries via Armitage-McPherson-Rowe recursive integration.
+
+    Uses Gauss-Legendre quadrature (N_NODES points). The GL representation
+    of the continuation density is stored as (nodes, weights, values) arrays,
+    and the transition convolution is computed via matrix multiply.
+
+    IMPORTANT: When updating the GL representation for the next look, we must
+    evaluate g_k at the new grid points BEFORE rebinding the old arrays.
+    """
+    info_fractions = [(k + 1) / planned_looks for k in range(planned_looks)]
+    cum_alphas = [spending_fn(t, overall_alpha) for t in info_fractions]
+
+    gl_ref_nodes, gl_ref_weights = np.polynomial.legendre.leggauss(N_NODES)
+
+    results = []
+    prev_cum_alpha = 0.0
+
+    # GL quadrature representation of continuation density from previous look
+    prev_nodes = None
+    prev_weights = None
+    prev_densities = None
+    prev_t = None
+
+    for k in range(planned_looks):
+        t = info_fractions[k]
+        target_cum = cum_alphas[k]
+        incremental = target_cum - prev_cum_alpha
+
+        if k == 0:
+            # Look 1: c_1 = Φ^{-1}(1 - α*(t_1)/2)
+            c = float(stats.norm.ppf(1 - target_cum / 2))
+
+            # g_1(z) = φ(z) on [-c, c]
+            prev_nodes, prev_weights = gl_on_interval(gl_ref_nodes, gl_ref_weights, -c, c)
+            prev_densities = stats.norm.pdf(prev_nodes)
+
+        else:
+            # Transition parameters
+            ratio = prev_t / t
+            r = np.sqrt(ratio)
+            sigma_t = np.sqrt(1.0 - ratio)
+
+            # Snapshot the previous look's representation (avoid late-binding issues)
+            w_nodes = prev_nodes
+            w_weights = prev_weights
+            w_densities = prev_densities
+
+            def eval_gk_vec(z_arr, w_n=w_nodes, w_w=w_weights, w_d=w_densities,
+                            r_val=r, sig=sigma_t):
+                """Evaluate g_k(z) = ∫ g_{k-1}(w) · f(z|w) dw via GL quadrature.
+
+                All dependencies passed as default args to avoid closure capture issues.
+                """
+                # z_arr shape: (M,), w_n shape: (N,)
+                z_col = z_arr[:, np.newaxis]     # (M, 1)
+                w_row = w_n[np.newaxis, :]       # (1, N)
+                args = (z_col - w_row * r_val) / sig
+                transition = stats.norm.pdf(args) / sig  # (M, N)
+                wv = (w_w * w_d)[np.newaxis, :]          # (1, N)
+                return np.sum(wv * transition, axis=1)    # (M,)
+
+            def continuation_prob(c_val, eval_fn=eval_gk_vec):
+                """∫_{-c}^{c} g_k(z) dz via GL quadrature."""
+                z_nodes, z_weights = gl_on_interval(gl_ref_nodes, gl_ref_weights,
+                                                    -c_val, c_val)
+                gk_at_z = eval_fn(z_nodes)
+                return float(np.sum(z_weights * gk_at_z))
+
+            # Bisection: find c_k such that continuation_prob(c_k) = 1 - target_cum
+            target_cont = 1.0 - target_cum
+            lo, hi = 0.5, 8.0
+            for _ in range(200):
+                mid = (lo + hi) / 2.0
+                prob = continuation_prob(mid)
+                if prob > target_cont:
+                    hi = mid
+                else:
+                    lo = mid
+                if hi - lo < 1e-12:
+                    break
+            c = (lo + hi) / 2.0
+
+            # Store g_k representation on [-c, c] for next iteration.
+            # Evaluate BEFORE updating prev_nodes (avoids late-binding bug).
+            new_nodes, new_weights = gl_on_interval(gl_ref_nodes, gl_ref_weights, -c, c)
+            new_densities = eval_gk_vec(new_nodes)
+            prev_nodes = new_nodes
+            prev_weights = new_weights
+            prev_densities = new_densities
+
+        prev_t = t
+        prev_cum_alpha = target_cum
+
+        results.append({
+            "look": k + 1,
+            "information_fraction": t,
+            "cumulative_alpha": target_cum,
+            "incremental_alpha": incremental,
+            "critical_value": c,
+        })
+
+    return results
+
+
+# All golden file configurations
+CONFIGS = [
+    ("gst_obf_2_looks.json", "OBrienFleming", obf_spending, 2, 0.05),
+    ("gst_obf_3_looks_alpha01.json", "OBrienFleming", obf_spending, 3, 0.01),
+    ("gst_obf_4_looks.json", "OBrienFleming", obf_spending, 4, 0.05),
+    ("gst_obf_5_looks_alpha10.json", "OBrienFleming", obf_spending, 5, 0.10),
+    ("gst_obf_6_looks.json", "OBrienFleming", obf_spending, 6, 0.05),
+    ("gst_pocock_2_looks.json", "Pocock", pocock_spending, 2, 0.05),
+    ("gst_pocock_3_looks.json", "Pocock", pocock_spending, 3, 0.05),
+    ("gst_pocock_4_looks.json", "Pocock", pocock_spending, 4, 0.05),
+    ("gst_pocock_5_looks_alpha10.json", "Pocock", pocock_spending, 5, 0.10),
+    ("gst_pocock_6_looks.json", "Pocock", pocock_spending, 6, 0.05),
+]
+
+
+def compare_with_existing():
+    """Compare newly generated values against existing golden files."""
+    print("=== GST Boundary Validation (scipy GL quadrature vs existing golden files) ===\n")
+
+    all_pass = True
+    for filename, spending_name, spending_fn, k, alpha in CONFIGS:
+        path = GOLDEN_DIR / filename
+
+        if not path.exists():
+            print(f"  {filename}: MISSING")
+            continue
+
+        with open(path) as f:
+            existing = json.load(f)
+
+        new_boundaries = gst_boundaries_reference(k, alpha, spending_fn)
+
+        print(f"  {filename} (K={k}, α={alpha}, {spending_name}):")
+
+        max_diff = 0.0
+        for old_b, new_b in zip(existing["boundaries"], new_boundaries):
+            look = old_b["look"]
+            old_c = old_b["critical_value"]
+            new_c = new_b["critical_value"]
+            diff = abs(old_c - new_c)
+            max_diff = max(max_diff, diff)
+            status = "OK" if diff < 1e-4 else "MISMATCH"
+            print(f"    Look {look}: existing={old_c:.8f}, scipy={new_c:.8f}, diff={diff:.2e} [{status}]")
+
+        overall = "PASS" if max_diff < 1e-4 else "FAIL"
+        if overall == "FAIL":
+            all_pass = False
+        print(f"    Max diff: {max_diff:.2e} [{overall}]\n")
+
+    return all_pass
+
+
+def generate_all():
+    """Generate and write all golden files."""
+    print("Generating GST boundary golden files via scipy GL recursive integration")
+    print(f"Output directory: {GOLDEN_DIR}\n")
+
+    for filename, spending_name, spending_fn, k, alpha in CONFIGS:
+        boundaries = gst_boundaries_reference(k, alpha, spending_fn)
+
+        golden = {
+            "test_name": filename.replace(".json", ""),
+            "spending_function": spending_name,
+            "planned_looks": k,
+            "overall_alpha": alpha,
+            "source": "scipy_gauss_legendre_201_nodes",
+            "r_command": (
+                f"gsDesign(k={k}, test.type=2, alpha={alpha}, "
+                f"sfu={'sfLDOF' if spending_name == 'OBrienFleming' else 'sfLDPocock'})"
+            ),
+            "boundaries": boundaries,
+        }
+
+        path = GOLDEN_DIR / filename
+        with open(path, "w") as f:
+            json.dump(golden, f, indent=2)
+            f.write("\n")
+
+        crits = [f"{b['critical_value']:.6f}" for b in boundaries]
+        print(f"  {filename}: K={k}, α={alpha}, {spending_name}")
+        print(f"    Boundaries: [{', '.join(crits)}]\n")
+
+
+if __name__ == "__main__":
+    if "--update" in sys.argv:
+        generate_all()
+        print("Golden files updated.")
+    else:
+        ok = compare_with_existing()
+        sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Summary

- Validated all 10 GST boundary golden files against an independent scipy Gauss-Legendre implementation (201 nodes, Armitage-McPherson-Rowe recursive integration) — the same algorithm R's `gsDesign` package uses
- All boundaries match to **13+ decimal places** (max diff 4.35e-13), far exceeding ADR-004's 4 dp requirement
- Added 5 `gst_evaluate` golden tests covering boundary crossing/non-crossing at various looks for both OBF and Pocock spending functions
- Added `scripts/generate_gst_golden.py` — reproducible scipy reference implementation for re-validation

### Validation matrix

| Config | K | α | Spending | Max diff | Status |
|--------|---|---|----------|----------|--------|
| `gst_obf_2_looks` | 2 | 0.05 | OBF | 2.06e-13 | PASS |
| `gst_obf_3_looks_alpha01` | 3 | 0.01 | OBF | 1.43e-13 | PASS |
| `gst_obf_4_looks` | 4 | 0.05 | OBF | 3.51e-13 | PASS |
| `gst_obf_5_looks_alpha10` | 5 | 0.10 | OBF | 3.00e-13 | PASS |
| `gst_obf_6_looks` | 6 | 0.05 | OBF | 4.35e-13 | PASS |
| `gst_pocock_2_looks` | 2 | 0.05 | Pocock | 2.31e-13 | PASS |
| `gst_pocock_3_looks` | 3 | 0.05 | Pocock | 3.30e-13 | PASS |
| `gst_pocock_4_looks` | 4 | 0.05 | Pocock | 3.83e-13 | PASS |
| `gst_pocock_5_looks_alpha10` | 5 | 0.10 | Pocock | 4.18e-13 | PASS |
| `gst_pocock_6_looks` | 6 | 0.05 | Pocock | 2.66e-13 | PASS |

### New evaluate tests

| Test | Z | Look | Spending | Boundary crossed |
|------|---|------|----------|-----------------|
| `obf_4_look1_no_cross` | 2.0 | 1/4 | OBF | No (z < 3.92) |
| `obf_4_look1_cross` | 4.5 | 1/4 | OBF | Yes (rare early stop) |
| `obf_4_look4_cross` | 3.0 | 4/4 | OBF | Yes (z > 2.04) |
| `pocock_3_look2_cross` | 2.5 | 2/3 | Pocock | Yes (z > 2.29) |
| `pocock_3_look3_no_cross` | 1.5 | 3/3 | Pocock | No (z < 2.30) |

## What this unblocks

- GST boundary validation milestone complete — production-ready sequential testing

## Test plan

- [x] `cargo test -p experimentation-stats --test sequential_golden` — 23/23 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass
- [x] `python3 scripts/generate_gst_golden.py` — all 10 configs PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)