### PR TITLE
fix(m4b): make Thompson crash-recovery test non-flaky

### DIFF
--- a/crates/experimentation-policy/src/core.rs
+++ b/crates/experimentation-policy/src/core.rs
@@ -1081,18 +1081,26 @@ mod tests {
 
             let (policy_tx, _reward_tx, _mgmt_tx, handle) = spawn_core(core);
 
-            // Verify Thompson prefers "a"
-            let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-            policy_tx
-                .send(SelectArmRequest {
-                    experiment_id: "thompson-1".into(),
-                    context: None,
-                    reply_tx,
-                })
-                .await
-                .unwrap();
-            let resp = reply_rx.await.unwrap().unwrap();
-            assert_eq!(resp.arm_id, "a", "Thompson should prefer arm 'a'");
+            // Verify Thompson prefers "a" (multi-trial: Thompson is probabilistic)
+            let mut a_count = 0;
+            for _ in 0..20 {
+                let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+                policy_tx
+                    .send(SelectArmRequest {
+                        experiment_id: "thompson-1".into(),
+                        context: None,
+                        reply_tx,
+                    })
+                    .await
+                    .unwrap();
+                if reply_rx.await.unwrap().unwrap().arm_id == "a" {
+                    a_count += 1;
+                }
+            }
+            assert!(
+                a_count >= 14,
+                "Thompson should pick 'a' at least 14/20 times after 30 rewards, got {a_count}"
+            );
 
             // Verify LinUCB prefers "x"
             let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
## Summary

- Fix flaky `test_multi_experiment_concurrent_crash_recovery` that fails ~3% of CI runs

## Root cause

The test asserted a **single** Thompson Sampling draw equals `"a"` after 30 rewards. With posteriors Beta(31,1) vs Beta(1,1), P(b beats a) = 1/32 ≈ 3%. This caused the test failure in PR #173's CI run.

## Fix

Changed to multi-trial assertion (≥14/20 draws must pick "a"), matching the pattern already used in `test_high_volume_crash_recovery` at line 1283. The test still validates that crash recovery restores learned policy parameters.

**Math**: With Beta(31,1) posterior, each draw picks "a" with ~97% probability. P(fewer than 14 out of 20) ≈ 1e-12 — effectively impossible to flake.

## Test plan
- [x] `cargo test --package experimentation-policy test_multi_experiment_concurrent_crash_recovery` — 5/5 passes
- [x] No other test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
