### PR TITLE
feat(m4a): wire IPW-adjusted analysis end-to-end

### DIFF
--- a/crates/experimentation-analysis/src/delta_reader.rs
+++ b/crates/experimentation-analysis/src/delta_reader.rs
@@ -245,6 +245,10 @@ pub struct ExperimentMetrics {
     /// Populated only when metric_summaries has a `session_id` column,
     /// indicating multiple rows per user (one per session).
     pub session_data: HashMap<String, Vec<(f64, String, String)>>,
+    /// IPW observations: metric_id → Vec<(value, variant_id, assignment_probability)>.
+    /// Populated only when metric_summaries has an `assignment_probability` column
+    /// (produced by M3 for bandit experiments).
+    pub ipw_data: HashMap<String, Vec<(f64, String, f64)>>,
 }
 
 /// Read metric_summaries from Delta Lake for a given experiment.
@@ -262,6 +266,7 @@ pub async fn read_metric_summaries(
     let mut metrics: MetricsByVariant = HashMap::new();
     let mut segment_data: SegmentData = HashMap::new();
     let mut session_data: HashMap<String, Vec<(f64, String, String)>> = HashMap::new();
+    let mut ipw_data: HashMap<String, Vec<(f64, String, f64)>> = HashMap::new();
     let mut variant_users: HashMap<String, HashSet<String>> = HashMap::new();
     let mut found = false;
 
@@ -288,6 +293,12 @@ pub async fn read_metric_summaries(
         let session_arr = batch
             .column_by_name("session_id")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+
+        // assignment_probability is optional — when present, enables IPW-adjusted analysis.
+        // Produced by M3 for bandit experiments (PR #170).
+        let prob_arr = batch
+            .column_by_name("assignment_probability")
+            .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
 
         for i in 0..batch.num_rows() {
             if exp_arr.is_null(i) || exp_arr.value(i) != experiment_id {
@@ -334,11 +345,20 @@ pub async fn read_metric_summaries(
             // Populate session-level data when session_id is present and non-null.
             if let Some(sess_arr) = session_arr {
                 if !sess_arr.is_null(i) {
-                    session_data.entry(metric).or_default().push((
-                        value,
-                        user_arr.value(i).to_string(),
-                        variant,
-                    ));
+                    session_data
+                        .entry(metric.clone())
+                        .or_default()
+                        .push((value, user_arr.value(i).to_string(), variant.clone()));
+                }
+            }
+
+            // Populate IPW data when assignment_probability is present and non-null.
+            if let Some(p_arr) = prob_arr {
+                if !p_arr.is_null(i) {
+                    ipw_data
+                        .entry(metric)
+                        .or_default()
+                        .push((value, variant, p_arr.value(i)));
                 }
             }
         }
@@ -361,6 +381,7 @@ pub async fn read_metric_summaries(
         variant_user_counts,
         segment_data,
         session_data,
+        ipw_data,
     })
 }
 
@@ -863,6 +884,120 @@ mod tests {
         assert_eq!(result.metrics.len(), 2);
         assert!(result.metrics.contains_key("ctr"));
         assert!(result.metrics.contains_key("revenue"));
+    }
+
+    // -----------------------------------------------------------------------
+    // IPW (assignment_probability) tests
+    // -----------------------------------------------------------------------
+
+    fn metric_summaries_schema_with_ipw() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("user_id", DataType::Utf8, false),
+            Field::new("variant_id", DataType::Utf8, false),
+            Field::new("metric_id", DataType::Utf8, false),
+            Field::new("metric_value", DataType::Float64, false),
+            Field::new("cuped_covariate", DataType::Float64, true),
+            Field::new("assignment_probability", DataType::Float64, true),
+        ]))
+    }
+
+    fn make_ipw_metric_batch(
+        experiment_ids: &[&str],
+        user_ids: &[&str],
+        variant_ids: &[&str],
+        metric_ids: &[&str],
+        metric_values: &[f64],
+        covariates: &[Option<f64>],
+        assignment_probs: &[Option<f64>],
+    ) -> RecordBatch {
+        let schema = metric_summaries_schema_with_ipw();
+        let cov_arr: Float64Array = covariates.iter().copied().collect();
+        let prob_arr: Float64Array = assignment_probs.iter().copied().collect();
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(experiment_ids.to_vec())),
+                Arc::new(StringArray::from(user_ids.to_vec())),
+                Arc::new(StringArray::from(variant_ids.to_vec())),
+                Arc::new(StringArray::from(metric_ids.to_vec())),
+                Arc::new(Float64Array::from(metric_values.to_vec())),
+                Arc::new(cov_arr),
+                Arc::new(prob_arr),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_metric_summaries_with_ipw() {
+        let tmp = TempDir::new().unwrap();
+        let batch = make_ipw_metric_batch(
+            &["exp-1", "exp-1", "exp-1", "exp-1"],
+            &["u1", "u2", "u3", "u4"],
+            &["control", "control", "treatment", "treatment"],
+            &["ctr", "ctr", "ctr", "ctr"],
+            &[0.1, 0.2, 0.3, 0.4],
+            &[None, None, None, None],
+            &[Some(0.5), Some(0.5), Some(0.3), Some(0.3)],
+        );
+        write_named_test_table(tmp.path(), "metric_summaries", batch).await;
+
+        let result = read_metric_summaries(tmp.path().to_str().unwrap(), "exp-1")
+            .await
+            .unwrap();
+
+        // ipw_data should be populated
+        assert!(result.ipw_data.contains_key("ctr"));
+        let ipw_obs = &result.ipw_data["ctr"];
+        assert_eq!(ipw_obs.len(), 4);
+        // Check assignment probabilities are read correctly
+        assert!((ipw_obs[0].2 - 0.5).abs() < 1e-10 || (ipw_obs[0].2 - 0.3).abs() < 1e-10);
+    }
+
+    #[tokio::test]
+    async fn test_read_metric_summaries_without_ipw_column() {
+        // Standard schema without assignment_probability → ipw_data should be empty
+        let tmp = TempDir::new().unwrap();
+        let batch = make_metric_batch(
+            &["exp-1", "exp-1", "exp-1", "exp-1"],
+            &["u1", "u2", "u3", "u4"],
+            &["control", "control", "treatment", "treatment"],
+            &["ctr", "ctr", "ctr", "ctr"],
+            &[0.1, 0.2, 0.3, 0.4],
+            &[None, None, None, None],
+        );
+        write_named_test_table(tmp.path(), "metric_summaries", batch).await;
+
+        let result = read_metric_summaries(tmp.path().to_str().unwrap(), "exp-1")
+            .await
+            .unwrap();
+
+        assert!(result.ipw_data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_read_metric_summaries_ipw_null_probabilities() {
+        // Some rows have null assignment_probability → only non-null ones in ipw_data
+        let tmp = TempDir::new().unwrap();
+        let batch = make_ipw_metric_batch(
+            &["exp-1", "exp-1", "exp-1", "exp-1"],
+            &["u1", "u2", "u3", "u4"],
+            &["control", "control", "treatment", "treatment"],
+            &["ctr", "ctr", "ctr", "ctr"],
+            &[0.1, 0.2, 0.3, 0.4],
+            &[None, None, None, None],
+            &[Some(0.5), None, Some(0.3), None],
+        );
+        write_named_test_table(tmp.path(), "metric_summaries", batch).await;
+
+        let result = read_metric_summaries(tmp.path().to_str().unwrap(), "exp-1")
+            .await
+            .unwrap();
+
+        assert!(result.ipw_data.contains_key("ctr"));
+        // Only 2 out of 4 rows have non-null assignment_probability
+        assert_eq!(result.ipw_data["ctr"].len(), 2);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/experimentation-analysis/src/grpc.rs
+++ b/crates/experimentation-analysis/src/grpc.rs
@@ -11,12 +11,13 @@ use experimentation_proto::experimentation::analysis::v1::analysis_service_serve
 use experimentation_proto::experimentation::analysis::v1::{
     AlgorithmStrength as ProtoAlgorithmStrength, AnalysisResult, GetAnalysisResultRequest,
     GetInterferenceAnalysisRequest, GetInterleavingAnalysisRequest, GetNoveltyAnalysisRequest,
-    InterferenceAnalysisResult, InterleavingAnalysisResult, MetricResult, NoveltyAnalysisResult,
-    PositionAnalysis as ProtoPositionAnalysis, RunAnalysisRequest, SegmentResult,
-    SessionLevelResult, SrmResult as ProtoSrmResult, TitleSpillover,
+    InterferenceAnalysisResult, InterleavingAnalysisResult, IpwResult as ProtoIpwResult,
+    MetricResult, NoveltyAnalysisResult, PositionAnalysis as ProtoPositionAnalysis,
+    RunAnalysisRequest, SegmentResult, SessionLevelResult, SrmResult as ProtoSrmResult,
+    TitleSpillover,
 };
 use experimentation_stats::{
-    cate, clustering, cuped, interference, interleaving, novelty, srm, ttest,
+    cate, clustering, cuped, interference, interleaving, ipw, novelty, srm, ttest,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -314,6 +315,13 @@ async fn compute_analysis(
                     variant_id,
                     alpha,
                 ),
+                ipw_result: compute_ipw_result(
+                    &data,
+                    metric_id,
+                    &control_variant,
+                    variant_id,
+                    alpha,
+                ),
             });
         }
     }
