### PR TITLE
fix(ci): add github_token to buf-setup-action to avoid rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           version: "latest"
           buf_user: ${{ secrets.BUF_USER }}
           buf_api_token: ${{ secrets.BUF_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint proto
         run: cd proto && buf lint


### PR DESCRIPTION
## Summary
- Adds `github_token: ${{ secrets.GITHUB_TOKEN }}` to `bufbuild/buf-setup-action@v1`
- Without it, the action makes unauthenticated GitHub API requests to resolve the buf download URL, hitting rate limits under concurrent CI load

## Root cause
Main CI schema job failed: `API rate limit exceeded for 40.76.117.229` in buf-setup-action. The action's own warning says "No github_token supplied, API requests will be subject to stricter rate limiting".

## Test plan
- [ ] schema job passes without rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
