### PR TITLE
feat(m4b): ADR-011 multi-objective reward composition on LMAX core

### DIFF
--- a/crates/experimentation-bandit/src/lib.rs
+++ b/crates/experimentation-bandit/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod cold_start;
 pub mod linucb;
+pub mod multi_objective;
 #[cfg(feature = "gpu")]
 pub mod neural;
 pub mod policy;

--- a/crates/experimentation-bandit/src/multi_objective.rs
+++ b/crates/experimentation-bandit/src/multi_objective.rs
@@ -1,0 +1,638 @@
+//! Multi-objective reward composition (ADR-011).
+//!
+//! Composes multiple per-metric reward signals into a single scalar that the
+//! bandit algorithm can update with. Three strategies:
+//!
+//! - **WeightedSum** — weighted average of normalised metric values.
+//! - **EpsilonConstraint** — optimise primary objective (highest weight), apply
+//!   Lagrangian penalty for each secondary objective that violates its slack bound.
+//! - **Tchebycheff** — minimise the maximum weighted deviation from per-metric
+//!   reference values; negated so higher = better.
+//!
+//! [`MetricNormalizer`] maintains EMA running mean / variance per metric
+//! (α = 0.01) so cross-metric scale differences are handled automatically.
+//!
+//! # RocksDB persistence
+//! The full [`RewardComposer`] state (objectives + method + normaliser) is
+//! serialisable via `serde_json` and can be embedded in a `SnapshotEnvelope`
+//! alongside the bandit posterior parameters.
+
+use experimentation_core::error::assert_finite;
+use std::collections::HashMap;
+
+/// EMA decay for running mean / variance.
+const EMA_ALPHA: f64 = 0.01;
+
+/// Small regularisation constant added to variance before taking sqrt.
+const VAR_EPS: f64 = 1e-8;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MetricStats
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// EMA running mean and variance for a single metric.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MetricStats {
+    /// EMA mean.
+    pub mean: f64,
+    /// EMA variance.
+    pub variance: f64,
+    /// Total observations processed.
+    pub n_obs: u64,
+}
+
+impl MetricStats {
+    fn new() -> Self {
+        // Neutral initialisation: mean = 0, variance = 1 (unit scale).
+        Self {
+            mean: 0.0,
+            variance: 1.0,
+            n_obs: 0,
+        }
+    }
+
+    /// Incorporate one observation, updating EMA statistics in place.
+    pub fn update(&mut self, value: f64) {
+        assert_finite(value, "MetricStats::update value");
+        // Welford-style EMA: delta uses old mean.
+        let delta = value - self.mean;
+        self.mean = (1.0 - EMA_ALPHA) * self.mean + EMA_ALPHA * value;
+        self.variance = (1.0 - EMA_ALPHA) * self.variance + EMA_ALPHA * delta * delta;
+        self.n_obs += 1;
+        assert_finite(self.mean, "MetricStats mean after update");
+        assert_finite(self.variance, "MetricStats variance after update");
+    }
+
+    /// Return z-score of `value` relative to current running statistics.
+    pub fn normalize(&self, value: f64) -> f64 {
+        let std = (self.variance + VAR_EPS).sqrt();
+        (value - self.mean) / std
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MetricNormalizer
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// EMA running normaliser for an arbitrary set of named metrics.
+///
+/// Maintains independent [`MetricStats`] per metric key. α = 0.01.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+pub struct MetricNormalizer {
+    pub stats: HashMap<String, MetricStats>,
+}
+
+impl MetricNormalizer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update the running stats for `metric` with `value`, then return its
+    /// z-score.
+    pub fn update_and_normalize(&mut self, metric: &str, value: f64) -> f64 {
+        let stats = self
+            .stats
+            .entry(metric.to_string())
+            .or_insert_with(MetricStats::new);
+        stats.update(value);
+        let z = stats.normalize(value);
+        assert_finite(z, "MetricNormalizer z-score");
+        z
+    }
+
+    /// Return the z-score of `value` for `metric` without updating stats.
+    /// Returns `value` unchanged if no history exists yet.
+    pub fn normalize_only(&self, metric: &str, value: f64) -> f64 {
+        self.stats
+            .get(metric)
+            .map(|s| s.normalize(value))
+            .unwrap_or(value)
+    }
+
+    /// Serialize normaliser state for RocksDB persistence.
+    pub fn serialize(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("MetricNormalizer serialization should not fail")
+    }
+
+    /// Deserialize normaliser state from RocksDB snapshot bytes.
+    pub fn deserialize(data: &[u8]) -> Self {
+        serde_json::from_slice(data).expect("MetricNormalizer deserialization failed")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// RewardObjective
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// One metric participating in multi-objective reward composition.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RewardObjective {
+    /// Key in the observed `metric_values` map.
+    pub metric_name: String,
+    /// Non-negative weight (used by WeightedSum and Tchebycheff).
+    pub weight: f64,
+    /// Allowable slack for EpsilonConstraint: violation occurs when
+    /// `normalised_value < -constraint_slack`.  `None` means unconstrained
+    /// (the objective is treated as a secondary optimisation target without a
+    /// hard bound).
+    pub constraint_slack: Option<f64>,
+    /// Reference value for Tchebycheff (normalised units, typically 0.0).
+    pub reference_value: f64,
+}
+
+impl RewardObjective {
+    /// Construct a simple weighted objective with no constraint.
+    pub fn new(metric_name: String, weight: f64) -> Self {
+        assert_finite(weight, "RewardObjective weight");
+        assert!(weight >= 0.0, "RewardObjective weight must be non-negative");
+        Self {
+            metric_name,
+            weight,
+            constraint_slack: None,
+            reference_value: 0.0,
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CompositionMethod
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Scalarisation strategy for multi-objective reward composition.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum CompositionMethod {
+    /// Weighted average of normalised metric values.
+    WeightedSum,
+    /// Optimise primary objective (highest weight) with Lagrangian penalty for
+    /// secondary objectives that violate their `constraint_slack` bounds.
+    EpsilonConstraint,
+    /// Tchebycheff scalarisation: reward = −max_i(w_i · |z_i − r_i|).
+    /// Pareto-aware — avoids rewarding extreme trade-offs.
+    Tchebycheff,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// RewardComposer
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Composes per-metric observations into a scalar reward for bandit updates.
+///
+/// The `compose` method:
+/// 1. Updates the running [`MetricNormalizer`] with every observed value.
+/// 2. Applies the configured [`CompositionMethod`] to the z-scored values.
+/// 3. Returns a real-valued scalar (not yet bounded to [0, 1] — callers that
+///    feed Beta-Bernoulli bandits should apply [`sigmoid`]).
+///
+/// The full struct is serialisable: pass `serialize()` bytes to
+/// `SnapshotEnvelope::reward_composer_state` for RocksDB persistence.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RewardComposer {
+    pub objectives: Vec<RewardObjective>,
+    pub method: CompositionMethod,
+    pub normalizer: MetricNormalizer,
+}
+
+impl RewardComposer {
+    /// Create a new composer.
+    ///
+    /// # Panics
+    /// Panics if `objectives` is empty or any weight is non-finite / negative.
+    pub fn new(objectives: Vec<RewardObjective>, method: CompositionMethod) -> Self {
+        assert!(
+            !objectives.is_empty(),
+            "RewardComposer requires at least one objective"
+        );
+        for obj in &objectives {
+            assert_finite(obj.weight, "RewardObjective weight");
+            assert!(
+                obj.weight >= 0.0,
+                "RewardObjective weight must be non-negative"
+            );
+        }
+        Self {
+            objectives,
+            method,
+            normalizer: MetricNormalizer::new(),
+        }
+    }
+
+    /// Compose `metric_values` into a scalar reward, updating running statistics.
+    ///
+    /// Metrics not present in `metric_values` are silently skipped (partial
+    /// observation is allowed).  Returns `0.0` if no objectives have matching
+    /// keys.
+    pub fn compose(&mut self, metric_values: &HashMap<String, f64>) -> f64 {
+        // Phase 1: collect (objective_index, metric_name, raw_value) for
+        // objectives that have an observation in this event.
+        let observed: Vec<(usize, String, f64)> = self
+            .objectives
+            .iter()
+            .enumerate()
+            .filter_map(|(i, obj)| {
+                metric_values
+                    .get(&obj.metric_name)
+                    .map(|&v| (i, obj.metric_name.clone(), v))
+            })
+            .collect();
+        // self.objectives borrow released — `observed` owns cloned strings.
+
+        if observed.is_empty() {
+            return 0.0;
+        }
+
+        // Phase 2: update normaliser and collect z-scores (sequential borrows,
+        // no overlap with objectives).
+        let normalized: Vec<(usize, f64)> = observed
+            .into_iter()
+            .map(|(i, name, v)| {
+                let z = self.normalizer.update_and_normalize(&name, v);
+                (i, z)
+            })
+            .collect();
+        // self.normalizer borrow released.
+
+        // Phase 3: scalarise.
+        let reward = match &self.method {
+            CompositionMethod::WeightedSum => {
+                let total_w: f64 = normalized.iter().map(|(i, _)| self.objectives[*i].weight).sum();
+                if total_w == 0.0 {
+                    return 0.0;
+                }
+                normalized
+                    .iter()
+                    .map(|(i, z)| self.objectives[*i].weight * z)
+                    .sum::<f64>()
+                    / total_w
+            }
+
+            CompositionMethod::EpsilonConstraint => {
+                // Primary = objective with highest weight.
+                let primary_idx = normalized
+                    .iter()
+                    .max_by(|(i, _), (j, _)| {
+                        self.objectives[*i]
+                            .weight
+                            .partial_cmp(&self.objectives[*j].weight)
+                            .unwrap()
+                    })
+                    .map(|(i, _)| *i)
+                    .unwrap();
+
+                let primary_z = normalized
+                    .iter()
+                    .find(|(i, _)| *i == primary_idx)
+                    .map(|(_, z)| *z)
+                    .unwrap_or(0.0);
+
+                // Penalty per violated constraint (unit Lagrange multiplier).
+                let penalty: f64 = normalized
+                    .iter()
+                    .filter(|(i, _)| *i != primary_idx)
+                    .map(|(i, z)| {
+                        if let Some(slack) = self.objectives[*i].constraint_slack {
+                            // Violation = amount by which z falls below -slack.
+                            (-slack - z).max(0.0)
+                        } else {
+                            0.0 // unconstrained objective
+                        }
+                    })
+                    .sum();
+
+                primary_z - penalty
+            }
+
+            CompositionMethod::Tchebycheff => {
+                // Reward = −max_i(w_i · |z_i − r_i|).  Higher is better.
+                let max_dev = normalized
+                    .iter()
+                    .map(|(i, z)| {
+                        let w = self.objectives[*i].weight;
+                        let r = self.objectives[*i].reference_value;
+                        w * (z - r).abs()
+                    })
+                    .fold(f64::NEG_INFINITY, f64::max);
+                -max_dev
+            }
+        };
+
+        assert_finite(reward, "RewardComposer composed reward");
+        // Clamp to ±10 σ for numerical safety before passing to bandit.
+        reward.clamp(-10.0, 10.0)
+    }
+
+    /// Serialize composer state (objectives + method + normaliser) for RocksDB.
+    pub fn serialize(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("RewardComposer serialization should not fail")
+    }
+
+    /// Deserialize composer state from RocksDB snapshot bytes.
+    pub fn deserialize(data: &[u8]) -> Self {
+        serde_json::from_slice(data).expect("RewardComposer deserialization failed")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Utilities
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Map a real-valued composed reward to (0, 1) via the logistic function.
+///
+/// Required when feeding composed rewards into Beta-Bernoulli (Thompson
+/// Sampling) bandits that require rewards in [0, 1].
+#[inline]
+pub fn sigmoid(x: f64) -> f64 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::thompson::{select_arm, BetaArm};
+    use rand::Rng;
+
+    fn make_objectives() -> Vec<RewardObjective> {
+        vec![
+            RewardObjective {
+                metric_name: "engagement".into(),
+                weight: 0.7,
+                constraint_slack: None,
+                reference_value: 0.0,
+            },
+            RewardObjective {
+                metric_name: "quality".into(),
+                weight: 0.3,
+                constraint_slack: None,
+                reference_value: 0.0,
+            },
+        ]
+    }
+
+    // ── MetricStats ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_metric_stats_constant_sequence() {
+        let mut stats = MetricStats::new();
+        for _ in 0..500 {
+            stats.update(1.0);
+        }
+        // Mean should converge to 1.0, variance to ~0 (decays at rate 0.99^t).
+        // After 500 updates: var ≈ 0.99^500 ≈ 0.007, but initial value is 1.0
+        // and EMA decay is slow; realistic bound is < 0.05.
+        assert!((stats.mean - 1.0).abs() < 0.05, "mean={}", stats.mean);
+        assert!(stats.variance < 0.05, "variance={}", stats.variance);
+    }
+
+    #[test]
+    fn test_metric_stats_normalization_direction() {
+        let mut stats = MetricStats::new();
+        // Warm up with values near 0.5.
+        for _ in 0..200 {
+            stats.update(0.5);
+        }
+        // A value above the mean should have a positive z-score.
+        let z_high = stats.normalize(0.9);
+        let z_low = stats.normalize(0.1);
+        assert!(z_high > 0.0, "z_high={z_high}");
+        assert!(z_low < 0.0, "z_low={z_low}");
+    }
+
+    // ── MetricNormalizer ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_normalizer_serialize_roundtrip() {
+        let mut n = MetricNormalizer::new();
+        for v in [0.1, 0.5, 0.8, 0.3] {
+            n.update_and_normalize("engagement", v);
+        }
+        let bytes = n.serialize();
+        let restored = MetricNormalizer::deserialize(&bytes);
+        let orig_stats = &n.stats["engagement"];
+        let rest_stats = &restored.stats["engagement"];
+        assert_eq!(orig_stats.n_obs, rest_stats.n_obs);
+        assert!((orig_stats.mean - rest_stats.mean).abs() < 1e-12);
+    }
+
+    // ── WeightedSum ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_weighted_sum_single_metric() {
+        let objs = vec![RewardObjective::new("eng".into(), 1.0)];
+        let mut composer = RewardComposer::new(objs, CompositionMethod::WeightedSum);
+
+        // Warm up so normaliser has a stable mean.
+        let mut metrics = HashMap::new();
+        for _ in 0..100 {
+            metrics.insert("eng".into(), 0.5_f64);
+            composer.compose(&metrics);
+        }
+        // Above-mean observation should yield positive composed reward.
+        metrics.insert("eng".into(), 0.9);
+        let r_high = composer.compose(&metrics);
+
+        metrics.insert("eng".into(), 0.1);
+        let r_low = composer.compose(&metrics);
+
+        assert!(r_high > r_low, "r_high={r_high} r_low={r_low}");
+    }
+
+    #[test]
+    fn test_weighted_sum_missing_metric_returns_zero() {
+        let objs = make_objectives();
+        let mut composer = RewardComposer::new(objs, CompositionMethod::WeightedSum);
+        let metrics = HashMap::new(); // No matching keys.
+        assert_eq!(composer.compose(&metrics), 0.0);
+    }
+
+    // ── EpsilonConstraint ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_epsilon_constraint_penalty_applied() {
+        let objs = vec![
+            RewardObjective {
+                metric_name: "primary".into(),
+                weight: 1.0,
+                constraint_slack: None,
+                reference_value: 0.0,
+            },
+            RewardObjective {
+                metric_name: "secondary".into(),
+                weight: 0.5,
+                constraint_slack: Some(0.5), // Must stay ≥ −0.5 σ
+                reference_value: 0.0,
+            },
+        ];
+        let mut composer = RewardComposer::new(objs, CompositionMethod::EpsilonConstraint);
+
+        // Warm up normaliser with mid-range values.
+        for _ in 0..200 {
+            let mut m = HashMap::new();
+            m.insert("primary".into(), 0.5_f64);
+            m.insert("secondary".into(), 0.5_f64);
+            composer.compose(&m);
+        }
+
+        // Unconstrained call: secondary satisfies constraint.
+        let mut good = HashMap::new();
+        good.insert("primary".into(), 0.9_f64);
+        good.insert("secondary".into(), 0.9_f64);
+        let r_good = composer.compose(&good);
+
+        // Constrained call: secondary violates constraint (very low value).
+        let mut bad = HashMap::new();
+        bad.insert("primary".into(), 0.9_f64);
+        bad.insert("secondary".into(), 0.01_f64); // Far below mean → penalty
+        let r_bad = composer.compose(&bad);
+
+        assert!(
+            r_good > r_bad,
+            "Constraint violation should reduce reward: r_good={r_good} r_bad={r_bad}"
+        );
+    }
+
+    // ── Tchebycheff ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_tchebycheff_balanced_preferred() {
+        let objs = make_objectives();
+        let mut composer_a = RewardComposer::new(objs.clone(), CompositionMethod::Tchebycheff);
+        let mut composer_b = RewardComposer::new(objs, CompositionMethod::Tchebycheff);
+
+        // Warm up both with balanced values.
+        for _ in 0..200 {
+            let mut m = HashMap::new();
+            m.insert("engagement".into(), 0.5_f64);
+            m.insert("quality".into(), 0.5_f64);
+            composer_a.compose(&m);
+            composer_b.compose(&m);
+        }
+
+        // Balanced outcome: both metrics near mean.
+        let mut balanced = HashMap::new();
+        balanced.insert("engagement".into(), 0.55_f64);
+        balanced.insert("quality".into(), 0.55_f64);
+        let r_balanced = composer_a.compose(&balanced);
+
+        // Extreme outcome: high engagement, low quality.
+        let mut extreme = HashMap::new();
+        extreme.insert("engagement".into(), 0.99_f64);
+        extreme.insert("quality".into(), 0.01_f64);
+        let r_extreme = composer_b.compose(&extreme);
+
+        // Tchebycheff should penalise extreme trade-offs.
+        assert!(
+            r_balanced > r_extreme,
+            "Balanced={r_balanced} should beat Extreme={r_extreme}"
+        );
+    }
+
+    // ── Serialize / Deserialize ──────────────────────────────────────────────
+
+    #[test]
+    fn test_composer_serialize_roundtrip() {
+        let objs = make_objectives();
+        let mut composer = RewardComposer::new(objs, CompositionMethod::WeightedSum);
+
+        // Update with some observations.
+        let mut m = HashMap::new();
+        m.insert("engagement".into(), 0.7_f64);
+        m.insert("quality".into(), 0.4_f64);
+        for _ in 0..50 {
+            composer.compose(&m);
+        }
+
+        let bytes = composer.serialize();
+        let restored = RewardComposer::deserialize(&bytes);
+
+        // Normaliser state preserved.
+        let orig_n = &composer.normalizer.stats["engagement"];
+        let rest_n = &restored.normalizer.stats["engagement"];
+        assert_eq!(orig_n.n_obs, rest_n.n_obs);
+        assert!((orig_n.mean - rest_n.mean).abs() < 1e-12);
+    }
+
+    // ── Sigmoid ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_sigmoid_properties() {
+        assert!((sigmoid(0.0) - 0.5).abs() < 1e-12);
+        assert!(sigmoid(10.0) > 0.99);
+        assert!(sigmoid(-10.0) < 0.01);
+        assert!(sigmoid(1.0) > sigmoid(-1.0));
+    }
+
+    // ── Convergence simulation ───────────────────────────────────────────────
+
+    /// Verify that a multi-objective bandit converges toward the arm with the
+    /// higher weighted-sum reward within 1 000 rounds.
+    ///
+    /// Ground truth:
+    ///   arm_a: E[engagement] = 0.80, E[quality] = 0.60
+    ///   arm_b: E[engagement] = 0.30, E[quality] = 0.70
+    ///
+    /// Weighted sum (w_eng=0.7, w_qual=0.3):
+    ///   arm_a expected: 0.74  >  arm_b expected: 0.42  → arm_a should win.
+    #[test]
+    fn test_weighted_sum_convergence() {
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+        let objs = make_objectives();
+        let mut composer = RewardComposer::new(objs, CompositionMethod::WeightedSum);
+
+        let mut arms = vec![
+            BetaArm::new("arm_a".into()),
+            BetaArm::new("arm_b".into()),
+        ];
+
+        const N_ROUNDS: usize = 1_000;
+        // Track arm_a selection rate over the final 200 rounds.
+        let mut arm_a_late_count = 0usize;
+        const LATE_START: usize = 800;
+
+        for round in 0..N_ROUNDS {
+            // Select arm via Thompson Sampling.
+            let selection = select_arm(&arms, &mut rng);
+
+            // Sample true metric values from Bernoulli distributions.
+            let (engagement, quality) = if selection.arm_id == "arm_a" {
+                (
+                    if rng.gen::<f64>() < 0.80 { 1.0 } else { 0.0 },
+                    if rng.gen::<f64>() < 0.60 { 1.0 } else { 0.0 },
+                )
+            } else {
+                (
+                    if rng.gen::<f64>() < 0.30 { 1.0 } else { 0.0 },
+                    if rng.gen::<f64>() < 0.70 { 1.0 } else { 0.0 },
+                )
+            };
+
+            // Compose into a scalar and map to (0, 1) for Beta-Bernoulli.
+            let mut metrics = HashMap::new();
+            metrics.insert("engagement".into(), engagement);
+            metrics.insert("quality".into(), quality);
+            let composed = composer.compose(&metrics);
+            let reward = sigmoid(composed);
+
+            // Update the selected arm's posterior.
+            let arm = arms
+                .iter_mut()
+                .find(|a| a.arm_id == selection.arm_id)
+                .unwrap();
+            arm.update(reward);
+
+            if round >= LATE_START && selection.arm_id == "arm_a" {
+                arm_a_late_count += 1;
+            }
+        }
+
+        let arm_a_late_rate = arm_a_late_count as f64 / (N_ROUNDS - LATE_START) as f64;
+        assert!(
+            arm_a_late_rate > 0.60,
+            "Expected arm_a late-phase selection rate > 60%, got {arm_a_late_rate:.2}"
+        );
+    }
+}

