### PR TITLE
feat(m6): experiment creation wizard with type-specific config

### DIFF
--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -106,6 +106,10 @@ export const handlers = [
       sequentialTestConfig: body.sequentialTestConfig,
       targetingRuleId: body.targetingRuleId as string | undefined,
       isCumulativeHoldout: (body.isCumulativeHoldout as boolean) || false,
+      interleavingConfig: body.interleavingConfig,
+      sessionConfig: body.sessionConfig,
+      banditExperimentConfig: body.banditExperimentConfig,
+      qoeConfig: body.qoeConfig,
       createdAt: new Date().toISOString(),
     };
 

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -87,6 +87,10 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
     ],
     guardrailAction: 'AUTO_PAUSE',
     isCumulativeHoldout: false,
+    qoeConfig: {
+      qoeMetrics: ['rebuffer_ratio', 'time_to_first_frame_ms', 'avg_bitrate_kbps', 'startup_failure_rate'],
+      deviceFilter: 'smart_tv',
+    },
     createdAt: '2026-03-01T14:30:00Z',
   },
   {
@@ -119,6 +123,13 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
     guardrailConfigs: [],
     guardrailAction: 'AUTO_PAUSE',
     isCumulativeHoldout: false,
+    interleavingConfig: {
+      method: 'TEAM_DRAFT',
+      algorithmIds: ['bm25_v2', 'semantic_search_v2'],
+      creditAssignment: 'BINARY_WIN',
+      creditMetricEvent: 'click',
+      maxListSize: 20,
+    },
     createdAt: '2026-02-20T09:15:00Z',
     startedAt: '2026-02-21T06:00:00Z',
   },
@@ -172,6 +183,13 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
     ],
     guardrailAction: 'ALERT_ONLY',
     isCumulativeHoldout: false,
+    banditExperimentConfig: {
+      algorithm: 'THOMPSON_SAMPLING',
+      rewardMetricId: 'play_through_rate',
+      contextFeatureKeys: ['content_genre', 'user_tenure_days', 'device_type'],
+      minExplorationFraction: 0.1,
+      warmupObservations: 200,
+    },
     createdAt: '2026-03-02T16:45:00Z',
   },
   // Transitional state experiments for testing StartingChecklist and ConcludingProgress

