### PR TITLE
feat(metrics): implement ADR-014 provider-side metrics

### DIFF
--- a/adrs/014-provider-side-metrics.md
+++ b/adrs/014-provider-side-metrics.md
@@ -1,0 +1,120 @@
+# ADR-014: Provider-Side Metrics
+
+**Status**: Accepted
+**Date**: 2026-03-23
+**Deciders**: Agent-3 (M3 Metrics)
+**Phase**: 5 — Cluster A (Multi-Stakeholder)
+
+---
+
+## Context
+
+The SVOD platform hosts content from multiple providers. Recommendation experiments
+can favour certain providers or genres over others, creating second-order effects on
+content diversity that are invisible to user-level engagement metrics alone.
+
+Providers and platform trust-and-safety teams need metrics that measure:
+- **Catalog coverage**: how much of the available catalog is actually recommended
+- **Content inequality**: Gini coefficient and entropy of the impression distribution
+- **Provider fairness**: equitable exposure across content providers
+- **User diversity**: per-user genre breadth, discovery of new content, and provider
+  variety in individual watch histories
+
+Without these metrics, experiments that improve CTR could simultaneously reduce
+catalog diversity or concentrate impressions on a handful of providers.
+
+---
+
+## Decision
+
+Implement 10 provider-side metric SQL templates in M3's Spark SQL renderer
+(`services/metrics/internal/spark/templates/`), backed by a new Delta Lake table
+(`delta.content_catalog`) that carries provider and genre metadata for each
+content item.
+
+### New Delta Tables
+
+**`delta.content_catalog`** — written by the content ingestion pipeline, read by M3.
+- Key columns: `content_id`, `provider_id`, `genre`, `popularity_rank`, `updated_at`.
+- Freshness invariant: `MAX(updated_at)` must be within 24 hours before any provider
+  metric computation. Enforced at the Go level in `ProviderMetricsJob.checkCatalogFreshness`.
+
+**`delta.experiment_level_metrics`** — written by M3 `ProviderMetricsJob`, read by M4a.
+- Stores aggregate (experiment, variant, metric_id) rows for metrics that cannot be
+  disaggregated to the user level (catalog coverage, Gini, entropy, parity).
+
+### Experiment-Level Metrics (→ `delta.experiment_level_metrics`)
+
+| Metric ID | Description |
+|---|---|
+| `catalog_coverage_rate` | Fraction of catalog items that appear in at least one impression per variant |
+| `catalog_gini_coefficient` | Gini coefficient of impression distribution across all catalog items (0 = equal, 1 = monopoly) |
+| `catalog_entropy` | Shannon entropy of impression distribution across observed content (nats) |
+| `longtail_impression_share` | Share of impressions going to content ranked below the `LongtailThreshold` percentile |
+| `provider_exposure_gini` | Gini coefficient of impressions distributed across content providers |
+| `provider_exposure_parity` | min_provider_share / max_provider_share (1.0 = perfect parity) |
+
+### User-Level Metrics (→ `delta.metric_summaries`)
+
+| Metric ID | Description |
+|---|---|
+| `user_genre_entropy` | Per-user Shannon entropy of genre distribution in watch history |
+| `user_discovery_rate` | Fraction of experiment-period content that is new-to-user (not seen before experiment start) |
+| `user_provider_diversity` | Count of distinct providers in each user's experiment-period watch history |
+| `intra_list_distance` | 1 − HHI over genres in user's consumed list (complement of Herfindahl-Hirschman Index) |
+
+### Freshness Validation
+
+Before any provider metric SQL is executed, `ProviderMetricsJob.checkCatalogFreshness`
+runs:
+
+```sql
+SELECT CAST(1 AS INT) AS is_fresh
+FROM (SELECT MAX(updated_at) AS last_updated FROM delta.content_catalog) t
+WHERE t.last_updated >= CURRENT_TIMESTAMP() - INTERVAL '24 HOURS'
+```
+
+If `RowCount == 0`, the job returns a descriptive error and no queries are logged.
+This prevents stale catalog metadata from silently corrupting diversity metrics.
+
+### Query Logging
+
+All provider metric queries are logged to `query_log` with `job_type = "provider_metric"`,
+consistent with the existing logging convention in all M3 jobs.
+
+---
+
+## TemplateParams Extensions
+
+Three new fields added to `spark.TemplateParams`:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `LongtailThreshold` | `float64` | `0.80` | PERCENT_RANK cutoff for longtail classification |
+| `ProviderField` | `string` | `"provider_id"` | Column name in `content_catalog` for provider |
+| `GenreField` | `string` | `"genre"` | Column name in `content_catalog` for genre |
+
+---
+
+## Consequences
+
+**Positive**
+- Providers can verify their content is receiving equitable exposure across experiment variants.
+- Platform can detect experiments that improve engagement at the cost of catalog narrowing.
+- `user_discovery_rate` and `user_genre_entropy` provide signals for novelty decay analysis (ADR-021).
+- Intra-list distance integrates naturally with interleaving and slate bandit (ADR-016) evaluations.
+
+**Negative / Risks**
+- Catalog-level Gini templates require a CROSS JOIN between all variants and all catalog items.
+  For large catalogs (>10M items), this may be expensive. Use approximate methods or partition
+  filtering if this becomes a bottleneck.
+- `user_discovery_rate` requires a full pre-experiment history scan of `delta.metric_events`.
+  Add a retention-based index or cache pre-experiment content sets if query time is unacceptable.
+
+---
+
+## Implementation
+
+- **ADR owner**: Agent-3 (M3 Metrics)
+- **Depends on**: None (self-contained M3 change)
+- **Consumed by**: M4a (ADR-021 feedback loop interference uses provider Gini and catalog entropy)