--- a/crates/experimentation-policy/src/core.rs
+++ b/crates/experimentation-policy/src/core.rs
@@ -13,6 +13,7 @@ use crate::types::{
 };
 use experimentation_bandit::cold_start;
 use experimentation_bandit::linucb::LinUcbPolicy;
+use experimentation_bandit::multi_objective::{sigmoid, RewardComposer};
 use experimentation_bandit::policy::AnyPolicy;
 use experimentation_bandit::thompson::ThompsonSamplingPolicy;
 use std::collections::HashMap;
@@ -41,6 +42,9 @@ pub struct PolicyCore {
     rewards_since_snapshot: HashMap<String, u64>,
     /// Last Kafka offset processed per experiment.
     last_kafka_offset: HashMap<String, i64>,
+    /// Multi-objective reward composers (ADR-011), keyed by experiment_id.
+    /// Present only for experiments registered with `reward_objectives`.
+    reward_composers: HashMap<String, RewardComposer>,
 }
 
 impl PolicyCore {
@@ -53,6 +57,7 @@ impl PolicyCore {
             config,
             rewards_since_snapshot: HashMap::new(),
             last_kafka_offset: HashMap::new(),
+            reward_composers: HashMap::new(),
         }
     }
 
@@ -76,6 +81,14 @@ impl PolicyCore {
             );
             self.last_kafka_offset
                 .insert(envelope.experiment_id.clone(), envelope.kafka_offset);
