### PR TITLE
feat(experimentation-stats,m5): ADR-014 guardrail Bonferroni correction + M5 metric validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,6 +1913,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "experimentation-flags"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "chrono",
+ "experimentation-core",
+ "experimentation-hash",
+ "experimentation-proto",
+ "prost 0.13.5",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-test",
+ "tonic",
+ "tonic-web",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "experimentation-hash"
 version = "0.1.0"
 dependencies = [

--- a/crates/experimentation-stats/src/multiple_comparison.rs
+++ b/crates/experimentation-stats/src/multiple_comparison.rs
@@ -77,6 +77,60 @@ pub fn benjamini_hochberg(p_values: &[f64], fdr: f64) -> Result<MultipleComparis
     })
 }
 
+/// Guardrail Bonferroni correction (ADR-014).
+///
+/// For K guardrail metrics, each runs at significance `alpha / K` to control
+/// the family-wise error rate across all guardrails.  The function returns
+/// the per-guardrail threshold and whether each guardrail is breached at that
+/// threshold.
+///
+/// Semantics differ from the standard `bonferroni` function:
+/// - Input is raw p-values from individual guardrail tests.
+/// - The corrected threshold is `alpha / K` (not `p × K`).
+/// - `rejected[i]` is `true` when the guardrail fires (p_i ≤ alpha/K),
+///   meaning a statistically significant degradation was detected.
+///
+/// # Arguments
+/// * `p_values` — one p-value per guardrail metric (in any order).
+/// * `alpha`    — family-wise significance level, e.g. 0.05.
+///
+/// # Returns
+/// `MultipleComparisonResult` where `p_values_adjusted` contains the raw
+/// p-values unchanged (the correction is applied to the threshold, not the
+/// p-values), and `rejected` reflects the `alpha/K` decision rule.
+pub fn guardrail_bonferroni(p_values: &[f64], alpha: f64) -> Result<GuardrailBonferroniResult> {
+    validate_p_values(p_values)?;
+    if alpha <= 0.0 || alpha >= 1.0 {
+        return Err(Error::Validation("alpha must be in (0, 1)".into()));
+    }
+
+    let k = p_values.len();
+    let threshold = alpha / k as f64;
+    assert_finite(threshold, "guardrail_bonferroni_threshold");
+
+    let rejected: Vec<bool> = p_values.iter().map(|&p| p <= threshold).collect();
+
+    Ok(GuardrailBonferroniResult {
+        p_values: p_values.to_vec(),
+        alpha_per_guardrail: threshold,
+        rejected,
+        num_guardrails: k,
+    })
+}
+
+/// Result of guardrail Bonferroni correction (ADR-014).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GuardrailBonferroniResult {
+    /// Raw p-values (in input order).
+    pub p_values: Vec<f64>,
+    /// Per-guardrail significance threshold: alpha / K.
+    pub alpha_per_guardrail: f64,
+    /// Whether each guardrail fired at the corrected threshold.
+    pub rejected: Vec<bool>,
+    /// K — number of guardrail metrics.
+    pub num_guardrails: usize,
+}
+
 /// Bonferroni FWER correction.
 ///
 /// Matches R's `p.adjust(p, method="bonferroni")`.
