### PR TITLE
fix(ci): download generated-code artifact in docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,13 @@ jobs:
           - { name: ui, path: ui }
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download generated proto code
+        uses: actions/download-artifact@v4
+        with:
+          name: generated-code
+          path: gen/
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary

- Add `actions/download-artifact@v4` step to the `docker` job, downloading `generated-code` to `gen/`

## Root Cause

The `docker` job builds images for all 8 services. Three Go services (`flags`, `management`, `metrics`) and the UI have:
```dockerfile
COPY gen/go/ gen/go/    # Go services
COPY gen/ts/ ../gen/ts/ # UI
```
But the `docker` job had no step to download the generated proto code artifact. The `gen/` directory never existed in the build context, causing every `docker build` to fail.

The `go`, `hash-parity`, and `typescript` jobs all correctly download the artifact first — `docker` was the only job missing it.

## Fix

Added before the Docker login step, mirroring the pattern from the `go` job exactly:
```yaml
- name: Download generated proto code
  uses: actions/download-artifact@v4
  with:
    name: generated-code
    path: gen/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