@@ -383,6 +391,66 @@ fn compute_session_level_result(
                 metric_id = metric_id,
                 error = %e,
                 "failed to compute clustered SE, skipping session_level_result"
+            );
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IPW-adjusted analysis helper
+// ---------------------------------------------------------------------------
+
+/// Compute IPW-adjusted treatment effect if assignment_probability data is available.
+///
+/// Returns `Some(ProtoIpwResult)` when `ipw_data` contains observations
+/// for this metric with both control and treatment arms, or `None` otherwise.
+fn compute_ipw_result(
+    data: &delta_reader::ExperimentMetrics,
+    metric_id: &str,
+    control_variant: &str,
+    treatment_variant: &str,
+    alpha: f64,
+) -> Option<ProtoIpwResult> {
+    let ipw_rows = data.ipw_data.get(metric_id)?;
+
+    let observations: Vec<ipw::IpwObservation> = ipw_rows
+        .iter()
+        .filter_map(|(value, variant_id, prob)| {
+            let is_treatment = if variant_id == treatment_variant {
+                true
+            } else if variant_id == control_variant {
+                false
+            } else {
+                return None; // skip other variants
+            };
+            Some(ipw::IpwObservation {
+                outcome: *value,
+                is_treatment,
+                assignment_probability: *prob,
+            })
+        })
+        .collect();
+
+    if observations.len() < 2 {
+        return None;
+    }
+
+    match ipw::ipw_estimate(&observations, alpha, 0.01) {
+        Ok(result) => Some(ProtoIpwResult {
+            effect: result.effect,
+            se: result.se,
+            ci_lower: result.ci_lower,
+            ci_upper: result.ci_upper,
+            p_value: result.p_value,
+            n_clipped: result.n_clipped as i32,
+            effective_sample_size: result.effective_sample_size,
+        }),
+        Err(e) => {
+            warn!(
+                metric_id = metric_id,
+                error = %e,
+                "failed to compute IPW-adjusted effect, skipping ipw_result"
             );
             None
         }
@@ -1717,6 +1785,187 @@ mod tests {
             result.cochran_q_p_value > 0.05,
             "cochran_q_p_value {} should be > 0.05 for homogeneous effects",
             result.cochran_q_p_value
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // IPW-adjusted analysis tests
+    // -----------------------------------------------------------------------
+
+    fn metric_summaries_schema_with_ipw() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("experiment_id", DataType::Utf8, false),
+            Field::new("user_id", DataType::Utf8, false),
+            Field::new("variant_id", DataType::Utf8, false),
+            Field::new("metric_id", DataType::Utf8, false),
+            Field::new("metric_value", DataType::Float64, false),
+            Field::new("cuped_covariate", DataType::Float64, true),
+            Field::new("assignment_probability", DataType::Float64, true),
+        ]))
+    }
+
+    fn make_ipw_analysis_data(
+        exp_ids: &[&str],
+        user_ids: &[&str],
+        variant_ids: &[&str],
+        metric_ids: &[&str],
+        values: &[f64],
+        covariates: &[Option<f64>],
+        assignment_probs: &[Option<f64>],
+    ) -> RecordBatch {
+        let cov_arr: Float64Array = covariates.iter().copied().collect();
+        let prob_arr: Float64Array = assignment_probs.iter().copied().collect();
+        RecordBatch::try_new(
+            metric_summaries_schema_with_ipw(),
+            vec![
+                Arc::new(StringArray::from(exp_ids.to_vec())),
+                Arc::new(StringArray::from(user_ids.to_vec())),
+                Arc::new(StringArray::from(variant_ids.to_vec())),
+                Arc::new(StringArray::from(metric_ids.to_vec())),
+                Arc::new(Float64Array::from(values.to_vec())),
+                Arc::new(cov_arr),
+                Arc::new(prob_arr),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_with_ipw() {
+        let tmp = TempDir::new().unwrap();
+        // 5 control + 5 treatment, with varying assignment probabilities (bandit-style)
+        let n = 10;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<&str> =
+            vec!["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10"];
+        let variant_ids: Vec<&str> = vec![
+            "control",
+            "control",
+            "control",
+            "control",
+            "control",
+            "treatment",
+            "treatment",
+            "treatment",
+            "treatment",
+            "treatment",
+        ];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 11.0, 12.0, 13.0, 14.0, 15.0];
+        let covariates: Vec<Option<f64>> = vec![None; n];
+        // Bandit-style: control gets 70%, treatment gets 30%
+        let probs: Vec<Option<f64>> = vec![
+            Some(0.7),
+            Some(0.7),
+            Some(0.7),
+            Some(0.7),
+            Some(0.7),
+            Some(0.3),
+            Some(0.3),
+            Some(0.3),
+            Some(0.3),
+            Some(0.3),
+        ];
+
+        let batch = make_ipw_analysis_data(
+            &exp_ids,
+            &user_ids,
+            &variant_ids,
+            &metric_ids,
+            &values,
+            &covariates,
+            &probs,
+        );
+        write_table(tmp.path(), "metric_summaries", batch).await;
+
+        let handler = test_handler(tmp.path().to_str().unwrap());
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+            }))
+            .await
+            .unwrap();
+
+        let result = resp.into_inner();
+        assert_eq!(result.metric_results.len(), 1);
+
+        let mr = &result.metric_results[0];
+        // IPW result should be populated
+        assert!(
+            mr.ipw_result.is_some(),
+            "ipw_result should be populated when assignment_probability is available"
+        );
+        let ipw = mr.ipw_result.as_ref().unwrap();
+        // IPW effect should be positive (treatment > control)
+        assert!(
+            ipw.effect > 0.0,
+            "IPW effect {} should be positive",
+            ipw.effect
+        );
+        // SE should be positive
+        assert!(ipw.se > 0.0, "IPW SE {} should be positive", ipw.se);
+        // CI should bracket the effect
+        assert!(ipw.ci_lower < ipw.effect);
+        assert!(ipw.ci_upper > ipw.effect);
+        // p-value should be significant for this large effect
+        assert!(
+            ipw.p_value < 0.05,
+            "IPW p_value {} should be < 0.05",
+            ipw.p_value
+        );
+        // ESS should be positive and less than N
+        assert!(ipw.effective_sample_size > 0.0);
+        assert!(ipw.effective_sample_size <= n as f64);
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_without_ipw_column() {
+        // Standard data without assignment_probability → ipw_result should be None
+        let tmp = TempDir::new().unwrap();
+        let n = 10;
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<&str> =
+            vec!["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10"];
+        let variant_ids: Vec<&str> = vec![
+            "control",
+            "control",
+            "control",
+            "control",
+            "control",
+            "treatment",
+            "treatment",
+            "treatment",
+            "treatment",
+            "treatment",
+        ];
+        let metric_ids: Vec<&str> = vec!["ctr"; n];
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 11.0, 12.0, 13.0, 14.0, 15.0];
+        let covariates: Vec<Option<f64>> = vec![None; n];
+
+        let batch = make_analysis_data(
+            &exp_ids,
+            &user_ids,
+            &variant_ids,
+            &metric_ids,
+            &values,
+            &covariates,
+        );
+        write_table(tmp.path(), "metric_summaries", batch).await;
+
+        let handler = test_handler(tmp.path().to_str().unwrap());
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+            }))
+            .await
+            .unwrap();
+
+        let result = resp.into_inner();
+        let mr = &result.metric_results[0];
+        // Without assignment_probability column, IPW result should be None
+        assert!(
+            mr.ipw_result.is_none(),
+            "ipw_result should be None when assignment_probability is not available"
         );
     }
 }