+
+            // ADR-011: restore RewardComposer state if present.
+            if let Some(composer_bytes) = &envelope.reward_composer_state {
+                let composer = RewardComposer::deserialize(composer_bytes);
+                self.reward_composers
+                    .insert(envelope.experiment_id.clone(), composer);
+            }
+
             self.policies
                 .insert(envelope.experiment_id, policy);
         }
@@ -126,6 +139,32 @@ impl PolicyCore {
                     min_exploration_fraction,
                 ))
             });
+    }
+
+    /// Register a Thompson Sampling experiment with multi-objective reward composition
+    /// (ADR-011).  If the experiment already exists, only the composer is updated.
+    ///
+    /// `composer` encapsulates all objective weights, composition method, and the
+    /// running [`MetricNormalizer`].  Reward events for this experiment must carry
+    /// `metric_values` in their [`RewardUpdate`]; the core will call
+    /// `composer.compose()` before updating the bandit posterior.
+    #[allow(dead_code)]
+    pub fn register_multi_objective_experiment(
+        &mut self,
+        experiment_id: String,
+        arm_ids: Vec<String>,
+        composer: RewardComposer,
+    ) {
+        self.policies
+            .entry(experiment_id.clone())
+            .or_insert_with(|| {
+                info!(%experiment_id, arms = ?arm_ids, "Registered new multi-objective Thompson experiment");
+                AnyPolicy::Thompson(ThompsonSamplingPolicy::new(
+                    experiment_id.clone(),
+                    arm_ids,
+                ))
+            });
+        self.reward_composers.insert(experiment_id, composer);
     }
 
     /// Run the single-threaded event loop.
