### PR TITLE
🎨 Palette: Copy ID & Audit Breadcrumbs

### DIFF
--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -6,6 +6,7 @@ import { listAuditLog } from '@/lib/api';
 import { AuditLogTable } from '@/components/audit-log-table';
 import { AuditFilters } from '@/components/audit-filters';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 export default function AuditLogPage() {
   const [entries, setEntries] = useState<AuditLogEntry[]>([]);
@@ -101,6 +102,11 @@ export default function AuditLogPage() {
 
   return (
     <div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Audit Log' },
+      ]} />
+
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Audit Log</h1>
 
       <AuditFilters

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -73,6 +73,12 @@ export default function ExperimentDetailPage() {
     }
   }, [experiment, addToast]);
 
+  const handleCopyId = useCallback(() => {
+    if (!experiment) return;
+    navigator.clipboard.writeText(experiment.experimentId);
+    addToast('Experiment ID copied to clipboard', 'success');
+  }, [experiment, addToast]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
@@ -98,6 +104,27 @@ export default function ExperimentDetailPage() {
         <div>
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold text-gray-900">{experiment.name}</h1>
+            <button
+              type="button"
+              onClick={handleCopyId}
+              className="group relative flex h-6 w-6 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              aria-label="Copy experiment ID"
+              title="Copy experiment ID"
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
+                />
+              </svg>
+            </button>
             <StateBadge state={experiment.state} />
             <TypeBadge type={experiment.type} />
           </div>


### PR DESCRIPTION
Implemented two micro-UX improvements focused on productivity and navigation consistency:

1. **Copy Experiment ID**: Added a clipboard icon button next to the experiment name in the detail view. This allows users (especially developers and analysts) to quickly grab the full UUID for use in external tools or CLI without selecting text manually.
2. **Audit Log Breadcrumbs**: Added the standard breadcrumb component to the Audit Log page, providing a clear path back to the Experiment List and aligning the page with the rest of the application's navigation patterns.

Accessibility:
- Added `aria-label="Copy experiment ID"` and `title="Copy experiment ID"` to the new button.
- Verified keyboard focus states for the new interactive element.

Verification:
- Ran `pnpm lint` and `pnpm test` in the `ui/` directory (all passing).
- Visually verified both changes using Playwright screenshots.
- Fixed a React Hook order violation found during linting.

---
*PR created automatically by Jules for task [4070837264188894560](https://jules.google.com/task/4070837264188894560) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