@@ -125,6 +179,136 @@ fn validate_p_values(p_values: &[f64]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -------------------------------------------------------------------------
+    // guardrail_bonferroni tests (ADR-014)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_guardrail_bonferroni_threshold() {
+        // K=3, alpha=0.05 → threshold = 0.05/3 ≈ 0.01667
+        let p = [0.01, 0.04, 0.03];
+        let result = guardrail_bonferroni(&p, 0.05).unwrap();
+        let expected_threshold = 0.05 / 3.0;
+        assert!((result.alpha_per_guardrail - expected_threshold).abs() < 1e-10);
+        assert_eq!(result.num_guardrails, 3);
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_rejection() {
+        // p=0.01 < 0.05/3=0.01667 → fires; others above threshold → no fire
+        let p = [0.01, 0.04, 0.03];
+        let result = guardrail_bonferroni(&p, 0.05).unwrap();
+        assert_eq!(result.rejected, vec![true, false, false]);
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_single_guardrail() {
+        // K=1 → threshold = alpha (no correction needed)
+        let result = guardrail_bonferroni(&[0.03], 0.05).unwrap();
+        assert!((result.alpha_per_guardrail - 0.05).abs() < 1e-10);
+        assert_eq!(result.rejected, vec![true]);
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_pvalues_unchanged() {
+        let p = [0.01, 0.04, 0.03];
+        let result = guardrail_bonferroni(&p, 0.05).unwrap();
+        assert_eq!(result.p_values, p.to_vec());
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_all_fire() {
+        // All p-values below alpha/K=0.01 → all fire
+        let p = [0.005, 0.008, 0.009];
+        let result = guardrail_bonferroni(&p, 0.05).unwrap();
+        assert_eq!(result.rejected, vec![true, true, true]);
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_none_fire() {
+        // All p-values above alpha/K → none fire
+        let p = [0.03, 0.04, 0.05];
+        let result = guardrail_bonferroni(&p, 0.05).unwrap();
+        // threshold = 0.05/3 ≈ 0.01667; all above → none fire
+        assert_eq!(result.rejected, vec![false, false, false]);
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_at_boundary() {
+        // p exactly equal to threshold fires (≤ rule)
+        let alpha = 0.05_f64;
+        let k = 4_f64;
+        let threshold = alpha / k;
+        let result = guardrail_bonferroni(&[threshold], alpha).unwrap();
+        assert_eq!(result.rejected, vec![true]);
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_validation_empty() {
+        assert!(guardrail_bonferroni(&[], 0.05).is_err());
+    }
+
+    #[test]
+    fn test_guardrail_bonferroni_validation_invalid_alpha() {
+        assert!(guardrail_bonferroni(&[0.5], 0.0).is_err());
+        assert!(guardrail_bonferroni(&[0.5], 1.0).is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "FAIL-FAST")]
+    fn test_guardrail_bonferroni_nan_panics() {
+        let _ = guardrail_bonferroni(&[f64::NAN], 0.05);
+    }
+
+    mod proptest_guardrail {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn guardrail_threshold_equals_alpha_over_k(
+                p_values in prop::collection::vec(0.0f64..=1.0f64, 1..=20),
+                alpha in (0.001f64..0.5f64),
+            ) {
+                let k = p_values.len();
+                let result = guardrail_bonferroni(&p_values, alpha).unwrap();
+                prop_assert!((result.alpha_per_guardrail - alpha / k as f64).abs() < 1e-14);
+            }
+
+            #[test]
+            fn guardrail_rejection_consistent_with_threshold(
+                p_values in prop::collection::vec(0.0f64..=1.0f64, 1..=20),
+                alpha in (0.001f64..0.5f64),
+            ) {
+                let result = guardrail_bonferroni(&p_values, alpha).unwrap();
+                for (i, &p) in p_values.iter().enumerate() {
+                    prop_assert_eq!(
+                        result.rejected[i],
+                        p <= result.alpha_per_guardrail,
+                        "rejection inconsistency at index {}: p={}, threshold={}",
+                        i, p, result.alpha_per_guardrail
+                    );
+                }
+            }
+
+            #[test]
+            fn guardrail_threshold_decreases_with_k(
+                alpha in (0.001f64..0.5f64),
+            ) {
+                // More guardrails → stricter threshold
+                let r1 = guardrail_bonferroni(&[0.05], alpha).unwrap();
+                let r2 = guardrail_bonferroni(&[0.05, 0.05], alpha).unwrap();
+                let r3 = guardrail_bonferroni(&[0.05, 0.05, 0.05], alpha).unwrap();
+                prop_assert!(r1.alpha_per_guardrail >= r2.alpha_per_guardrail);
+                prop_assert!(r2.alpha_per_guardrail >= r3.alpha_per_guardrail);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // bonferroni tests
+    // -------------------------------------------------------------------------
 
     #[test]
     fn test_bonferroni_basic() {

--- a/docs/coordination/status/agent-4-status.md
+++ b/docs/coordination/status/agent-4-status.md
@@ -6,14 +6,37 @@
 ## Current Sprint
 
 Sprint: 5.0
-Focus: ADR-015 AVLM, ADR-017 TC/JIVE, ADR-018 E-values, ADR-011 Multi-objective, ADR-012 LP constraints
-Branch: work/eager-koala
+Focus: ADR-015 AVLM, ADR-017 TC/JIVE, ADR-018 E-values, ADR-014 Guardrail beta-correction, ADR-011 Multi-objective, ADR-012 LP constraints
+Branch: work/nice-lion
 
 ## In Progress
 
-- [ ] ADR-018 E-values + online FDR
 - [ ] ADR-011 Multi-objective bandits
 - [ ] ADR-012 LP constraints
+
+## Completed (Phase 5)
+
+- [x] **ADR-014 Phase 1 — Guardrail Bonferroni beta-correction** (2026-03-23, work/nice-lion)
+  - `guardrail_bonferroni()` in `crates/experimentation-stats/src/multiple_comparison.rs`
+    - Per-guardrail threshold = alpha/K; `rejected[i]` = true when p_i ≤ alpha/K
+    - `GuardrailBonferroniResult` struct with `p_values`, `alpha_per_guardrail`, `rejected`, `num_guardrails`
+    - 9 unit tests + 3 proptest invariants (threshold=alpha/K, rejection consistent with threshold, threshold decreases with K)
+    - All 181 experimentation-stats tests green
+  - M5 validation enforcement (`services/management/internal/validation/metric.go`):
+    - `ValidateCreateMetricDefinition` now requires `stakeholder` and `aggregation_level` (not UNSPECIFIED)
+    - PROVIDER aggregation requires PROVIDER stakeholder
+    - New exported: `ValidateBanditRewardMetricAggregation(m)` — enforces USER aggregation
+    - New exported: `ValidateGuardrailMetricAggregation(m)` — enforces USER or EXPERIMENT aggregation
+    - 12 new ADR-014 test cases; all management tests green
+  - Store layer (`services/management/internal/store/`):
+    - `MetricDefinitionRow`: added `Stakeholder`, `AggregationLevel` string fields
+    - `metric_convert.go`: bidirectional proto↔row mapping for new fields
+    - `metric.go`: SQL updated (INSERT, SELECT, Scan) for new columns
+  - DB migration: `sql/migrations/007_metric_stakeholder_aggregation.sql`
+  - Handler enforcement (`services/management/internal/handlers/lifecycle.go`):
+    - `validateMetricsForStart`: after existence check, validates each guardrail metric via `ValidateGuardrailMetricAggregation`
+    - `validateTypeConfigForStart`: after reward metric existence check, validates via `ValidateBanditRewardMetricAggregation`
+  - Infrastructure: generated missing `gen/go/go.mod` + full buf codegen (common/v1, management/v1, analysis/v1, etc.) — unblocked all Go compilation
 
 ## Completed (Phase 5)
 

--- a/services/management/internal/handlers/integration_test.go
+++ b/services/management/internal/handlers/integration_test.go
@@ -1803,12 +1803,14 @@ func createQoeMetric(t *testing.T, client managementv1connect.ExperimentManageme
 	t.Helper()
 	_, err := client.CreateMetricDefinition(context.Background(), connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 		Metric: &commonv1.MetricDefinition{
-			MetricId:        metricID,
-			Name:            metricID + " (QoE)",
-			Description:     "QoE metric for testing",
-			Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
-			SourceEventType: "qoe_rebuffer",
-			IsQoeMetric:     true,
+			MetricId:         metricID,
+			Name:             metricID + " (QoE)",
+			Description:      "QoE metric for testing",
+			Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+			SourceEventType:  "qoe_rebuffer",
+			IsQoeMetric:      true,
+			Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+			AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 		},
 	}))
 	require.NoError(t, err)
@@ -1818,12 +1820,14 @@ func createNonQoeMetric(t *testing.T, client managementv1connect.ExperimentManag
 	t.Helper()
 	_, err := client.CreateMetricDefinition(context.Background(), connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 		Metric: &commonv1.MetricDefinition{
-			MetricId:        metricID,
-			Name:            metricID + " (non-QoE)",
-			Description:     "Non-QoE metric for testing",
-			Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
-			SourceEventType: "generic_event",
-			IsQoeMetric:     false,
+			MetricId:         metricID,
+			Name:             metricID + " (non-QoE)",
+			Description:      "Non-QoE metric for testing",
+			Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+			SourceEventType:  "generic_event",
+			IsQoeMetric:      false,
+			Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+			AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 		},
 	}))
 	require.NoError(t, err)

--- a/services/management/internal/handlers/lifecycle.go
+++ b/services/management/internal/handlers/lifecycle.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/org/experimentation-platform/services/management/internal/allocation"
 	"github.com/org/experimentation-platform/services/management/internal/store"
+	"github.com/org/experimentation-platform/services/management/internal/validation"
 )
 
 // rollbackToDraft attempts to roll back an experiment from STARTING to DRAFT,
@@ -532,7 +533,8 @@ func (s *ExperimentService) ResumeExperiment(
 }
 
 // validateMetricsForStart checks that the experiment's primary, secondary, and
-// guardrail metrics all exist in the metric_definitions table.
+// guardrail metrics all exist in the metric_definitions table. Also enforces
+// ADR-014: guardrail metrics must use USER or EXPERIMENT aggregation.
 func (s *ExperimentService) validateMetricsForStart(ctx context.Context, experimentID string) error {
 	expRow, _, guardrails, err := s.store.GetByID(ctx, experimentID)
 	if err != nil {
@@ -554,6 +556,19 @@ func (s *ExperimentService) validateMetricsForStart(ctx context.Context, experim
 		return connect.NewError(connect.CodeInvalidArgument,
 			fmt.Errorf("metric %q does not exist", missing))
 	}
+
+	// ADR-014: guardrail metrics must use USER or EXPERIMENT aggregation.
+	for _, g := range guardrails {
+		mrow, err := s.metrics.GetByID(ctx, g.MetricID)
+		if err != nil {
+			return internalError("fetch guardrail metric for aggregation check", err)
+		}
+		mDef := store.RowToMetricDefinition(mrow)
+		if verr := validation.ValidateGuardrailMetricAggregation(mDef); verr != nil {
+			return verr
+		}
+	}
+
 	return nil
 }
 
@@ -597,6 +612,17 @@ func (s *ExperimentService) validateTypeConfigForStart(ctx context.Context, expe
 		return connect.NewError(connect.CodeInvalidArgument,
 			fmt.Errorf("bandit_config.reward_metric_id %q does not exist in metric_definitions", rewardMetricID))
 	}
+
+	// ADR-014: bandit reward metric must use USER aggregation.
+	mrow, err := s.metrics.GetByID(ctx, rewardMetricID)
+	if err != nil {
+		return internalError("fetch bandit reward metric for aggregation check", err)
+	}
+	mDef := store.RowToMetricDefinition(mrow)
+	if verr := validation.ValidateBanditRewardMetricAggregation(mDef); verr != nil {
+		return verr
+	}
+
 	return nil
 }
 

--- a/services/management/internal/handlers/metric_integration_test.go
+++ b/services/management/internal/handlers/metric_integration_test.go
@@ -22,11 +22,13 @@ func TestCreateMetricDefinition_Mean(t *testing.T) {
 	resp, err := env.client.CreateMetricDefinition(context.Background(),
 		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 			Metric: &commonv1.MetricDefinition{
-				Name:            "avg_watch_time",
-				Description:     "Average watch time per session",
-				Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
-				SourceEventType: "watch_event",
-				LowerIsBetter:   false,
+				Name:             "avg_watch_time",
+				Description:      "Average watch time per session",
+				Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+				SourceEventType:  "watch_event",
+				LowerIsBetter:    false,
+				Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+				AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 			},
 		}))
 	require.NoError(t, err)
@@ -44,10 +46,12 @@ func TestCreateMetricDefinition_WithExplicitID(t *testing.T) {
 	resp, err := env.client.CreateMetricDefinition(context.Background(),
 		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 			Metric: &commonv1.MetricDefinition{
-				MetricId:        "custom-metric-001",
-				Name:            "explicit_id_metric",
-				Type:            commonv1.MetricType_METRIC_TYPE_COUNT,
-				SourceEventType: "click",
+				MetricId:         "custom-metric-001",
+				Name:             "explicit_id_metric",
+				Type:             commonv1.MetricType_METRIC_TYPE_COUNT,
+				SourceEventType:  "click",
+				Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+				AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 			},
 		}))
 	require.NoError(t, err)
@@ -65,6 +69,8 @@ func TestCreateMetricDefinition_Ratio(t *testing.T) {
 				Type:                 commonv1.MetricType_METRIC_TYPE_RATIO,
 				NumeratorEventType:   "revenue",
 				DenominatorEventType: "session",
+				Stakeholder:          commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+				AggregationLevel:     commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 			},
 		}))
 	require.NoError(t, err)
@@ -79,12 +85,14 @@ func TestCreateMetricDefinition_Percentile(t *testing.T) {
 	resp, err := env.client.CreateMetricDefinition(context.Background(),
 		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 			Metric: &commonv1.MetricDefinition{
-				Name:            "p95_ttff",
-				Type:            commonv1.MetricType_METRIC_TYPE_PERCENTILE,
-				SourceEventType: "ttff_event",
-				Percentile:      0.95,
-				LowerIsBetter:   true,
-				IsQoeMetric:     true,
+				Name:             "p95_ttff",
+				Type:             commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+				SourceEventType:  "ttff_event",
+				Percentile:       0.95,
+				LowerIsBetter:    true,
+				IsQoeMetric:      true,
+				Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+				AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 			},
 		}))
 	require.NoError(t, err)
@@ -100,9 +108,11 @@ func TestCreateMetricDefinition_Custom(t *testing.T) {
 	resp, err := env.client.CreateMetricDefinition(context.Background(),
 		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 			Metric: &commonv1.MetricDefinition{
-				Name:      "custom_engagement",
-				Type:      commonv1.MetricType_METRIC_TYPE_CUSTOM,
-				CustomSql: "SELECT AVG(score) FROM engagement_events",
+				Name:             "custom_engagement",
+				Type:             commonv1.MetricType_METRIC_TYPE_CUSTOM,
+				CustomSql:        "SELECT AVG(score) FROM engagement_events",
+				Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+				AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 			},
 		}))
 	require.NoError(t, err)