@@ -206,6 +245,24 @@ impl PolicyCore {
     }
 
     fn handle_reward_update(&mut self, update: RewardUpdate) {
+        // ADR-011: if metric_values are present and a RewardComposer is
+        // registered for this experiment, compose the scalar reward first.
+        let scalar_reward = if let Some(metrics) = &update.metric_values {
+            if let Some(composer) = self.reward_composers.get_mut(&update.experiment_id) {
+                let composed = composer.compose(metrics);
+                // Beta-Bernoulli (Thompson) expects reward ∈ [0, 1].
+                // Map the real-valued composed score via sigmoid.
+                match self.policies.get(&update.experiment_id) {
+                    Some(AnyPolicy::Thompson(_)) => sigmoid(composed),
+                    _ => composed,
+                }
+            } else {
+                update.reward
+            }
+        } else {
+            update.reward
+        };
+
         let policy = match self.policies.get_mut(&update.experiment_id) {
             Some(p) => p,
             None => {
@@ -217,7 +274,7 @@ impl PolicyCore {
             }
         };
 
-        policy.update(&update.arm_id, update.reward, update.context.as_ref());
+        policy.update(&update.arm_id, scalar_reward, update.context.as_ref());
         self.last_kafka_offset
             .insert(update.experiment_id.clone(), update.kafka_offset);
 
@@ -380,12 +437,19 @@ impl PolicyCore {
             .copied()
             .unwrap_or(-1);
 
-        let envelope = SnapshotStore::make_envelope(
+        // ADR-011: persist RewardComposer state alongside policy posteriors.
+        let reward_composer_state = self
+            .reward_composers
+            .get(experiment_id)
+            .map(|c| c.serialize());
+
+        let envelope = SnapshotStore::make_envelope_with_composer(
             experiment_id.to_string(),
             policy.policy_type().to_string(),
             policy.serialize(),
             policy.total_rewards(),
             kafka_offset,
+            reward_composer_state,
         );
 
         if let Err(e) = self.snapshot_store.write_snapshot(&envelope) {
@@ -491,6 +555,7 @@ mod tests {
                     reward: 1.0,
                     context: None,
                     kafka_offset: 1,
+                    metric_values: None,
                 })
                 .await
                 .unwrap();
@@ -552,6 +617,7 @@ mod tests {
                         reward: 1.0,
                         context: None,
                         kafka_offset: i,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -649,6 +715,7 @@ mod tests {
                     reward: 1.0,
                     context: Some(ctx.clone()),
                     kafka_offset: 1,
+                    metric_values: None,
                 })
                 .await
                 .unwrap();
@@ -704,6 +771,7 @@ mod tests {
                         reward: 1.0,
                         context: Some(ctx.clone()),
                         kafka_offset: i,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -811,6 +879,7 @@ mod tests {
                     reward: 1.0,
                     context: Some(ctx.clone()),
                     kafka_offset: i,
+                    metric_values: None,
                 })
                 .await
                 .unwrap();
@@ -821,6 +890,7 @@ mod tests {
                     reward: 0.2,
                     context: Some(ctx.clone()),
                     kafka_offset: 50 + i,
+                    metric_values: None,
                 })
                 .await
                 .unwrap();
@@ -921,6 +991,7 @@ mod tests {
                         reward: 1.0,
                         context: Some(ctx.clone()),
                         kafka_offset: i * 2,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -931,6 +1002,7 @@ mod tests {
                         reward: 0.0,
                         context: Some(ctx.clone()),
                         kafka_offset: i * 2 + 1,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -1036,6 +1108,7 @@ mod tests {
                         reward: 1.0,
                         context: None,
                         kafka_offset: i * 3,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -1047,6 +1120,7 @@ mod tests {
                         reward: 1.0,
                         context: Some(ctx.clone()),
                         kafka_offset: i * 3 + 1,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -1058,6 +1132,7 @@ mod tests {
                         reward: 1.0,
                         context: Some(ctx.clone()),
                         kafka_offset: i * 3 + 2,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -1161,6 +1236,7 @@ mod tests {
                         reward: 1.0,
                         context: None,
                         kafka_offset: i,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -1243,6 +1319,7 @@ mod tests {
                         reward,
                         context: None,
                         kafka_offset: i,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -1264,6 +1341,7 @@ mod tests {
                         reward,
                         context: Some(ctx.clone()),
                         kafka_offset: 1200 + i,
+                        metric_values: None,
                     })
                     .await
                     .unwrap();
@@ -1418,6 +1496,104 @@ mod tests {
         drop(_reward_tx);
         drop(mgmt_tx);
         handle.await.unwrap();
+
+        let _ = std::fs::remove_dir_all(&db_path);
+    }
+
+    /// ADR-011: verify that RewardComposer state (normaliser mean/variance)
+    /// survives a crash-and-restore cycle via RocksDB.
+    #[tokio::test]
+    async fn test_multi_objective_composer_crash_recovery() {
+        use experimentation_bandit::multi_objective::{
+            CompositionMethod, RewardComposer, RewardObjective,
+        };
+
+        let db_path = temp_db_path("multi-obj-crash");
+
+        // Phase 1: train a multi-objective experiment for 50 rewards then crash.
+        let saved_n_obs;
+        {
+            let store = SnapshotStore::open(&db_path).unwrap();
+            let config = test_config(db_path.to_str().unwrap());
+
+            let composer = RewardComposer::new(
+                vec![
+                    RewardObjective::new("engagement".into(), 0.7),
+                    RewardObjective::new("quality".into(), 0.3),
+                ],
+                CompositionMethod::WeightedSum,
+            );
+
+            let mut core = PolicyCore::new(store, config);
+            core.register_multi_objective_experiment(
+                "mo-exp".into(),
+                vec!["arm_a".into(), "arm_b".into()],
+                composer,
+            );
+
+            let (_policy_tx, reward_tx, _mgmt_tx, handle) = spawn_core(core);
+
+            // Send enough rewards to trigger snapshots (snapshot_interval = 5).
+            for i in 0..50i64 {
+                reward_tx
+                    .send(RewardUpdate {
+                        experiment_id: "mo-exp".into(),
+                        arm_id: "arm_a".into(),
+                        reward: 0.0, // unused — composer takes over
+                        context: None,
+                        kafka_offset: i,
+                        metric_values: Some(
+                            [("engagement".into(), 0.8_f64), ("quality".into(), 0.6_f64)]
+                                .into_iter()
+                                .collect(),
+                        ),
+                    })
+                    .await
+                    .unwrap();
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // Peek at the composer state before crash so we can verify restoration.
+            // We can't inspect core directly after spawn_core (it's moved), so we
+            // rely on the snapshot. Just store the expected n_obs.
+            saved_n_obs = 50u64;
+
+            drop(reward_tx);
+            drop(_policy_tx);
+            drop(_mgmt_tx);
+            handle.await.unwrap();
+        }
+
+        // Phase 2: restore and verify composer state was persisted.
+        {
+            let store = SnapshotStore::open(&db_path).unwrap();
+            let config = test_config(db_path.to_str().unwrap());
+
+            let mut core = PolicyCore::new(store, config);
+            let restored = core.restore_from_snapshots().unwrap();
+            assert_eq!(restored, 1, "should restore 1 multi-objective experiment");
+
+            // The composer should have been restored — check it is present.
+            assert!(
+                core.reward_composers.contains_key("mo-exp"),
+                "RewardComposer should be restored from RocksDB snapshot"
+            );
+
+            let composer = &core.reward_composers["mo-exp"];
+            // Normaliser should have accumulated at least some observations for
+            // the snapshotted batches (snapshot_interval = 5 → ≥ 45 obs in last snap).
+            let eng_n_obs = composer
+                .normalizer
+                .stats
+                .get("engagement")
+                .map(|s| s.n_obs)
+                .unwrap_or(0);
+            assert!(
+                eng_n_obs >= 45,
+                "engagement normaliser should have ≥ 45 obs after restore, got {eng_n_obs} (saved {saved_n_obs})"
+            );
+        }
 
         let _ = std::fs::remove_dir_all(&db_path);
     }

--- a/crates/experimentation-policy/src/kafka.rs
+++ b/crates/experimentation-policy/src/kafka.rs
@@ -145,6 +145,7 @@ async fn consume_loop(
             reward: reward_event.reward,
             context,
             kafka_offset: message.offset(),
+               metric_values: None,
         };
 
         // Send to PolicyCore; blocks if channel is full (backpressure)
@@ -314,6 +315,7 @@ mod tests {
             reward: event.reward,
             context,
             kafka_offset: 42,
+            metric_values: None,
         };
         assert_eq!(update.experiment_id, "exp-2");
         assert_eq!(update.arm_id, "arm-b");
@@ -343,6 +345,7 @@ mod tests {
             reward: event.reward,
             context,
             kafka_offset: 0,
+            metric_values: None,
         };
         assert!(update.context.is_none());
         assert_eq!(update.reward, 0.0);

--- a/crates/experimentation-policy/src/snapshot.rs
+++ b/crates/experimentation-policy/src/snapshot.rs
@@ -23,6 +23,11 @@ pub struct SnapshotEnvelope {
     pub kafka_offset: i64,
     /// Snapshot creation time (epoch milliseconds).
     pub snapshot_at_epoch_ms: i64,
+    /// Serialized [`RewardComposer`] state for multi-objective bandits (ADR-011).
+    /// `None` for single-objective experiments.  Old snapshots without this
+    /// field deserialize to `None` via the serde default.
+    #[serde(default)]
+    pub reward_composer_state: Option<Vec<u8>>,
 }
 
 fn default_policy_type() -> String {
@@ -138,6 +143,28 @@ impl SnapshotStore {
             total_rewards_processed,
             kafka_offset,
             snapshot_at_epoch_ms: Utc::now().timestamp_millis(),
+            reward_composer_state: None,
+        }
+    }
+
+    /// Create a snapshot envelope that also embeds [`RewardComposer`] state
+    /// (ADR-011).
+    pub fn make_envelope_with_composer(
+        experiment_id: String,
+        policy_type: String,
+        policy_state: Vec<u8>,
+        total_rewards_processed: u64,
+        kafka_offset: i64,
+        reward_composer_state: Option<Vec<u8>>,
+    ) -> SnapshotEnvelope {
+        SnapshotEnvelope {
+            experiment_id,
+            policy_type,
+            policy_state,
+            total_rewards_processed,
+            kafka_offset,
+            snapshot_at_epoch_ms: Utc::now().timestamp_millis(),
+            reward_composer_state,
         }
     }
 }
@@ -185,6 +212,7 @@ mod tests {
             total_rewards_processed: 100,
             kafka_offset: 42,
             snapshot_at_epoch_ms: 1000,
+            reward_composer_state: None,
         };
         let env2 = SnapshotEnvelope {
             experiment_id: "exp-1".into(),
@@ -193,6 +221,7 @@ mod tests {
             total_rewards_processed: 200,
             kafka_offset: 84,
             snapshot_at_epoch_ms: 2000,
+            reward_composer_state: None,
         };
 
         store.write_snapshot(&env1).unwrap();
@@ -221,6 +250,7 @@ mod tests {
                     total_rewards_processed: ts as u64,
                     kafka_offset: 0,
                     snapshot_at_epoch_ms: ts,
+                    reward_composer_state: None,
                 })
                 .unwrap();
         }
@@ -248,6 +278,7 @@ mod tests {
                     total_rewards_processed: ts as u64,
                     kafka_offset: 0,
                     snapshot_at_epoch_ms: ts,
+                    reward_composer_state: None,
                 })
                 .unwrap();
         }
@@ -280,6 +311,7 @@ mod tests {
                     total_rewards_processed: ts as u64,
                     kafka_offset: 0,
                     snapshot_at_epoch_ms: ts,
+                    reward_composer_state: None,
                 })
                 .unwrap();
         }

--- a/crates/experimentation-policy/src/types.rs
+++ b/crates/experimentation-policy/src/types.rs
@@ -28,12 +28,18 @@ pub struct RewardUpdate {
     pub experiment_id: String,
     /// Arm that was shown to the user.
     pub arm_id: String,
-    /// Observed reward value (0.0 or 1.0 for binary).
+    /// Scalar reward (0.0–1.0 for binary rewards; used when `metric_values` is
+    /// absent or no composer is registered for this experiment).
     pub reward: f64,
     /// Optional context features for contextual bandits.
     pub context: Option<HashMap<String, f64>>,
     /// Kafka offset for snapshot bookmarking.
     pub kafka_offset: i64,
+    /// Per-metric observed values for multi-objective composition (ADR-011).
+    /// When non-empty and a [`RewardComposer`] is registered for this
+    /// experiment, the policy core composes these into a scalar reward before
+    /// calling `policy.update()`.
+    pub metric_values: Option<HashMap<String, f64>>,
 }
 
 /// Request to create a cold-start bandit.

--- a/docs/coordination/status/agent-4-status.md
+++ b/docs/coordination/status/agent-4-status.md
@@ -63,6 +63,29 @@ Branch: work/bright-platypus
 
 ## Completed (Phase 5)
 
+- [x] **ADR-011 — Multi-objective reward composition** (2026-03-23, work/happy-koala)
+  - `crates/experimentation-bandit/src/multi_objective.rs` (new)
+    - `MetricStats`: EMA running mean/variance (α=0.01), Welford-style update
+    - `MetricNormalizer`: keyed EMA normaliser over arbitrary metric names; serialize/deserialize for RocksDB
+    - `RewardObjective`: metric_name, weight, `constraint_slack: Option<f64>`, reference_value
+    - `CompositionMethod`: `WeightedSum`, `EpsilonConstraint` (Lagrangian), `Tchebycheff`
+    - `RewardComposer`: 3-phase compose (collect → normalise → scalarise); clamps to ±10σ; serialize/deserialize
+    - `sigmoid()`: maps composed real reward to (0, 1) for Beta-Bernoulli policies
+  - `crates/experimentation-bandit/src/lib.rs`: added `pub mod multi_objective`
+  - `crates/experimentation-policy/src/types.rs`: `RewardUpdate` gains `metric_values: Option<HashMap<String, f64>>`
+  - `crates/experimentation-policy/src/snapshot.rs`: `SnapshotEnvelope` gains `reward_composer_state: Option<Vec<u8>>` (serde default for backward compat); `make_envelope_with_composer()` factory
+  - `crates/experimentation-policy/src/core.rs`:
+    - `PolicyCore` gains `reward_composers: HashMap<String, RewardComposer>`
+    - `register_multi_objective_experiment()`: registers Thompson + composer atomically
+    - `handle_reward_update()`: composes metric_values → scalar, applies sigmoid for Thompson policies
+    - `write_snapshot()`: persists composer state alongside policy posteriors
+    - `restore_from_snapshots()`: restores composer state on startup
+  - Tests:
+    - 10 unit tests in `multi_objective.rs` (MetricStats convergence, normalisation direction, WeightedSum, EpsilonConstraint penalty, Tchebycheff balance, roundtrip)
+    - `test_weighted_sum_convergence`: 1000-round simulation — arm_a (E[eng]=0.8, E[qual]=0.6) beats arm_b (E[eng]=0.3, E[qual]=0.7) with w=(0.7, 0.3); arm_a selection rate >60% in final 200 rounds
+    - `test_multi_objective_composer_crash_recovery`: normaliser survives crash-and-restore via RocksDB; ≥45 obs restored after 50 reward events
+    - All 35 policy tests + 33 bandit tests green; workspace-wide 0 failures
+
 - [x] **ADR-014 Phase 1 — Guardrail Bonferroni beta-correction** (2026-03-23, work/nice-lion)
   - `guardrail_bonferroni()` in `crates/experimentation-stats/src/multiple_comparison.rs`
     - Per-guardrail threshold = alpha/K; `rejected[i]` = true when p_i ≤ alpha/K


### PR DESCRIPTION
## Summary

- Implements ADR-011: multi-objective reward composition for the bandit policy service (M4b)
- New `experimentation-bandit::multi_objective` module: `MetricNormalizer` (EMA α=0.01), `RewardComposer` (WeightedSum / EpsilonConstraint / Tchebycheff)
- LMAX core wired to compose `metric_values` → scalar reward before posterior update; `sigmoid()` maps to (0,1) for Beta-Bernoulli
- `RewardComposer` state persisted in `SnapshotEnvelope.reward_composer_state` (backward-compat serde default); restored on startup

## Files changed

| File | Change |
|------|--------|
| `crates/experimentation-bandit/src/multi_objective.rs` | NEW — MetricStats, MetricNormalizer, RewardObjective, CompositionMethod, RewardComposer, sigmoid |
| `crates/experimentation-bandit/src/lib.rs` | `pub mod multi_objective` |
| `crates/experimentation-policy/src/types.rs` | `RewardUpdate.metric_values: Option<HashMap<String,f64>>` |
| `crates/experimentation-policy/src/snapshot.rs` | `SnapshotEnvelope.reward_composer_state`, `make_envelope_with_composer()` |
| `crates/experimentation-policy/src/core.rs` | `reward_composers` map, compose logic, persist/restore |
| `crates/experimentation-policy/src/kafka.rs` | `metric_values: None` in Kafka event bridge |

## Test plan

- [x] 10 unit tests: MetricStats convergence, normalisation direction, WeightedSum, EpsilonConstraint penalty, Tchebycheff balance preference, serialize roundtrip
- [x] Convergence simulation: 1000 rounds, arm_a (E[eng]=0.8, E[qual]=0.6) with w=(0.7,0.3) vs arm_b (E[eng]=0.3, E[qual]=0.7) — arm_a selection rate >60% in final 200 rounds
- [x] Crash-recovery integration test: normaliser (≥45 obs) survives crash-and-restore via RocksDB
- [x] `cargo test -p experimentation-bandit`: 33 passed, 0 failed
- [x] `cargo test -p experimentation-policy`: 35 passed, 0 failed
- [x] `cargo test --workspace`: 0 failures

## Notes / opportunities for follow-up

- ADR-012 (LP constraints) builds directly on this — `RewardComposer` output feeds into the LP post-processing layer
- `metric_values` in `RewardUpdate` arrives as `None` from the existing Kafka consumer; Phase 2 will parse per-metric fields from the Kafka event schema (proto-aligned)
- `constraint_slack` is `Option<f64>` to avoid JSON serialisation issues with `f64::INFINITY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
