### PR TITLE
fix(docker): add clang/libclang-dev for librocksdb-sys bindgen in policy Dockerfile

### DIFF
--- a/crates/experimentation-policy/Dockerfile
+++ b/crates/experimentation-policy/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev libcurl4-openssl-dev pkg-config
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev libcurl4-openssl-dev pkg-config clang libclang-dev
 RUN cargo build --release --package experimentation-policy
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
- Add `clang` and `libclang-dev` to the builder stage `apt-get` install line in `crates/experimentation-policy/Dockerfile`
- Required for `librocksdb-sys` bindgen to locate `libclang` during compile

## Test plan
- [ ] CI Docker build for `experimentation-policy` passes
- [ ] `cargo build --release --package experimentation-policy` succeeds inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