--- a/delta/content_catalog.sql
+++ b/delta/content_catalog.sql
@@ -1,0 +1,40 @@
+-- ============================================================================
+-- Delta Lake: content_catalog
+-- ADR-014 Provider-Side Metrics: catalog of all available content with
+-- provider and genre metadata. Written by the content ingestion pipeline.
+-- Read by M3 provider-metric SQL templates.
+--
+-- Freshness invariant: MAX(updated_at) must be within 24 hours before any
+-- provider-side metric computation. Enforced by ProviderMetricsJob.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS delta.content_catalog (
+    content_id          STRING      NOT NULL,
+    provider_id         STRING      NOT NULL,
+    title               STRING,
+    genre               STRING,         -- Primary genre label (e.g. "Drama", "Comedy")
+    subgenre            STRING,         -- Optional secondary genre
+    content_type        STRING,         -- 'movie', 'series', 'episode', 'short'
+    duration_seconds    BIGINT,
+    release_year        INT,
+    country_of_origin   STRING,
+    language            STRING,
+    is_original         BOOLEAN,        -- Platform original (TRUE) vs licensed (FALSE)
+    is_licensed         BOOLEAN,
+    popularity_rank     BIGINT,         -- Global rank by rolling 30-day impressions (1 = most popular)
+    updated_at          TIMESTAMP   NOT NULL   -- Freshness anchor for M3 staleness check
+)
+USING DELTA
+PARTITIONED BY (provider_id STRING)
+TBLPROPERTIES (
+    'delta.autoOptimize.optimizeWrite' = 'true',
+    'delta.autoOptimize.autoCompact' = 'true',
+    'delta.logRetentionDuration' = 'interval 90 days',
+    'delta.deletedFileRetentionDuration' = 'interval 7 days'
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_catalog_content
+    ON delta.content_catalog (content_id);
+
+CREATE INDEX IF NOT EXISTS idx_content_catalog_genre
+    ON delta.content_catalog (genre);

--- a/delta/experiment_level_metrics.sql
+++ b/delta/experiment_level_metrics.sql
@@ -1,0 +1,24 @@
+-- ============================================================================
+-- Delta Lake: experiment_level_metrics
+-- ADR-014 Provider-Side Metrics: experiment-scoped aggregate metrics.
+-- Unlike delta.metric_summaries (per-user), this table holds one row per
+-- (experiment, variant, metric_id) for catalog- and provider-level metrics
+-- that cannot be meaningfully disaggregated to the user level.
+--
+-- Written by M3 ProviderMetricsJob. Read by M4a for provider-side analysis.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS delta.experiment_level_metrics (
+    experiment_id       STRING      NOT NULL,
+    variant_id          STRING      NOT NULL,
+    metric_id           STRING      NOT NULL,   -- e.g. 'catalog_coverage_rate'
+    metric_value        DOUBLE      NOT NULL,
+    computation_date    DATE        NOT NULL
+)
+USING DELTA
+PARTITIONED BY (computation_date DATE, experiment_id STRING)
+TBLPROPERTIES (
+    'delta.autoOptimize.optimizeWrite' = 'true',
+    'delta.autoOptimize.autoCompact' = 'true',
+    'delta.logRetentionDuration' = 'interval 365 days'
+);

--- a/docs/coordination/status/agent-3-status.md
+++ b/docs/coordination/status/agent-3-status.md
@@ -1,23 +1,35 @@
 # Agent-3 Status — Phase 5
 
 **Module**: M3 Metrics
-**Last updated**: [date]
+**Last updated**: 2026-03-23
 
 ## Current Sprint
 
 Sprint: 5.0
-Focus: ADR-014 Provider metrics, ADR-015 MLRATE, ADR-017 user_trajectories
-Branch: agent-3/feat/[current-work]
-
-## In Progress
-
-- [ ] [Milestone description] (ADR-XXX)
-  - Blocked by: [none | Agent-M: description]
-  - ETA: [date]
+Focus: ADR-014 Provider metrics
+Branch: work/zealous-owl
 
 ## Completed (Phase 5)
 
-_None yet._
+- [x] **ADR-014 Provider-Side Metrics** — PR pending
+  - Created `delta/content_catalog.sql` DDL (provider_id, genre, updated_at, popularity_rank)
+  - Created `delta/experiment_level_metrics.sql` DDL (aggregate per experiment/variant/metric)
+  - Implemented 10 SQL templates in `services/metrics/internal/spark/templates/`:
+    - **Experiment-level** (→ `delta.experiment_level_metrics`):
+      `catalog_coverage_rate`, `catalog_gini_coefficient`, `catalog_entropy`,
+      `longtail_impression_share`, `provider_exposure_gini`, `provider_exposure_parity`
+    - **User-level** (→ `delta.metric_summaries`):
+      `user_genre_entropy`, `user_discovery_rate`, `user_provider_diversity`, `intra_list_distance`
+  - Extended `spark.TemplateParams` with `LongtailThreshold`, `ProviderField`, `GenreField`
+  - Added 10 new `Render*` methods to `SQLRenderer`
+  - Implemented `ProviderMetricsJob` with `checkCatalogFreshness` (24-hour staleness guard)
+  - All queries logged to `query_log` with `job_type = "provider_metric"`
+  - Template validation test updated: 17 → 27 templates, all passing
+  - Full `services/metrics/...` test suite: green
+
+## In Progress
+
+_None._
 
 ## Blocked
 
@@ -25,4 +37,6 @@ _None._
 
 ## Next Up
 
-- [Next milestone] — depends on: [Agent-Proto schema | none]
+- ADR-015 AVLM (CUPED + mSPRT unification) — no external dependencies
+- ADR-021 Feedback Loop Interference — consumes `catalog_gini_coefficient` and
+  `provider_exposure_gini` from ADR-014; can begin after ADR-014 merges

--- a/services/metrics/internal/jobs/provider_metrics.go
+++ b/services/metrics/internal/jobs/provider_metrics.go
@@ -1,0 +1,228 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
+	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+)
+
+const (
+	// catalogFreshnessSQL returns 1 row when content_catalog.updated_at is within 24 h,
+	// 0 rows when stale. Used by checkCatalogFreshness.
+	catalogFreshnessSQL = `SELECT CAST(1 AS INT) AS is_fresh
+FROM (SELECT MAX(updated_at) AS last_updated FROM delta.content_catalog) t
+WHERE t.last_updated >= CURRENT_TIMESTAMP() - INTERVAL '24 HOURS'`
+
+	// defaultProviderField is the column name in content_catalog for the provider.
+	defaultProviderField = "provider_id"
+	// defaultGenreField is the column name in content_catalog for the genre.
+	defaultGenreField = "genre"
+	// defaultLongtailThreshold is the PERCENT_RANK cutoff for longtail content.
+	defaultLongtailThreshold = 0.80
+)
+
+// ProviderMetricsResult summarises the outcome of a provider metrics run.
+type ProviderMetricsResult struct {
+	ExperimentID      string
+	MetricsComputed   int
+	RowsWritten       int64
+	CompletedAt       time.Time
+}
+
+// providerMetricSpec describes a single provider-side metric and which Delta
+// table its output should be written to.
+type providerMetricSpec struct {
+	metricID    string
+	jobType     string
+	targetTable string
+	render      func(*spark.SQLRenderer, spark.TemplateParams) (string, error)
+}
+
+// experimentLevelSpecs returns the specs for metrics that produce one row per
+// (experiment, variant) and land in delta.experiment_level_metrics.
+func experimentLevelSpecs(r *spark.SQLRenderer) []providerMetricSpec {
+	return []providerMetricSpec{
+		{
+			metricID:    "catalog_coverage_rate",
+			jobType:     "provider_metric",
+			targetTable: "delta.experiment_level_metrics",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderCatalogCoverageRate(p) },
+		},
+		{
+			metricID:    "catalog_gini_coefficient",
+			jobType:     "provider_metric",
+			targetTable: "delta.experiment_level_metrics",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderCatalogGiniCoefficient(p) },
+		},
+		{
+			metricID:    "catalog_entropy",
+			jobType:     "provider_metric",
+			targetTable: "delta.experiment_level_metrics",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderCatalogEntropy(p) },
+		},
+		{
+			metricID:    "longtail_impression_share",
+			jobType:     "provider_metric",
+			targetTable: "delta.experiment_level_metrics",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderLongtailImpressionShare(p) },
+		},
+		{
+			metricID:    "provider_exposure_gini",
+			jobType:     "provider_metric",
+			targetTable: "delta.experiment_level_metrics",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderProviderExposureGini(p) },
+		},
+		{
+			metricID:    "provider_exposure_parity",
+			jobType:     "provider_metric",
+			targetTable: "delta.experiment_level_metrics",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderProviderExposureParity(p) },
+		},
+	}
+}
+
+// userLevelSpecs returns the specs for metrics that produce one row per
+// (experiment, user, variant) and land in delta.metric_summaries.
+func userLevelSpecs(r *spark.SQLRenderer) []providerMetricSpec {
+	return []providerMetricSpec{
+		{
+			metricID:    "user_genre_entropy",
+			jobType:     "provider_metric",
+			targetTable: "delta.metric_summaries",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderUserGenreEntropy(p) },
+		},
+		{
+			metricID:    "user_discovery_rate",
+			jobType:     "provider_metric",
+			targetTable: "delta.metric_summaries",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderUserDiscoveryRate(p) },
+		},
+		{
+			metricID:    "user_provider_diversity",
+			jobType:     "provider_metric",
+			targetTable: "delta.metric_summaries",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderUserProviderDiversity(p) },
+		},
+		{
+			metricID:    "intra_list_distance",
+			jobType:     "provider_metric",
+			targetTable: "delta.metric_summaries",
+			render:      func(rr *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return rr.RenderIntraListDistance(p) },
+		},
+	}
+}
+
+// ProviderMetricsJob computes ADR-014 provider-side metrics for a single
+// experiment. It validates content_catalog freshness before running any SQL.
+type ProviderMetricsJob struct {
+	config   *config.ConfigStore
+	renderer *spark.SQLRenderer
+	executor spark.SQLExecutor
+	queryLog querylog.Writer
+}
+
+// NewProviderMetricsJob creates a new provider metrics job.
+func NewProviderMetricsJob(
+	cfg *config.ConfigStore,
+	renderer *spark.SQLRenderer,
+	executor spark.SQLExecutor,
+	ql querylog.Writer,
+) *ProviderMetricsJob {
+	return &ProviderMetricsJob{
+		config:   cfg,
+		renderer: renderer,
+		executor: executor,
+		queryLog: ql,
+	}
+}
+
+// Run computes all provider-side metrics for the given experiment.
+// Returns an error if content_catalog is stale (updated_at > 24h ago).
+func (j *ProviderMetricsJob) Run(ctx context.Context, experimentID string) (*ProviderMetricsResult, error) {
+	if err := j.checkCatalogFreshness(ctx); err != nil {
+		return nil, fmt.Errorf("jobs: provider metrics aborted for %s: %w", experimentID, err)
+	}
+
+	exp, err := j.config.GetExperiment(experimentID)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: %w", err)
+	}
+
+	computationDate := time.Now().Format("2006-01-02")
+
+	baseParams := spark.TemplateParams{
+		ExperimentID:         exp.ExperimentID,
+		SourceEventType:      "impression", // default event type for impression-based provider metrics
+		ComputationDate:      computationDate,
+		ExperimentStartDate:  exp.StartedAt,
+		ProviderField:        defaultProviderField,
+		GenreField:           defaultGenreField,
+		LongtailThreshold:    defaultLongtailThreshold,
+	}
+
+	var totalRows int64
+	metricsComputed := 0
+
+	allSpecs := append(experimentLevelSpecs(j.renderer), userLevelSpecs(j.renderer)...)
+	for _, spec := range allSpecs {
+		params := baseParams
+		params.MetricID = spec.metricID
+
+		sql, err := spec.render(j.renderer, params)
+		if err != nil {
+			return nil, fmt.Errorf("jobs: render provider metric %s: %w", spec.metricID, err)
+		}
+
+		result, err := j.executor.ExecuteAndWrite(ctx, sql, spec.targetTable)
+		if err != nil {
+			return nil, fmt.Errorf("jobs: execute provider metric %s: %w", spec.metricID, err)
+		}
+
+		if err := j.queryLog.Log(ctx, querylog.Entry{
+			ExperimentID: experimentID,
+			MetricID:     spec.metricID,
+			SQLText:      sql,
+			RowCount:     result.RowCount,
+			DurationMs:   result.Duration.Milliseconds(),
+			JobType:      spec.jobType,
+		}); err != nil {
+			return nil, fmt.Errorf("jobs: log provider metric %s: %w", spec.metricID, err)
+		}
+
+		totalRows += result.RowCount
+		metricsComputed++
+
+		slog.Info("computed provider metric",
+			"experiment_id", experimentID,
+			"metric_id", spec.metricID,
+			"target_table", spec.targetTable,
+			"rows", result.RowCount,
+			"duration_ms", result.Duration.Milliseconds(),
+		)
+	}
+
+	return &ProviderMetricsResult{
+		ExperimentID:    experimentID,
+		MetricsComputed: metricsComputed,
+		RowsWritten:     totalRows,
+		CompletedAt:     time.Now(),
+	}, nil
+}
+
+// checkCatalogFreshness validates that delta.content_catalog was updated within
+// the last 24 hours. Returns a descriptive error if the catalog is stale.
+func (j *ProviderMetricsJob) checkCatalogFreshness(ctx context.Context) error {
+	result, err := j.executor.ExecuteSQL(ctx, catalogFreshnessSQL)
+	if err != nil {
+		return fmt.Errorf("catalog freshness check failed: %w", err)
+	}
+	if result.RowCount == 0 {
+		return fmt.Errorf("content_catalog staleness violation: updated_at is older than 24 hours — provider metrics require fresh catalog data")
+	}
+	return nil
+}

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -43,6 +43,10 @@ type TemplateParams struct {
 	Percentile float64 // percentile value in (0,1), e.g. 0.50 for p50, 0.95 for p95
 	// Custom metric fields
 	CustomSQL string // user-provided Spark SQL expression for CUSTOM metrics
+	// Provider-side metric fields (ADR-014)
+	LongtailThreshold float64 // PERCENT_RANK threshold for longtail classification (e.g. 0.80)
+	ProviderField     string  // provider column name in content_catalog (default "provider_id")
+	GenreField        string  // genre column name in content_catalog (default "genre")
 }
 
 type SQLRenderer struct {
@@ -82,6 +86,21 @@ func (r *SQLRenderer) RenderSessionLevelMean(p TemplateParams) (string, error) {
 func (r *SQLRenderer) RenderQoEEngagementCorrelation(p TemplateParams) (string, error) { return r.Render("qoe_engagement_correlation.sql.tmpl", p) }
 func (r *SQLRenderer) RenderCustom(p TemplateParams) (string, error)               { return r.Render("custom.sql.tmpl", p) }
 func (r *SQLRenderer) RenderPercentile(p TemplateParams) (string, error)           { return r.Render("percentile.sql.tmpl", p) }
+
+// Provider-side metric renderers (ADR-014).
+// Experiment-level metrics — results go to delta.experiment_level_metrics.
+func (r *SQLRenderer) RenderCatalogCoverageRate(p TemplateParams) (string, error)    { return r.Render("catalog_coverage_rate.sql.tmpl", p) }
+func (r *SQLRenderer) RenderCatalogGiniCoefficient(p TemplateParams) (string, error) { return r.Render("catalog_gini_coefficient.sql.tmpl", p) }
+func (r *SQLRenderer) RenderCatalogEntropy(p TemplateParams) (string, error)         { return r.Render("catalog_entropy.sql.tmpl", p) }
+func (r *SQLRenderer) RenderLongtailImpressionShare(p TemplateParams) (string, error) { return r.Render("longtail_impression_share.sql.tmpl", p) }
+func (r *SQLRenderer) RenderProviderExposureGini(p TemplateParams) (string, error)   { return r.Render("provider_exposure_gini.sql.tmpl", p) }
+func (r *SQLRenderer) RenderProviderExposureParity(p TemplateParams) (string, error) { return r.Render("provider_exposure_parity.sql.tmpl", p) }
+
+// User-level provider metrics — results go to delta.metric_summaries.
+func (r *SQLRenderer) RenderUserGenreEntropy(p TemplateParams) (string, error)      { return r.Render("user_genre_entropy.sql.tmpl", p) }
+func (r *SQLRenderer) RenderUserDiscoveryRate(p TemplateParams) (string, error)     { return r.Render("user_discovery_rate.sql.tmpl", p) }
+func (r *SQLRenderer) RenderUserProviderDiversity(p TemplateParams) (string, error) { return r.Render("user_provider_diversity.sql.tmpl", p) }
+func (r *SQLRenderer) RenderIntraListDistance(p TemplateParams) (string, error)     { return r.Render("intra_list_distance.sql.tmpl", p) }
 
 func (r *SQLRenderer) RenderForType(metricType string, p TemplateParams) (string, error) {
 	switch strings.ToUpper(metricType) {

--- a/services/metrics/internal/spark/template_validation_test.go
+++ b/services/metrics/internal/spark/template_validation_test.go
@@ -36,6 +36,10 @@ func minimalParams() TemplateParams {
 		EngagementSourceType: "heartbeat",
 		Percentile:           0.50,
 		CustomSQL:            "SELECT user_id, AVG(value) AS metric_value FROM delta.metric_events GROUP BY user_id",
+		// Provider-side metric fields (ADR-014).
+		LongtailThreshold: 0.80,
+		ProviderField:     "provider_id",
+		GenreField:        "genre",
 	}
 }
 
@@ -191,6 +195,90 @@ func allTemplateSpecs() []templateSpec {
 				"CORR(", "pearson_correlation",
 				"delta.qoe_events", "delta.metric_events",
 				"STDDEV_SAMP",
+			},
+		},
+		// Provider-side metrics (ADR-014) — experiment level.
+		{
+			name:   "catalog_coverage_rate",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderCatalogCoverageRate(p) },
+			contains: []string{
+				"delta.content_catalog", "covered_items", "total_items",
+				"NULLIF(ct.total_items", "delta.exposures",
+			},
+		},
+		{
+			name:   "catalog_gini_coefficient",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderCatalogGiniCoefficient(p) },
+			contains: []string{
+				"delta.content_catalog", "gini_coefficient",
+				"ROW_NUMBER()", "rank_asc", "total_impressions",
+			},
+		},
+		{
+			name:   "catalog_entropy",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderCatalogEntropy(p) },
+			contains: []string{
+				"catalog_entropy", "LOG(", "total_impressions",
+				"variant_content_impressions", "delta.metric_events",
+			},
+		},
+		{
+			name:   "longtail_impression_share",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderLongtailImpressionShare(p) },
+			contains: []string{
+				"PERCENT_RANK()", "longtail_content",
+				"longtail_impressions", "0.8", // LongtailThreshold
+				"delta.metric_events",
+			},
+		},
+		{
+			name:   "provider_exposure_gini",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderProviderExposureGini(p) },
+			contains: []string{
+				"delta.content_catalog", "provider_gini", "provider_id",
+				"ROW_NUMBER()", "rank_asc",
+			},
+		},
+		{
+			name:   "provider_exposure_parity",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderProviderExposureParity(p) },
+			contains: []string{
+				"delta.content_catalog", "provider_parity", "provider_id",
+				"MIN(provider_share)", "MAX(provider_share)",
+			},
+		},
+		// Provider-side metrics (ADR-014) — user level.
+		{
+			name:   "user_genre_entropy",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderUserGenreEntropy(p) },
+			contains: []string{
+				"delta.content_catalog", "genre", "user_entropy",
+				"assignment_probability", "LOG(",
+			},
+		},
+		{
+			name:   "user_discovery_rate",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderUserDiscoveryRate(p) },
+			contains: []string{
+				"pre_experiment_content", "experiment_content", "new_content",
+				"2024-01-08", // ExperimentStartDate
+				"assignment_probability",
+			},
+		},
+		{
+			name:   "user_provider_diversity",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderUserProviderDiversity(p) },
+			contains: []string{
+				"delta.content_catalog", "distinct_providers", "provider_id",
+				"COUNT(DISTINCT", "assignment_probability",
+			},
+		},
+		{
+			name:   "intra_list_distance",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderIntraListDistance(p) },
+			contains: []string{
+				"delta.content_catalog", "genre", "POWER(",
+				"user_ild", "1.0 -", "assignment_probability",
 			},
 		},
 	}
