### PR TITLE
fix(ci): create gen/go/go.mod in docker job before image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,24 @@ jobs:
           name: generated-code
           path: gen/
 
+      - name: Create gen/go module file
+        run: |
+          cat > gen/go/go.mod << 'GOMOD'
+          module github.com/org/experimentation/gen/go
+
+          go 1.25
+
+          require (
+          	connectrpc.com/connect v1.17.0
+          	google.golang.org/protobuf v1.35.0
+          )
+
+          require (
+          	github.com/google/go-cmp v0.6.0 // indirect
+          	golang.org/x/net v0.29.0 // indirect
+          )
+          GOMOD
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Problem

The Docker job downloads generated proto code via `download-artifact` (proto `.pb.go` files only), but `gen/go/go.mod` is never in that artifact because:
- `gen/` is fully gitignored
- `buf generate` produces `.pb.go` files, not `go.mod`
- `go.mod` is created manually only in the `go` CI job

All three Go service Dockerfiles (`flags`, `management`, `metrics`) do:
```
COPY gen/go/ gen/go/
RUN CGO_ENABLED=0 go build ...
```

`services/go.mod` has `replace github.com/org/experimentation/gen/go => ../gen/go`, so `go build` requires `gen/go/go.mod` to exist. Without it, the Docker build fails.

## Fix

Add a step in the `docker` job — after `download-artifact`, before `docker build` — that creates `gen/go/go.mod` with the same static content the `go` job already creates.

## Why not commit gen/go/go.mod?

`gen/` is uniformly gitignored as generated code. Un-ignoring one file risks confusion. The step approach is consistent with how the `go` job already handles this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