@@ -176,9 +186,11 @@ func TestGetMetricDefinition(t *testing.T) {
 	createResp, err := env.client.CreateMetricDefinition(context.Background(),
 		connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 			Metric: &commonv1.MetricDefinition{
-				Name:            "get_test_metric",
-				Type:            commonv1.MetricType_METRIC_TYPE_PROPORTION,
-				SourceEventType: "conversion",
+				Name:             "get_test_metric",
+				Type:             commonv1.MetricType_METRIC_TYPE_PROPORTION,
+				SourceEventType:  "conversion",
+				Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+				AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 			},
 		}))
 	require.NoError(t, err)
@@ -221,9 +233,11 @@ func TestListMetricDefinitions(t *testing.T) {
 		_, err := env.client.CreateMetricDefinition(context.Background(),
 			connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 				Metric: &commonv1.MetricDefinition{
-					Name:            fmt.Sprintf("list_test_%d", i),
-					Type:            commonv1.MetricType_METRIC_TYPE_COUNT,
-					SourceEventType: "click",
+					Name:             fmt.Sprintf("list_test_%d", i),
+					Type:             commonv1.MetricType_METRIC_TYPE_COUNT,
+					SourceEventType:  "click",
+					Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+					AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 				},
 			}))
 		require.NoError(t, err)
