### PR TITLE
feat(m1): SDK LocalProvider hash-based variant assignment

### DIFF
--- a/sdks/server-go/experimentation.go
+++ b/sdks/server-go/experimentation.go
@@ -138,14 +138,40 @@ func (p *LocalProvider) GetAssignment(_ context.Context, experimentID string, at
 	if !ok {
 		return nil, nil
 	}
+	if len(config.Variants) == 0 {
+		return nil, nil
+	}
 
-	// TODO (Agent-1): Use CGo binding to experimentation_bucket() from experimentation-ffi
-	//   1. bucket = experimentation_bucket(attrs.UserID, config.HashSalt, config.TotalBuckets)
-	//   2. if bucket < config.AllocationStart || bucket > config.AllocationEnd → nil
-	//   3. Map bucket to variant by cumulative traffic fractions
-	_ = config
-	_ = attrs
-	return nil, nil
+	bucket := computeBucket(attrs.UserID, config.HashSalt, uint32(config.TotalBuckets))
+
+	if !isInAllocation(bucket, uint32(config.AllocationStart), uint32(config.AllocationEnd)) {
+		return nil, nil
+	}
+
+	allocSize := float64(config.AllocationEnd - config.AllocationStart + 1)
+	relativeBucket := float64(bucket - uint32(config.AllocationStart))
+
+	cumulative := 0.0
+	for _, v := range config.Variants {
+		cumulative += v.TrafficFraction * allocSize
+		if relativeBucket < cumulative {
+			return &Assignment{
+				ExperimentID: config.ExperimentID,
+				VariantName:  v.Name,
+				Payload:      v.Payload,
+				FromCache:    true,
+			}, nil
+		}
+	}
+
+	// FP rounding fallback — assign to last variant
+	last := config.Variants[len(config.Variants)-1]
+	return &Assignment{
+		ExperimentID: config.ExperimentID,
+		VariantName:  last.Name,
+		Payload:      last.Payload,
+		FromCache:    true,
+	}, nil
 }
 
 func (p *LocalProvider) GetAllAssignments(ctx context.Context, attrs UserAttributes) (map[string]*Assignment, error) {

--- a/sdks/server-go/experimentation_test.go
+++ b/sdks/server-go/experimentation_test.go
@@ -1,0 +1,266 @@
+package experimentation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// MurmurHash3 parity tests
+// ---------------------------------------------------------------------------
+
+func TestMurmurhash3KnownValues(t *testing.T) {
+	tests := []struct {
+		data     string
+		seed     uint32
+		expected uint32
+	}{
+		{"", 0, 0},
+		{"hello", 0, 0x248bfa47},
+		{"hello", 1, 0xbb4abcad},
+	}
+	for _, tt := range tests {
+		got := Murmurhash3X86_32([]byte(tt.data), tt.seed)
+		if got != tt.expected {
+			t.Errorf("Murmurhash3X86_32(%q, %d) = 0x%08x, want 0x%08x", tt.data, tt.seed, got, tt.expected)
+		}
+	}
+}
+
+func TestMurmurhash3Deterministic(t *testing.T) {
+	h1 := Murmurhash3X86_32([]byte("test_input"), 42)
+	h2 := Murmurhash3X86_32([]byte("test_input"), 42)
+	if h1 != h2 {
+		t.Errorf("non-deterministic: got %d and %d", h1, h2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bucket parity with test vectors (from test-vectors/hash_vectors.json)
+// ---------------------------------------------------------------------------
+
+func TestBucketParity(t *testing.T) {
+	vectors := []struct {
+		userID         string
+		salt           string
+		totalBuckets   uint32
+		expectedBucket uint32
+	}{
+		{"user_000000", "experiment_default_salt", 10000, 3913},
+		{"user_000001", "experiment_default_salt", 10000, 4234},
+		{"user_000002", "experiment_default_salt", 10000, 5578},
+		{"user_000003", "experiment_default_salt", 10000, 8009},
+		{"user_000004", "experiment_default_salt", 10000, 2419},
+		{"user_000005", "experiment_default_salt", 10000, 5885},
+		{"user_000006", "experiment_default_salt", 10000, 5586},
+		{"user_000007", "experiment_default_salt", 10000, 9853},
+		{"user_000008", "experiment_default_salt", 10000, 2730},
+		{"user_000009", "experiment_default_salt", 10000, 27},
+	}
+	for _, v := range vectors {
+		got := computeBucket(v.userID, v.salt, v.totalBuckets)
+		if got != v.expectedBucket {
+			t.Errorf("computeBucket(%q, %q, %d) = %d, want %d",
+				v.userID, v.salt, v.totalBuckets, got, v.expectedBucket)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LocalProvider tests
+// ---------------------------------------------------------------------------
+
+var twoVariantConfig = ExperimentConfig{
+	ExperimentID:    "exp_ab_test",
+	HashSalt:        "salt_ab",
+	LayerName:       "default",
+	AllocationStart: 0,
+	AllocationEnd:   9999,
+	TotalBuckets:    10000,
+	Variants: []VariantConfig{
+		{Name: "control", TrafficFraction: 0.5, IsControl: true, Payload: map[string]any{"color": "blue"}},
+		{Name: "treatment", TrafficFraction: 0.5, IsControl: false, Payload: map[string]any{"color": "red"}},
+	},
+}
+
+var threeVariantConfig = ExperimentConfig{
+	ExperimentID:    "exp_abc",
+	HashSalt:        "salt_abc",
+	LayerName:       "default",
+	AllocationStart: 0,
+	AllocationEnd:   9999,
+	TotalBuckets:    10000,
+	Variants: []VariantConfig{
+		{Name: "control", TrafficFraction: 0.34, IsControl: true},
+		{Name: "variant_a", TrafficFraction: 0.33, IsControl: false},
+		{Name: "variant_b", TrafficFraction: 0.33, IsControl: false},
+	},
+}
+
+func TestLocalProviderUnknownExperiment(t *testing.T) {
+	p := NewLocalProvider([]ExperimentConfig{twoVariantConfig})
+	a, err := p.GetAssignment(context.Background(), "nonexistent", UserAttributes{UserID: "user1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != nil {
+		t.Error("expected nil for unknown experiment")
+	}
+}
+
+func TestLocalProviderDeterministic(t *testing.T) {
+	p := NewLocalProvider([]ExperimentConfig{twoVariantConfig})
+	ctx := context.Background()
+	attrs := UserAttributes{UserID: "user_stable_123"}
+
+	a1, err := p.GetAssignment(ctx, "exp_ab_test", attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a2, err := p.GetAssignment(ctx, "exp_ab_test", attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a1 == nil || a2 == nil {
+		t.Fatal("expected non-nil assignment")
+	}
+	if a1.VariantName != a2.VariantName {
+		t.Errorf("non-deterministic: got %q and %q", a1.VariantName, a2.VariantName)
+	}
+}
+
+func TestLocalProviderFromCache(t *testing.T) {
+	p := NewLocalProvider([]ExperimentConfig{twoVariantConfig})
+	a, err := p.GetAssignment(context.Background(), "exp_ab_test", UserAttributes{UserID: "user1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == nil {
+		t.Fatal("expected non-nil")
+	}
+	if !a.FromCache {
+		t.Error("expected FromCache=true")
+	}
+}
+
+func TestLocalProviderExclusion(t *testing.T) {
+	narrow := ExperimentConfig{
+		ExperimentID:    "exp_narrow",
+		HashSalt:        "salt_ab",
+		LayerName:       "default",
+		AllocationStart: 0,
+		AllocationEnd:   0, // only bucket 0
+		TotalBuckets:    10000,
+		Variants:        twoVariantConfig.Variants,
+	}
+	p := NewLocalProvider([]ExperimentConfig{narrow})
+	ctx := context.Background()
+
+	nullCount := 0
+	for i := 0; i < 50; i++ {
+		a, err := p.GetAssignment(ctx, "exp_narrow", UserAttributes{UserID: fmt.Sprintf("exclude_test_%d", i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a == nil {
+			nullCount++
+		}
+	}
+	if nullCount < 40 {
+		t.Errorf("expected most users excluded, got %d/50 nil", nullCount)
+	}
+}
+
+func TestLocalProviderDistribution(t *testing.T) {
+	p := NewLocalProvider([]ExperimentConfig{twoVariantConfig})
+	ctx := context.Background()
+	counts := map[string]int{"control": 0, "treatment": 0}
+
+	for i := 0; i < 1000; i++ {
+		a, err := p.GetAssignment(ctx, "exp_ab_test", UserAttributes{UserID: fmt.Sprintf("dist_user_%d", i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a != nil {
+			counts[a.VariantName]++
+		}
+	}
+
+	if counts["control"] < 350 {
+		t.Errorf("control count too low: %d", counts["control"])
+	}
+	if counts["treatment"] < 350 {
+		t.Errorf("treatment count too low: %d", counts["treatment"])
+	}
+}
+
+func TestLocalProviderThreeVariants(t *testing.T) {
+	p := NewLocalProvider([]ExperimentConfig{threeVariantConfig})
+	ctx := context.Background()
+	variants := make(map[string]bool)
+
+	for i := 0; i < 500; i++ {
+		a, err := p.GetAssignment(ctx, "exp_abc", UserAttributes{UserID: fmt.Sprintf("three_var_%d", i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a != nil {
+			variants[a.VariantName] = true
+		}
+	}
+
+	if len(variants) != 3 {
+		t.Errorf("expected 3 variants, got %d: %v", len(variants), variants)
+	}
+}
+
+func TestLocalProviderFPRoundingFallback(t *testing.T) {
+	fpConfig := ExperimentConfig{
+		ExperimentID:    "exp_fp",
+		HashSalt:        "salt_fp",
+		LayerName:       "default",
+		AllocationStart: 0,
+		AllocationEnd:   9999,
+		TotalBuckets:    10000,
+		Variants: []VariantConfig{
+			{Name: "a", TrafficFraction: 0.333, IsControl: true},
+			{Name: "b", TrafficFraction: 0.333, IsControl: false},
+			{Name: "c", TrafficFraction: 0.334, IsControl: false},
+		},
+	}
+	p := NewLocalProvider([]ExperimentConfig{fpConfig})
+	ctx := context.Background()
+
+	valid := map[string]bool{"a": true, "b": true, "c": true}
+	for i := 0; i < 100; i++ {
+		a, err := p.GetAssignment(ctx, "exp_fp", UserAttributes{UserID: fmt.Sprintf("fp_user_%d", i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a == nil {
+			t.Fatalf("expected non-nil for fp_user_%d", i)
+		}
+		if !valid[a.VariantName] {
+			t.Errorf("unexpected variant %q", a.VariantName)
+		}
+	}
+}
+
+func TestLocalProviderGetAllAssignments(t *testing.T) {
+	p := NewLocalProvider([]ExperimentConfig{twoVariantConfig, threeVariantConfig})
+	ctx := context.Background()
+	results, err := p.GetAllAssignments(ctx, UserAttributes{UserID: "multi_user_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 assignments, got %d", len(results))
+	}
+	if _, ok := results["exp_ab_test"]; !ok {
+		t.Error("missing exp_ab_test")
+	}
+	if _, ok := results["exp_abc"]; !ok {
+		t.Error("missing exp_abc")
+	}
+}

--- a/sdks/server-go/hash_cgo.go
+++ b/sdks/server-go/hash_cgo.go
@@ -1,0 +1,44 @@
+//go:build cgo && has_ffi
+
+package experimentation
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../crates/experimentation-ffi/target
+#cgo LDFLAGS: -L${SRCDIR}/../../target/release -L${SRCDIR}/../../target/debug -lexperimentation_ffi
+#include "experimentation_ffi.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// computeBucket uses the Rust FFI library for deterministic hashing.
+func computeBucket(userID, salt string, totalBuckets uint32) uint32 {
+	if totalBuckets == 0 {
+		panic("totalBuckets must be > 0")
+	}
+
+	cUserID := C.CString(userID)
+	cSalt := C.CString(salt)
+	defer C.free(unsafe.Pointer(cUserID))
+	defer C.free(unsafe.Pointer(cSalt))
+
+	result := C.experimentation_bucket(cUserID, cSalt, C.uint32_t(totalBuckets))
+	if uint32(result) == C.EXPERIMENTATION_BUCKET_ERROR {
+		panic(fmt.Sprintf("experimentation_bucket returned error for user_id=%q salt=%q total_buckets=%d",
+			userID, salt, totalBuckets))
+	}
+
+	return uint32(result)
+}
+
+// isInAllocation checks allocation membership via the Rust FFI library.
+func isInAllocation(bucket, start, end uint32) bool {
+	return C.experimentation_is_in_allocation(
+		C.uint32_t(bucket),
+		C.uint32_t(start),
+		C.uint32_t(end),
+	) == 1
+}

--- a/sdks/server-go/hash_pure.go
+++ b/sdks/server-go/hash_pure.go
@@ -1,0 +1,21 @@
+//go:build !cgo || !has_ffi
+
+package experimentation
+
+import "fmt"
+
+// computeBucket uses the pure Go MurmurHash3 implementation when CGo/FFI is unavailable.
+func computeBucket(userID, salt string, totalBuckets uint32) uint32 {
+	if totalBuckets == 0 {
+		panic("totalBuckets must be > 0")
+	}
+
+	key := fmt.Sprintf("%s\x00%s", userID, salt)
+	hash := Murmurhash3X86_32([]byte(key), 0)
+	return hash % totalBuckets
+}
+
+// isInAllocation checks if a bucket is within [start, end] (inclusive).
+func isInAllocation(bucket, start, end uint32) bool {
+	return bucket >= start && bucket <= end
+}

--- a/sdks/server-go/murmur3.go
+++ b/sdks/server-go/murmur3.go
@@ -1,0 +1,67 @@
+package experimentation
+
+// Pure Go MurmurHash3 x86 32-bit implementation.
+// Reference: crates/experimentation-hash/src/murmur3.rs
+// Must produce identical output for all inputs.
+
+const (
+	c1 = 0xcc9e2d51
+	c2 = 0x1b873593
+)
+
+// Murmurhash3X86_32 computes a MurmurHash3 x86 32-bit hash, little-endian.
+func Murmurhash3X86_32(data []byte, seed uint32) uint32 {
+	length := len(data)
+	nBlocks := length / 4
+	h1 := seed
+
+	// Body: process 4-byte blocks (little-endian)
+	for i := 0; i < nBlocks; i++ {
+		off := i * 4
+		k1 := uint32(data[off]) |
+			uint32(data[off+1])<<8 |
+			uint32(data[off+2])<<16 |
+			uint32(data[off+3])<<24
+
+		k1 *= c1
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2
+
+		h1 ^= k1
+		h1 = (h1 << 13) | (h1 >> 19) // rotl32(h1, 13)
+		h1 = h1*5 + 0xe6546b64
+	}
+
+	// Tail: remaining bytes
+	tail := data[nBlocks*4:]
+	var k1 uint32
+	switch len(tail) {
+	case 3:
+		k1 ^= uint32(tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint32(tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint32(tail[0])
+		k1 *= c1
+		k1 = (k1 << 15) | (k1 >> 17)
+		k1 *= c2
+		h1 ^= k1
+	}
+
+	// Finalization
+	h1 ^= uint32(length)
+	h1 = fmix32(h1)
+
+	return h1
+}
+
+func fmix32(h uint32) uint32 {
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+}

--- a/sdks/server-python/experimentation/__init__.py
+++ b/sdks/server-python/experimentation/__init__.py
@@ -21,6 +21,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+import mmh3
+
 
 # ---------------------------------------------------------------------------
 # Core Types
@@ -149,12 +151,38 @@ class LocalProvider(AssignmentProvider):
         config = self._experiments.get(experiment_id)
         if config is None:
             return None
+        if not config.variants:
+            return None
 
-        # TODO (Agent-1): Use Python MurmurHash3 binding (or WASM via wasmtime)
-        #   1. bucket = murmur3(f"{attrs.user_id}:{config.hash_salt}") % config.total_buckets
-        #   2. if bucket < config.allocation_start or bucket > config.allocation_end → None
-        #   3. Map bucket to variant by cumulative traffic fractions
-        return None
+        key = f"{attrs.user_id}\x00{config.hash_salt}"
+        raw_hash: int = mmh3.hash(key, seed=0, signed=False)
+        bucket = raw_hash % config.total_buckets
+
+        if bucket < config.allocation_start or bucket > config.allocation_end:
+            return None
+
+        alloc_size = float(config.allocation_end - config.allocation_start + 1)
+        relative_bucket = float(bucket - config.allocation_start)
+
+        cumulative = 0.0
+        for variant in config.variants:
+            cumulative += variant.traffic_fraction * alloc_size
+            if relative_bucket < cumulative:
+                return Assignment(
+                    experiment_id=config.experiment_id,
+                    variant_name=variant.name,
+                    payload=variant.payload,
+                    from_cache=True,
+                )
+
+        # FP rounding fallback — assign to last variant
+        last = config.variants[-1]
+        return Assignment(
+            experiment_id=config.experiment_id,
+            variant_name=last.name,
+            payload=last.payload,
+            from_cache=True,
+        )
 
     async def get_all_assignments(
         self, attrs: UserAttributes

--- a/sdks/server-python/pyproject.toml
+++ b/sdks/server-python/pyproject.toml
@@ -9,6 +9,7 @@ description = "Experimentation Platform — Python Server SDK with provider abst
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.27.0",
+    "mmh3>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/sdks/server-python/src/experimentation/providers.py
+++ b/sdks/server-python/src/experimentation/providers.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import abc
 from typing import Any
 
+import mmh3
+
 from experimentation.types import Assignment, ExperimentConfig, UserAttributes
 
 
@@ -90,14 +92,38 @@ class LocalProvider(AssignmentProvider):
         config = self._experiments.get(experiment_id)
         if config is None:
             return None
+        if not config.variants:
+            return None
 
-        # TODO (Agent-1): Implement MurmurHash3 bucket assignment
-        #   Use the Python FFI binding or pure-Python reference:
-        #     1. bucket = murmur3(f"{attrs.user_id}:{config.hash_salt}") % config.total_buckets
-        #     2. if bucket < config.allocation_start or bucket > config.allocation_end → None
-        #     3. Map bucket to variant by cumulative traffic fractions
-        _ = attrs
-        return None
+        key = f"{attrs.user_id}\x00{config.hash_salt}"
+        raw_hash = mmh3.hash(key, seed=0, signed=False)
+        bucket = raw_hash % config.total_buckets
+
+        if bucket < config.allocation_start or bucket > config.allocation_end:
+            return None
+
+        alloc_size = float(config.allocation_end - config.allocation_start + 1)
+        relative_bucket = float(bucket - config.allocation_start)
+
+        cumulative = 0.0
+        for variant in config.variants:
+            cumulative += variant.traffic_fraction * alloc_size
+            if relative_bucket < cumulative:
+                return Assignment(
+                    experiment_id=config.experiment_id,
+                    variant_name=variant.name,
+                    payload=variant.payload,
+                    from_cache=True,
+                )
+
+        # FP rounding fallback — assign to last variant
+        last = config.variants[-1]
+        return Assignment(
+            experiment_id=config.experiment_id,
+            variant_name=last.name,
+            payload=last.payload,
+            from_cache=True,
+        )
 
     async def get_all_assignments(
         self, attrs: UserAttributes

--- a/sdks/server-python/tests/test_local_provider.py
+++ b/sdks/server-python/tests/test_local_provider.py
@@ -1,0 +1,197 @@
+"""Tests for LocalProvider hash-based variant assignment."""
+
+import pytest
+
+from experimentation import (
+    Assignment,
+    ExperimentConfig,
+    LocalProvider,
+    UserAttributes,
+    VariantConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hash parity with test vectors (from test-vectors/hash_vectors.json)
+# ---------------------------------------------------------------------------
+
+
+def _compute_bucket(user_id: str, salt: str, total_buckets: int) -> int:
+    import mmh3
+
+    key = f"{user_id}\x00{salt}"
+    raw_hash = mmh3.hash(key, seed=0, signed=False)
+    return raw_hash % total_buckets
+
+
+PARITY_VECTORS = [
+    ("user_000000", "experiment_default_salt", 10000, 3913),
+    ("user_000001", "experiment_default_salt", 10000, 4234),
+    ("user_000002", "experiment_default_salt", 10000, 5578),
+    ("user_000003", "experiment_default_salt", 10000, 8009),
+    ("user_000004", "experiment_default_salt", 10000, 2419),
+    ("user_000005", "experiment_default_salt", 10000, 5885),
+    ("user_000006", "experiment_default_salt", 10000, 5586),
+    ("user_000007", "experiment_default_salt", 10000, 9853),
+    ("user_000008", "experiment_default_salt", 10000, 2730),
+    ("user_000009", "experiment_default_salt", 10000, 27),
+]
+
+
+@pytest.mark.parametrize("user_id,salt,total_buckets,expected", PARITY_VECTORS)
+def test_bucket_parity(user_id: str, salt: str, total_buckets: int, expected: int) -> None:
+    assert _compute_bucket(user_id, salt, total_buckets) == expected
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TWO_VARIANT_CONFIG = ExperimentConfig(
+    experiment_id="exp_ab_test",
+    hash_salt="salt_ab",
+    layer_name="default",
+    variants=[
+        VariantConfig(name="control", traffic_fraction=0.5, is_control=True, payload={"color": "blue"}),
+        VariantConfig(name="treatment", traffic_fraction=0.5, is_control=False, payload={"color": "red"}),
+    ],
+    allocation_start=0,
+    allocation_end=9999,
+    total_buckets=10000,
+)
+
+THREE_VARIANT_CONFIG = ExperimentConfig(
+    experiment_id="exp_abc",
+    hash_salt="salt_abc",
+    layer_name="default",
+    variants=[
+        VariantConfig(name="control", traffic_fraction=0.34, is_control=True),
+        VariantConfig(name="variant_a", traffic_fraction=0.33),
+        VariantConfig(name="variant_b", traffic_fraction=0.33),
+    ],
+    allocation_start=0,
+    allocation_end=9999,
+    total_buckets=10000,
+)
+
+
+# ---------------------------------------------------------------------------
+# LocalProvider tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_experiment() -> None:
+    provider = LocalProvider([TWO_VARIANT_CONFIG])
+    result = await provider.get_assignment("nonexistent", UserAttributes(user_id="user1"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_deterministic() -> None:
+    provider = LocalProvider([TWO_VARIANT_CONFIG])
+    attrs = UserAttributes(user_id="user_stable_123")
+    a1 = await provider.get_assignment("exp_ab_test", attrs)
+    a2 = await provider.get_assignment("exp_ab_test", attrs)
+    assert a1 is not None
+    assert a2 is not None
+    assert a1.variant_name == a2.variant_name
+
+
+@pytest.mark.asyncio
+async def test_from_cache() -> None:
+    provider = LocalProvider([TWO_VARIANT_CONFIG])
+    result = await provider.get_assignment("exp_ab_test", UserAttributes(user_id="user1"))
+    assert result is not None
+    assert result.from_cache is True
+
+
+@pytest.mark.asyncio
+async def test_payload() -> None:
+    provider = LocalProvider([TWO_VARIANT_CONFIG])
+    result = await provider.get_assignment("exp_ab_test", UserAttributes(user_id="user1"))
+    assert result is not None
+    assert result.payload is not None
+
+
+@pytest.mark.asyncio
+async def test_exclusion() -> None:
+    narrow = ExperimentConfig(
+        experiment_id="exp_narrow",
+        hash_salt="salt_ab",
+        layer_name="default",
+        variants=TWO_VARIANT_CONFIG.variants,
+        allocation_start=0,
+        allocation_end=0,  # only bucket 0
+        total_buckets=10000,
+    )
+    provider = LocalProvider([narrow])
+    null_count = 0
+    for i in range(50):
+        result = await provider.get_assignment(
+            "exp_narrow", UserAttributes(user_id=f"exclude_test_{i}")
+        )
+        if result is None:
+            null_count += 1
+    assert null_count > 40
+
+
+@pytest.mark.asyncio
+async def test_distribution() -> None:
+    provider = LocalProvider([TWO_VARIANT_CONFIG])
+    counts: dict[str, int] = {"control": 0, "treatment": 0}
+    for i in range(1000):
+        result = await provider.get_assignment(
+            "exp_ab_test", UserAttributes(user_id=f"dist_user_{i}")
+        )
+        if result is not None:
+            counts[result.variant_name] += 1
+    assert counts["control"] > 350
+    assert counts["treatment"] > 350
+
+
+@pytest.mark.asyncio
+async def test_three_variants() -> None:
+    provider = LocalProvider([THREE_VARIANT_CONFIG])
+    variants: set[str] = set()
+    for i in range(500):
+        result = await provider.get_assignment(
+            "exp_abc", UserAttributes(user_id=f"three_var_{i}")
+        )
+        if result is not None:
+            variants.add(result.variant_name)
+    assert len(variants) == 3
+
+
+@pytest.mark.asyncio
+async def test_fp_rounding_fallback() -> None:
+    fp_config = ExperimentConfig(
+        experiment_id="exp_fp",
+        hash_salt="salt_fp",
+        layer_name="default",
+        variants=[
+            VariantConfig(name="a", traffic_fraction=0.333, is_control=True),
+            VariantConfig(name="b", traffic_fraction=0.333),
+            VariantConfig(name="c", traffic_fraction=0.334),
+        ],
+        allocation_start=0,
+        allocation_end=9999,
+        total_buckets=10000,
+    )
+    provider = LocalProvider([fp_config])
+    valid = {"a", "b", "c"}
+    for i in range(100):
+        result = await provider.get_assignment(
+            "exp_fp", UserAttributes(user_id=f"fp_user_{i}")
+        )
+        assert result is not None
+        assert result.variant_name in valid
+
+
+@pytest.mark.asyncio
+async def test_get_all_assignments() -> None:
+    provider = LocalProvider([TWO_VARIANT_CONFIG, THREE_VARIANT_CONFIG])
+    results = await provider.get_all_assignments(UserAttributes(user_id="multi_user_1"))
+    assert len(results) == 2
+    assert "exp_ab_test" in results
+    assert "exp_abc" in results

--- a/sdks/web/src/index.test.ts
+++ b/sdks/web/src/index.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { murmurhash3_x86_32 } from './murmur3';
+import {
+  LocalProvider,
+  type ExperimentConfig,
+  type UserAttributes,
+} from './index';
+
+// ---------------------------------------------------------------------------
+// MurmurHash3 parity tests (from test-vectors/hash_vectors.json)
+// ---------------------------------------------------------------------------
+
+describe('murmurhash3_x86_32', () => {
+  const encoder = new TextEncoder();
+
+  it('empty string with seed 0 returns 0', () => {
+    expect(murmurhash3_x86_32(new Uint8Array(0), 0)).toBe(0);
+  });
+
+  it('known value: "hello" seed=0', () => {
+    expect(murmurhash3_x86_32(encoder.encode('hello'), 0)).toBe(0x248bfa47);
+  });
+
+  it('known value: "hello" seed=1', () => {
+    expect(murmurhash3_x86_32(encoder.encode('hello'), 1)).toBe(0xbb4abcad);
+  });
+
+  it('is deterministic', () => {
+    const data = encoder.encode('test_input');
+    const h1 = murmurhash3_x86_32(data, 42);
+    const h2 = murmurhash3_x86_32(data, 42);
+    expect(h1).toBe(h2);
+  });
+});
+
+// Bucket helper matching Rust: bucket = hash(userId + "\x00" + salt, seed=0) % totalBuckets
+function computeBucket(userId: string, salt: string, totalBuckets: number): number {
+  const encoder = new TextEncoder();
+  const key = encoder.encode(`${userId}\x00${salt}`);
+  const hash = murmurhash3_x86_32(key, 0);
+  return hash % totalBuckets;
+}
+
+describe('bucket parity with test vectors', () => {
+  // First 10 entries from test-vectors/hash_vectors.json
+  const vectors = [
+    { user_id: 'user_000000', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 3913 },
+    { user_id: 'user_000001', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 4234 },
+    { user_id: 'user_000002', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 5578 },
+    { user_id: 'user_000003', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 8009 },
+    { user_id: 'user_000004', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 2419 },
+    { user_id: 'user_000005', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 5885 },
+    { user_id: 'user_000006', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 5586 },
+    { user_id: 'user_000007', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 9853 },
+    { user_id: 'user_000008', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 2730 },
+    { user_id: 'user_000009', salt: 'experiment_default_salt', total_buckets: 10000, expected_bucket: 27 },
+  ];
+
+  for (const v of vectors) {
+    it(`${v.user_id} → bucket ${v.expected_bucket}`, () => {
+      const bucket = computeBucket(v.user_id, v.salt, v.total_buckets);
+      expect(bucket).toBe(v.expected_bucket);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// LocalProvider tests
+// ---------------------------------------------------------------------------
+
+const twoVariantConfig: ExperimentConfig = {
+  experimentId: 'exp_ab_test',
+  hashSalt: 'salt_ab',
+  layerName: 'default',
+  variants: [
+    { name: 'control', trafficFraction: 0.5, isControl: true, payload: { color: 'blue' } },
+    { name: 'treatment', trafficFraction: 0.5, isControl: false, payload: { color: 'red' } },
+  ],
+  allocationStart: 0,
+  allocationEnd: 9999,
+  totalBuckets: 10000,
+};
+
+const threeVariantConfig: ExperimentConfig = {
+  experimentId: 'exp_abc',
+  hashSalt: 'salt_abc',
+  layerName: 'default',
+  variants: [
+    { name: 'control', trafficFraction: 0.34, isControl: true, payload: {} },
+    { name: 'variant_a', trafficFraction: 0.33, isControl: false, payload: {} },
+    { name: 'variant_b', trafficFraction: 0.33, isControl: false, payload: {} },
+  ],
+  allocationStart: 0,
+  allocationEnd: 9999,
+  totalBuckets: 10000,
+};
+
+describe('LocalProvider.getAssignment', () => {
+  it('returns null for unknown experiment', async () => {
+    const provider = new LocalProvider({ experiments: [twoVariantConfig] });
+    const result = await provider.getAssignment('nonexistent', { userId: 'user1' });
+    expect(result).toBeNull();
+  });
+
+  it('is deterministic — same user gets same variant', async () => {
+    const provider = new LocalProvider({ experiments: [twoVariantConfig] });
+    const attrs: UserAttributes = { userId: 'user_stable_123' };
+    const a1 = await provider.getAssignment('exp_ab_test', attrs);
+    const a2 = await provider.getAssignment('exp_ab_test', attrs);
+    expect(a1).not.toBeNull();
+    expect(a1!.variantName).toBe(a2!.variantName);
+  });
+
+  it('returns fromCache: true', async () => {
+    const provider = new LocalProvider({ experiments: [twoVariantConfig] });
+    const result = await provider.getAssignment('exp_ab_test', { userId: 'user1' });
+    expect(result).not.toBeNull();
+    expect(result!.fromCache).toBe(true);
+  });
+
+  it('returns payload from config', async () => {
+    const provider = new LocalProvider({ experiments: [twoVariantConfig] });
+    const result = await provider.getAssignment('exp_ab_test', { userId: 'user1' });
+    expect(result).not.toBeNull();
+    expect(result!.payload).toBeDefined();
+  });
+
+  it('excludes user outside allocation range', async () => {
+    const narrowConfig: ExperimentConfig = {
+      ...twoVariantConfig,
+      experimentId: 'exp_narrow',
+      allocationStart: 0,
+      allocationEnd: 0, // only bucket 0
+    };
+    const provider = new LocalProvider({ experiments: [narrowConfig] });
+
+    // Most users should land outside bucket 0
+    let nullCount = 0;
+    for (let i = 0; i < 50; i++) {
+      const result = await provider.getAssignment('exp_narrow', { userId: `exclude_test_${i}` });
+      if (result === null) nullCount++;
+    }
+    expect(nullCount).toBeGreaterThan(40);
+  });
+
+  it('distributes users across variants by traffic fraction', async () => {
+    const provider = new LocalProvider({ experiments: [twoVariantConfig] });
+    const counts: Record<string, number> = { control: 0, treatment: 0 };
+
+    for (let i = 0; i < 1000; i++) {
+      const result = await provider.getAssignment('exp_ab_test', { userId: `dist_user_${i}` });
+      if (result) counts[result.variantName]++;
+    }
+
+    // With 50/50 split over 1000 users, expect roughly even distribution
+    expect(counts.control).toBeGreaterThan(350);
+    expect(counts.treatment).toBeGreaterThan(350);
+  });
+
+  it('handles three-variant experiments', async () => {
+    const provider = new LocalProvider({ experiments: [threeVariantConfig] });
+    const variants = new Set<string>();
+
+    for (let i = 0; i < 500; i++) {
+      const result = await provider.getAssignment('exp_abc', { userId: `three_var_${i}` });
+      if (result) variants.add(result.variantName);
+    }
+
+    expect(variants.size).toBe(3);
+  });
+
+  it('FP rounding fallback assigns last variant', async () => {
+    // Config where fractions don't perfectly sum to 1.0
+    const fpConfig: ExperimentConfig = {
+      experimentId: 'exp_fp',
+      hashSalt: 'salt_fp',
+      layerName: 'default',
+      variants: [
+        { name: 'a', trafficFraction: 0.333, isControl: true, payload: {} },
+        { name: 'b', trafficFraction: 0.333, isControl: false, payload: {} },
+        { name: 'c', trafficFraction: 0.334, isControl: false, payload: {} },
+      ],
+      allocationStart: 0,
+      allocationEnd: 9999,
+      totalBuckets: 10000,
+    };
+    const provider = new LocalProvider({ experiments: [fpConfig] });
+
+    // All users should be assigned to one of the variants
+    for (let i = 0; i < 100; i++) {
+      const result = await provider.getAssignment('exp_fp', { userId: `fp_user_${i}` });
+      expect(result).not.toBeNull();
+      expect(['a', 'b', 'c']).toContain(result!.variantName);
+    }
+  });
+});
+
+describe('LocalProvider.getAllAssignments', () => {
+  it('returns assignments for all matching experiments', async () => {
+    const provider = new LocalProvider({
+      experiments: [twoVariantConfig, threeVariantConfig],
+    });
+    const results = await provider.getAllAssignments({ userId: 'multi_user_1' });
+    expect(results.size).toBe(2);
+    expect(results.has('exp_ab_test')).toBe(true);
+    expect(results.has('exp_abc')).toBe(true);
+  });
+});

--- a/sdks/web/src/index.ts
+++ b/sdks/web/src/index.ts
@@ -17,6 +17,8 @@
  *   const variant = await client.getVariant('homepage_recs_v2');
  */
 
+import { murmurhash3_x86_32 } from './murmur3';
+
 // ---------------------------------------------------------------------------
 // Core Types
 // ---------------------------------------------------------------------------
@@ -131,22 +133,42 @@ export class RemoteProvider implements AssignmentProvider {
 // LocalProvider
 // ---------------------------------------------------------------------------
 
+export interface WasmHashModule {
+  wasm_bucket(userId: string, salt: string, totalBuckets: number): number;
+  wasm_is_in_allocation(bucket: number, start: number, end: number): boolean;
+}
+
 export interface LocalProviderConfig {
   /** Static experiment configs for local evaluation. */
   experiments: ExperimentConfig[];
+  /** Optional WASM hash module. Falls back to pure-TS MurmurHash3 if not provided. */
+  wasmModule?: WasmHashModule;
 }
 
 export class LocalProvider implements AssignmentProvider {
   private experiments: Map<string, ExperimentConfig> = new Map();
+  private wasmModule?: WasmHashModule;
 
   constructor(config: LocalProviderConfig) {
     for (const exp of config.experiments) {
       this.experiments.set(exp.experimentId, exp);
     }
+    this.wasmModule = config.wasmModule;
   }
 
   async initialize(): Promise<void> {
     // No-op for static config
+  }
+
+  private computeBucket(userId: string, salt: string, totalBuckets: number): number {
+    if (this.wasmModule) {
+      return this.wasmModule.wasm_bucket(userId, salt, totalBuckets);
+    }
+    // Pure-TS fallback
+    const encoder = new TextEncoder();
+    const key = encoder.encode(`${userId}\x00${salt}`);
+    const hash = murmurhash3_x86_32(key, 0);
+    return hash % totalBuckets;
   }
 
   async getAssignment(
@@ -155,15 +177,42 @@ export class LocalProvider implements AssignmentProvider {
   ): Promise<Assignment | null> {
     const config = this.experiments.get(experimentId);
     if (!config) return null;
+    if (config.variants.length === 0) return null;
 
-    // TODO (Agent-1): Implement MurmurHash3 bucket assignment in WASM
-    //   1. hash = murmur3(`${attributes.userId}:${config.hashSalt}`)
-    //   2. bucket = hash % config.totalBuckets
-    //   3. if bucket < config.allocationStart || bucket > config.allocationEnd → null
-    //   4. map bucket to variant by cumulative traffic fractions
-    void attributes;
-    void config;
-    return null;
+    const bucket = this.computeBucket(
+      attributes.userId,
+      config.hashSalt,
+      config.totalBuckets,
+    );
+
+    if (bucket < config.allocationStart || bucket > config.allocationEnd) {
+      return null;
+    }
+
+    const allocSize = config.allocationEnd - config.allocationStart + 1;
+    const relativeBucket = bucket - config.allocationStart;
+
+    let cumulative = 0.0;
+    for (const variant of config.variants) {
+      cumulative += variant.trafficFraction * allocSize;
+      if (relativeBucket < cumulative) {
+        return {
+          experimentId: config.experimentId,
+          variantName: variant.name,
+          payload: variant.payload,
+          fromCache: true,
+        };
+      }
+    }
+
+    // FP rounding fallback — assign to last variant
+    const last = config.variants[config.variants.length - 1];
+    return {
+      experimentId: config.experimentId,
+      variantName: last.name,
+      payload: last.payload,
+      fromCache: true,
+    };
   }
 
   async getAllAssignments(

--- a/sdks/web/src/murmur3.ts
+++ b/sdks/web/src/murmur3.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure TypeScript MurmurHash3 x86 32-bit implementation.
+ *
+ * Reference: crates/experimentation-hash/src/murmur3.rs
+ * This must produce identical output for all inputs.
+ */
+
+const C1 = 0xcc9e2d51;
+const C2 = 0x1b873593;
+
+function imul(a: number, b: number): number {
+  return Math.imul(a, b);
+}
+
+function rotl32(x: number, r: number): number {
+  return (x << r) | (x >>> (32 - r));
+}
+
+function fmix32(h: number): number {
+  h ^= h >>> 16;
+  h = imul(h, 0x85ebca6b);
+  h ^= h >>> 13;
+  h = imul(h, 0xc2b2ae35);
+  h ^= h >>> 16;
+  return h >>> 0;
+}
+
+/**
+ * MurmurHash3 x86 32-bit, little-endian.
+ * Matches the Rust reference implementation exactly.
+ */
+export function murmurhash3_x86_32(data: Uint8Array, seed: number): number {
+  const len = data.length;
+  const nBlocks = Math.floor(len / 4);
+  let h1 = seed >>> 0;
+
+  // Body: process 4-byte blocks (little-endian)
+  for (let i = 0; i < nBlocks; i++) {
+    const offset = i * 4;
+    let k1 =
+      data[offset] |
+      (data[offset + 1] << 8) |
+      (data[offset + 2] << 16) |
+      (data[offset + 3] << 24);
+
+    k1 = imul(k1, C1);
+    k1 = rotl32(k1, 15);
+    k1 = imul(k1, C2);
+
+    h1 ^= k1;
+    h1 = rotl32(h1, 13);
+    h1 = (imul(h1, 5) + 0xe6546b64) | 0;
+  }
+
+  // Tail: remaining bytes
+  const tailStart = nBlocks * 4;
+  let k1 = 0;
+  switch (len - tailStart) {
+    case 3:
+      k1 ^= data[tailStart + 2] << 16;
+    // fallthrough
+    case 2:
+      k1 ^= data[tailStart + 1] << 8;
+    // fallthrough
+    case 1:
+      k1 ^= data[tailStart];
+      k1 = imul(k1, C1);
+      k1 = rotl32(k1, 15);
+      k1 = imul(k1, C2);
+      h1 ^= k1;
+  }
+
+  // Finalization
+  h1 ^= len;
+  h1 = fmix32(h1);
+
+  return h1 >>> 0;
+}


### PR DESCRIPTION
## Summary

- Wire deterministic MurmurHash3 bucket assignment into all three SDK `LocalProvider` implementations (Web, Go, Python), completing the offline/local evaluation path per ADR-007
- Each SDK uses identical algorithm to the Rust reference: `bucket = hash(userId + "\x00" + salt, seed=0) % totalBuckets`, with cumulative traffic fraction variant selection and FP rounding fallback
- All three SDKs verified against 10 hardcoded test vectors from `test-vectors/hash_vectors.json`

### Web SDK
- New `sdks/web/src/murmur3.ts` — Pure TypeScript MurmurHash3 x86 32-bit fallback
- `LocalProviderConfig` accepts optional `wasmModule` for WASM hash binding injection
- 23 tests (4 MurmurHash3, 10 parity vectors, 9 LocalProvider)

### Go SDK
- New `sdks/server-go/murmur3.go` — Pure Go MurmurHash3 x86 32-bit
- New `sdks/server-go/hash_pure.go` — Pure Go bridge (default, no build tags)
- New `sdks/server-go/hash_cgo.go` — CGo FFI bridge (`cgo && has_ffi` build tag)
- 11 tests (2 MurmurHash3, 10 parity vectors, 7 LocalProvider)

### Python SDK
- Added `mmh3>=4.0` dependency for unsigned 32-bit MurmurHash3
- Wired both `experimentation/__init__.py` (flat) and `src/experimentation/providers.py` (modular)
- 19 tests (10 parity vectors, 9 LocalProvider)

## Test plan

- [x] `cd sdks/web && npx vitest run` — 23/23 pass
- [x] `cd sdks/server-go && GOWORK=off go test ./...` — 11/11 pass
- [x] `cd sdks/server-python && python3 -m pytest tests/test_local_provider.py` — 19/19 pass
- [x] Cross-SDK hash parity: all 3 SDKs produce identical bucket for same (user_id, salt, total_buckets)
- [x] Rust baseline unchanged: `cargo test -p experimentation-hash` passes
- [ ] CI validates lint + build

🤖 Generated with [Claude Code](https://claude.com/claude-code)