### PR TITLE
fix(ci): download generated-code artifact in docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,15 @@ jobs:
           - { name: ui, path: ui }
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-code
+          path: proto/gen/
+
+      - name: Stage generated code for Dockerfiles
+        run: mkdir -p gen && cp -r proto/gen/* gen/
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary

- The `docker` job was doing `actions/checkout@v4` but never downloading the `generated-code` artifact uploaded by the `schema` job
- All service Dockerfiles reference `gen/go/` and `gen/ts/` at the repo root, but `buf generate` outputs to `proto/gen/`
- Added `actions/download-artifact@v4` (path: `proto/gen/`) then `cp -r proto/gen/* gen/` to make generated code available at the expected paths

## Root cause

`schema` job: `buf generate` → uploads `proto/gen/` as artifact `generated-code`
`go` + `typescript` jobs: correctly download to `gen/`
`docker` job: **missing both steps** → Docker builds fail with missing `gen/go/` / `gen/ts/`

## Changes

`.github/workflows/ci.yml` — added two steps in the `docker` job after checkout:
1. `actions/download-artifact@v4` with `name: generated-code`, `path: proto/gen/`
2. `run: mkdir -p gen && cp -r proto/gen/* gen/`

## Test plan

- [ ] CI passes on this PR (docker job runs only on main pushes, but prior jobs validate artifact upload/download chain)
- [ ] Verify `gen/go/` and `gen/ts/` are present in docker build context after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