@@ -266,9 +280,11 @@ func TestListMetricDefinitions_TypeFilter(t *testing.T) {
 		_, err := env.client.CreateMetricDefinition(context.Background(),
 			connect.NewRequest(&mgmtv1.CreateMetricDefinitionRequest{
 				Metric: &commonv1.MetricDefinition{
-					Name:            tt.name,
-					Type:            tt.typ,
-					SourceEventType: "test_event",
+					Name:             tt.name,
+					Type:             tt.typ,
+					SourceEventType:  "test_event",
+					Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+					AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 				},
 			}))
 		require.NoError(t, err)
@@ -314,10 +330,12 @@ func TestCreateMetricDefinition_DuplicateID(t *testing.T) {
 	defer cleanup()
 
 	m := &commonv1.MetricDefinition{
-		MetricId:        "dup-metric-id",
-		Name:            "dup_metric",
-		Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
-		SourceEventType: "ev",
+		MetricId:         "dup-metric-id",
+		Name:             "dup_metric",
+		Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType:  "ev",
+		Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 	}
 
 	_, err := env.client.CreateMetricDefinition(context.Background(),
@@ -343,6 +361,8 @@ func TestCreateMetricDefinition_WithCupedCovariate(t *testing.T) {
 				SourceEventType:         "view",
 				CupedCovariateMetricId:  "some-covariate-id",
 				MinimumDetectableEffect: 0.02,
+				Stakeholder:             commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+				AggregationLevel:        commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 			},
 		}))
 	require.NoError(t, err)