--- a/crates/experimentation-analysis/src/store.rs
+++ b/crates/experimentation-analysis/src/store.rs
@@ -10,8 +10,9 @@ use sqlx::postgres::{PgPool, PgPoolOptions};
 use uuid::Uuid;
 
 use experimentation_proto::experimentation::analysis::v1::{
-    AnalysisResult, InterferenceAnalysisResult, MetricResult, NoveltyAnalysisResult, SegmentResult,
-    SequentialResult, SessionLevelResult, SrmResult as ProtoSrmResult,
+    AnalysisResult, InterferenceAnalysisResult, IpwResult as ProtoIpwResult, MetricResult,
+    NoveltyAnalysisResult, SegmentResult, SequentialResult, SessionLevelResult,
+    SrmResult as ProtoSrmResult,
 };
 
 // ---------------------------------------------------------------------------
@@ -47,6 +48,8 @@ pub struct CachedMetricResult {
     pub sequential_result: Option<CachedSequentialResult>,
     pub segment_results: Vec<CachedSegmentResult>,
     pub session_level_result: Option<CachedSessionLevelResult>,
+    #[serde(default)]
+    pub ipw_result: Option<CachedIpwResult>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -75,6 +78,17 @@ pub struct CachedSessionLevelResult {
     pub design_effect: f64,
     pub naive_p_value: f64,
     pub clustered_p_value: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CachedIpwResult {
+    pub effect: f64,
+    pub se: f64,
+    pub ci_lower: f64,
+    pub ci_upper: f64,
+    pub p_value: f64,
+    pub n_clipped: i32,
+    pub effective_sample_size: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -148,6 +162,7 @@ impl From<&MetricResult> for CachedMetricResult {
                 .session_level_result
                 .as_ref()
                 .map(CachedSessionLevelResult::from),
+            ipw_result: m.ipw_result.as_ref().map(CachedIpwResult::from),
         }
     }
 }
@@ -175,6 +190,7 @@ impl From<&CachedMetricResult> for MetricResult {
                 .session_level_result
                 .as_ref()
                 .map(SessionLevelResult::from),
+            ipw_result: c.ipw_result.as_ref().map(ProtoIpwResult::from),
         }
     }
 }
