### PR TITLE
fix(docker): add clang libclang-dev for librocksdb-sys bindgen in policy

### DIFF
--- a/crates/experimentation-policy/Dockerfile
+++ b/crates/experimentation-policy/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev libcurl4-openssl-dev pkg-config
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev libcurl4-openssl-dev pkg-config clang libclang-dev
 RUN cargo build --release --package experimentation-policy
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
- Adds `clang libclang-dev` to the builder apt-get install in `crates/experimentation-policy/Dockerfile`
- `librocksdb-sys` uses bindgen which requires libclang at compile time; `rust:1.88-slim` does not include it

## Root cause
`docker(policy)` CI fails: bindgen cannot find libclang when compiling `librocksdb-sys`.

## Test plan
- [ ] CI docker(policy) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)