### PR TITLE
feat(m6): /portfolio/provider-health page (ADR-014)

### DIFF
--- a/docs/coordination/status/agent-6-status.md
+++ b/docs/coordination/status/agent-6-status.md
@@ -1,23 +1,31 @@
 # Agent-6 Status — Phase 5
 
 **Module**: M6 UI
-**Last updated**: [date]
+**Last updated**: 2026-03-23
 
 ## Current Sprint
 
 Sprint: 5.0
 Focus: Portfolio page, provider health, new results tabs, enhanced bandit dashboard
-Branch: agent-6/feat/[current-work]
+Branch: work/silly-raccoon
 
 ## In Progress
 
-- [ ] [Milestone description] (ADR-XXX)
-  - Blocked by: [none | Agent-M: description]
-  - ETA: [date]
+- [ ] Portfolio index page `/portfolio` (ADR-019) — not yet implemented (out of scope for this PR)
 
 ## Completed (Phase 5)
 
-_None yet._
+- [x] `/portfolio/provider-health` page (ADR-014)
+  - Time series charts: catalog coverage, provider Gini coefficient, long-tail impression share
+  - Provider dropdown filter (re-fetches data on change)
+  - Code-split via `next/dynamic` — chart bundle deferred
+  - `React.memo` on all three chart components (`CatalogCoverageChart`, `ProviderGiniChart`, `LongTailImpressionChart`)
+  - MSW mock handler: `METRICS_SVC/GetProviderHealth` with seed data (3 providers, 4 series, 14-day time series)
+  - 8 tests passing
+  - Portfolio nav link added to `NavHeader`
+  - Types: `ProviderHealthPoint`, `ProviderHealthSeries`, `ProviderInfo`, `ProviderHealthResult`
+  - API: `getProviderHealth(providerId?)` → M3 `MetricComputationService/GetProviderHealth`
+  - Ready to integrate with Agent-3 `GetProviderHealth` RPC when M3 provider metrics are available
 
 ## Blocked
 
@@ -25,4 +33,6 @@ _None._
 
 ## Next Up
 
-- [Next milestone] — depends on: [Agent-Proto schema | none]
+- `/portfolio` index page (ADR-019) — portfolio-level metrics dashboard
+- New results tabs (AVLM sequential results, e-value display)
+- Enhanced bandit dashboard

--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -4,7 +4,7 @@ import {
   SEED_NOVELTY_RESULTS, SEED_INTERFERENCE_RESULTS, SEED_INTERLEAVING_RESULTS,
   SEED_BANDIT_RESULTS, SEED_HOLDOUT_RESULTS, SEED_GUARDRAIL_STATUS, SEED_QOE_RESULTS,
   SEED_GST_RESULTS, SEED_CATE_RESULTS, SEED_LAYERS, SEED_LAYER_ALLOCATIONS,
-  SEED_METRIC_DEFINITIONS, SEED_AUDIT_LOG, SEED_FLAGS,
+  SEED_METRIC_DEFINITIONS, SEED_AUDIT_LOG, SEED_FLAGS, SEED_PROVIDER_HEALTH,
 } from './seed-data';
 import type { UserRole } from '@/lib/auth';
 import { hasAtLeast, isValidRole } from '@/lib/auth';
@@ -742,6 +742,19 @@ export const handlers = [
   }),
 
   // PromoteToExperiment
