### PR TITLE
fix(docker): ensure gen/go/go.mod available in Docker build context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,24 @@ jobs:
           name: generated-code
           path: gen/
 
+      - name: Create gen/go module file
+        run: |
+          cat > gen/go/go.mod << 'GOMOD'
+          module github.com/org/experimentation/gen/go
+
+          go 1.25
+
+          require (
+          	connectrpc.com/connect v1.17.0
+          	google.golang.org/protobuf v1.35.0
+          )
+
+          require (
+          	github.com/google/go-cmp v0.6.0 // indirect
+          	golang.org/x/net v0.29.0 // indirect
+          )
+          GOMOD
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary

- **Root cause**: `gen/` is fully gitignored (`.gitignore` line 14), so `gen/go/go.mod` is never committed and is absent from the `generated-code` artifact produced by `buf generate`
- **Failure**: The `docker` job downloads the artifact to `gen/` but never creates `gen/go/go.mod`, causing all Go service Docker builds to fail with `open /build/gen/go/go.mod: no such file or directory`
- **Why it breaks Docker**: `services/go.mod` has `replace github.com/org/experimentation/gen/go => ../gen/go`. The Dockerfiles copy `gen/go/` into the build context — without a `go.mod`, Go refuses to treat it as a module

## Fix

Added a "Create gen/go module file" step to the `docker` job (after artifact download, before Docker build) that writes `gen/go/go.mod` — exactly mirroring what the `go` job already does at CI lines 150–168.

## Investigation notes

- The `go` job (Stage 3) correctly creates `gen/go/go.mod` before `go build`; the `docker` job (Stage 6) was missing the equivalent step
- Option 1 (un-gitignore `gen/go/go.mod`) was considered but rejected: it would require manual maintenance every time proto dependencies change, and regenerating the file in CI is already the established pattern
- No other jobs (`rust`, `typescript`, `hash-parity`) reference `gen/go/go.mod`

## Opportunities (not implemented)

- Extract the `gen/go/go.mod` creation into a reusable composite action to eliminate the duplication between the `go` and `docker` jobs
- Add a `go.sum` for `gen/go` if stricter module verification is needed inside Docker builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