@@ -428,7 +516,8 @@ func TestTemplateValidation_PercentileValues(t *testing.T) {
 // catch any new templates that are added without validation coverage.
 func TestTemplateValidation_TemplateCount(t *testing.T) {
 	specs := allTemplateSpecs()
-	// 17 renderable templates (exposure_join is a sub-template, not directly rendered).
-	assert.Equal(t, 17, len(specs),
-		"allTemplateSpecs should cover all 17 renderable templates; if you added a new template, add it to allTemplateSpecs()")
+	// 27 renderable templates: 17 original + 10 provider-side metrics from ADR-014.
+	// (exposure_join is a sub-template, not directly rendered.)
+	assert.Equal(t, 27, len(specs),
+		"allTemplateSpecs should cover all 27 renderable templates; if you added a new template, add it to allTemplateSpecs()")
 }

--- a/services/metrics/internal/spark/templates/catalog_coverage_rate.sql.tmpl
+++ b/services/metrics/internal/spark/templates/catalog_coverage_rate.sql.tmpl
@@ -1,0 +1,32 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+recommended_content AS (
+    SELECT DISTINCT eu.variant_id, me.content_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+),
+catalog_total AS (
+    SELECT COUNT(DISTINCT content_id) AS total_items
+    FROM delta.content_catalog
+),
+variant_coverage AS (
+    SELECT
+        rc.variant_id,
+        COUNT(DISTINCT rc.content_id) AS covered_items
+    FROM recommended_content rc
+    INNER JOIN delta.content_catalog cc ON rc.content_id = cc.content_id
+    GROUP BY rc.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    vc.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CAST(vc.covered_items AS DOUBLE) / NULLIF(ct.total_items, 0) AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM variant_coverage vc
+CROSS JOIN catalog_total ct

--- a/services/metrics/internal/spark/templates/catalog_entropy.sql.tmpl
+++ b/services/metrics/internal/spark/templates/catalog_entropy.sql.tmpl
@@ -1,0 +1,38 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+variant_content_impressions AS (
+    SELECT eu.variant_id, me.content_id, COUNT(*) AS impression_count
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+    GROUP BY eu.variant_id, me.content_id
+),
+variant_totals AS (
+    SELECT variant_id, SUM(impression_count) AS total_impressions
+    FROM variant_content_impressions
+    GROUP BY variant_id
+),
+entropy_calc AS (
+    SELECT
+        vci.variant_id,
+        -SUM(
+            CASE WHEN vci.impression_count > 0 AND vt.total_impressions > 0 THEN
+                (CAST(vci.impression_count AS DOUBLE) / vt.total_impressions) *
+                LOG(CAST(vci.impression_count AS DOUBLE) / vt.total_impressions)
+            ELSE 0.0 END
+        ) AS catalog_entropy
+    FROM variant_content_impressions vci
+    INNER JOIN variant_totals vt ON vci.variant_id = vt.variant_id
+    GROUP BY vci.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    variant_id,
+    '{{.MetricID}}' AS metric_id,
+    catalog_entropy AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM entropy_calc

--- a/services/metrics/internal/spark/templates/catalog_gini_coefficient.sql.tmpl
+++ b/services/metrics/internal/spark/templates/catalog_gini_coefficient.sql.tmpl
@@ -1,0 +1,51 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+variant_content_impressions AS (
+    SELECT eu.variant_id, me.content_id, COUNT(*) AS impression_count
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+    GROUP BY eu.variant_id, me.content_id
+),
+catalog_items AS (
+    SELECT DISTINCT content_id FROM delta.content_catalog
+),
+all_variant_items AS (
+    SELECT eu.variant_id, ci.content_id,
+        COALESCE(vci.impression_count, 0) AS impression_count
+    FROM (SELECT DISTINCT variant_id FROM exposed_users) eu
+    CROSS JOIN catalog_items ci
+    LEFT JOIN variant_content_impressions vci
+        ON eu.variant_id = vci.variant_id AND ci.content_id = vci.content_id
+),
+ranked AS (
+    SELECT
+        variant_id,
+        impression_count,
+        ROW_NUMBER() OVER (PARTITION BY variant_id ORDER BY impression_count ASC) AS rank_asc,
+        COUNT(*) OVER (PARTITION BY variant_id) AS n,
+        SUM(impression_count) OVER (PARTITION BY variant_id) AS total_impressions
+    FROM all_variant_items
+),
+gini_calc AS (
+    SELECT
+        variant_id,
+        CASE
+            WHEN MAX(total_impressions) = 0 THEN 0.0
+            ELSE (2.0 * SUM(rank_asc * impression_count) / (MAX(n) * MAX(total_impressions)))
+                 - (MAX(n) + 1.0) / MAX(n)
+        END AS gini_coefficient
+    FROM ranked
+    GROUP BY variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    variant_id,
+    '{{.MetricID}}' AS metric_id,
+    gini_coefficient AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM gini_calc

--- a/services/metrics/internal/spark/templates/intra_list_distance.sql.tmpl
+++ b/services/metrics/internal/spark/templates/intra_list_distance.sql.tmpl
@@ -1,0 +1,44 @@
+WITH exposed_users AS (
+    -- ILD = 1 - SUM_g(p_g^2) (complement of HHI over genres).
+    -- Range [0,1]: 0 = single genre, 1 = every item is a different genre.
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+user_genre_counts AS (
+    SELECT eu.user_id, eu.variant_id, cc.{{.GenreField}} AS genre, COUNT(*) AS genre_count
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    INNER JOIN delta.content_catalog cc ON me.content_id = cc.content_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+      AND cc.{{.GenreField}} IS NOT NULL
+    GROUP BY eu.user_id, eu.variant_id, cc.{{.GenreField}}
+),
+user_totals AS (
+    SELECT user_id, variant_id, SUM(genre_count) AS total_count
+    FROM user_genre_counts
+    GROUP BY user_id, variant_id
+),
+user_ild AS (
+    SELECT
+        ugc.user_id,
+        ugc.variant_id,
+        1.0 - SUM(
+            POWER(CAST(ugc.genre_count AS DOUBLE) / NULLIF(ut.total_count, 0), 2)
+        ) AS metric_value
+    FROM user_genre_counts ugc
+    INNER JOIN user_totals ut ON ugc.user_id = ut.user_id AND ugc.variant_id = ut.variant_id
+    GROUP BY ugc.user_id, ugc.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    uild.user_id,
+    uild.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    uild.metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM user_ild uild
+INNER JOIN exposed_users eu ON uild.user_id = eu.user_id AND uild.variant_id = eu.variant_id

--- a/services/metrics/internal/spark/templates/longtail_impression_share.sql.tmpl
+++ b/services/metrics/internal/spark/templates/longtail_impression_share.sql.tmpl
@@ -1,0 +1,51 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+variant_content_impressions AS (
+    SELECT eu.variant_id, me.content_id, COUNT(*) AS impression_count
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+    GROUP BY eu.variant_id, me.content_id
+),
+content_global_impressions AS (
+    SELECT content_id, SUM(impression_count) AS total_impressions
+    FROM variant_content_impressions
+    GROUP BY content_id
+),
+content_ranked AS (
+    SELECT
+        content_id,
+        total_impressions,
+        PERCENT_RANK() OVER (ORDER BY total_impressions DESC) AS popularity_pct_rank
+    FROM content_global_impressions
+),
+longtail_content AS (
+    -- Content ranked below LongtailThreshold by popularity is considered longtail.
+    -- e.g. LongtailThreshold=0.80 means the bottom 20% by impressions.
+    SELECT content_id
+    FROM content_ranked
+    WHERE popularity_pct_rank >= {{.LongtailThreshold}}
+),
+longtail_share AS (
+    SELECT
+        vci.variant_id,
+        SUM(CASE WHEN lc.content_id IS NOT NULL THEN vci.impression_count ELSE 0 END)
+            AS longtail_impressions,
+        SUM(vci.impression_count) AS total_impressions
+    FROM variant_content_impressions vci
+    LEFT JOIN longtail_content lc ON vci.content_id = lc.content_id
+    GROUP BY vci.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CASE WHEN total_impressions = 0 THEN 0.0
+         ELSE CAST(longtail_impressions AS DOUBLE) / total_impressions
+    END AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM longtail_share

--- a/services/metrics/internal/spark/templates/provider_exposure_gini.sql.tmpl
+++ b/services/metrics/internal/spark/templates/provider_exposure_gini.sql.tmpl
@@ -1,0 +1,55 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+variant_provider_impressions AS (
+    SELECT eu.variant_id, cc.{{.ProviderField}} AS provider_id, COUNT(*) AS impression_count
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    INNER JOIN delta.content_catalog cc ON me.content_id = cc.content_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+      AND cc.{{.ProviderField}} IS NOT NULL
+    GROUP BY eu.variant_id, cc.{{.ProviderField}}
+),
+all_providers AS (
+    SELECT DISTINCT {{.ProviderField}} AS provider_id
+    FROM delta.content_catalog
+    WHERE {{.ProviderField}} IS NOT NULL
+),
+all_variant_providers AS (
+    SELECT eu.variant_id, ap.provider_id,
+        COALESCE(vpi.impression_count, 0) AS impression_count
+    FROM (SELECT DISTINCT variant_id FROM exposed_users) eu
+    CROSS JOIN all_providers ap
+    LEFT JOIN variant_provider_impressions vpi
+        ON eu.variant_id = vpi.variant_id AND ap.provider_id = vpi.provider_id
+),
+ranked AS (
+    SELECT
+        variant_id,
+        impression_count,
+        ROW_NUMBER() OVER (PARTITION BY variant_id ORDER BY impression_count ASC) AS rank_asc,
+        COUNT(*) OVER (PARTITION BY variant_id) AS n,
+        SUM(impression_count) OVER (PARTITION BY variant_id) AS total_impressions
+    FROM all_variant_providers
+),
+gini_calc AS (
+    SELECT
+        variant_id,
+        CASE
+            WHEN MAX(total_impressions) = 0 THEN 0.0
+            ELSE (2.0 * SUM(rank_asc * impression_count) / (MAX(n) * MAX(total_impressions)))
+                 - (MAX(n) + 1.0) / MAX(n)
+        END AS provider_gini
+    FROM ranked
+    GROUP BY variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    variant_id,
+    '{{.MetricID}}' AS metric_id,
+    provider_gini AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM gini_calc

--- a/services/metrics/internal/spark/templates/provider_exposure_parity.sql.tmpl
+++ b/services/metrics/internal/spark/templates/provider_exposure_parity.sql.tmpl
@@ -1,0 +1,45 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+variant_provider_impressions AS (
+    SELECT eu.variant_id, cc.{{.ProviderField}} AS provider_id, COUNT(*) AS impression_count
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    INNER JOIN delta.content_catalog cc ON me.content_id = cc.content_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+      AND cc.{{.ProviderField}} IS NOT NULL
+    GROUP BY eu.variant_id, cc.{{.ProviderField}}
+),
+variant_totals AS (
+    SELECT variant_id, SUM(impression_count) AS total_impressions
+    FROM variant_provider_impressions
+    GROUP BY variant_id
+),
+provider_shares AS (
+    SELECT
+        vpi.variant_id,
+        CAST(vpi.impression_count AS DOUBLE) / NULLIF(vt.total_impressions, 0) AS provider_share
+    FROM variant_provider_impressions vpi
+    INNER JOIN variant_totals vt ON vpi.variant_id = vt.variant_id
+),
+parity_calc AS (
+    SELECT
+        variant_id,
+        -- Parity = min_share / max_share. Range [0, 1] where 1.0 = perfectly equal distribution.
+        CASE
+            WHEN MAX(provider_share) = 0.0 THEN 1.0
+            ELSE MIN(provider_share) / MAX(provider_share)
+        END AS provider_parity
+    FROM provider_shares
+    GROUP BY variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    variant_id,
+    '{{.MetricID}}' AS metric_id,
+    provider_parity AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM parity_calc

--- a/services/metrics/internal/spark/templates/user_discovery_rate.sql.tmpl
+++ b/services/metrics/internal/spark/templates/user_discovery_rate.sql.tmpl
@@ -1,0 +1,46 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+pre_experiment_content AS (
+    -- Content each user consumed before the experiment started (lookback for novelty baseline).
+    SELECT DISTINCT user_id, content_id
+    FROM delta.metric_events
+    WHERE event_type = '{{.SourceEventType}}'
+      AND content_id IS NOT NULL
+      AND event_timestamp < CAST('{{.ExperimentStartDate}}' AS TIMESTAMP)
+),
+experiment_content AS (
+    -- Distinct content consumed by each user during the experiment window.
+    SELECT DISTINCT eu.user_id, eu.variant_id, me.content_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+      AND me.event_timestamp >= CAST('{{.ExperimentStartDate}}' AS TIMESTAMP)
+),
+user_discovery AS (
+    SELECT
+        ec.user_id,
+        ec.variant_id,
+        COUNT(DISTINCT ec.content_id) AS total_content,
+        COUNT(DISTINCT CASE WHEN pec.content_id IS NULL THEN ec.content_id END) AS new_content
+    FROM experiment_content ec
+    LEFT JOIN pre_experiment_content pec
+        ON ec.user_id = pec.user_id AND ec.content_id = pec.content_id
+    GROUP BY ec.user_id, ec.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    ud.user_id,
+    ud.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CASE WHEN ud.total_content = 0 THEN 0.0
+         ELSE CAST(ud.new_content AS DOUBLE) / ud.total_content
+    END AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM user_discovery ud
+INNER JOIN exposed_users eu ON ud.user_id = eu.user_id AND ud.variant_id = eu.variant_id

--- a/services/metrics/internal/spark/templates/user_genre_entropy.sql.tmpl
+++ b/services/metrics/internal/spark/templates/user_genre_entropy.sql.tmpl
@@ -1,0 +1,43 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+user_genre_counts AS (
+    SELECT eu.user_id, eu.variant_id, cc.{{.GenreField}} AS genre, COUNT(*) AS genre_count
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    INNER JOIN delta.content_catalog cc ON me.content_id = cc.content_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+      AND cc.{{.GenreField}} IS NOT NULL
+    GROUP BY eu.user_id, eu.variant_id, cc.{{.GenreField}}
+),
+user_totals AS (
+    SELECT user_id, variant_id, SUM(genre_count) AS total_count
+    FROM user_genre_counts
+    GROUP BY user_id, variant_id
+),
+user_entropy AS (
+    SELECT
+        ugc.user_id,
+        ugc.variant_id,
+        -SUM(
+            (CAST(ugc.genre_count AS DOUBLE) / ut.total_count) *
+            LOG(CAST(ugc.genre_count AS DOUBLE) / ut.total_count)
+        ) AS metric_value
+    FROM user_genre_counts ugc
+    INNER JOIN user_totals ut ON ugc.user_id = ut.user_id AND ugc.variant_id = ut.variant_id
+    GROUP BY ugc.user_id, ugc.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    ue.user_id,
+    ue.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    ue.metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM user_entropy ue
+INNER JOIN exposed_users eu ON ue.user_id = eu.user_id AND ue.variant_id = eu.variant_id

--- a/services/metrics/internal/spark/templates/user_provider_diversity.sql.tmpl
+++ b/services/metrics/internal/spark/templates/user_provider_diversity.sql.tmpl
@@ -1,0 +1,27 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+user_provider_counts AS (
+    SELECT eu.user_id, eu.variant_id,
+        COUNT(DISTINCT cc.{{.ProviderField}}) AS distinct_providers
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    INNER JOIN delta.content_catalog cc ON me.content_id = cc.content_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND me.content_id IS NOT NULL
+      AND cc.{{.ProviderField}} IS NOT NULL
+    GROUP BY eu.user_id, eu.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    upc.user_id,
+    upc.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CAST(upc.distinct_providers AS DOUBLE) AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM user_provider_counts upc
+INNER JOIN exposed_users eu ON upc.user_id = eu.user_id AND upc.variant_id = eu.variant_id


### PR DESCRIPTION
## Summary

- **New Delta DDL**: `delta/content_catalog.sql` (provider/genre metadata with freshness anchor) and `delta/experiment_level_metrics.sql` (aggregate per-experiment results)
- **10 SQL templates** in `services/metrics/internal/spark/templates/`: 6 experiment-level (coverage rate, Gini, entropy, longtail share, provider Gini, parity) + 4 user-level (genre entropy, discovery rate, provider diversity, intra-list distance)
- **`ProviderMetricsJob`**: orchestrates all 10 metrics; enforces 24-hour catalog freshness guard before any SQL executes
- **`TemplateParams` extended** with `LongtailThreshold`, `ProviderField`, `GenreField`
- **Template validation tests** updated from 17 → 27 templates; full `services/metrics/...` suite green

## Implementation details

**Freshness validation** (`checkCatalogFreshness`): queries `SELECT MAX(updated_at) FROM delta.content_catalog` via `ExecuteSQL`, returns a descriptive error if `RowCount == 0` (i.e., no rows updated within the last 24 hours). All provider metric queries are blocked until the check passes.

**Experiment-level vs user-level split**: Catalog and provider aggregates that produce one row per (experiment, variant) land in `delta.experiment_level_metrics`. Per-user diversity metrics (entropy, discovery rate, provider diversity, ILD) follow the existing `delta.metric_summaries` schema.

**Intra-list distance** is implemented as `1 − Σ p_g²` (complement of HHI over genres), which is algebraically equivalent to average pairwise binary genre distance and avoids an expensive quadratic join.

All queries logged to `query_log` with `job_type = "provider_metric"`.

## Test plan

- [x] `go test ./services/metrics/internal/spark/... -run TestTemplateValidation` — 27/27 templates pass all 5 validation suites (render, SQL structure, parameter substitution, SELECT-only, no semicolons)
- [x] `go test ./services/metrics/...` — full service suite green (11 packages)
- [ ] Integration: wire `ProviderMetricsJob` into M3 handler/scheduler (out of scope for this PR — can be follow-up once M4a consumes `experiment_level_metrics`)

## Opportunities noted (not implemented)

- Approximate Gini for large catalogs (>10M items): CROSS JOIN in `catalog_gini_coefficient` and `provider_exposure_gini` may be expensive; consider sampling or pre-aggregated popularity bins
- `user_discovery_rate` scans full pre-experiment `delta.metric_events` history — a materialized per-user content set would improve performance
- Wire `ProviderMetricsJob` into the M3 job scheduler and expose metrics via M3 RPC handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