+  // GetProviderHealth (ADR-014)
+  http.post(`${METRICS_SVC}/GetProviderHealth`, async ({ request }) => {
+    const body = await request.json() as { providerId?: string };
+    const allSeries = SEED_PROVIDER_HEALTH.series;
+    const filteredSeries = body.providerId
+      ? allSeries.filter((s) => s.providerId === body.providerId)
+      : allSeries;
+    return HttpResponse.json({
+      ...SEED_PROVIDER_HEALTH,
+      series: filteredSeries,
+    });
+  }),
+
   http.post(`${FLAGS_SVC}/PromoteToExperiment`, async ({ request }) => {
     const denied = checkAuth(request.headers, 'experimenter');
     if (denied) return denied;

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -3,7 +3,7 @@ import type {
   NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
   BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult, QoeDashboardResult,
   GstTrajectoryResult, CateAnalysisResult, Layer, LayerAllocation, MetricDefinition,
-  AuditLogEntry, Flag,
+  AuditLogEntry, Flag, ProviderHealthResult,
 } from '@/lib/types';
 
 const INITIAL_EXPERIMENTS: Experiment[] = [
@@ -1673,6 +1673,71 @@ export let SEED_LAYERS: Record<string, Layer> = structuredClone(INITIAL_LAYERS);
 export let SEED_LAYER_ALLOCATIONS: Record<string, LayerAllocation[]> = structuredClone(INITIAL_LAYER_ALLOCATIONS);
 export let SEED_AUDIT_LOG: AuditLogEntry[] = structuredClone(INITIAL_AUDIT_LOG);
 
+// --- Provider Health Seed Data (ADR-014) ---
+
+function makeProviderPoints(
+  baseCoverage: number,
+  baseGini: number,
+  baseLongTail: number,
+  trendCoverage: number,
+  trendGini: number,
+  trendLongTail: number,
+): ProviderHealthResult['series'][number]['points'] {
+  // 14 daily data points starting 2026-03-09
+  return Array.from({ length: 14 }, (_, i) => {
+    const date = new Date('2026-03-09');
+    date.setDate(date.getDate() + i);
+    const noise = (k: number) => Math.sin(i * k) * 0.005;
+    return {
+      date: date.toISOString().slice(0, 10),
+      catalogCoverage: Math.min(1, Math.max(0, baseCoverage + trendCoverage * i + noise(0.8))),
+      providerGini: Math.min(1, Math.max(0, baseGini + trendGini * i + noise(1.1))),
+      longTailImpressionShare: Math.min(1, Math.max(0, baseLongTail + trendLongTail * i + noise(0.6))),
+    };
+  });
+}
+
+const INITIAL_PROVIDER_HEALTH: ProviderHealthResult = {
+  providers: [
+    { providerId: 'prov-originals', providerName: 'StreamCo Originals' },
+    { providerId: 'prov-studio-a', providerName: 'Studio A' },
+    { providerId: 'prov-indie', providerName: 'Indie Collective' },
+  ],
+  series: [
+    {
+      providerId: 'prov-originals',
+      providerName: 'StreamCo Originals',
+      experimentId: '11111111-1111-1111-1111-111111111111',
+      experimentName: 'homepage_recs_v2',
+      points: makeProviderPoints(0.68, 0.42, 0.14, 0.003, -0.002, 0.004),
+    },
+    {
+      providerId: 'prov-originals',
+      providerName: 'StreamCo Originals',
+      experimentId: '33333333-3333-3333-3333-333333333333',
+      experimentName: 'search_ranking_interleave',
+      points: makeProviderPoints(0.71, 0.40, 0.16, 0.002, -0.001, 0.003),
+    },
+    {
+      providerId: 'prov-studio-a',
+      providerName: 'Studio A',
+      experimentId: '11111111-1111-1111-1111-111111111111',
+      experimentName: 'homepage_recs_v2',
+      points: makeProviderPoints(0.55, 0.51, 0.11, 0.004, -0.003, 0.005),
+    },
+    {
+      providerId: 'prov-indie',
+      providerName: 'Indie Collective',
+      experimentId: '11111111-1111-1111-1111-111111111111',
+      experimentName: 'homepage_recs_v2',
+      points: makeProviderPoints(0.38, 0.62, 0.22, 0.005, -0.004, 0.003),
+    },
+  ],
+  computedAt: '2026-03-23T00:00:00Z',
+};
+
+export let SEED_PROVIDER_HEALTH: ProviderHealthResult = structuredClone(INITIAL_PROVIDER_HEALTH);
+
 /** Reset seed data to initial state. Call in afterEach for test isolation. */
 export function resetSeedData(): void {
   SEED_FLAGS = structuredClone(INITIAL_FLAGS);
@@ -1692,4 +1757,5 @@ export function resetSeedData(): void {
   SEED_LAYERS = structuredClone(INITIAL_LAYERS);
   SEED_LAYER_ALLOCATIONS = structuredClone(INITIAL_LAYER_ALLOCATIONS);
   SEED_AUDIT_LOG = structuredClone(INITIAL_AUDIT_LOG);
+  SEED_PROVIDER_HEALTH = structuredClone(INITIAL_PROVIDER_HEALTH);
 }

--- a/ui/src/__tests__/provider-health.test.tsx
+++ b/ui/src/__tests__/provider-health.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ProviderHealthPage from '@/app/portfolio/provider-health/page';
+import { SEED_PROVIDER_HEALTH } from '@/__mocks__/seed-data';
+
+const METRICS_SVC = '*/experimentation.metrics.v1.MetricComputationService';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/portfolio/provider-health',
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// Mock dynamic imports so chart components render synchronously in tests
+vi.mock('next/dynamic', () => ({
+  default: (fn: () => Promise<{ default: React.ComponentType<unknown> }>) => {
+    // Return a placeholder that renders a div with data-testid
+    const Comp = (props: Record<string, unknown>) => {
+      const { series } = props as { series: unknown[] };
+      return <div data-testid="chart-component" data-series-count={series?.length ?? 0} />;
+    };
+    void fn; // suppress unused warning
+    return Comp;
+  },
+}));
+
+async function renderAndWait() {
+  render(<ProviderHealthPage />);
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: 'Provider Health', level: 1 })).toBeInTheDocument();
+  });
+}
+
+describe('Provider Health Page', () => {
+  beforeEach(() => {
+    // Default handler is already registered in __mocks__/handlers.ts
+  });
+
+  it('renders page heading and description', async () => {
+    await renderAndWait();
+    expect(screen.getByRole('heading', { name: 'Provider Health', level: 1 })).toBeInTheDocument();
+    expect(screen.getByText(/catalog coverage, gini concentration/i)).toBeInTheDocument();
+  });
+
+  it('renders provider dropdown with all provider options', async () => {
+    await renderAndWait();
+    const select = screen.getByTestId('provider-filter');
+    expect(select).toBeInTheDocument();
+
+    // Should have "All providers" + one option per unique provider
+    const uniqueProviders = SEED_PROVIDER_HEALTH.providers;
+    const options = Array.from((select as HTMLSelectElement).options);
+    expect(options[0].value).toBe('');
+    expect(options[0].text).toBe('All providers');
+    expect(options.length).toBe(1 + uniqueProviders.length);
+  });
+
+  it('renders chart components with series data', async () => {
+    await renderAndWait();
+    const charts = screen.getAllByTestId('chart-component');
+    // 3 charts rendered (coverage, gini, long-tail)
+    expect(charts).toHaveLength(3);
+    // All series present when no filter
+    for (const chart of charts) {
+      expect(Number(chart.getAttribute('data-series-count'))).toBeGreaterThan(0);
+    }
+  });
+
+  it('filters series when a provider is selected', async () => {
+    const user = userEvent.setup();
+    // Override handler to return filtered data for a specific provider
+    server.use(
+      http.post(`${METRICS_SVC}/GetProviderHealth`, async ({ request }) => {
+        const body = await request.json() as { providerId?: string };
+        const filtered = SEED_PROVIDER_HEALTH.series.filter(
+          (s) => !body.providerId || s.providerId === body.providerId,
+        );
+        return HttpResponse.json({ ...SEED_PROVIDER_HEALTH, series: filtered });
+      }),
+    );
+
+    render(<ProviderHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Provider Health', level: 1 })).toBeInTheDocument();
+    });
+
+    const select = screen.getByTestId('provider-filter');
+    const targetProvider = SEED_PROVIDER_HEALTH.providers[0];
+    await user.selectOptions(select, targetProvider.providerId);
+
+    // After filter change, data should reload
+    await waitFor(() => {
+      const charts = screen.getAllByTestId('chart-component');
+      // Filtered: only series matching prov-originals (2 series)
+      const expectedCount = SEED_PROVIDER_HEALTH.series.filter(
+        (s) => s.providerId === targetProvider.providerId,
+      ).length;
+      for (const chart of charts) {
+        expect(Number(chart.getAttribute('data-series-count'))).toBe(expectedCount);
+      }
+    });
+  });
+
+  it('shows error state when API fails', async () => {
+    server.use(
+      http.post(`${METRICS_SVC}/GetProviderHealth`, () => {
+        return HttpResponse.json({ message: 'Internal server error' }, { status: 500 });
+      }),
+    );
+
+    render(<ProviderHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no series returned', async () => {
+    server.use(
+      http.post(`${METRICS_SVC}/GetProviderHealth`, () => {
+        return HttpResponse.json({
+          ...SEED_PROVIDER_HEALTH,
+          series: [],
+        });
+      }),
+    );
+
+    render(<ProviderHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/no data available/i)).toBeInTheDocument();
+    });
+  });
+
+  it('displays computed-at timestamp', async () => {
+    await renderAndWait();
+    expect(screen.getByTestId('computed-at')).toBeInTheDocument();
+  });
+
+  it('has breadcrumb linking to /portfolio', async () => {
+    await renderAndWait();
+    const portfolioLink = screen.getByRole('link', { name: 'Portfolio' });
+    expect(portfolioLink).toHaveAttribute('href', '/portfolio');
+  });
+});