--- a/services/management/internal/store/metric.go
+++ b/services/management/internal/store/metric.go
@@ -24,13 +24,16 @@ type MetricDefinitionRow struct {
 	IsQoeMetric            bool
 	CupedCovariateMetricID string
 	MinimumDetectableEffect *float64
-	CreatedAt              time.Time
+	// ADR-014 Phase 5 fields.
+	Stakeholder      string // "USER" | "PROVIDER" | "PLATFORM"
+	AggregationLevel string // "USER" | "EXPERIMENT" | "PROVIDER"
+	CreatedAt        time.Time
 }
 
 const metricCols = `metric_id, name, COALESCE(description, ''), type, COALESCE(source_event_type, ''),
 	COALESCE(numerator_event_type, ''), COALESCE(denominator_event_type, ''), percentile, COALESCE(custom_sql, ''),
 	lower_is_better, is_qoe_metric, COALESCE(cuped_covariate_metric_id, ''),
-	minimum_detectable_effect, created_at`
+	minimum_detectable_effect, COALESCE(stakeholder, ''), COALESCE(aggregation_level, ''), created_at`
 
 // MetricStore provides database operations for metric definitions.
 type MetricStore struct {
@@ -50,18 +53,18 @@ func (s *MetricStore) Insert(ctx context.Context, row MetricDefinitionRow) (Metr
 			metric_id, name, description, type, source_event_type,
 			numerator_event_type, denominator_event_type, percentile, custom_sql,
 			lower_is_better, is_qoe_metric, cuped_covariate_metric_id,
-			minimum_detectable_effect
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+			minimum_detectable_effect, stakeholder, aggregation_level
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
 		RETURNING `+metricCols,
 		row.MetricID, row.Name, row.Description, row.Type, row.SourceEventType,
 		row.NumeratorEventType, row.DenominatorEventType, row.Percentile, row.CustomSQL,
 		row.LowerIsBetter, row.IsQoeMetric, row.CupedCovariateMetricID,
-		row.MinimumDetectableEffect,
+		row.MinimumDetectableEffect, row.Stakeholder, row.AggregationLevel,
 	).Scan(
 		&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
 		&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
 		&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
-		&out.MinimumDetectableEffect, &out.CreatedAt,
+		&out.MinimumDetectableEffect, &out.Stakeholder, &out.AggregationLevel, &out.CreatedAt,
 	)
 	return out, err
 }
