### PR TITLE
fix(docker): add g++ libssl-dev pkg-config for rdkafka-sys cmake build

### DIFF
--- a/crates/experimentation-pipeline/Dockerfile
+++ b/crates/experimentation-pipeline/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev pkg-config
 RUN cargo build --release --package experimentation-pipeline
 
 FROM debian:bookworm-slim

--- a/crates/experimentation-policy/Dockerfile
+++ b/crates/experimentation-policy/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev pkg-config
 RUN cargo build --release --package experimentation-policy
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Problem

`rust:1.88-slim` (Debian bookworm slim) does not include `g++`. The `rdkafka-sys` crate uses cmake to build librdkafka from source, which requires a C++ compiler. `experimentation-pipeline` and `experimentation-policy` both link rdkafka; `assignment` and `analysis` do not.

Docker build fails with: `c++ not found`

## Fix

Add `g++ libssl-dev pkg-config` to the `apt-get install` step in:
- `crates/experimentation-pipeline/Dockerfile`
- `crates/experimentation-policy/Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
