### PR TITLE
fix(docker): add g++ and OpenSSL deps for rdkafka-sys cmake build

### DIFF
--- a/crates/experimentation-pipeline/Dockerfile
+++ b/crates/experimentation-pipeline/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev pkg-config
 RUN cargo build --release --package experimentation-pipeline
 
 FROM debian:bookworm-slim

--- a/crates/experimentation-policy/Dockerfile
+++ b/crates/experimentation-policy/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev pkg-config
 RUN cargo build --release --package experimentation-policy
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary

- Add `g++`, `libssl-dev`, and `pkg-config` to the builder stage of `crates/experimentation-pipeline/Dockerfile` and `crates/experimentation-policy/Dockerfile`

## Root Cause

`rdkafka-sys` builds `librdkafka` from source using cmake, which requires a C++ compiler and OpenSSL development headers. The `rust:1.88-slim` base image does not include these, causing CI to fail for both `experimentation-pipeline` and `experimentation-policy`.

## Test plan

- [ ] Docker build succeeds for `experimentation-pipeline`
- [ ] Docker build succeeds for `experimentation-policy`
- [ ] `cargo build --release --package experimentation-pipeline` passes in container
- [ ] `cargo build --release --package experimentation-policy` passes in container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