@@ -75,7 +78,7 @@ func (s *MetricStore) GetByID(ctx context.Context, metricID string) (MetricDefin
 		&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
 		&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
 		&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
-		&out.MinimumDetectableEffect, &out.CreatedAt,
+		&out.MinimumDetectableEffect, &out.Stakeholder, &out.AggregationLevel, &out.CreatedAt,
 	)
 	if err != nil {
 		return MetricDefinitionRow{}, err
@@ -136,7 +139,7 @@ func (s *MetricStore) ListMetrics(ctx context.Context, pageSize int32, pageToken
 			&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
 			&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
 			&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
-			&out.MinimumDetectableEffect, &out.CreatedAt,
+			&out.MinimumDetectableEffect, &out.Stakeholder, &out.AggregationLevel, &out.CreatedAt,
 		); err != nil {
 			return nil, "", err
 		}
@@ -203,7 +206,7 @@ func (s *MetricStore) GetByIDTx(ctx context.Context, tx pgx.Tx, metricID string)
 		&out.MetricID, &out.Name, &out.Description, &out.Type, &out.SourceEventType,
 		&out.NumeratorEventType, &out.DenominatorEventType, &out.Percentile, &out.CustomSQL,
 		&out.LowerIsBetter, &out.IsQoeMetric, &out.CupedCovariateMetricID,
-		&out.MinimumDetectableEffect, &out.CreatedAt,
+		&out.MinimumDetectableEffect, &out.Stakeholder, &out.AggregationLevel, &out.CreatedAt,
 	)
 	if err != nil {
 		return MetricDefinitionRow{}, err

--- a/services/management/internal/store/metric_convert.go
+++ b/services/management/internal/store/metric_convert.go
@@ -4,6 +4,34 @@ import (
 	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
+// --- MetricStakeholder conversions (ADR-014) ---
+
+var stakeholderToString = map[commonv1.MetricStakeholder]string{
+	commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER:     "USER",
+	commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PROVIDER: "PROVIDER",
+	commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PLATFORM: "PLATFORM",
+}
+
+var stringToStakeholder = map[string]commonv1.MetricStakeholder{
+	"USER":     commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+	"PROVIDER": commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PROVIDER,
+	"PLATFORM": commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PLATFORM,
+}
+
+// --- MetricAggregationLevel conversions (ADR-014) ---
+
+var aggregationLevelToString = map[commonv1.MetricAggregationLevel]string{
+	commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER:       "USER",
+	commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_EXPERIMENT: "EXPERIMENT",
+	commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_PROVIDER:   "PROVIDER",
+}
+
+var stringToAggregationLevel = map[string]commonv1.MetricAggregationLevel{
+	"USER":       commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
+	"EXPERIMENT": commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_EXPERIMENT,
+	"PROVIDER":   commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_PROVIDER,
+}
+
 // --- MetricType conversions ---
 
 var metricTypeToString = map[commonv1.MetricType]string{
@@ -48,6 +76,8 @@ func MetricDefinitionToRow(m *commonv1.MetricDefinition) MetricDefinitionRow {
 		LowerIsBetter:          m.GetLowerIsBetter(),
 		IsQoeMetric:            m.GetIsQoeMetric(),
 		CupedCovariateMetricID: m.GetCupedCovariateMetricId(),
+		Stakeholder:            stakeholderToString[m.GetStakeholder()],
+		AggregationLevel:       aggregationLevelToString[m.GetAggregationLevel()],
 	}
 
 	if p := m.GetPercentile(); p != 0 {
@@ -74,6 +104,8 @@ func RowToMetricDefinition(row MetricDefinitionRow) *commonv1.MetricDefinition {
 		LowerIsBetter:          row.LowerIsBetter,
 		IsQoeMetric:            row.IsQoeMetric,
 		CupedCovariateMetricId: row.CupedCovariateMetricID,
+		Stakeholder:            stringToStakeholder[row.Stakeholder],
+		AggregationLevel:       stringToAggregationLevel[row.AggregationLevel],
 	}
 
 	if row.Percentile != nil {

--- a/services/management/internal/validation/metric.go
+++ b/services/management/internal/validation/metric.go
@@ -20,7 +20,71 @@ func ValidateCreateMetricDefinition(m *commonv1.MetricDefinition) *connect.Error
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("type is required"))
 	}
 
-	return validateMetricTypeFields(m)
+	if err := validateMetricTypeFields(m); err != nil {
+		return err
+	}
+	return validateMetricStakeholderAggregation(m)
+}
+
+// validateMetricStakeholderAggregation enforces ADR-014 structural rules at
+// metric definition time:
+//   - MetricStakeholder must be set (not UNSPECIFIED).
+//   - MetricAggregationLevel must be set (not UNSPECIFIED).
+//   - PROVIDER aggregation is only valid for PROVIDER-stakeholder metrics.
+//
+// Use-case constraints (bandit rewards must use USER aggregation; guardrails
+// accept USER or EXPERIMENT) are enforced at experiment-start time via
+// ValidateBanditRewardMetricAggregation and ValidateGuardrailMetricAggregation
+// when the actual metric definition is fetched from the store.
+func validateMetricStakeholderAggregation(m *commonv1.MetricDefinition) *connect.Error {
+	stakeholder := m.GetStakeholder()
+	aggLevel := m.GetAggregationLevel()
+
+	if stakeholder == commonv1.MetricStakeholder_METRIC_STAKEHOLDER_UNSPECIFIED {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("stakeholder is required (ADR-014): set USER, PROVIDER, or PLATFORM"))
+	}
+	if aggLevel == commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_UNSPECIFIED {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("aggregation_level is required (ADR-014): set USER, EXPERIMENT, or PROVIDER"))
+	}
+
+	// PROVIDER aggregation is only meaningful for provider-stakeholder metrics.
+	if aggLevel == commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_PROVIDER &&
+		stakeholder != commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PROVIDER {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("aggregation_level PROVIDER is only valid for PROVIDER stakeholder metrics; got stakeholder %s", stakeholder))
+	}
+
+	return nil
+}
+
+// ValidateBanditRewardMetricAggregation enforces that a bandit reward metric
+// uses USER aggregation (ADR-014). Called at experiment-start time after
+// fetching the metric definition from the store.
+func ValidateBanditRewardMetricAggregation(m *commonv1.MetricDefinition) *connect.Error {
+	if m.GetAggregationLevel() != commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER {
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("bandit reward metric %q must use USER aggregation_level (ADR-014); got %s",
+				m.GetName(), m.GetAggregationLevel()))
+	}
+	return nil
+}
+
+// ValidateGuardrailMetricAggregation enforces that a guardrail metric uses
+// USER or EXPERIMENT aggregation (ADR-014). PROVIDER aggregation is not
+// supported for guardrails. Called at experiment-start time.
+func ValidateGuardrailMetricAggregation(m *commonv1.MetricDefinition) *connect.Error {
+	level := m.GetAggregationLevel()
+	switch level {
+	case commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
+		commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_EXPERIMENT:
+		return nil
+	default:
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("guardrail metric %q must use USER or EXPERIMENT aggregation_level (ADR-014); got %s",
+				m.GetName(), level))
+	}
 }
 
 func validateMetricTypeFields(m *commonv1.MetricDefinition) *connect.Error {

--- a/services/management/internal/validation/metric_test.go
+++ b/services/management/internal/validation/metric_test.go
@@ -121,9 +121,11 @@ func TestValidateCreateMetricDefinition_NegativeMDE(t *testing.T) {
 
 func TestValidateCreateMetricDefinition_ValidMean(t *testing.T) {
 	m := &commonv1.MetricDefinition{
-		Name:            "avg_watch_time",
-		Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
-		SourceEventType: "watch_event",
+		Name:             "avg_watch_time",
+		Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType:  "watch_event",
+		Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 	}
 	err := ValidateCreateMetricDefinition(m)
 	assert.Nil(t, err)
@@ -135,6 +137,8 @@ func TestValidateCreateMetricDefinition_ValidRatio(t *testing.T) {
 		Type:                 commonv1.MetricType_METRIC_TYPE_RATIO,
 		NumeratorEventType:   "revenue",
 		DenominatorEventType: "session",
+		Stakeholder:          commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PLATFORM,
+		AggregationLevel:     commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 	}
 	err := ValidateCreateMetricDefinition(m)
 	assert.Nil(t, err)
@@ -142,10 +146,12 @@ func TestValidateCreateMetricDefinition_ValidRatio(t *testing.T) {
 
 func TestValidateCreateMetricDefinition_ValidPercentile(t *testing.T) {
 	m := &commonv1.MetricDefinition{
-		Name:            "p95_ttff",
-		Type:            commonv1.MetricType_METRIC_TYPE_PERCENTILE,
-		SourceEventType: "ttff_event",
-		Percentile:      0.95,
+		Name:             "p95_ttff",
+		Type:             commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+		SourceEventType:  "ttff_event",
+		Percentile:       0.95,
+		Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
 	}
 	err := ValidateCreateMetricDefinition(m)
 	assert.Nil(t, err)
@@ -153,10 +159,146 @@ func TestValidateCreateMetricDefinition_ValidPercentile(t *testing.T) {
 
 func TestValidateCreateMetricDefinition_ValidCustom(t *testing.T) {
 	m := &commonv1.MetricDefinition{
-		Name:      "custom_engagement",
-		Type:      commonv1.MetricType_METRIC_TYPE_CUSTOM,
-		CustomSql: "SELECT AVG(engagement_score) FROM events",
+		Name:             "custom_engagement",
+		Type:             commonv1.MetricType_METRIC_TYPE_CUSTOM,
+		CustomSql:        "SELECT AVG(engagement_score) FROM events",
+		Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PLATFORM,
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_EXPERIMENT,
 	}
 	err := ValidateCreateMetricDefinition(m)
 	assert.Nil(t, err)
+}
+
+// --- ADR-014: MetricStakeholder / MetricAggregationLevel tests ---
+
+func TestValidateCreateMetricDefinition_StakeholderRequired(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "some_metric",
+		Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType:  "evt",
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
+		// Stakeholder intentionally omitted (UNSPECIFIED)
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "stakeholder is required")
+}
+
+func TestValidateCreateMetricDefinition_AggregationLevelRequired(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:            "some_metric",
+		Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType: "evt",
+		Stakeholder:     commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+		// AggregationLevel intentionally omitted (UNSPECIFIED)
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "aggregation_level is required")
+}
+
+func TestValidateCreateMetricDefinition_ProviderAggRequiresProviderStakeholder(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "catalog_coverage",
+		Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType:  "impression",
+		Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER, // wrong for PROVIDER agg
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_PROVIDER,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "aggregation_level PROVIDER is only valid for PROVIDER stakeholder")
+}
+
+func TestValidateCreateMetricDefinition_ProviderAggWithProviderStakeholder(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "catalog_coverage",
+		Type:             commonv1.MetricType_METRIC_TYPE_MEAN,
+		SourceEventType:  "impression",
+		Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_PROVIDER,
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_PROVIDER,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.Nil(t, err)
+}
+
+func TestValidateCreateMetricDefinition_UserMetricWithExperimentAgg(t *testing.T) {
+	// USER stakeholder with EXPERIMENT aggregation is valid (for guardrail use).
+	m := &commonv1.MetricDefinition{
+		Name:             "churn_rate",
+		Type:             commonv1.MetricType_METRIC_TYPE_PROPORTION,
+		SourceEventType:  "churn",
+		Stakeholder:      commonv1.MetricStakeholder_METRIC_STAKEHOLDER_USER,
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_EXPERIMENT,
+	}
+	err := ValidateCreateMetricDefinition(m)
+	assert.Nil(t, err)
+}
+
+// --- ValidateBanditRewardMetricAggregation tests ---
+
+func TestValidateBanditRewardMetricAggregation_UserAggValid(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "ctr",
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
+	}
+	assert.Nil(t, ValidateBanditRewardMetricAggregation(m))
+}
+
+func TestValidateBanditRewardMetricAggregation_ExperimentAggRejected(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "overall_conversion",
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_EXPERIMENT,
+	}
+	err := ValidateBanditRewardMetricAggregation(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "USER aggregation_level")
+}
+
+func TestValidateBanditRewardMetricAggregation_ProviderAggRejected(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "catalog_coverage",
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_PROVIDER,
+	}
+	err := ValidateBanditRewardMetricAggregation(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "USER aggregation_level")
+}
+
+// --- ValidateGuardrailMetricAggregation tests ---
+
+func TestValidateGuardrailMetricAggregation_UserAggValid(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "error_rate",
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_USER,
+	}
+	assert.Nil(t, ValidateGuardrailMetricAggregation(m))
+}
+
+func TestValidateGuardrailMetricAggregation_ExperimentAggValid(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "churn_rate",
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_EXPERIMENT,
+	}
+	assert.Nil(t, ValidateGuardrailMetricAggregation(m))
+}
+
+func TestValidateGuardrailMetricAggregation_ProviderAggRejected(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name:             "catalog_metric",
+		AggregationLevel: commonv1.MetricAggregationLevel_METRIC_AGGREGATION_LEVEL_PROVIDER,
+	}
+	err := ValidateGuardrailMetricAggregation(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "USER or EXPERIMENT aggregation_level")
+}
+
+func TestValidateGuardrailMetricAggregation_UnspecifiedRejected(t *testing.T) {
+	m := &commonv1.MetricDefinition{
+		Name: "some_guardrail",
+		// AggregationLevel UNSPECIFIED
+	}
+	err := ValidateGuardrailMetricAggregation(m)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "USER or EXPERIMENT aggregation_level")
 }

