### PR TITLE
fix(docker): bump Rust base image to 1.85 to support getrandom 0.4.2

### DIFF
--- a/crates/experimentation-analysis/Dockerfile
+++ b/crates/experimentation-analysis/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal runtime image.
-FROM rust:1.80-slim as builder
+FROM rust:1.85-slim as builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/

--- a/crates/experimentation-assignment/Dockerfile
+++ b/crates/experimentation-assignment/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal runtime image.
-FROM rust:1.80-slim as builder
+FROM rust:1.85-slim as builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/

--- a/crates/experimentation-pipeline/Dockerfile
+++ b/crates/experimentation-pipeline/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal runtime image.
-FROM rust:1.80-slim as builder
+FROM rust:1.85-slim as builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/

--- a/crates/experimentation-policy/Dockerfile
+++ b/crates/experimentation-policy/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal runtime image.
-FROM rust:1.80-slim as builder
+FROM rust:1.85-slim as builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/


### PR DESCRIPTION
## Summary

- `getrandom 0.4.2` (pulled into `Cargo.lock`) requires Rust >= 1.82
- All 4 crate Dockerfiles were pinned to `rust:1.80-slim`, breaking CI builds
- Bumped to `rust:1.85-slim` in:
  - `crates/experimentation-analysis/Dockerfile`
  - `crates/experimentation-assignment/Dockerfile`
  - `crates/experimentation-pipeline/Dockerfile`
  - `crates/experimentation-policy/Dockerfile`

## Test plan

- [ ] CI Docker build jobs pass for all 4 crates after this change
- [ ] No other Dockerfiles in the repo reference `rust:1.80-slim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