--- a/ui/src/app/portfolio/provider-health/page.tsx
+++ b/ui/src/app/portfolio/provider-health/page.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import { getProviderHealth } from '@/lib/api';
+import type { ProviderHealthResult, ProviderHealthSeries } from '@/lib/types';
+import { RetryableError } from '@/components/retryable-error';
+
+// Code-split: chart bundle loaded only when page is rendered
+const CatalogCoverageChart = dynamic(
+  () =>
+    import('@/components/charts/provider-health-charts').then(
+      (m) => ({ default: m.CatalogCoverageChart }),
+    ),
+  {
+    ssr: false,
+    loading: () => <ChartSkeleton />,
+  },
+);
+
+const ProviderGiniChart = dynamic(
+  () =>
+    import('@/components/charts/provider-health-charts').then(
+      (m) => ({ default: m.ProviderGiniChart }),
+    ),
+  {
+    ssr: false,
+    loading: () => <ChartSkeleton />,
+  },
+);
+
+const LongTailImpressionChart = dynamic(
+  () =>
+    import('@/components/charts/provider-health-charts').then(
+      (m) => ({ default: m.LongTailImpressionChart }),
+    ),
+  {
+    ssr: false,
+    loading: () => <ChartSkeleton />,
+  },
+);
+
+function ChartSkeleton() {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="mb-2 h-4 w-40 animate-pulse rounded bg-gray-200" />
+      <div className="h-[260px] animate-pulse rounded bg-gray-100" />
+    </div>
+  );
+}
+
+export default function ProviderHealthPage() {
+  const [result, setResult] = useState<ProviderHealthResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedProvider, setSelectedProvider] = useState<string>('');
+
+  const fetchData = useCallback(async (providerId?: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getProviderHealth(providerId || undefined);
+      setResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load provider health data.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  function handleProviderChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const value = e.target.value;
+    setSelectedProvider(value);
+    fetchData(value || undefined);
+  }
+
+  const series: ProviderHealthSeries[] = result?.series ?? [];
+  const providers = result?.providers ?? [];
+
+  if (loading && !result) {
+    return (
+      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+        <span className="sr-only">Loading</span>
+      </div>
+    );
+  }
+
+  if (error && !result) {
+    return <RetryableError message={error} onRetry={() => fetchData(selectedProvider || undefined)} context="provider health data" />;
+  }
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
+        <Link href="/portfolio" className="hover:text-gray-700">Portfolio</Link>
+        <span aria-hidden="true">/</span>
+        <span className="text-gray-900 font-medium">Provider Health</span>
+      </nav>
+
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Provider Health</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Catalog coverage, Gini concentration, and long-tail impression share across running experiments.
+          </p>
+        </div>
+
+        {/* Provider filter */}
+        <div className="flex items-center gap-2">
+          <label htmlFor="provider-select" className="text-sm font-medium text-gray-700">
+            Provider
+          </label>
+          <select
+            id="provider-select"
+            value={selectedProvider}
+            onChange={handleProviderChange}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            data-testid="provider-filter"
+            aria-label="Filter by provider"
+          >
+            <option value="">All providers</option>
+            {providers.map((p) => (
+              <option key={p.providerId} value={p.providerId}>
+                {p.providerName}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {loading && result && (
+        <div className="mb-4 flex items-center gap-2 text-sm text-gray-500" role="status">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-indigo-600" />
+          Refreshing…
+        </div>
+      )}
+
+      {error && result && (
+        <div className="mb-4 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm text-yellow-800" role="alert">
+          {error}
+        </div>
+      )}
+
+      {series.length === 0 && !loading ? (
+        <div className="rounded-lg border border-gray-200 bg-white py-16 text-center">
+          <p className="text-sm text-gray-500">No data available for the selected provider.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          <section aria-labelledby="coverage-heading">
+            <h2 id="coverage-heading" className="sr-only">Catalog Coverage</h2>
+            <CatalogCoverageChart series={series} />
+          </section>
+
+          <section aria-labelledby="gini-heading">
+            <h2 id="gini-heading" className="sr-only">Provider Gini Coefficient</h2>
+            <ProviderGiniChart series={series} />
+          </section>
+
+          <section aria-labelledby="longtail-heading">
+            <h2 id="longtail-heading" className="sr-only">Long-Tail Impression Share</h2>
+            <LongTailImpressionChart series={series} />
+          </section>
+        </div>
+      )}
+
+      {result && (
+        <p className="mt-4 text-xs text-gray-400" data-testid="computed-at">
+          Data computed at: {new Date(result.computedAt).toLocaleString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/charts/provider-health-charts.tsx
+++ b/ui/src/components/charts/provider-health-charts.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { memo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import type { ProviderHealthSeries } from '@/lib/types';
+
+const SERIES_COLORS = ['#4f46e5', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'];
+
+type MetricKey = 'catalogCoverage' | 'providerGini' | 'longTailImpressionShare';
+
+interface ProviderMetricChartProps {
+  series: ProviderHealthSeries[];
+  metric: MetricKey;
+  title: string;
+  description: string;
+}
+
+function buildChartData(
+  series: ProviderHealthSeries[],
+  metric: MetricKey,
+): { date: string; [key: string]: string | number }[] {
+  const dateMap = new Map<string, { date: string; [key: string]: string | number }>();
+  for (const s of series) {
+    const key = series.length > 1
+      ? `${s.providerName} — ${s.experimentName}`
+      : s.experimentName;
+    for (const pt of s.points) {
+      if (!dateMap.has(pt.date)) {
+        dateMap.set(pt.date, { date: pt.date });
+      }
+      dateMap.get(pt.date)![key] = pt[metric];
+    }
+  }
+  return Array.from(dateMap.values()).sort((a, b) =>
+    (a.date as string).localeCompare(b.date as string),
+  );
+}
+
+function pctFmt(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function ProviderMetricChartInner({ series, metric, title, description }: ProviderMetricChartProps) {
+  if (series.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-6">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+        <p className="mt-8 text-center text-sm text-gray-500">No data available for selected provider.</p>
+      </div>
+    );
+  }
+
+  const seriesKeys = series.map((s) =>
+    series.length > 1
+      ? `${s.providerName} — ${s.experimentName}`
+      : s.experimentName,
+  );
+  const chartData = buildChartData(series, metric);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="mb-2">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+        <p className="text-xs text-gray-500">{description}</p>
+      </div>
+      <div role="img" aria-label={`Time series: ${title}`}>
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={chartData} margin={{ top: 5, right: 16, bottom: 20, left: 4 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10 }}
+              tickFormatter={(v: string) => v.slice(5)}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tick={{ fontSize: 11 }}
+              tickFormatter={pctFmt}
+              width={52}
+              domain={[0, 'auto']}
+            />
+            <Tooltip formatter={(v: number) => [pctFmt(v), undefined]} />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            {seriesKeys.map((key, i) => (
+              <Line
+                key={key}
+                dataKey={key}
+                stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
+                strokeWidth={2}
+                dot={false}
+                connectNulls={false}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export const CatalogCoverageChart = memo(function CatalogCoverageChart(props: Omit<ProviderMetricChartProps, 'metric' | 'title' | 'description'>) {
+  return (
+    <ProviderMetricChartInner
+      {...props}
+      metric="catalogCoverage"
+      title="Catalog Coverage"
+      description="Fraction of provider catalog titles receiving at least one impression."
+    />
+  );
+});
+
+export const ProviderGiniChart = memo(function ProviderGiniChart(props: Omit<ProviderMetricChartProps, 'metric' | 'title' | 'description'>) {
+  return (
+    <ProviderMetricChartInner
+      {...props}
+      metric="providerGini"
+      title="Provider Gini Coefficient"
+      description="Impression concentration across provider titles. Lower is more equitable."
+    />
+  );
+});
+
+export const LongTailImpressionChart = memo(function LongTailImpressionChart(props: Omit<ProviderMetricChartProps, 'metric' | 'title' | 'description'>) {
+  return (
+    <ProviderMetricChartInner
+      {...props}
+      metric="longTailImpressionShare"
+      title="Long-Tail Impression Share"
+      description="Fraction of impressions going to titles outside the provider's top-20% by popularity."
+    />
+  );
+});

--- a/ui/src/components/nav-header.tsx
+++ b/ui/src/components/nav-header.tsx
@@ -59,6 +59,14 @@ export function NavHeader() {
           >
             Monitoring
           </Link>
+          <Link
+            href="/portfolio/provider-health"
+            className={`text-sm font-medium transition-colors hover:text-gray-900 ${pathname.startsWith('/portfolio') ? 'text-indigo-600' : 'text-gray-600'}`}
+            aria-current={pathname.startsWith('/portfolio') ? 'page' : undefined}
+            data-testid="nav-portfolio"
+          >
+            Portfolio
+          </Link>
         </div>
 
         <div className="flex items-center gap-3">

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   Flag, FlagType, ListFlagsResponse,
   InterleavingConfig, SessionConfig, BanditExperimentConfig, QoeConfig,
   AuditLogEntry, AuditAction, ListAuditLogResponse,
+  ProviderHealthResult,
 } from './types';
 import type { ExperimentState, ExperimentType, MetricType, LifecycleSegment } from './types';
 
@@ -695,4 +696,14 @@ export async function promoteToExperiment(
     { skipCache: true, clearCacheOnSuccess: true },
   );
   return adaptExperiment(raw);
+}
+
+// --- Provider Health (ADR-014) ---
+
+export async function getProviderHealth(providerId?: string): Promise<ProviderHealthResult> {
+  const request: Record<string, unknown> = {};
+  if (providerId) request.providerId = providerId;
+  return callRpc<Record<string, unknown>, ProviderHealthResult>(
+    METRICS_URL, METRICS_SVC, 'GetProviderHealth', request,
+  );
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -571,3 +571,31 @@ export interface BanditDashboardResult {
   minExplorationFraction: number;
   rewardHistory: RewardHistoryPoint[];
 }
+
+// --- Provider Health (ADR-014) ---
+
+export interface ProviderHealthPoint {
+  date: string;
+  catalogCoverage: number;
+  providerGini: number;
+  longTailImpressionShare: number;
+}
+
+export interface ProviderHealthSeries {
+  providerId: string;
+  providerName: string;
+  experimentId: string;
+  experimentName: string;
+  points: ProviderHealthPoint[];
+}
+
+export interface ProviderInfo {
+  providerId: string;
+  providerName: string;
+}
+
+export interface ProviderHealthResult {
+  series: ProviderHealthSeries[];
+  providers: ProviderInfo[];
+  computedAt: string;
+}


### PR DESCRIPTION
## Summary

- **New page** `/portfolio/provider-health` — provider-side health metrics dashboard (ADR-014 M6 section)
- **3 time-series charts** (Recharts, code-split via `next/dynamic`): catalog coverage, provider Gini coefficient, long-tail impression share
- **Provider dropdown filter** — re-fetches M3 `GetProviderHealth` RPC on change, filters server-side
- **`React.memo`** on all three chart components: `CatalogCoverageChart`, `ProviderGiniChart`, `LongTailImpressionChart`
- **MSW mock** with 3 providers, 4 series (provider × experiment), 14-day deterministic time series
- **Portfolio nav link** added to `NavHeader`

## Files changed

| File | Change |
|------|--------|
| `ui/src/lib/types.ts` | `ProviderHealthPoint`, `ProviderHealthSeries`, `ProviderInfo`, `ProviderHealthResult` |
| `ui/src/lib/api.ts` | `getProviderHealth(providerId?)` → `MetricComputationService/GetProviderHealth` |
| `ui/src/__mocks__/seed-data.ts` | `SEED_PROVIDER_HEALTH` with deterministic sin-wave series |
| `ui/src/__mocks__/handlers.ts` | `GetProviderHealth` MSW handler with optional `providerId` filter |
| `ui/src/components/charts/provider-health-charts.tsx` | 3 memoized chart components (NEW) |
| `ui/src/app/portfolio/provider-health/page.tsx` | Page with dynamic imports, loading/error/empty states (NEW) |
| `ui/src/components/nav-header.tsx` | Portfolio nav link |
| `ui/src/__tests__/provider-health.test.tsx` | 8 tests (NEW) |
| `docs/coordination/status/agent-6-status.md` | Updated |

## Test plan

- [x] 8 unit tests passing (`npm test`)
- [x] Provider dropdown renders all 3 seed providers
- [x] Filtering re-fetches and narrows series count
- [x] Error state shows retry button
- [x] Empty state message when no series returned
- [x] `computed-at` timestamp displayed
- [x] Breadcrumb links to `/portfolio`

## Integration notes

- Ready to wire to Agent-3 when `MetricComputationService/GetProviderHealth` RPC is implemented
- MSW mock can be disabled by removing the handler entry in `handlers.ts`

## Opportunities (not implemented)

- `/portfolio` index page (ADR-019) — win rate, learning rate, annualized impact dashboard
- Date-range picker for time-series window selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