--- a/sql/migrations/007_metric_stakeholder_aggregation.sql
+++ b/sql/migrations/007_metric_stakeholder_aggregation.sql
@@ -1,0 +1,17 @@
+-- ADR-014: Add stakeholder and aggregation_level to metric_definitions.
+--
+-- stakeholder: who benefits from this metric (USER / PROVIDER / PLATFORM).
+--   Drives multi-stakeholder analysis routing in M4a.
+-- aggregation_level: unit of observation for M3 computation (USER / EXPERIMENT / PROVIDER).
+--   USER     → standard per-user analysis (required for bandit rewards).
+--   EXPERIMENT → whole-experiment aggregation (valid for guardrails only).
+--   PROVIDER → per-content-provider aggregation (requires stakeholder=PROVIDER).
+--
+-- Both columns default to '' so existing rows remain valid during migration;
+-- new metrics must supply explicit values (enforced at the application layer).
+
+ALTER TABLE metric_definitions
+    ADD COLUMN IF NOT EXISTS stakeholder       TEXT NOT NULL DEFAULT ''
+        CHECK (stakeholder IN ('', 'USER', 'PROVIDER', 'PLATFORM')),
+    ADD COLUMN IF NOT EXISTS aggregation_level TEXT NOT NULL DEFAULT ''
+        CHECK (aggregation_level IN ('', 'USER', 'EXPERIMENT', 'PROVIDER'));

