### PR TITLE
fix(workspace): regenerate Cargo.lock — remove duplicate experimentation-flags entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,31 +1867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "experimentation-flags"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64",
- "chrono",
- "experimentation-core",
- "experimentation-hash",
- "experimentation-proto",
- "prost 0.13.5",
- "prost-types",
- "serde",
- "serde_json",
- "sqlx",
- "thiserror 2.0.18",
- "tokio",
- "tokio-test",
- "tonic",
- "tonic-web",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
 name = "experimentation-hash"
 version = "0.1.0"
 dependencies = [


### PR DESCRIPTION
## Summary
- Regenerates `Cargo.lock` via `cargo generate-lockfile` to remove a duplicate `experimentation-flags` entry introduced when PR #215 (ADR-024) was merged
- Duplicate entry caused: `error: failed to parse lock file — package 'experimentation-flags' is specified twice in the lockfile`

## Test plan
- [ ] rust CI job passes (clippy + tests no longer fail on lockfile parse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
