### PR TITLE
fix(docker): bump Go base image to 1.25 to match go.mod

### DIFF
--- a/services/flags/Dockerfile
+++ b/services/flags/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 WORKDIR /build
 COPY services/ services/
 COPY gen/go/ gen/go/

--- a/services/management/Dockerfile
+++ b/services/management/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 WORKDIR /build
 COPY services/ services/
 COPY gen/go/ gen/go/

--- a/services/metrics/Dockerfile
+++ b/services/metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 WORKDIR /build
 COPY services/ services/
 COPY gen/go/ gen/go/


### PR DESCRIPTION
## Summary

- Updated `FROM golang:1.22-bookworm` → `FROM golang:1.25-bookworm` in three Go service Dockerfiles
- Affected: `services/flags/Dockerfile`, `services/management/Dockerfile`, `services/metrics/Dockerfile`

## Root Cause

`services/go.mod` requires `go 1.25.0` but all three Dockerfiles used the `golang:1.22` base image. Docker builds failed with:
```
go.mod requires go >= 1.25.0 (running go 1.22.12)
```

## Test Plan

- [ ] Docker build succeeds for all three services with `golang:1.25-bookworm`
- [ ] CI Go service docker job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