--- a/sql/migrations/099_seed_test.sql
+++ b/sql/migrations/099_seed_test.sql
@@ -5,8 +5,8 @@ INSERT INTO layers (layer_id, name, description, total_buckets)
 VALUES ('a0000000-0000-0000-0000-000000000001', 'default', 'Default traffic layer for general A/B tests', 10000)
 ON CONFLICT (name) DO NOTHING;
 
-INSERT INTO metric_definitions (metric_id, name, type, source_event_type)
+INSERT INTO metric_definitions (metric_id, name, type, source_event_type, stakeholder, aggregation_level)
 VALUES
-    ('watch_time_minutes', 'Watch Time (minutes)', 'MEAN', 'heartbeat'),
-    ('metric-1', 'Test Metric 1', 'MEAN', 'test_event')
+    ('watch_time_minutes', 'Watch Time (minutes)', 'MEAN', 'heartbeat', 'USER', 'USER'),
+    ('metric-1', 'Test Metric 1', 'MEAN', 'test_event', 'USER', 'USER')
 ON CONFLICT (metric_id) DO NOTHING;


### PR DESCRIPTION
## Summary

- **`guardrail_bonferroni()`** in `crates/experimentation-stats/src/multiple_comparison.rs`: implements ADR-014 Bonferroni correction on the power side for guardrail metrics. Each guardrail runs at significance `alpha/K` where K = number of guardrails.
- **M5 validation enforcement**: `ValidateCreateMetricDefinition` now requires `MetricStakeholder` and `MetricAggregationLevel` to be set (not UNSPECIFIED). New exported helpers `ValidateBanditRewardMetricAggregation` (USER agg required) and `ValidateGuardrailMetricAggregation` (USER or EXPERIMENT agg) called at experiment-start time.
- **Store + migration**: `MetricDefinitionRow` gains `Stakeholder`/`AggregationLevel` fields; migration `007_metric_stakeholder_aggregation.sql` adds columns to DB.

## Changes

### experimentation-stats (`multiple_comparison.rs`)
- `guardrail_bonferroni(p_values, alpha) -> GuardrailBonferroniResult`
  - Threshold = `alpha / K`; `rejected[i] = p_i <= threshold`
  - `GuardrailBonferroniResult`: raw p-values, per-guardrail threshold, rejection flags, K
- 9 unit tests + 3 proptest invariants (threshold formula, rejection consistency, threshold monotonic with K)
- All 181 experimentation-stats lib tests pass

### M5 validation (`services/management/internal/validation/metric.go`)
- `ValidateCreateMetricDefinition`: requires stakeholder + aggregation_level; PROVIDER agg requires PROVIDER stakeholder
- `ValidateBanditRewardMetricAggregation(m)`: rejects non-USER aggregation
- `ValidateGuardrailMetricAggregation(m)`: rejects non-USER/non-EXPERIMENT aggregation
- 12 new ADR-014 test cases; all management tests green

### Store layer
- `MetricDefinitionRow`: +`Stakeholder`, `AggregationLevel` string fields
- `metric_convert.go`: bidirectional proto↔row conversion maps for new fields
- `metric.go`: INSERT includes columns 14-15; SELECT/Scan updated to 17 fields

### DB migration (`sql/migrations/007_metric_stakeholder_aggregation.sql`)
- Adds `stakeholder TEXT NOT NULL DEFAULT ''` with CHECK constraint
- Adds `aggregation_level TEXT NOT NULL DEFAULT ''` with CHECK constraint
- Empty string default preserves existing rows during migration

### Handler enforcement (`handlers/lifecycle.go`)
- `validateMetricsForStart`: validates each guardrail metric's aggregation level after existence check
- `validateTypeConfigForStart`: validates bandit reward metric's aggregation level after existence check

### Infrastructure (gen/)
- Ran `buf generate` to produce full `gen/go/` proto stubs (common/v1, management/v1, analysis/v1, etc.) + `gen/go/go.mod`. These files are gitignored and regenerated at build time per PR #205 precedent.

## Test plan
- [x] `cargo test -p experimentation-stats` — 181 passed, 0 failed
- [x] `go test ./management/...` — all packages green
- [ ] Integration: apply migration 007 and run contract tests with new metric fixtures

## Notes / opportunities
- The `guardrail_bonferroni` function operates on p-values from the analysis service (M4a). M4a will need to call this before returning `GuardrailAnalysisResult`. That wire-up is out of scope here but the API is ready.
- `ValidateGuardrailMetricAggregation` rejects UNSPECIFIED aggregation level — existing guardrail tests that don't set this field will need fixture updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