--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -142,18 +142,18 @@ describe('Accessibility', () => {
   // --- ExperimentForm ---
 
   describe('ExperimentForm', () => {
-    it('all required inputs have aria-required="true"', () => {
+    it('all required inputs on step 1 have aria-required="true"', () => {
       render(
         <AuthProvider initialUser={defaultUser}>
           <ExperimentForm onSubmit={async () => {}} />
         </AuthProvider>,
       );
 
+      // Wizard step 1 (Basics) is shown by default — Primary Metric is on step 4
       expect(screen.getByLabelText(/^Name/)).toHaveAttribute('aria-required', 'true');
       expect(screen.getByLabelText(/Owner Email/)).toHaveAttribute('aria-required', 'true');
       expect(screen.getByLabelText(/Experiment Type/)).toHaveAttribute('aria-required', 'true');
       expect(screen.getByLabelText(/Layer ID/)).toHaveAttribute('aria-required', 'true');
-      expect(screen.getByLabelText(/Primary Metric/)).toHaveAttribute('aria-required', 'true');
     });
   });
 

--- a/ui/src/__tests__/experiment-form.test.tsx
+++ b/ui/src/__tests__/experiment-form.test.tsx
@@ -28,16 +28,39 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+/** Navigate to a specific step by filling and clicking Next. */
+async function navigateToStep(user: ReturnType<typeof userEvent.setup>, targetStep: number) {
+  if (targetStep >= 1) {
+    // Fill basics
+    await user.type(screen.getByLabelText(/Name \*/), 'test_experiment');
+    await user.type(screen.getByLabelText(/Owner Email/), 'test@streamco.com');
+    await user.type(screen.getByLabelText(/Layer ID/), 'layer-test');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+  }
+  if (targetStep >= 2) {
+    // Skip type config (AB = no extra config)
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+  }
+  if (targetStep >= 3) {
+    // Skip variants (defaults valid)
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+  }
+  if (targetStep >= 4) {
+    // Fill metrics
+    await user.type(screen.getByLabelText(/Primary Metric/), 'conversion_rate');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+  }
+}
+
 describe('New Experiment Page', () => {
   it('renders the create experiment form', () => {
     renderNewPage();
 
     expect(screen.getByRole('heading', { name: 'Create Experiment' })).toBeInTheDocument();
-    expect(screen.getByLabelText(/Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Name \*/)).toBeInTheDocument();
     expect(screen.getByLabelText(/Owner Email/)).toBeInTheDocument();
     expect(screen.getByLabelText(/Experiment Type/)).toBeInTheDocument();
     expect(screen.getByLabelText(/Layer ID/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Primary Metric/)).toBeInTheDocument();
   });
 
   it('shows breadcrumb with link to experiments list', () => {
@@ -47,8 +70,11 @@ describe('New Experiment Page', () => {
     expect(experimentsLink.closest('a')).toHaveAttribute('href', '/');
   });
 
-  it('renders default two variants (control + treatment)', () => {
+  it('renders default two variants on variants step', async () => {
+    const user = userEvent.setup();
     renderNewPage();
+
+    await navigateToStep(user, 2);
 
     // Default variants: control and treatment
     const nameInputs = screen.getAllByLabelText(/Variant \d+ name/);
@@ -59,42 +85,38 @@ describe('New Experiment Page', () => {
     const user = userEvent.setup();
     renderNewPage();
 
-    const submitBtn = screen.getByRole('button', { name: 'Create Experiment' });
-    await user.click(submitBtn);
+    await user.click(screen.getByRole('button', { name: 'Next' }));
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Experiment name is required');
+    expect(screen.getByRole('alert')).toHaveTextContent(/name/i);
   });
 
   it('shows validation error for missing owner email', async () => {
     const user = userEvent.setup();
     renderNewPage();
 
-    await user.type(screen.getByLabelText(/Name/), 'test_experiment');
-    await user.click(screen.getByRole('button', { name: 'Create Experiment' }));
+    await user.type(screen.getByLabelText(/Name \*/), 'test_experiment');
+    await user.click(screen.getByRole('button', { name: 'Next' }));
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Owner email is required');
+    expect(screen.getByRole('alert')).toHaveTextContent(/email/i);
   });
 
   it('shows validation error for missing layer ID', async () => {
     const user = userEvent.setup();
     renderNewPage();
 
-    await user.type(screen.getByLabelText(/Name/), 'test_experiment');
+    await user.type(screen.getByLabelText(/Name \*/), 'test_experiment');
     await user.type(screen.getByLabelText(/Owner Email/), 'test@streamco.com');
-    await user.click(screen.getByRole('button', { name: 'Create Experiment' }));
+    await user.click(screen.getByRole('button', { name: 'Next' }));
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Layer ID is required');
+    expect(screen.getByRole('alert')).toHaveTextContent(/layer/i);
   });
 
   it('successfully creates experiment and navigates to detail page', async () => {
     const user = userEvent.setup();
     renderNewPage();
 
-    // Fill required fields
-    await user.type(screen.getByLabelText(/Name/), 'my_new_experiment');
-    await user.type(screen.getByLabelText(/Owner Email/), 'test@streamco.com');
-    await user.type(screen.getByLabelText(/Layer ID/), 'layer-test');
-    await user.type(screen.getByLabelText(/Primary Metric/), 'conversion_rate');
+    // Navigate through all steps to review
+    await navigateToStep(user, 4);
 
     // Submit
     await user.click(screen.getByRole('button', { name: 'Create Experiment' }));
@@ -116,9 +138,11 @@ describe('New Experiment Page', () => {
     expect(typeSelect).toHaveValue('INTERLEAVING');
   });
 
-  it('can add and remove variants', async () => {
+  it('can add and remove variants on variants step', async () => {
     const user = userEvent.setup();
     renderNewPage();
+
+    await navigateToStep(user, 2);
 
     // Start with 2 variants
     expect(screen.getAllByLabelText(/Variant \d+ name/)).toHaveLength(2);
@@ -133,9 +157,11 @@ describe('New Experiment Page', () => {
     expect(screen.getAllByLabelText(/Variant \d+ name/)).toHaveLength(2);
   });
 
-  it('can add and remove guardrails', async () => {
+  it('can add and remove guardrails on metrics step', async () => {
     const user = userEvent.setup();
     renderNewPage();
+
+    await navigateToStep(user, 3);
 
     // Initially no guardrails
     expect(screen.getByText(/No guardrails configured/)).toBeInTheDocument();
@@ -152,9 +178,11 @@ describe('New Experiment Page', () => {
     expect(screen.getByText(/No guardrails configured/)).toBeInTheDocument();
   });
 
-  it('can toggle sequential testing options', async () => {
+  it('can toggle sequential testing options on metrics step', async () => {
     const user = userEvent.setup();
     renderNewPage();
+
+    await navigateToStep(user, 3);
 
     // Sequential testing is off by default
     expect(screen.queryByLabelText(/Method/)).not.toBeInTheDocument();
@@ -166,8 +194,11 @@ describe('New Experiment Page', () => {
     expect(screen.getByLabelText(/Overall Alpha/)).toBeInTheDocument();
   });
 
-  it('shows traffic sum indicator', () => {
+  it('shows traffic sum indicator on variants step', async () => {
+    const user = userEvent.setup();
     renderNewPage();
+
+    await navigateToStep(user, 2);
 
     // Default: 50% + 50% = 100.0%
     expect(screen.getByText('Total traffic: 100.0%')).toBeInTheDocument();

--- a/ui/src/__tests__/experiment-wizard.test.tsx
+++ b/ui/src/__tests__/experiment-wizard.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import NewExperimentPage from '@/app/experiments/new/page';
+import { AuthProvider } from '@/lib/auth-context';
+import type { AuthUser } from '@/lib/auth-context';
+
+const experimenterUser: AuthUser = { email: 'test@streamco.com', role: 'experimenter' };
+
+function renderNewPage(user: AuthUser = experimenterUser) {
+  return render(
+    <AuthProvider initialUser={user}>
+      <NewExperimentPage />
+    </AuthProvider>,
+  );
+}
+
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+/** Helper to fill basics step and advance */
+async function fillBasicsAndAdvance(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/Name \*/), 'my_experiment');
+  await user.type(screen.getByLabelText(/Owner Email/), 'test@streamco.com');
+  await user.type(screen.getByLabelText(/Layer ID/), 'layer-test');
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+}
+
+/** Helper to fill through to review step for AB tests */
+async function fillToReview(user: ReturnType<typeof userEvent.setup>) {
+  // Step 1: Basics
+  await fillBasicsAndAdvance(user);
+  // Step 2: Type Config (AB = no extra config)
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+  // Step 3: Variants (defaults are valid)
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+  // Step 4: Metrics
+  await user.type(screen.getByLabelText(/Primary Metric/), 'click_through_rate');
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+}
+
+describe('Experiment Creation Wizard', () => {
+  it('renders step indicator with 5 steps', () => {
+    renderNewPage();
+    const nav = screen.getByLabelText('Wizard progress');
+    expect(nav).toBeInTheDocument();
+    expect(within(nav).getByText('Basics')).toBeInTheDocument();
+    expect(within(nav).getByText('Review')).toBeInTheDocument();
+  });
+
+  it('shows Step 1 (Basics) by default', () => {
+    renderNewPage();
+    expect(screen.getByLabelText(/Name \*/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Owner Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Experiment Type/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Layer ID/)).toBeInTheDocument();
+  });
+
+  it('validates step 1 before allowing Next', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    // Try to advance without filling fields
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/name/i);
+  });
+
+  it('navigates forward and backward with Next/Back', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    await fillBasicsAndAdvance(user);
+
+    // Should be on Step 2 (Type Config)
+    expect(screen.getByText(/Configuration/)).toBeInTheDocument();
+
+    // Go back
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByLabelText(/Name \*/)).toBeInTheDocument();
+  });
+
+  it('type selection changes step 2 content - INTERLEAVING shows method field', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    // Change type to INTERLEAVING
+    await user.selectOptions(screen.getByLabelText(/Experiment Type/), 'INTERLEAVING');
+    await fillBasicsAndAdvance(user);
+
+    // Step 2 should show interleaving-specific fields
+    expect(screen.getByLabelText(/Interleaving Method/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Credit Metric Event/)).toBeInTheDocument();
+  });
+
+  it('AB type shows "no extra config" on step 2', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    await fillBasicsAndAdvance(user);
+
+    // Step 2 should show "no additional configuration" for AB
+    expect(screen.getByText(/No additional configuration/)).toBeInTheDocument();
+  });
+
+  it('full happy path: fill all steps, review shows values, submit calls API', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    await fillToReview(user);
+
+    // Should be on Review step
+    expect(screen.getByText('Review Experiment')).toBeInTheDocument();
+    expect(screen.getByText('my_experiment')).toBeInTheDocument();
+    expect(screen.getByText('click_through_rate')).toBeInTheDocument();
+
+    // Submit
+    await user.click(screen.getByRole('button', { name: 'Create Experiment' }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/experiments\/[0-9a-f-]+$/),
+      );
+    });
+  });
+
+  it('review Edit links jump to correct step', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    await fillToReview(user);
+
+    // Click "Edit" on the Basic Information section
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    await user.click(editButtons[0]); // First Edit = Basics
+
+    // Should be back on step 1
+    expect(screen.getByLabelText(/Name \*/)).toBeInTheDocument();
+  });
+
+  it('submit button only on review step', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    // Step 1: should have Next, not Create Experiment
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create Experiment' })).not.toBeInTheDocument();
+
+    // Navigate to review
+    await fillToReview(user);
+
+    // Review step: should have Create Experiment, not Next
+    expect(screen.getByRole('button', { name: 'Create Experiment' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+  });
+
+  it('viewer cannot access form (permission guard)', () => {
+    const viewer: AuthUser = { email: 'viewer@streamco.com', role: 'viewer' };
+    renderNewPage(viewer);
+
+    expect(screen.getByTestId('insufficient-permissions')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Name \*/)).not.toBeInTheDocument();
+  });
+
+  it('PLAYBACK_QOE shows QoE metric checkboxes on step 2', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    await user.selectOptions(screen.getByLabelText(/Experiment Type/), 'PLAYBACK_QOE');
+    await fillBasicsAndAdvance(user);
+
+    expect(screen.getByText('Rebuffer Ratio')).toBeInTheDocument();
+    expect(screen.getByText('Time to First Frame (ms)')).toBeInTheDocument();
+  });
+});

--- a/ui/src/__tests__/type-config-validation.test.ts
+++ b/ui/src/__tests__/type-config-validation.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateBasics,
+  validateInterleavingConfig,
+  validateSessionConfig,
+  validateBanditConfig,
+  validateQoeConfig,
+  validateTypeConfig,
+  validateMetricsStep,
+} from '@/lib/validation';
+import type {
+  InterleavingConfig, SessionConfig, BanditExperimentConfig, QoeConfig,
+} from '@/lib/types';
+
+describe('validateBasics', () => {
+  it('fails when name is empty', () => {
+    const result = validateBasics({ name: '', ownerEmail: 'a@b.com', layerId: 'layer-1' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/name/i);
+  });
+
+  it('fails when ownerEmail is empty', () => {
+    const result = validateBasics({ name: 'test', ownerEmail: '', layerId: 'layer-1' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/email/i);
+  });
+
+  it('fails when layerId is empty', () => {
+    const result = validateBasics({ name: 'test', ownerEmail: 'a@b.com', layerId: '' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/layer/i);
+  });
+
+  it('passes with all fields filled', () => {
+    const result = validateBasics({ name: 'test', ownerEmail: 'a@b.com', layerId: 'layer-1' });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateInterleavingConfig', () => {
+  const base: InterleavingConfig = {
+    method: 'TEAM_DRAFT',
+    algorithmIds: ['algo-1', 'algo-2'],
+    creditAssignment: 'BINARY_WIN',
+    creditMetricEvent: 'click',
+    maxListSize: 10,
+  };
+
+  it('fails with fewer than 2 algorithm IDs', () => {
+    const result = validateInterleavingConfig({ ...base, algorithmIds: ['algo-1'] });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/algorithm/i);
+  });
+
+  it('fails with fewer than 3 algorithm IDs for MULTILEAVE', () => {
+    const result = validateInterleavingConfig({
+      ...base,
+      method: 'MULTILEAVE',
+      algorithmIds: ['algo-1', 'algo-2'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('3');
+  });
+
+  it('passes MULTILEAVE with 3 algorithms', () => {
+    const result = validateInterleavingConfig({
+      ...base,
+      method: 'MULTILEAVE',
+      algorithmIds: ['algo-1', 'algo-2', 'algo-3'],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails when creditMetricEvent is empty', () => {
+    const result = validateInterleavingConfig({ ...base, creditMetricEvent: '' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/credit metric/i);
+  });
+
+  it('fails when maxListSize is less than 1', () => {
+    const result = validateInterleavingConfig({ ...base, maxListSize: 0 });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/list size/i);
+  });
+
+  it('passes with valid config', () => {
+    expect(validateInterleavingConfig(base).valid).toBe(true);
+  });
+});
+
+describe('validateSessionConfig', () => {
+  const base: SessionConfig = {
+    sessionIdAttribute: 'session_id',
+    allowCrossSessionVariation: false,
+    minSessionsPerUser: 1,
+  };
+
+  it('fails when sessionIdAttribute is empty', () => {
+    const result = validateSessionConfig({ ...base, sessionIdAttribute: '' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/session/i);
+  });
+
+  it('fails when minSessionsPerUser is less than 1', () => {
+    const result = validateSessionConfig({ ...base, minSessionsPerUser: 0 });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/sessions/i);
+  });
+
+  it('passes with valid config', () => {
+    expect(validateSessionConfig(base).valid).toBe(true);
+  });
+});
+
+describe('validateBanditConfig', () => {
+  const base: BanditExperimentConfig = {
+    algorithm: 'THOMPSON_SAMPLING',
+    rewardMetricId: 'conversion_rate',
+    contextFeatureKeys: ['genre', 'device'],
+    minExplorationFraction: 0.1,
+    warmupObservations: 100,
+  };
+
+  it('fails when rewardMetricId is empty', () => {
+    const result = validateBanditConfig({ ...base, rewardMetricId: '' }, false);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/reward/i);
+  });
+
+  it('fails for contextual bandit with no context features', () => {
+    const result = validateBanditConfig({ ...base, contextFeatureKeys: [] }, true);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/context feature/i);
+  });
+
+  it('passes for non-contextual bandit with no context features', () => {
+    const result = validateBanditConfig({ ...base, contextFeatureKeys: [] }, false);
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails when explorationFraction is out of range', () => {
+    const result = validateBanditConfig({ ...base, minExplorationFraction: 1.5 }, false);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/exploration/i);
+  });
+
+  it('passes with valid config', () => {
+    expect(validateBanditConfig(base, true).valid).toBe(true);
+  });
+});
+
+describe('validateQoeConfig', () => {
+  it('fails with empty metrics array', () => {
+    const config: QoeConfig = { qoeMetrics: [], deviceFilter: '' };
+    const result = validateQoeConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/metric/i);
+  });
+
+  it('passes with at least one metric', () => {
+    const config: QoeConfig = { qoeMetrics: ['rebuffer_ratio'], deviceFilter: '' };
+    expect(validateQoeConfig(config).valid).toBe(true);
+  });
+});
+
+describe('validateTypeConfig (dispatcher)', () => {
+  const configs = {
+    interleavingConfig: {
+      method: 'TEAM_DRAFT' as const,
+      algorithmIds: ['a', 'b'],
+      creditAssignment: 'BINARY_WIN' as const,
+      creditMetricEvent: 'click',
+      maxListSize: 10,
+    },
+    sessionConfig: {
+      sessionIdAttribute: 'sid',
+      allowCrossSessionVariation: false,
+      minSessionsPerUser: 1,
+    },
+    banditExperimentConfig: {
+      algorithm: 'THOMPSON_SAMPLING' as const,
+      rewardMetricId: 'ctr',
+      contextFeatureKeys: ['genre'],
+      minExplorationFraction: 0.1,
+      warmupObservations: 100,
+    },
+    qoeConfig: {
+      qoeMetrics: ['rebuffer_ratio'],
+      deviceFilter: '',
+    },
+  };
+
+  it('validates AB type as always valid', () => {
+    expect(validateTypeConfig('AB', configs).valid).toBe(true);
+  });
+
+  it('validates INTERLEAVING type', () => {
+    expect(validateTypeConfig('INTERLEAVING', configs).valid).toBe(true);
+  });
+
+  it('validates CONTEXTUAL_BANDIT type', () => {
+    expect(validateTypeConfig('CONTEXTUAL_BANDIT', configs).valid).toBe(true);
+  });
+});
+
+describe('validateMetricsStep', () => {
+  it('fails when primaryMetricId is empty', () => {
+    const result = validateMetricsStep({ primaryMetricId: '', guardrails: [] });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/primary metric/i);
+  });
+
+  it('fails when a guardrail has empty metricId', () => {
+    const result = validateMetricsStep({
+      primaryMetricId: 'ctr',
+      guardrails: [{ metricId: '', threshold: 0.01, consecutiveBreachesRequired: 1 }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/guardrail/i);
+  });
+
+  it('passes with valid fields', () => {
+    const result = validateMetricsStep({
+      primaryMetricId: 'ctr',
+      guardrails: [{ metricId: 'crash_rate', threshold: 0.01, consecutiveBreachesRequired: 1 }],
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/ui/src/components/experiment-form.tsx
+++ b/ui/src/components/experiment-form.tsx
@@ -1,547 +1,206 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import type {
   CreateExperimentRequest,
-  ExperimentType,
-  GuardrailAction,
-  GuardrailConfig,
-  SequentialMethod,
   SequentialTestConfig,
-  Variant,
 } from '@/lib/types';
-import { generateVariantId, validateVariants, validateJsonPayload } from '@/lib/validation';
-import { TYPE_LABELS, formatPercent } from '@/lib/utils';
+import {
+  validateBasics,
+  validateTypeConfig,
+  validateVariants,
+  validateMetricsStep,
+} from '@/lib/validation';
+import {
+  WizardProvider,
+  useWizard,
+  WIZARD_STEPS,
+} from './wizard/wizard-context';
+import { StepIndicator } from './wizard/step-indicator';
+import { BasicsStep } from './wizard/steps/basics-step';
+import { TypeConfigStep } from './wizard/steps/type-config-step';
+import { VariantsStep } from './wizard/steps/variants-step';
+import { MetricsStep } from './wizard/steps/metrics-step';
+import { ReviewStep } from './wizard/steps/review-step';
 
 interface ExperimentFormProps {
   onSubmit: (req: CreateExperimentRequest) => Promise<void>;
 }
 
-const EXPERIMENT_TYPES: ExperimentType[] = [
-  'AB', 'MULTIVARIATE', 'INTERLEAVING', 'SESSION_LEVEL',
-  'PLAYBACK_QOE', 'MAB', 'CONTEXTUAL_BANDIT', 'CUMULATIVE_HOLDOUT',
-];
+function WizardOrchestrator({ onSubmit }: ExperimentFormProps) {
+  const { state, dispatch } = useWizard();
+  const { currentStep } = state;
+  const isLastStep = currentStep === WIZARD_STEPS.length - 1;
 
-const SEQUENTIAL_METHODS: SequentialMethod[] = ['MSPRT', 'GST_OBF', 'GST_POCOCK'];
-
-function defaultVariants(): Variant[] {
-  return [
-    { variantId: generateVariantId(), name: 'control', trafficFraction: 0.5, isControl: true, payloadJson: '{}' },
-    { variantId: generateVariantId(), name: 'treatment', trafficFraction: 0.5, isControl: false, payloadJson: '{}' },
-  ];
-}
-
-export function ExperimentForm({ onSubmit }: ExperimentFormProps) {
-  // Core fields
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [ownerEmail, setOwnerEmail] = useState('');
-  const [type, setType] = useState<ExperimentType>('AB');
-  const [layerId, setLayerId] = useState('');
-  const [primaryMetricId, setPrimaryMetricId] = useState('');
-  const [secondaryMetricsInput, setSecondaryMetricsInput] = useState('');
-  const [isCumulativeHoldout, setIsCumulativeHoldout] = useState(false);
-  const [targetingRuleId, setTargetingRuleId] = useState('');
-
-  // Guardrails
-  const [guardrailAction, setGuardrailAction] = useState<GuardrailAction>('AUTO_PAUSE');
-  const [guardrails, setGuardrails] = useState<GuardrailConfig[]>([]);
-
-  // Sequential testing
-  const [enableSequential, setEnableSequential] = useState(false);
-  const [sequentialMethod, setSequentialMethod] = useState<SequentialMethod>('MSPRT');
-  const [plannedLooks, setPlannedLooks] = useState(0);
-  const [overallAlpha, setOverallAlpha] = useState(0.05);
-
-  // Variants
-  const [variants, setVariants] = useState<Variant[]>(defaultVariants);
-
-  // Form state
-  const [submitting, setSubmitting] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
-
-  const addGuardrail = useCallback(() => {
-    setGuardrails((prev) => [
-      ...prev,
-      { metricId: '', threshold: 0, consecutiveBreachesRequired: 1 },
-    ]);
-  }, []);
-
-  const removeGuardrail = useCallback((index: number) => {
-    setGuardrails((prev) => prev.filter((_, i) => i !== index));
-  }, []);
-
-  const updateGuardrail = useCallback((index: number, field: keyof GuardrailConfig, value: string | number) => {
-    setGuardrails((prev) => {
-      const next = [...prev];
-      next[index] = { ...next[index], [field]: value };
-      return next;
-    });
-  }, []);
-
-  // Variant management
-  const addVariant = useCallback(() => {
-    setVariants((prev) => [
-      ...prev,
-      { variantId: generateVariantId(), name: '', trafficFraction: 0, isControl: false, payloadJson: '{}' },
-    ]);
-  }, []);
-
-  const removeVariant = useCallback((index: number) => {
-    setVariants((prev) => prev.filter((_, i) => i !== index));
-  }, []);
-
-  const updateVariant = useCallback((index: number, field: keyof Variant, value: string | number | boolean) => {
-    setVariants((prev) => {
-      const next = [...prev];
-      if (field === 'isControl' && value === true) {
-        next.forEach((v, i) => { next[i] = { ...v, isControl: i === index }; });
-      } else {
-        next[index] = { ...next[index], [field]: value };
+  const validateCurrentStep = useCallback((): boolean => {
+    let result: { valid: boolean; error?: string } | ReturnType<typeof validateVariants>;
+    switch (currentStep) {
+      case 0:
+        result = validateBasics(state);
+        if (!result.valid) {
+          dispatch({ type: 'SET_STEP_ERROR', step: 0, error: result.error ?? null });
+          return false;
+        }
+        break;
+      case 1:
+        result = validateTypeConfig(state.type, state);
+        if (!result.valid) {
+          dispatch({ type: 'SET_STEP_ERROR', step: 1, error: result.error ?? null });
+          return false;
+        }
+        break;
+      case 2: {
+        const vr = validateVariants(state.variants, state.type);
+        if (!vr.valid) {
+          dispatch({ type: 'SET_STEP_ERROR', step: 2, error: vr.bannerError || vr.errors[0]?.message || 'Invalid variant configuration' });
+          return false;
+        }
+        break;
       }
-      return next;
-    });
-  }, []);
+      case 3:
+        result = validateMetricsStep(state);
+        if (!result.valid) {
+          dispatch({ type: 'SET_STEP_ERROR', step: 3, error: result.error ?? null });
+          return false;
+        }
+        break;
+    }
+    dispatch({ type: 'SET_STEP_ERROR', step: currentStep, error: null });
+    return true;
+  }, [currentStep, state, dispatch]);
 
-  const trafficSum = variants.reduce((acc, v) => acc + v.trafficFraction, 0);
-  const trafficSumValid = Math.abs(trafficSum - 1.0) < 1e-9;
+  const goNext = useCallback(() => {
+    if (validateCurrentStep() && currentStep < WIZARD_STEPS.length - 1) {
+      dispatch({ type: 'SET_STEP', step: currentStep + 1 });
+    }
+  }, [validateCurrentStep, currentStep, dispatch]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const goBack = useCallback(() => {
+    if (currentStep > 0) {
+      dispatch({ type: 'SET_STEP', step: currentStep - 1 });
+    }
+  }, [currentStep, dispatch]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
-    setFormError(null);
+    dispatch({ type: 'SET_FIELD', field: 'formError', value: null });
 
-    // Validate core fields
-    if (!name.trim()) { setFormError('Experiment name is required'); return; }
-    if (!ownerEmail.trim()) { setFormError('Owner email is required'); return; }
-    if (!layerId.trim()) { setFormError('Layer ID is required'); return; }
-    if (!primaryMetricId.trim()) { setFormError('Primary metric is required'); return; }
-
-    // Validate variants
-    const variantResult = validateVariants(variants, type);
-    if (!variantResult.valid) {
-      setFormError(variantResult.bannerError || variantResult.errors[0]?.message || 'Invalid variant configuration');
-      return;
-    }
-
-    // Validate guardrail metric IDs
-    for (const g of guardrails) {
-      if (!g.metricId.trim()) { setFormError('All guardrail metrics must have an ID'); return; }
-    }
-
-    const secondaryMetricIds = secondaryMetricsInput
+    const secondaryMetricIds = state.secondaryMetricsInput
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
 
-    const sequentialTestConfig: SequentialTestConfig | undefined = enableSequential
-      ? { method: sequentialMethod, plannedLooks, overallAlpha }
+    const sequentialTestConfig: SequentialTestConfig | undefined = state.enableSequential
+      ? { method: state.sequentialMethod, plannedLooks: state.plannedLooks, overallAlpha: state.overallAlpha }
       : undefined;
 
+    // Build type-specific config
+    const typeConfigs: Pick<CreateExperimentRequest, 'interleavingConfig' | 'sessionConfig' | 'banditExperimentConfig' | 'qoeConfig'> = {};
+    switch (state.type) {
+      case 'INTERLEAVING':
+        typeConfigs.interleavingConfig = {
+          ...state.interleavingConfig,
+          algorithmIds: state.interleavingConfig.algorithmIds.filter(Boolean),
+        };
+        break;
+      case 'SESSION_LEVEL':
+        typeConfigs.sessionConfig = state.sessionConfig;
+        break;
+      case 'MAB':
+      case 'CONTEXTUAL_BANDIT':
+        typeConfigs.banditExperimentConfig = {
+          ...state.banditExperimentConfig,
+          contextFeatureKeys: state.banditExperimentConfig.contextFeatureKeys.filter(Boolean),
+        };
+        break;
+      case 'PLAYBACK_QOE':
+        typeConfigs.qoeConfig = state.qoeConfig;
+        break;
+    }
+
     const req: CreateExperimentRequest = {
-      name: name.trim(),
-      description: description.trim(),
-      ownerEmail: ownerEmail.trim(),
-      type,
-      variants,
-      layerId: layerId.trim(),
-      primaryMetricId: primaryMetricId.trim(),
+      name: state.name.trim(),
+      description: state.description.trim(),
+      ownerEmail: state.ownerEmail.trim(),
+      type: state.type,
+      variants: state.variants,
+      layerId: state.layerId.trim(),
+      primaryMetricId: state.primaryMetricId.trim(),
       secondaryMetricIds,
-      guardrailConfigs: guardrails,
-      guardrailAction,
+      guardrailConfigs: state.guardrails,
+      guardrailAction: state.guardrailAction,
       sequentialTestConfig,
-      targetingRuleId: targetingRuleId.trim() || undefined,
-      isCumulativeHoldout,
+      targetingRuleId: state.targetingRuleId.trim() || undefined,
+      isCumulativeHoldout: state.isCumulativeHoldout,
+      ...typeConfigs,
     };
 
-    setSubmitting(true);
+    dispatch({ type: 'SET_FIELD', field: 'submitting', value: true });
     try {
       await onSubmit(req);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : 'Failed to create experiment');
+      dispatch({ type: 'SET_FIELD', field: 'formError', value: err instanceof Error ? err.message : 'Failed to create experiment' });
     } finally {
-      setSubmitting(false);
+      dispatch({ type: 'SET_FIELD', field: 'submitting', value: false });
     }
-  };
+  }, [onSubmit, state, dispatch]);
+
+  const stepError = state.stepErrors[currentStep];
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-8">
-      {formError && (
-        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
-          {formError}
+    <form onSubmit={handleSubmit}>
+      <StepIndicator currentStep={currentStep} />
+
+      {(state.formError || stepError) && (
+        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
+          {state.formError || stepError}
         </div>
       )}
 
-      {/* Basic Info */}
-      <section>
-        <h2 className="mb-4 text-lg font-semibold text-gray-900">Basic Information</h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <div>
-            <label htmlFor="exp-name" className="block text-sm font-medium text-gray-700">
-              Name <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="exp-name"
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g., homepage_recs_v3"
-              aria-required="true"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label htmlFor="exp-owner" className="block text-sm font-medium text-gray-700">
-              Owner Email <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="exp-owner"
-              type="email"
-              value={ownerEmail}
-              onChange={(e) => setOwnerEmail(e.target.value)}
-              placeholder="e.g., alice@streamco.com"
-              aria-required="true"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div className="sm:col-span-2">
-            <label htmlFor="exp-description" className="block text-sm font-medium text-gray-700">
-              Description
-            </label>
-            <textarea
-              id="exp-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-              placeholder="What hypothesis is this experiment testing?"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label htmlFor="exp-type" className="block text-sm font-medium text-gray-700">
-              Experiment Type <span className="text-red-500">*</span>
-            </label>
-            <select
-              id="exp-type"
-              value={type}
-              onChange={(e) => setType(e.target.value as ExperimentType)}
-              aria-required="true"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              {EXPERIMENT_TYPES.map((t) => (
-                <option key={t} value={t}>{TYPE_LABELS[t]}</option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label htmlFor="exp-layer" className="block text-sm font-medium text-gray-700">
-              Layer ID <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="exp-layer"
-              type="text"
-              value={layerId}
-              onChange={(e) => setLayerId(e.target.value)}
-              placeholder="e.g., layer-homepage"
-              aria-required="true"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-      </section>
+      <div className="mb-6">
+        {currentStep === 0 && <BasicsStep />}
+        {currentStep === 1 && <TypeConfigStep />}
+        {currentStep === 2 && <VariantsStep />}
+        {currentStep === 3 && <MetricsStep />}
+        {currentStep === 4 && <ReviewStep />}
+      </div>
 
-      {/* Metrics */}
-      <section>
-        <h2 className="mb-4 text-lg font-semibold text-gray-900">Metrics</h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <div>
-            <label htmlFor="exp-primary-metric" className="block text-sm font-medium text-gray-700">
-              Primary Metric <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="exp-primary-metric"
-              type="text"
-              value={primaryMetricId}
-              onChange={(e) => setPrimaryMetricId(e.target.value)}
-              placeholder="e.g., click_through_rate"
-              aria-required="true"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label htmlFor="exp-secondary-metrics" className="block text-sm font-medium text-gray-700">
-              Secondary Metrics
-            </label>
-            <input
-              id="exp-secondary-metrics"
-              type="text"
-              value={secondaryMetricsInput}
-              onChange={(e) => setSecondaryMetricsInput(e.target.value)}
-              placeholder="Comma-separated, e.g., watch_time, revenue"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Variants */}
-      <section>
-        <h2 className="mb-4 text-lg font-semibold text-gray-900">Variants</h2>
-        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Traffic</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Control</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Payload JSON</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
-              {variants.map((v, i) => (
-                <tr key={v.variantId}>
-                  <td className="px-4 py-2">
-                    <input
-                      type="text"
-                      value={v.name}
-                      onChange={(e) => updateVariant(i, 'name', e.target.value)}
-                      aria-label={`Variant ${i + 1} name`}
-                      className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
-                    />
-                  </td>
-                  <td className="px-4 py-2">
-                    <input
-                      type="number"
-                      min={0}
-                      max={1}
-                      step={0.01}
-                      value={v.trafficFraction}
-                      onChange={(e) => updateVariant(i, 'trafficFraction', parseFloat(e.target.value) || 0)}
-                      aria-label={`Variant ${i + 1} traffic`}
-                      className="w-24 rounded border border-gray-300 px-2 py-1 text-sm"
-                    />
-                  </td>
-                  <td className="px-4 py-2 text-center">
-                    <input
-                      type="radio"
-                      name="create-control-variant"
-                      checked={v.isControl}
-                      onChange={() => updateVariant(i, 'isControl', true)}
-                      aria-label={`Set ${v.name || `variant ${i + 1}`} as control`}
-                    />
-                  </td>
-                  <td className="px-4 py-2">
-                    <textarea
-                      value={v.payloadJson}
-                      onChange={(e) => updateVariant(i, 'payloadJson', e.target.value)}
-                      aria-label={`Variant ${i + 1} payload`}
-                      rows={1}
-                      className={`w-full rounded border px-2 py-1 font-mono text-xs ${
-                        !validateJsonPayload(v.payloadJson) ? 'border-red-500' : 'border-gray-300'
-                      }`}
-                    />
-                  </td>
-                  <td className="px-4 py-2">
-                    <button
-                      type="button"
-                      onClick={() => removeVariant(i)}
-                      disabled={variants.length <= 2}
-                      className="text-sm text-red-600 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400"
-                    >
-                      Remove
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <div className="mt-2 flex items-center justify-between">
-          <span className={`text-sm font-medium ${trafficSumValid ? 'text-green-700' : 'text-red-700'}`}>
-            Total traffic: {formatPercent(trafficSum)}
-          </span>
-          <button
-            type="button"
-            onClick={addVariant}
-            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
-            Add Variant
-          </button>
-        </div>
-      </section>
-
-      {/* Guardrails */}
-      <section>
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-gray-900">Guardrails</h2>
-          <button
-            type="button"
-            onClick={addGuardrail}
-            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
-            Add Guardrail
-          </button>
-        </div>
-        {guardrails.length > 0 && (
-          <div className="space-y-3">
-            {guardrails.map((g, i) => (
-              <div key={i} className="flex items-end gap-3 rounded-lg border border-gray-200 bg-white p-3">
-                <div className="flex-1">
-                  <label className="block text-xs font-medium text-gray-500">Metric ID</label>
-                  <input
-                    type="text"
-                    value={g.metricId}
-                    onChange={(e) => updateGuardrail(i, 'metricId', e.target.value)}
-                    aria-label={`Guardrail ${i + 1} metric`}
-                    className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
-                  />
-                </div>
-                <div className="w-28">
-                  <label className="block text-xs font-medium text-gray-500">Threshold</label>
-                  <input
-                    type="number"
-                    step="any"
-                    value={g.threshold}
-                    onChange={(e) => updateGuardrail(i, 'threshold', parseFloat(e.target.value) || 0)}
-                    aria-label={`Guardrail ${i + 1} threshold`}
-                    className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
-                  />
-                </div>
-                <div className="w-28">
-                  <label className="block text-xs font-medium text-gray-500">Breaches</label>
-                  <input
-                    type="number"
-                    min={1}
-                    value={g.consecutiveBreachesRequired}
-                    onChange={(e) => updateGuardrail(i, 'consecutiveBreachesRequired', parseInt(e.target.value) || 1)}
-                    aria-label={`Guardrail ${i + 1} breaches required`}
-                    className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
-                  />
-                </div>
-                <button
-                  type="button"
-                  onClick={() => removeGuardrail(i)}
-                  className="mb-1 text-sm text-red-600 hover:text-red-800"
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-            <div>
-              <label htmlFor="guardrail-action" className="block text-sm font-medium text-gray-700">Action on Breach</label>
-              <select
-                id="guardrail-action"
-                value={guardrailAction}
-                onChange={(e) => setGuardrailAction(e.target.value as GuardrailAction)}
-                className="mt-1 block w-48 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
-              >
-                <option value="AUTO_PAUSE">Auto-Pause</option>
-                <option value="ALERT_ONLY">Alert Only</option>
-              </select>
-            </div>
-          </div>
-        )}
-        {guardrails.length === 0 && (
-          <p className="text-sm text-gray-500">No guardrails configured. Click &ldquo;Add Guardrail&rdquo; to add one.</p>
-        )}
-      </section>
-
-      {/* Sequential Testing */}
-      <section>
-        <h2 className="mb-4 text-lg font-semibold text-gray-900">Sequential Testing</h2>
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={enableSequential}
-            onChange={(e) => setEnableSequential(e.target.checked)}
-            className="rounded border-gray-300"
-          />
-          <span className="text-sm text-gray-700">Enable sequential testing</span>
-        </label>
-        {enableSequential && (
-          <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <div>
-              <label htmlFor="seq-method" className="block text-sm font-medium text-gray-700">Method</label>
-              <select
-                id="seq-method"
-                value={sequentialMethod}
-                onChange={(e) => setSequentialMethod(e.target.value as SequentialMethod)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
-              >
-                {SEQUENTIAL_METHODS.map((m) => (
-                  <option key={m} value={m}>{m}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="seq-looks" className="block text-sm font-medium text-gray-700">Planned Looks</label>
-              <input
-                id="seq-looks"
-                type="number"
-                min={0}
-                value={plannedLooks}
-                onChange={(e) => setPlannedLooks(parseInt(e.target.value) || 0)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
-              />
-            </div>
-            <div>
-              <label htmlFor="seq-alpha" className="block text-sm font-medium text-gray-700">Overall Alpha</label>
-              <input
-                id="seq-alpha"
-                type="number"
-                min={0}
-                max={1}
-                step={0.01}
-                value={overallAlpha}
-                onChange={(e) => setOverallAlpha(parseFloat(e.target.value) || 0.05)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
-              />
-            </div>
-          </div>
-        )}
-      </section>
-
-      {/* Advanced Options */}
-      <section>
-        <h2 className="mb-4 text-lg font-semibold text-gray-900">Advanced</h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <div>
-            <label htmlFor="exp-targeting" className="block text-sm font-medium text-gray-700">
-              Targeting Rule ID
-            </label>
-            <input
-              id="exp-targeting"
-              type="text"
-              value={targetingRuleId}
-              onChange={(e) => setTargetingRuleId(e.target.value)}
-              placeholder="Optional"
-              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
-            />
-          </div>
-          <div className="flex items-end">
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={isCumulativeHoldout}
-                onChange={(e) => setIsCumulativeHoldout(e.target.checked)}
-                className="rounded border-gray-300"
-              />
-              <span className="text-sm text-gray-700">Cumulative holdout experiment</span>
-            </label>
-          </div>
-        </div>
-      </section>
-
-      {/* Submit */}
       <div className="flex items-center gap-3 border-t border-gray-200 pt-6">
-        <button
-          type="submit"
-          disabled={submitting}
-          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50"
-        >
-          {submitting ? 'Creating...' : 'Create Experiment'}
-        </button>
+        {currentStep > 0 && (
+          <button
+            type="button"
+            onClick={goBack}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+          >
+            Back
+          </button>
+        )}
+        {!isLastStep ? (
+          <button
+            type="button"
+            onClick={goNext}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+          >
+            Next
+          </button>
+        ) : (
+          <button
+            type="submit"
+            disabled={state.submitting}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50"
+          >
+            {state.submitting ? 'Creating...' : 'Create Experiment'}
+          </button>
+        )}
       </div>
     </form>
+  );
+}
+
+export function ExperimentForm({ onSubmit }: ExperimentFormProps) {
+  return (
+    <WizardProvider>
+      <WizardOrchestrator onSubmit={onSubmit} />
+    </WizardProvider>
   );
 }

--- a/ui/src/components/wizard/step-indicator.tsx
+++ b/ui/src/components/wizard/step-indicator.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { WIZARD_STEPS } from './wizard-context';
+
+interface StepIndicatorProps {
+  currentStep: number;
+  onStepClick?: (step: number) => void;
+}
+
+export function StepIndicator({ currentStep, onStepClick }: StepIndicatorProps) {
+  return (
+    <nav aria-label="Wizard progress" className="mb-8">
+      <ol className="flex items-center">
+        {WIZARD_STEPS.map((label, i) => {
+          const isCompleted = i < currentStep;
+          const isCurrent = i === currentStep;
+
+          return (
+            <li key={label} className="flex items-center">
+              {i > 0 && (
+                <div
+                  className={`mx-2 h-0.5 w-8 sm:w-12 ${isCompleted ? 'bg-indigo-600' : 'bg-gray-300'}`}
+                  aria-hidden="true"
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => onStepClick?.(i)}
+                disabled={!onStepClick}
+                aria-current={isCurrent ? 'step' : undefined}
+                className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                  isCurrent
+                    ? 'bg-indigo-600 text-white'
+                    : isCompleted
+                      ? 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200'
+                      : 'bg-gray-100 text-gray-500'
+                } ${onStepClick ? 'cursor-pointer' : 'cursor-default'}`}
+              >
+                <span
+                  className={`flex h-5 w-5 items-center justify-center rounded-full text-xs ${
+                    isCurrent
+                      ? 'bg-white text-indigo-600'
+                      : isCompleted
+                        ? 'bg-indigo-600 text-white'
+                        : 'bg-gray-300 text-gray-600'
+                  }`}
+                >
+                  {isCompleted ? '\u2713' : i + 1}
+                </span>
+                <span className="hidden sm:inline">{label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/ui/src/components/wizard/steps/bandit-config-form.tsx
+++ b/ui/src/components/wizard/steps/bandit-config-form.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+import type { BanditAlgorithm } from '@/lib/types';
+
+const ALGORITHMS: { value: BanditAlgorithm; label: string }[] = [
+  { value: 'THOMPSON_SAMPLING', label: 'Thompson Sampling' },
+  { value: 'LINEAR_UCB', label: 'Linear UCB' },
+  { value: 'THOMPSON_LINEAR', label: 'Thompson Linear' },
+  { value: 'NEURAL_CONTEXTUAL', label: 'Neural Contextual' },
+];
+
+export function BanditConfigForm() {
+  const { state, dispatch } = useWizard();
+  const config = state.banditExperimentConfig;
+  const isContextual = state.type === 'CONTEXTUAL_BANDIT';
+
+  const update = (partial: Partial<typeof config>) =>
+    dispatch({ type: 'SET_FIELD', field: 'banditExperimentConfig', value: { ...config, ...partial } });
+
+  const updateFeatureKey = (index: number, value: string) => {
+    const keys = [...config.contextFeatureKeys];
+    keys[index] = value;
+    update({ contextFeatureKeys: keys });
+  };
+
+  const addFeatureKey = () => update({ contextFeatureKeys: [...config.contextFeatureKeys, ''] });
+
+  const removeFeatureKey = (index: number) =>
+    update({ contextFeatureKeys: config.contextFeatureKeys.filter((_, i) => i !== index) });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label htmlFor="bandit-algorithm" className="block text-sm font-medium text-gray-700">
+          Algorithm <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="bandit-algorithm"
+          value={config.algorithm}
+          onChange={(e) => update({ algorithm: e.target.value as BanditAlgorithm })}
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        >
+          {ALGORITHMS.map((a) => (
+            <option key={a.value} value={a.value}>{a.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="reward-metric" className="block text-sm font-medium text-gray-700">
+          Reward Metric ID <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="reward-metric"
+          type="text"
+          value={config.rewardMetricId}
+          onChange={(e) => update({ rewardMetricId: e.target.value })}
+          placeholder="e.g., conversion_rate"
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        />
+      </div>
+
+      {isContextual && (
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <label className="block text-sm font-medium text-gray-700">
+              Context Feature Keys <span className="text-red-500">*</span>
+            </label>
+            <button
+              type="button"
+              onClick={addFeatureKey}
+              className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Add Feature
+            </button>
+          </div>
+          {config.contextFeatureKeys.length === 0 && (
+            <p className="text-sm text-gray-500">No context features configured. Click &ldquo;Add Feature&rdquo; to add one.</p>
+          )}
+          {config.contextFeatureKeys.map((key, i) => (
+            <div key={i} className="mb-2 flex gap-2">
+              <input
+                type="text"
+                value={key}
+                onChange={(e) => updateFeatureKey(i, e.target.value)}
+                placeholder={`Feature key ${i + 1}`}
+                aria-label={`Context feature ${i + 1}`}
+                className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+              />
+              <button
+                type="button"
+                onClick={() => removeFeatureKey(i)}
+                className="text-sm text-red-600 hover:text-red-800"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="exploration-fraction" className="block text-sm font-medium text-gray-700">
+            Min Exploration Fraction
+          </label>
+          <input
+            id="exploration-fraction"
+            type="number"
+            min={0}
+            max={1}
+            step={0.01}
+            value={config.minExplorationFraction}
+            onChange={(e) => update({ minExplorationFraction: parseFloat(e.target.value) || 0 })}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="warmup-obs" className="block text-sm font-medium text-gray-700">
+            Warmup Observations
+          </label>
+          <input
+            id="warmup-obs"
+            type="number"
+            min={0}
+            value={config.warmupObservations}
+            onChange={(e) => update({ warmupObservations: parseInt(e.target.value) || 0 })}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/wizard/steps/basics-step.tsx
+++ b/ui/src/components/wizard/steps/basics-step.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+import { TYPE_LABELS } from '@/lib/utils';
+import type { ExperimentType } from '@/lib/types';
+
+const EXPERIMENT_TYPES: ExperimentType[] = [
+  'AB', 'MULTIVARIATE', 'INTERLEAVING', 'SESSION_LEVEL',
+  'PLAYBACK_QOE', 'MAB', 'CONTEXTUAL_BANDIT', 'CUMULATIVE_HOLDOUT',
+];
+
+export function BasicsStep() {
+  const { state, dispatch } = useWizard();
+
+  const setField = (field: string, value: unknown) =>
+    dispatch({ type: 'SET_FIELD', field, value });
+
+  return (
+    <section>
+      <h2 className="mb-4 text-lg font-semibold text-gray-900">Basic Information</h2>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="exp-name" className="block text-sm font-medium text-gray-700">
+            Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="exp-name"
+            type="text"
+            value={state.name}
+            onChange={(e) => setField('name', e.target.value)}
+            placeholder="e.g., homepage_recs_v3"
+            aria-required="true"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="exp-owner" className="block text-sm font-medium text-gray-700">
+            Owner Email <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="exp-owner"
+            type="email"
+            value={state.ownerEmail}
+            onChange={(e) => setField('ownerEmail', e.target.value)}
+            placeholder="e.g., alice@streamco.com"
+            aria-required="true"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <label htmlFor="exp-description" className="block text-sm font-medium text-gray-700">
+            Description
+          </label>
+          <textarea
+            id="exp-description"
+            value={state.description}
+            onChange={(e) => setField('description', e.target.value)}
+            rows={2}
+            placeholder="What hypothesis is this experiment testing?"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="exp-type" className="block text-sm font-medium text-gray-700">
+            Experiment Type <span className="text-red-500">*</span>
+          </label>
+          <select
+            id="exp-type"
+            value={state.type}
+            onChange={(e) => setField('type', e.target.value as ExperimentType)}
+            aria-required="true"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          >
+            {EXPERIMENT_TYPES.map((t) => (
+              <option key={t} value={t}>{TYPE_LABELS[t]}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="exp-layer" className="block text-sm font-medium text-gray-700">
+            Layer ID <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="exp-layer"
+            type="text"
+            value={state.layerId}
+            onChange={(e) => setField('layerId', e.target.value)}
+            placeholder="e.g., layer-homepage"
+            aria-required="true"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="exp-targeting" className="block text-sm font-medium text-gray-700">
+            Targeting Rule ID
+          </label>
+          <input
+            id="exp-targeting"
+            type="text"
+            value={state.targetingRuleId}
+            onChange={(e) => setField('targetingRuleId', e.target.value)}
+            placeholder="Optional"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div className="flex items-end">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={state.isCumulativeHoldout}
+              onChange={(e) => setField('isCumulativeHoldout', e.target.checked)}
+              className="rounded border-gray-300"
+            />
+            <span className="text-sm text-gray-700">Cumulative holdout experiment</span>
+          </label>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/wizard/steps/interleaving-config-form.tsx
+++ b/ui/src/components/wizard/steps/interleaving-config-form.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+import type { InterleavingMethod, CreditAssignment } from '@/lib/types';
+
+const METHODS: { value: InterleavingMethod; label: string }[] = [
+  { value: 'TEAM_DRAFT', label: 'Team Draft' },
+  { value: 'OPTIMIZED', label: 'Optimized' },
+  { value: 'MULTILEAVE', label: 'Multileave' },
+];
+
+const CREDIT_ASSIGNMENTS: { value: CreditAssignment; label: string }[] = [
+  { value: 'BINARY_WIN', label: 'Binary Win' },
+  { value: 'PROPORTIONAL', label: 'Proportional' },
+  { value: 'WEIGHTED', label: 'Weighted' },
+];
+
+export function InterleavingConfigForm() {
+  const { state, dispatch } = useWizard();
+  const config = state.interleavingConfig;
+
+  const update = (partial: Partial<typeof config>) =>
+    dispatch({ type: 'SET_FIELD', field: 'interleavingConfig', value: { ...config, ...partial } });
+
+  const updateAlgorithmId = (index: number, value: string) => {
+    const ids = [...config.algorithmIds];
+    ids[index] = value;
+    update({ algorithmIds: ids });
+  };
+
+  const addAlgorithmId = () => update({ algorithmIds: [...config.algorithmIds, ''] });
+
+  const removeAlgorithmId = (index: number) =>
+    update({ algorithmIds: config.algorithmIds.filter((_, i) => i !== index) });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label htmlFor="interleave-method" className="block text-sm font-medium text-gray-700">
+          Interleaving Method <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="interleave-method"
+          value={config.method}
+          onChange={(e) => update({ method: e.target.value as InterleavingMethod })}
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        >
+          {METHODS.map((m) => (
+            <option key={m.value} value={m.value}>{m.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <label className="block text-sm font-medium text-gray-700">
+            Algorithm IDs <span className="text-red-500">*</span>
+          </label>
+          <button
+            type="button"
+            onClick={addAlgorithmId}
+            className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Add Algorithm
+          </button>
+        </div>
+        {config.algorithmIds.map((id, i) => (
+          <div key={i} className="mb-2 flex gap-2">
+            <input
+              type="text"
+              value={id}
+              onChange={(e) => updateAlgorithmId(i, e.target.value)}
+              placeholder={`Algorithm ${i + 1} ID`}
+              aria-label={`Algorithm ${i + 1} ID`}
+              className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+            {config.algorithmIds.length > 2 && (
+              <button
+                type="button"
+                onClick={() => removeAlgorithmId(i)}
+                className="text-sm text-red-600 hover:text-red-800"
+              >
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <label htmlFor="credit-assignment" className="block text-sm font-medium text-gray-700">
+          Credit Assignment
+        </label>
+        <select
+          id="credit-assignment"
+          value={config.creditAssignment}
+          onChange={(e) => update({ creditAssignment: e.target.value as CreditAssignment })}
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        >
+          {CREDIT_ASSIGNMENTS.map((c) => (
+            <option key={c.value} value={c.value}>{c.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="credit-metric" className="block text-sm font-medium text-gray-700">
+          Credit Metric Event <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="credit-metric"
+          type="text"
+          value={config.creditMetricEvent}
+          onChange={(e) => update({ creditMetricEvent: e.target.value })}
+          placeholder="e.g., click"
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="max-list-size" className="block text-sm font-medium text-gray-700">
+          Max List Size
+        </label>
+        <input
+          id="max-list-size"
+          type="number"
+          min={1}
+          value={config.maxListSize}
+          onChange={(e) => update({ maxListSize: parseInt(e.target.value) || 1 })}
+          className="mt-1 block w-32 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/wizard/steps/metrics-step.tsx
+++ b/ui/src/components/wizard/steps/metrics-step.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+import type { GuardrailAction, SequentialMethod } from '@/lib/types';
+
+const SEQUENTIAL_METHODS: SequentialMethod[] = ['MSPRT', 'GST_OBF', 'GST_POCOCK'];
+
+export function MetricsStep() {
+  const { state, dispatch } = useWizard();
+
+  const setField = (field: string, value: unknown) =>
+    dispatch({ type: 'SET_FIELD', field, value });
+
+  return (
+    <section className="space-y-8">
+      {/* Metrics */}
+      <div>
+        <h2 className="mb-4 text-lg font-semibold text-gray-900">Metrics</h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="exp-primary-metric" className="block text-sm font-medium text-gray-700">
+              Primary Metric <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="exp-primary-metric"
+              type="text"
+              value={state.primaryMetricId}
+              onChange={(e) => setField('primaryMetricId', e.target.value)}
+              placeholder="e.g., click_through_rate"
+              aria-required="true"
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="exp-secondary-metrics" className="block text-sm font-medium text-gray-700">
+              Secondary Metrics
+            </label>
+            <input
+              id="exp-secondary-metrics"
+              type="text"
+              value={state.secondaryMetricsInput}
+              onChange={(e) => setField('secondaryMetricsInput', e.target.value)}
+              placeholder="Comma-separated, e.g., watch_time, revenue"
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Guardrails */}
+      <div>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">Guardrails</h2>
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'ADD_GUARDRAIL' })}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Add Guardrail
+          </button>
+        </div>
+        {state.guardrails.length > 0 ? (
+          <div className="space-y-3">
+            {state.guardrails.map((g, i) => (
+              <div key={i} className="flex items-end gap-3 rounded-lg border border-gray-200 bg-white p-3">
+                <div className="flex-1">
+                  <label className="block text-xs font-medium text-gray-500">Metric ID</label>
+                  <input
+                    type="text"
+                    value={g.metricId}
+                    onChange={(e) => dispatch({ type: 'UPDATE_GUARDRAIL', index: i, field: 'metricId', value: e.target.value })}
+                    aria-label={`Guardrail ${i + 1} metric`}
+                    className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  />
+                </div>
+                <div className="w-28">
+                  <label className="block text-xs font-medium text-gray-500">Threshold</label>
+                  <input
+                    type="number"
+                    step="any"
+                    value={g.threshold}
+                    onChange={(e) => dispatch({ type: 'UPDATE_GUARDRAIL', index: i, field: 'threshold', value: parseFloat(e.target.value) || 0 })}
+                    aria-label={`Guardrail ${i + 1} threshold`}
+                    className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  />
+                </div>
+                <div className="w-28">
+                  <label className="block text-xs font-medium text-gray-500">Breaches</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={g.consecutiveBreachesRequired}
+                    onChange={(e) => dispatch({ type: 'UPDATE_GUARDRAIL', index: i, field: 'consecutiveBreachesRequired', value: parseInt(e.target.value) || 1 })}
+                    aria-label={`Guardrail ${i + 1} breaches required`}
+                    className="mt-1 block w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: 'REMOVE_GUARDRAIL', index: i })}
+                  className="mb-1 text-sm text-red-600 hover:text-red-800"
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <div>
+              <label htmlFor="guardrail-action" className="block text-sm font-medium text-gray-700">Action on Breach</label>
+              <select
+                id="guardrail-action"
+                value={state.guardrailAction}
+                onChange={(e) => setField('guardrailAction', e.target.value as GuardrailAction)}
+                className="mt-1 block w-48 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
+              >
+                <option value="AUTO_PAUSE">Auto-Pause</option>
+                <option value="ALERT_ONLY">Alert Only</option>
+              </select>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">No guardrails configured. Click &ldquo;Add Guardrail&rdquo; to add one.</p>
+        )}
+      </div>
+
+      {/* Sequential Testing */}
+      <div>
+        <h2 className="mb-4 text-lg font-semibold text-gray-900">Sequential Testing</h2>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={state.enableSequential}
+            onChange={(e) => setField('enableSequential', e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          <span className="text-sm text-gray-700">Enable sequential testing</span>
+        </label>
+        {state.enableSequential && (
+          <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div>
+              <label htmlFor="seq-method" className="block text-sm font-medium text-gray-700">Method</label>
+              <select
+                id="seq-method"
+                value={state.sequentialMethod}
+                onChange={(e) => setField('sequentialMethod', e.target.value as SequentialMethod)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
+              >
+                {SEQUENTIAL_METHODS.map((m) => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="seq-looks" className="block text-sm font-medium text-gray-700">Planned Looks</label>
+              <input
+                id="seq-looks"
+                type="number"
+                min={0}
+                value={state.plannedLooks}
+                onChange={(e) => setField('plannedLooks', parseInt(e.target.value) || 0)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
+              />
+            </div>
+            <div>
+              <label htmlFor="seq-alpha" className="block text-sm font-medium text-gray-700">Overall Alpha</label>
+              <input
+                id="seq-alpha"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={state.overallAlpha}
+                onChange={(e) => setField('overallAlpha', parseFloat(e.target.value) || 0.05)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/wizard/steps/qoe-config-form.tsx
+++ b/ui/src/components/wizard/steps/qoe-config-form.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+
+const QOE_METRICS = [
+  { id: 'rebuffer_ratio', label: 'Rebuffer Ratio' },
+  { id: 'time_to_first_frame_ms', label: 'Time to First Frame (ms)' },
+  { id: 'avg_bitrate_kbps', label: 'Avg Bitrate (kbps)' },
+  { id: 'resolution_switches', label: 'Resolution Switches' },
+  { id: 'startup_failure_rate', label: 'Startup Failure Rate' },
+];
+
+export function QoeConfigForm() {
+  const { state, dispatch } = useWizard();
+  const config = state.qoeConfig;
+
+  const update = (partial: Partial<typeof config>) =>
+    dispatch({ type: 'SET_FIELD', field: 'qoeConfig', value: { ...config, ...partial } });
+
+  const toggleMetric = (metricId: string) => {
+    const metrics = config.qoeMetrics.includes(metricId)
+      ? config.qoeMetrics.filter((m) => m !== metricId)
+      : [...config.qoeMetrics, metricId];
+    update({ qoeMetrics: metrics });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700">
+          QoE Metrics <span className="text-red-500">*</span>
+        </label>
+        <p className="mb-2 text-xs text-gray-500">Select the QoE metrics to monitor in this experiment.</p>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {QOE_METRICS.map((metric) => (
+            <label key={metric.id} className="flex items-center gap-2 rounded border border-gray-200 p-2">
+              <input
+                type="checkbox"
+                checked={config.qoeMetrics.includes(metric.id)}
+                onChange={() => toggleMetric(metric.id)}
+                className="rounded border-gray-300"
+              />
+              <span className="text-sm text-gray-700">{metric.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="device-filter" className="block text-sm font-medium text-gray-700">
+          Device Filter
+        </label>
+        <input
+          id="device-filter"
+          type="text"
+          value={config.deviceFilter}
+          onChange={(e) => update({ deviceFilter: e.target.value })}
+          placeholder="e.g., smart_tv, mobile (optional)"
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/wizard/steps/review-step.tsx
+++ b/ui/src/components/wizard/steps/review-step.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+import { TYPE_LABELS } from '@/lib/utils';
+import { formatPercent } from '@/lib/utils';
+
+interface ReviewSectionProps {
+  title: string;
+  step: number;
+  onEdit: (step: number) => void;
+  children: React.ReactNode;
+}
+
+function ReviewSection({ title, step, onEdit, children }: ReviewSectionProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+        <button
+          type="button"
+          onClick={() => onEdit(step)}
+          className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+        >
+          Edit
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function DlRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-2 py-1">
+      <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="text-xs text-gray-900">{value || '\u2014'}</dd>
+    </div>
+  );
+}
+
+export function ReviewStep() {
+  const { state, dispatch } = useWizard();
+
+  const goToStep = (step: number) => dispatch({ type: 'SET_STEP', step });
+
+  const trafficSum = state.variants.reduce((acc, v) => acc + v.trafficFraction, 0);
+
+  return (
+    <section className="space-y-4">
+      <h2 className="mb-4 text-lg font-semibold text-gray-900">Review Experiment</h2>
+
+      {/* Basics */}
+      <ReviewSection title="Basic Information" step={0} onEdit={goToStep}>
+        <dl>
+          <DlRow label="Name" value={state.name} />
+          <DlRow label="Owner" value={state.ownerEmail} />
+          <DlRow label="Type" value={TYPE_LABELS[state.type]} />
+          <DlRow label="Layer" value={state.layerId} />
+          <DlRow label="Description" value={state.description} />
+          {state.targetingRuleId && <DlRow label="Targeting Rule" value={state.targetingRuleId} />}
+          {state.isCumulativeHoldout && <DlRow label="Cumulative Holdout" value="Yes" />}
+        </dl>
+      </ReviewSection>
+
+      {/* Type Config */}
+      <ReviewSection title={`${TYPE_LABELS[state.type]} Config`} step={1} onEdit={goToStep}>
+        {renderTypeConfigSummary(state)}
+      </ReviewSection>
+
+      {/* Variants */}
+      <ReviewSection title="Variants" step={2} onEdit={goToStep}>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-xs">
+            <thead>
+              <tr className="border-b border-gray-100">
+                <th className="py-1 pr-4 text-left font-medium text-gray-500">Name</th>
+                <th className="py-1 pr-4 text-left font-medium text-gray-500">Traffic</th>
+                <th className="py-1 pr-4 text-left font-medium text-gray-500">Control</th>
+                <th className="py-1 text-left font-medium text-gray-500">Payload</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.variants.map((v) => (
+                <tr key={v.variantId} className="border-b border-gray-50">
+                  <td className="py-1 pr-4 text-gray-900">{v.name || '\u2014'}</td>
+                  <td className="py-1 pr-4 text-gray-900">{formatPercent(v.trafficFraction)}</td>
+                  <td className="py-1 pr-4">{v.isControl ? <span className="rounded bg-blue-100 px-1.5 py-0.5 text-blue-700">Control</span> : '\u2014'}</td>
+                  <td className="py-1 font-mono text-gray-600">{v.payloadJson.length > 50 ? v.payloadJson.slice(0, 50) + '\u2026' : v.payloadJson}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className={`mt-2 text-xs font-medium ${Math.abs(trafficSum - 1.0) < 1e-9 ? 'text-green-700' : 'text-red-700'}`}>
+          Total traffic: {formatPercent(trafficSum)}
+        </p>
+      </ReviewSection>
+
+      {/* Metrics & Guardrails */}
+      <ReviewSection title="Metrics & Guardrails" step={3} onEdit={goToStep}>
+        <dl>
+          <DlRow label="Primary Metric" value={state.primaryMetricId} />
+          <DlRow label="Secondary Metrics" value={state.secondaryMetricsInput || 'None'} />
+          {state.guardrails.length > 0 && (
+            <DlRow
+              label="Guardrails"
+              value={state.guardrails.map((g) => `${g.metricId} (${g.threshold})`).join(', ')}
+            />
+          )}
+          {state.guardrails.length > 0 && (
+            <DlRow label="Guardrail Action" value={state.guardrailAction === 'AUTO_PAUSE' ? 'Auto-Pause' : 'Alert Only'} />
+          )}
+          {state.enableSequential && (
+            <>
+              <DlRow label="Sequential Method" value={state.sequentialMethod} />
+              <DlRow label="Planned Looks" value={String(state.plannedLooks)} />
+              <DlRow label="Overall Alpha" value={String(state.overallAlpha)} />
+            </>
+          )}
+        </dl>
+      </ReviewSection>
+    </section>
+  );
+}
+
+function renderTypeConfigSummary(state: ReturnType<typeof useWizard>['state']) {
+  switch (state.type) {
+    case 'INTERLEAVING': {
+      const c = state.interleavingConfig;
+      return (
+        <dl>
+          <DlRow label="Method" value={c.method} />
+          <DlRow label="Algorithm IDs" value={c.algorithmIds.filter(Boolean).join(', ')} />
+          <DlRow label="Credit Assignment" value={c.creditAssignment} />
+          <DlRow label="Credit Metric" value={c.creditMetricEvent} />
+          <DlRow label="Max List Size" value={String(c.maxListSize)} />
+        </dl>
+      );
+    }
+    case 'SESSION_LEVEL': {
+      const c = state.sessionConfig;
+      return (
+        <dl>
+          <DlRow label="Session ID Attribute" value={c.sessionIdAttribute} />
+          <DlRow label="Cross-Session" value={c.allowCrossSessionVariation ? 'Yes' : 'No'} />
+          <DlRow label="Min Sessions" value={String(c.minSessionsPerUser)} />
+        </dl>
+      );
+    }
+    case 'MAB':
+    case 'CONTEXTUAL_BANDIT': {
+      const c = state.banditExperimentConfig;
+      return (
+        <dl>
+          <DlRow label="Algorithm" value={c.algorithm} />
+          <DlRow label="Reward Metric" value={c.rewardMetricId} />
+          {state.type === 'CONTEXTUAL_BANDIT' && (
+            <DlRow label="Context Features" value={c.contextFeatureKeys.filter(Boolean).join(', ')} />
+          )}
+          <DlRow label="Exploration Fraction" value={String(c.minExplorationFraction)} />
+          <DlRow label="Warmup Observations" value={String(c.warmupObservations)} />
+        </dl>
+      );
+    }
+    case 'PLAYBACK_QOE': {
+      const c = state.qoeConfig;
+      return (
+        <dl>
+          <DlRow label="QoE Metrics" value={c.qoeMetrics.join(', ') || 'None selected'} />
+          <DlRow label="Device Filter" value={c.deviceFilter || 'None'} />
+        </dl>
+      );
+    }
+    default:
+      return <p className="text-xs text-gray-500">No type-specific configuration.</p>;
+  }
+}

--- a/ui/src/components/wizard/steps/session-config-form.tsx
+++ b/ui/src/components/wizard/steps/session-config-form.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+
+export function SessionConfigForm() {
+  const { state, dispatch } = useWizard();
+  const config = state.sessionConfig;
+
+  const update = (partial: Partial<typeof config>) =>
+    dispatch({ type: 'SET_FIELD', field: 'sessionConfig', value: { ...config, ...partial } });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label htmlFor="session-id-attr" className="block text-sm font-medium text-gray-700">
+          Session ID Attribute <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="session-id-attr"
+          type="text"
+          value={config.sessionIdAttribute}
+          onChange={(e) => update({ sessionIdAttribute: e.target.value })}
+          placeholder="e.g., session_id"
+          className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        />
+      </div>
+
+      <div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={config.allowCrossSessionVariation}
+            onChange={(e) => update({ allowCrossSessionVariation: e.target.checked })}
+            className="rounded border-gray-300"
+          />
+          <span className="text-sm text-gray-700">Allow cross-session variation</span>
+        </label>
+      </div>
+
+      <div>
+        <label htmlFor="min-sessions" className="block text-sm font-medium text-gray-700">
+          Minimum Sessions Per User
+        </label>
+        <input
+          id="min-sessions"
+          type="number"
+          min={1}
+          value={config.minSessionsPerUser}
+          onChange={(e) => update({ minSessionsPerUser: parseInt(e.target.value) || 1 })}
+          className="mt-1 block w-32 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/wizard/steps/type-config-step.tsx
+++ b/ui/src/components/wizard/steps/type-config-step.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+import { TYPE_LABELS } from '@/lib/utils';
+import { InterleavingConfigForm } from './interleaving-config-form';
+import { SessionConfigForm } from './session-config-form';
+import { BanditConfigForm } from './bandit-config-form';
+import { QoeConfigForm } from './qoe-config-form';
+
+export function TypeConfigStep() {
+  const { state } = useWizard();
+
+  return (
+    <section>
+      <h2 className="mb-4 text-lg font-semibold text-gray-900">
+        {TYPE_LABELS[state.type]} Configuration
+      </h2>
+      {renderConfigForm(state.type)}
+    </section>
+  );
+}
+
+function renderConfigForm(type: string) {
+  switch (type) {
+    case 'INTERLEAVING':
+      return <InterleavingConfigForm />;
+    case 'SESSION_LEVEL':
+      return <SessionConfigForm />;
+    case 'MAB':
+    case 'CONTEXTUAL_BANDIT':
+      return <BanditConfigForm />;
+    case 'PLAYBACK_QOE':
+      return <QoeConfigForm />;
+    default:
+      return (
+        <p className="rounded-md bg-gray-50 p-4 text-sm text-gray-600">
+          No additional configuration needed for this experiment type.
+        </p>
+      );
+  }
+}

--- a/ui/src/components/wizard/steps/variants-step.tsx
+++ b/ui/src/components/wizard/steps/variants-step.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useWizard } from '../wizard-context';
+import { validateJsonPayload } from '@/lib/validation';
+import { formatPercent } from '@/lib/utils';
+
+export function VariantsStep() {
+  const { state, dispatch } = useWizard();
+  const { variants } = state;
+
+  const trafficSum = variants.reduce((acc, v) => acc + v.trafficFraction, 0);
+  const trafficSumValid = Math.abs(trafficSum - 1.0) < 1e-9;
+
+  return (
+    <section>
+      <h2 className="mb-4 text-lg font-semibold text-gray-900">Variants</h2>
+      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Traffic</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Control</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Payload JSON</th>
+              <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {variants.map((v, i) => (
+              <tr key={v.variantId}>
+                <td className="px-4 py-2">
+                  <input
+                    type="text"
+                    value={v.name}
+                    onChange={(e) => dispatch({ type: 'UPDATE_VARIANT', index: i, field: 'name', value: e.target.value })}
+                    aria-label={`Variant ${i + 1} name`}
+                    className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  />
+                </td>
+                <td className="px-4 py-2">
+                  <input
+                    type="number"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={v.trafficFraction}
+                    onChange={(e) => dispatch({ type: 'UPDATE_VARIANT', index: i, field: 'trafficFraction', value: parseFloat(e.target.value) || 0 })}
+                    aria-label={`Variant ${i + 1} traffic`}
+                    className="w-24 rounded border border-gray-300 px-2 py-1 text-sm"
+                  />
+                </td>
+                <td className="px-4 py-2 text-center">
+                  <input
+                    type="radio"
+                    name="wizard-control-variant"
+                    checked={v.isControl}
+                    onChange={() => dispatch({ type: 'UPDATE_VARIANT', index: i, field: 'isControl', value: true })}
+                    aria-label={`Set ${v.name || `variant ${i + 1}`} as control`}
+                  />
+                </td>
+                <td className="px-4 py-2">
+                  <textarea
+                    value={v.payloadJson}
+                    onChange={(e) => dispatch({ type: 'UPDATE_VARIANT', index: i, field: 'payloadJson', value: e.target.value })}
+                    aria-label={`Variant ${i + 1} payload`}
+                    rows={1}
+                    className={`w-full rounded border px-2 py-1 font-mono text-xs ${
+                      !validateJsonPayload(v.payloadJson) ? 'border-red-500' : 'border-gray-300'
+                    }`}
+                  />
+                </td>
+                <td className="px-4 py-2">
+                  <button
+                    type="button"
+                    onClick={() => dispatch({ type: 'REMOVE_VARIANT', index: i })}
+                    disabled={variants.length <= 2}
+                    className="text-sm text-red-600 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400"
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-2 flex items-center justify-between">
+        <span className={`text-sm font-medium ${trafficSumValid ? 'text-green-700' : 'text-red-700'}`}>
+          Total traffic: {formatPercent(trafficSum)}
+        </span>
+        <button
+          type="button"
+          onClick={() => dispatch({ type: 'ADD_VARIANT' })}
+          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Add Variant
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/wizard/wizard-context.tsx
+++ b/ui/src/components/wizard/wizard-context.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { createContext, useContext, useReducer, type ReactNode } from 'react';
+import type {
+  ExperimentType, Variant, GuardrailConfig, GuardrailAction, SequentialMethod,
+  InterleavingConfig, SessionConfig, BanditExperimentConfig, QoeConfig,
+} from '@/lib/types';
+import { generateVariantId } from '@/lib/validation';
+
+export interface WizardState {
+  currentStep: number;
+  // Step 1: Basics
+  name: string;
+  description: string;
+  ownerEmail: string;
+  type: ExperimentType;
+  layerId: string;
+  targetingRuleId: string;
+  isCumulativeHoldout: boolean;
+  // Step 2: Type-specific config
+  interleavingConfig: InterleavingConfig;
+  sessionConfig: SessionConfig;
+  banditExperimentConfig: BanditExperimentConfig;
+  qoeConfig: QoeConfig;
+  // Step 3: Variants
+  variants: Variant[];
+  // Step 4: Metrics & Guardrails
+  primaryMetricId: string;
+  secondaryMetricsInput: string;
+  guardrails: GuardrailConfig[];
+  guardrailAction: GuardrailAction;
+  enableSequential: boolean;
+  sequentialMethod: SequentialMethod;
+  plannedLooks: number;
+  overallAlpha: number;
+  // Status
+  submitting: boolean;
+  formError: string | null;
+  stepErrors: Record<number, string | null>;
+}
+
+export const DEFAULT_INTERLEAVING_CONFIG: InterleavingConfig = {
+  method: 'TEAM_DRAFT',
+  algorithmIds: ['', ''],
+  creditAssignment: 'BINARY_WIN',
+  creditMetricEvent: '',
+  maxListSize: 10,
+};
+
+export const DEFAULT_SESSION_CONFIG: SessionConfig = {
+  sessionIdAttribute: '',
+  allowCrossSessionVariation: false,
+  minSessionsPerUser: 1,
+};
+
+export const DEFAULT_BANDIT_CONFIG: BanditExperimentConfig = {
+  algorithm: 'THOMPSON_SAMPLING',
+  rewardMetricId: '',
+  contextFeatureKeys: [],
+  minExplorationFraction: 0.1,
+  warmupObservations: 100,
+};
+
+export const DEFAULT_QOE_CONFIG: QoeConfig = {
+  qoeMetrics: [],
+  deviceFilter: '',
+};
+
+function defaultVariants(): Variant[] {
+  return [
+    { variantId: generateVariantId(), name: 'control', trafficFraction: 0.5, isControl: true, payloadJson: '{}' },
+    { variantId: generateVariantId(), name: 'treatment', trafficFraction: 0.5, isControl: false, payloadJson: '{}' },
+  ];
+}
+
+export function createInitialState(): WizardState {
+  return {
+    currentStep: 0,
+    name: '',
+    description: '',
+    ownerEmail: '',
+    type: 'AB',
+    layerId: '',
+    targetingRuleId: '',
+    isCumulativeHoldout: false,
+    interleavingConfig: { ...DEFAULT_INTERLEAVING_CONFIG, algorithmIds: ['', ''] },
+    sessionConfig: { ...DEFAULT_SESSION_CONFIG },
+    banditExperimentConfig: { ...DEFAULT_BANDIT_CONFIG, contextFeatureKeys: [] },
+    qoeConfig: { ...DEFAULT_QOE_CONFIG, qoeMetrics: [] },
+    variants: defaultVariants(),
+    primaryMetricId: '',
+    secondaryMetricsInput: '',
+    guardrails: [],
+    guardrailAction: 'AUTO_PAUSE',
+    enableSequential: false,
+    sequentialMethod: 'MSPRT',
+    plannedLooks: 0,
+    overallAlpha: 0.05,
+    submitting: false,
+    formError: null,
+    stepErrors: {},
+  };
+}
+
+export type WizardAction =
+  | { type: 'SET_FIELD'; field: string; value: unknown }
+  | { type: 'SET_STEP'; step: number }
+  | { type: 'ADD_VARIANT' }
+  | { type: 'REMOVE_VARIANT'; index: number }
+  | { type: 'UPDATE_VARIANT'; index: number; field: keyof Variant; value: string | number | boolean }
+  | { type: 'ADD_GUARDRAIL' }
+  | { type: 'REMOVE_GUARDRAIL'; index: number }
+  | { type: 'UPDATE_GUARDRAIL'; index: number; field: keyof GuardrailConfig; value: string | number }
+  | { type: 'SET_STEP_ERROR'; step: number; error: string | null }
+  | { type: 'RESET' };
+
+function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case 'SET_FIELD':
+      return { ...state, [action.field]: action.value };
+
+    case 'SET_STEP':
+      return { ...state, currentStep: action.step };
+
+    case 'ADD_VARIANT':
+      return {
+        ...state,
+        variants: [
+          ...state.variants,
+          { variantId: generateVariantId(), name: '', trafficFraction: 0, isControl: false, payloadJson: '{}' },
+        ],
+      };
+
+    case 'REMOVE_VARIANT':
+      return { ...state, variants: state.variants.filter((_, i) => i !== action.index) };
+
+    case 'UPDATE_VARIANT': {
+      const variants = [...state.variants];
+      if (action.field === 'isControl' && action.value === true) {
+        variants.forEach((v, i) => { variants[i] = { ...v, isControl: i === action.index }; });
+      } else {
+        variants[action.index] = { ...variants[action.index], [action.field]: action.value };
+      }
+      return { ...state, variants };
+    }
+
+    case 'ADD_GUARDRAIL':
+      return {
+        ...state,
+        guardrails: [...state.guardrails, { metricId: '', threshold: 0, consecutiveBreachesRequired: 1 }],
+      };
+
+    case 'REMOVE_GUARDRAIL':
+      return { ...state, guardrails: state.guardrails.filter((_, i) => i !== action.index) };
+
+    case 'UPDATE_GUARDRAIL': {
+      const guardrails = [...state.guardrails];
+      guardrails[action.index] = { ...guardrails[action.index], [action.field]: action.value };
+      return { ...state, guardrails };
+    }
+
+    case 'SET_STEP_ERROR':
+      return { ...state, stepErrors: { ...state.stepErrors, [action.step]: action.error } };
+
+    case 'RESET':
+      return createInitialState();
+
+    default:
+      return state;
+  }
+}
+
+interface WizardContextValue {
+  state: WizardState;
+  dispatch: React.Dispatch<WizardAction>;
+}
+
+const WizardContext = createContext<WizardContextValue | null>(null);
+
+export function WizardProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(wizardReducer, undefined, createInitialState);
+  return (
+    <WizardContext.Provider value={{ state, dispatch }}>
+      {children}
+    </WizardContext.Provider>
+  );
+}
+
+export function useWizard(): WizardContextValue {
+  const ctx = useContext(WizardContext);
+  if (!ctx) throw new Error('useWizard must be used within WizardProvider');
+  return ctx;
+}
+
+export const WIZARD_STEPS = ['Basics', 'Type Config', 'Variants', 'Metrics & Guardrails', 'Review'] as const;

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   GstTrajectoryResult, CateAnalysisResult, Layer, LayerAllocation,
   SurrogateProjection, SrmResult, MetricResult, SegmentResult,
   MetricDefinition, ListMetricDefinitionsResponse,
+  InterleavingConfig, SessionConfig, BanditExperimentConfig, QoeConfig,
 } from './types';
 import type { ExperimentState, ExperimentType, MetricType, LifecycleSegment } from './types';
 
@@ -212,6 +213,10 @@ function adaptExperiment(proto: Record<string, unknown>): Experiment {
     targetingRuleId: proto.targetingRuleId as string | undefined,
     surrogateModelId: proto.surrogateModelId as string | undefined,
     isCumulativeHoldout: (proto.isCumulativeHoldout as boolean) || false,
+    interleavingConfig: proto.interleavingConfig as InterleavingConfig | undefined,
+    sessionConfig: proto.sessionConfig as SessionConfig | undefined,
+    banditExperimentConfig: proto.banditExperimentConfig as BanditExperimentConfig | undefined,
+    qoeConfig: proto.qoeConfig as QoeConfig | undefined,
     createdAt: (proto.createdAt as string) || '',
     startedAt: proto.startedAt as string | undefined,
     concludedAt: proto.concludedAt as string | undefined,

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -62,6 +62,10 @@ export interface Experiment {
   targetingRuleId?: string;
   surrogateModelId?: string;
   isCumulativeHoldout: boolean;
+  interleavingConfig?: InterleavingConfig;
+  sessionConfig?: SessionConfig;
+  banditExperimentConfig?: BanditExperimentConfig;
+  qoeConfig?: QoeConfig;
   createdAt: string;
   startedAt?: string;
   concludedAt?: string;
@@ -86,6 +90,10 @@ export interface CreateExperimentRequest {
   sequentialTestConfig?: SequentialTestConfig;
   targetingRuleId?: string;
   isCumulativeHoldout: boolean;
+  interleavingConfig?: InterleavingConfig;
+  sessionConfig?: SessionConfig;
+  banditExperimentConfig?: BanditExperimentConfig;
+  qoeConfig?: QoeConfig;
 }
 
 export interface QueryLogEntry {
@@ -426,6 +434,38 @@ export interface MetricDefinition {
 export interface ListMetricDefinitionsResponse {
   metrics: MetricDefinition[];
   nextPageToken: string;
+}
+
+// --- Type-specific experiment config (wizard step 2) ---
+
+export type InterleavingMethod = 'TEAM_DRAFT' | 'OPTIMIZED' | 'MULTILEAVE';
+export type CreditAssignment = 'BINARY_WIN' | 'PROPORTIONAL' | 'WEIGHTED';
+
+export interface InterleavingConfig {
+  method: InterleavingMethod;
+  algorithmIds: string[];
+  creditAssignment: CreditAssignment;
+  creditMetricEvent: string;
+  maxListSize: number;
+}
+
+export interface SessionConfig {
+  sessionIdAttribute: string;
+  allowCrossSessionVariation: boolean;
+  minSessionsPerUser: number;
+}
+
+export interface BanditExperimentConfig {
+  algorithm: BanditAlgorithm;
+  rewardMetricId: string;
+  contextFeatureKeys: string[];
+  minExplorationFraction: number;
+  warmupObservations: number;
+}
+
+export interface QoeConfig {
+  qoeMetrics: string[];
+  deviceFilter: string;
 }
 
 export type BanditAlgorithm = 'THOMPSON_SAMPLING' | 'LINEAR_UCB' | 'THOMPSON_LINEAR' | 'NEURAL_CONTEXTUAL';

--- a/ui/src/lib/validation.ts
+++ b/ui/src/lib/validation.ts
@@ -1,4 +1,8 @@
-import type { ExperimentType, Variant } from './types';
+import type {
+  ExperimentType, Variant,
+  InterleavingConfig, SessionConfig, BanditExperimentConfig, QoeConfig,
+  GuardrailConfig,
+} from './types';
 
 const EPSILON = 1e-9;
 
@@ -49,6 +53,112 @@ export interface ValidationResult {
   valid: boolean;
   errors: VariantError[];
   bannerError?: string;
+}
+
+// --- Wizard step validators ---
+
+export interface StepValidation {
+  valid: boolean;
+  error?: string;
+}
+
+interface BasicsFields {
+  name: string;
+  ownerEmail: string;
+  layerId: string;
+}
+
+export function validateBasics(fields: BasicsFields): StepValidation {
+  if (!fields.name.trim()) return { valid: false, error: 'Experiment name is required' };
+  if (!fields.ownerEmail.trim()) return { valid: false, error: 'Owner email is required' };
+  if (!fields.layerId.trim()) return { valid: false, error: 'Layer ID is required' };
+  return { valid: true };
+}
+
+export function validateInterleavingConfig(config: InterleavingConfig): StepValidation {
+  const minAlgorithms = config.method === 'MULTILEAVE' ? 3 : 2;
+  if (config.algorithmIds.filter(Boolean).length < minAlgorithms) {
+    return { valid: false, error: `At least ${minAlgorithms} algorithm IDs required for ${config.method}` };
+  }
+  if (!config.creditMetricEvent.trim()) {
+    return { valid: false, error: 'Credit metric event is required' };
+  }
+  if (config.maxListSize < 1) {
+    return { valid: false, error: 'Max list size must be at least 1' };
+  }
+  return { valid: true };
+}
+
+export function validateSessionConfig(config: SessionConfig): StepValidation {
+  if (!config.sessionIdAttribute.trim()) {
+    return { valid: false, error: 'Session ID attribute is required' };
+  }
+  if (config.minSessionsPerUser < 1) {
+    return { valid: false, error: 'Minimum sessions per user must be at least 1' };
+  }
+  return { valid: true };
+}
+
+export function validateBanditConfig(config: BanditExperimentConfig, isContextual: boolean): StepValidation {
+  if (!config.rewardMetricId.trim()) {
+    return { valid: false, error: 'Reward metric ID is required' };
+  }
+  if (isContextual && config.contextFeatureKeys.filter(Boolean).length === 0) {
+    return { valid: false, error: 'At least one context feature key is required for contextual bandits' };
+  }
+  if (config.minExplorationFraction < 0 || config.minExplorationFraction > 1) {
+    return { valid: false, error: 'Exploration fraction must be between 0 and 1' };
+  }
+  if (config.warmupObservations < 0) {
+    return { valid: false, error: 'Warmup observations must be non-negative' };
+  }
+  return { valid: true };
+}
+
+export function validateQoeConfig(config: QoeConfig): StepValidation {
+  if (config.qoeMetrics.length === 0) {
+    return { valid: false, error: 'At least one QoE metric must be selected' };
+  }
+  return { valid: true };
+}
+
+export function validateTypeConfig(type: ExperimentType, configs: {
+  interleavingConfig: InterleavingConfig;
+  sessionConfig: SessionConfig;
+  banditExperimentConfig: BanditExperimentConfig;
+  qoeConfig: QoeConfig;
+}): StepValidation {
+  switch (type) {
+    case 'INTERLEAVING':
+      return validateInterleavingConfig(configs.interleavingConfig);
+    case 'SESSION_LEVEL':
+      return validateSessionConfig(configs.sessionConfig);
+    case 'MAB':
+      return validateBanditConfig(configs.banditExperimentConfig, false);
+    case 'CONTEXTUAL_BANDIT':
+      return validateBanditConfig(configs.banditExperimentConfig, true);
+    case 'PLAYBACK_QOE':
+      return validateQoeConfig(configs.qoeConfig);
+    default:
+      return { valid: true };
+  }
+}
+
+interface MetricsFields {
+  primaryMetricId: string;
+  guardrails: GuardrailConfig[];
+}
+
+export function validateMetricsStep(fields: MetricsFields): StepValidation {
+  if (!fields.primaryMetricId.trim()) {
+    return { valid: false, error: 'Primary metric is required' };
+  }
+  for (const g of fields.guardrails) {
+    if (!g.metricId.trim()) {
+      return { valid: false, error: 'All guardrail metrics must have an ID' };
+    }
+  }
+  return { valid: true };
 }
 
 /** Full validation for a variant set. Returns field-level and banner errors. */


### PR DESCRIPTION
## Summary
- Replace monolithic experiment creation form with a 5-step wizard: Basics → Type Config → Variants → Metrics & Guardrails → Review
- Add type-specific configuration sub-forms for INTERLEAVING (method, algorithm IDs, credit assignment), SESSION_LEVEL (session ID attribute, cross-session), MAB/CONTEXTUAL_BANDIT (algorithm, reward metric, context features), and PLAYBACK_QOE (metric checkboxes, device filter)
- WizardProvider with useReducer centralizes state management, replacing 20+ useState calls
- Per-step validation prevents advancing with missing required fields; Review step has per-section "Edit" links to jump back

## Files Changed
- 6 modified: `types.ts`, `validation.ts`, `api.ts`, `experiment-form.tsx`, `seed-data.ts`, `handlers.ts`
- 13 new: wizard context, step indicator, 9 step/sub-form components, 2 test files
- 1 updated test: `accessibility.test.tsx` adjusted for wizard multi-step UI

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — all 413 tests pass (37 new: 26 validation + 11 wizard integration)
- [x] Wizard navigates correctly through all 5 steps
- [x] Each experiment type shows correct type-specific config fields on step 2
- [x] Step validation prevents advancing with missing required fields
- [x] Review step shows all configured values and "Edit" links work
- [x] Submit creates experiment with type-specific config in request body
- [x] Existing tests updated for multi-step navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