@@ -249,6 +265,34 @@ impl From<&CachedSessionLevelResult> for SessionLevelResult {
             design_effect: c.design_effect,
             naive_p_value: c.naive_p_value,
             clustered_p_value: c.clustered_p_value,
+        }
+    }
+}
+
+impl From<&ProtoIpwResult> for CachedIpwResult {
+    fn from(i: &ProtoIpwResult) -> Self {
+        Self {
+            effect: i.effect,
+            se: i.se,
+            ci_lower: i.ci_lower,
+            ci_upper: i.ci_upper,
+            p_value: i.p_value,
+            n_clipped: i.n_clipped,
+            effective_sample_size: i.effective_sample_size,
+        }
+    }
+}
+
+impl From<&CachedIpwResult> for ProtoIpwResult {
+    fn from(c: &CachedIpwResult) -> Self {
+        Self {
+            effect: c.effect,
+            se: c.se,
+            ci_lower: c.ci_lower,
+            ci_upper: c.ci_upper,
+            p_value: c.p_value,
+            n_clipped: c.n_clipped,
+            effective_sample_size: c.effective_sample_size,
         }
     }
 }
@@ -545,6 +589,7 @@ mod tests {
                 sequential_result: None,
                 segment_results: vec![],
                 session_level_result: None,
+                ipw_result: None,
             }],
             srm_result: Some(ProtoSrmResult {
                 chi_squared: 0.1,

--- a/proto/experimentation/analysis/v1/analysis_service.proto
+++ b/proto/experimentation/analysis/v1/analysis_service.proto
@@ -53,6 +53,8 @@ message MetricResult {
   repeated SegmentResult segment_results = 16;
   // Session-level: both naive and clustered estimates.
   SessionLevelResult session_level_result = 17;
+  // IPW-adjusted result for bandit experiments (when assignment_probability available).
+  IpwResult ipw_result = 18;
 }
 
 message SequentialResult {
@@ -84,6 +86,22 @@ message SessionLevelResult {
   double design_effect = 3;
   double naive_p_value = 4;
   double clustered_p_value = 5;
+}
+
+// IPW-adjusted treatment effect for bandit experiments.
+// Populated when metric_summaries has an assignment_probability column.
+message IpwResult {
+  // IPW-adjusted treatment effect (Hájek estimator).
+  double effect = 1;
+  // Standard error of the IPW effect estimate (sandwich variance).
+  double se = 2;
+  double ci_lower = 3;
+  double ci_upper = 4;
+  double p_value = 5;
+  // Number of observations with clipped assignment probabilities.
+  int32 n_clipped = 6;
+  // Kish's effective sample size (accounts for variable weighting).
+  double effective_sample_size = 7;
 }
 
 // AnalysisResult is the top-level result for an experiment.


### PR DESCRIPTION
## Summary
- Add `IpwResult` proto message and wire `assignment_probability` from Delta Lake `metric_summaries` through the full analysis pipeline
- When M3 provides `assignment_probability` (PR #170), bandit experiments automatically get IPW-adjusted treatment effects using the Hájek estimator with probability clipping
- PostgreSQL cache roundtrip via `CachedIpwResult` for `GetAnalysisResult`

## Changes
| File | Change |
|------|--------|
| `analysis_service.proto` | Add `IpwResult` message (field 18 on `MetricResult`) |
| `delta_reader.rs` | Read optional `assignment_probability` column, populate `ipw_data` on `ExperimentMetrics` |
| `grpc.rs` | `compute_ipw_result()` helper wired into `compute_analysis()` per-metric loop |
| `store.rs` | `CachedIpwResult` struct + bidirectional `From` impls for cache serialization |

## How it works
1. `delta_reader::read_metric_summaries()` checks for optional `assignment_probability` column (same pattern as `session_id`, `lifecycle_segment`)
2. When present, populates `ipw_data: HashMap<String, Vec<(f64, String, f64)>>` — metric_id → (value, variant_id, prob)
3. `compute_ipw_result()` builds `IpwObservation` structs, calls `ipw::ipw_estimate()` with `min_probability=0.01`
4. Result mapped to `ProtoIpwResult` and included in `MetricResult.ipw_result`
5. Graceful degradation: no `assignment_probability` column → `ipw_result: None`

## Dependency
- **Requires Agent-3 PR #170** to populate `assignment_probability` in `metric_summaries` SQL templates
- Without PR #170, `ipw_result` is always `None` (no column → no data → no IPW)
- This PR is the consumer side; PR #170 is the producer side

## Test plan
- [x] `cargo test -p experimentation-analysis` — 39 unit + 12 contract tests pass
- [x] `cargo clippy -p experimentation-analysis --all-features -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass (0 failures)
- [x] New tests: `test_read_metric_summaries_with_ipw`, `test_read_metric_summaries_without_ipw_column`, `test_read_metric_summaries_ipw_null_probabilities`, `test_run_analysis_with_ipw`, `test_run_analysis_without_ipw_column`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
