### PR TITLE
fix(docker): add libcurl4-openssl-dev for rdkafka-sys curl dep

### DIFF
--- a/crates/experimentation-pipeline/Dockerfile
+++ b/crates/experimentation-pipeline/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev pkg-config
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev libcurl4-openssl-dev pkg-config
 RUN cargo build --release --package experimentation-pipeline
 
 FROM debian:bookworm-slim

--- a/crates/experimentation-policy/Dockerfile
+++ b/crates/experimentation-policy/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev pkg-config
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev libcurl4-openssl-dev pkg-config
 RUN cargo build --release --package experimentation-policy
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary

- Add `libcurl4-openssl-dev` to `apt-get install` in `crates/experimentation-pipeline/Dockerfile`
- Add `libcurl4-openssl-dev` to `apt-get install` in `crates/experimentation-policy/Dockerfile`

## Problem

The rdkafka-sys cmake build fails with:
```
fatal error: curl/curl.h: No such file or directory
```

The `libcurl4-openssl-dev` package provides the missing `curl/curl.h` header required by the rdkafka-sys build script.

## Test plan

- [ ] Docker build for `experimentation-pipeline` passes rdkafka-sys cmake step
- [ ] Docker build for `experimentation-policy` passes rdkafka-sys cmake step
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
