### PR TITLE
feat(experimentation-analysis): wire AVLM into M4a RunAnalysis (ADR-015)

### DIFF
--- a/crates/experimentation-analysis/src/config.rs
+++ b/crates/experimentation-analysis/src/config.rs
@@ -13,6 +13,9 @@ pub struct AnalysisConfig {
     pub default_js_threshold: f64,
     /// PostgreSQL connection URL. None = caching disabled.
     pub database_url: Option<String>,
+    /// Default mixing variance τ² for AVLM/mSPRT martingale.
+    /// Controls sensitivity: larger τ² → faster detection of large effects, less of small.
+    pub default_tau_sq: f64,
 }
 
 impl AnalysisConfig {
@@ -25,6 +28,7 @@ impl AnalysisConfig {
             default_alpha: parse_env("ANALYSIS_DEFAULT_ALPHA", 0.05),
             default_js_threshold: parse_env("ANALYSIS_JS_THRESHOLD", 0.05),
             database_url: std::env::var("DATABASE_URL").ok(),
+            default_tau_sq: parse_env("ANALYSIS_DEFAULT_TAU_SQ", 0.5),
         }
     }
 }

--- a/crates/experimentation-analysis/src/grpc.rs
+++ b/crates/experimentation-analysis/src/grpc.rs
@@ -14,12 +14,15 @@ use experimentation_proto::experimentation::analysis::v1::{
     GetSwitchbackAnalysisRequest, GetSyntheticControlAnalysisRequest, InterferenceAnalysisResult,
     InterleavingAnalysisResult, IpwResult as ProtoIpwResult, MetricResult, NoveltyAnalysisResult,
     PositionAnalysis as ProtoPositionAnalysis, RunAnalysisRequest, SegmentResult,
-    SessionLevelResult, SrmResult as ProtoSrmResult, SwitchbackAnalysisResult,
+    SequentialResult, SessionLevelResult, SrmResult as ProtoSrmResult, SwitchbackAnalysisResult,
     SyntheticControlAnalysisResult, TitleSpillover,
 };
 use experimentation_stats::{
-    cate, clustering, cuped, interference, interleaving, ipw, novelty, srm, ttest,
+    avlm, cate, clustering, cuped, interference, interleaving, ipw, novelty, srm, ttest,
 };
+
+/// Proto enum value for SEQUENTIAL_METHOD_AVLM (ADR-015).
+const SEQUENTIAL_METHOD_AVLM: i32 = 4;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
@@ -200,6 +203,8 @@ fn to_proto_novelty_result(
 async fn compute_analysis(
     config: &AnalysisConfig,
     experiment_id: &str,
+    sequential_method: i32,
+    tau_sq: f64,
 ) -> Result<AnalysisResult, Status> {
     let data = delta_reader::read_metric_summaries(&config.delta_lake_path, experiment_id)
         .await
@@ -263,13 +268,34 @@ async fn compute_analysis(
                 0.0
             };
 
-            // CUPED: only if all observations in both groups have non-null covariates.
+            // AVLM (ADR-015) or CUPED depending on sequential_method.
             let control_covs: Vec<f64> = control_tuples.iter().filter_map(|(_, c)| *c).collect();
             let treatment_covs: Vec<f64> =
                 treatment_tuples.iter().filter_map(|(_, c)| *c).collect();
 
-            let (cuped_effect, cuped_ci_lower, cuped_ci_upper, variance_reduction_pct) =
-                if control_covs.len() == control_values.len()
+            let (cuped_effect, cuped_ci_lower, cuped_ci_upper, variance_reduction_pct, avlm_sequential) =
+                if sequential_method == SEQUENTIAL_METHOD_AVLM {
+                    // AVLM: anytime-valid regression-adjusted CI (ADR-015).
+                    // Passes x=0 when covariate is null → falls back to mSPRT CS.
+                    let effective_tau_sq = if tau_sq > 0.0 { tau_sq } else { config.default_tau_sq };
+                    match compute_avlm_result(control_tuples, treatment_tuples, effective_tau_sq, alpha) {
+                        Ok(Some(av)) => {
+                            let seq = SequentialResult {
+                                boundary_crossed: av.is_significant,
+                                alpha_spent: if av.is_significant { alpha } else { 0.0 },
+                                alpha_remaining: if av.is_significant { 0.0 } else { alpha },
+                                current_look: 1,
+                                adjusted_p_value: 0.0,
+                            };
+                            (av.adjusted_effect, av.ci_lower, av.ci_upper, av.variance_reduction * 100.0, Some(seq))
+                        }
+                        Ok(None) => (0.0, 0.0, 0.0, 0.0, None),
+                        Err(e) => {
+                            warn!(metric_id, error = e, "AVLM failed, skipping sequential result");
+                            (0.0, 0.0, 0.0, 0.0, None)
+                        }
+                    }
+                } else if control_covs.len() == control_values.len()
                     && treatment_covs.len() == treatment_values.len()
                     && control_covs.len() >= 2
                     && treatment_covs.len() >= 2
@@ -286,11 +312,12 @@ async fn compute_analysis(
                             cr.ci_lower,
                             cr.ci_upper,
                             cr.variance_reduction * 100.0,
+                            None,
                         ),
-                        Err(_) => (0.0, 0.0, 0.0, 0.0),
+                        Err(_) => (0.0, 0.0, 0.0, 0.0, None),
                     }
                 } else {
-                    (0.0, 0.0, 0.0, 0.0)
+                    (0.0, 0.0, 0.0, 0.0, None)
                 };
 
             // CATE: per-segment results if lifecycle_segment data exists.
@@ -312,7 +339,7 @@ async fn compute_analysis(
                 cuped_ci_lower,
                 cuped_ci_upper,
                 variance_reduction_pct,
-                sequential_result: None,
+                sequential_result: avlm_sequential,
                 segment_results,
                 session_level_result: compute_session_level_result(
                     &data,
@@ -609,6 +636,33 @@ fn compute_experiment_cochran_q(
 }
 
 // ---------------------------------------------------------------------------
+// AVLM analysis helper (ADR-015)
+// ---------------------------------------------------------------------------
+
+/// Run AVLM sequential test by streaming all observations from both arms.
+///
+/// When the covariate (`cov`) is `None` for any observation, passes `0.0` for `x`,
+/// which causes `AvlmSequentialTest` to fall back to the unadjusted mSPRT confidence
+/// sequence (since `var_x_pool == 0` triggers `unadjusted_confidence_sequence()`).
+fn compute_avlm_result(
+    control_tuples: &[(f64, Option<f64>)],
+    treatment_tuples: &[(f64, Option<f64>)],
+    tau_sq: f64,
+    alpha: f64,
+) -> Result<Option<avlm::AvlmResult>, String> {
+    let mut test = avlm::AvlmSequentialTest::new(tau_sq, alpha).map_err(|e| e.to_string())?;
+    for &(y, cov) in control_tuples {
+        test.update(y, cov.unwrap_or(0.0), false)
+            .map_err(|e| e.to_string())?;
+    }
+    for &(y, cov) in treatment_tuples {
+        test.update(y, cov.unwrap_or(0.0), true)
+            .map_err(|e| e.to_string())?;
+    }
+    test.confidence_sequence().map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
 // gRPC trait implementation
 // ---------------------------------------------------------------------------
 
@@ -618,11 +672,12 @@ impl AnalysisService for AnalysisServiceHandler {
         &self,
         request: Request<RunAnalysisRequest>,
     ) -> Result<Response<AnalysisResult>, Status> {
-        let experiment_id = request.into_inner().experiment_id;
+        let req = request.into_inner();
+        let experiment_id = req.experiment_id;
         if experiment_id.is_empty() {
             return Err(Status::invalid_argument("experiment_id is required"));
         }
-        let result = compute_analysis(&self.config, &experiment_id).await?;
+        let result = compute_analysis(&self.config, &experiment_id, req.sequential_method, req.tau_sq).await?;
 
         // Fire-and-forget cache write.
         if let (Some(store), Some(uuid)) = (&self.store, try_parse_uuid(&experiment_id)) {
@@ -654,8 +709,8 @@ impl AnalysisService for AnalysisServiceHandler {
             }
         }
 
-        // Cache miss or no store: compute from Delta Lake.
-        let result = compute_analysis(&self.config, &experiment_id).await?;
+        // Cache miss or no store: compute from Delta Lake (fixed-horizon, no sequential method).
+        let result = compute_analysis(&self.config, &experiment_id, 0, 0.0).await?;
 
         // Write through to cache.
         if let (Some(store), Some(uuid)) = (&self.store, try_parse_uuid(&experiment_id)) {
@@ -818,6 +873,7 @@ mod tests {
             default_alpha: 0.05,
             default_js_threshold: 0.05,
             database_url: None,
+            default_tau_sq: 0.5,
         }
     }
 
@@ -1052,6 +1108,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -1110,6 +1167,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -1160,6 +1218,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -1176,6 +1235,7 @@ mod tests {
         let err = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "".into(),
+                ..Default::default()
             }))
             .await
             .unwrap_err();
@@ -1193,6 +1253,7 @@ mod tests {
         let err = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-999".into(),
+                ..Default::default()
             }))
             .await
             .unwrap_err();
@@ -1596,6 +1657,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -1676,6 +1738,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -1789,6 +1852,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -1909,6 +1973,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();
@@ -1983,6 +2048,7 @@ mod tests {
         let resp = handler
             .run_analysis(Request::new(RunAnalysisRequest {
                 experiment_id: "exp-1".into(),
+                ..Default::default()
             }))
             .await
             .unwrap();

--- a/crates/experimentation-analysis/tests/m4a_m6_contract_test.rs
+++ b/crates/experimentation-analysis/tests/m4a_m6_contract_test.rs
@@ -51,6 +51,7 @@ fn test_config(path: &str) -> AnalysisConfig {
         default_alpha: 0.05,
         default_js_threshold: 0.05,
         database_url: None,
+        default_tau_sq: 0.5,
     }
 }
 
@@ -298,6 +299,7 @@ async fn contract_analysis_result_field_presence() {
     let resp = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -348,6 +350,7 @@ async fn contract_metric_result_all_fields() {
     let resp = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -409,6 +412,7 @@ async fn contract_srm_result_map_fields() {
     let resp = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -471,6 +475,7 @@ async fn contract_srm_mismatch_detected() {
     let resp = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -540,6 +545,7 @@ async fn contract_segment_result_lifecycle_enum_values() {
     let resp = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -601,6 +607,7 @@ async fn contract_optional_sub_messages_absent() {
     let resp = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -679,6 +686,7 @@ async fn contract_interleaving_analysis() {
     let resp = handler
         .get_interleaving_analysis(Request::new(GetInterleavingAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -753,6 +761,7 @@ async fn contract_novelty_analysis() {
     let resp = handler
         .get_novelty_analysis(Request::new(GetNoveltyAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -841,6 +850,7 @@ async fn contract_interference_analysis_with_spillover() {
     let resp = handler
         .get_interference_analysis(Request::new(GetInterferenceAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -951,6 +961,7 @@ async fn contract_not_found_for_missing_experiment() {
     let err = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: missing.into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -960,6 +971,7 @@ async fn contract_not_found_for_missing_experiment() {
     let err = handler
         .get_analysis_result(Request::new(GetAnalysisResultRequest {
             experiment_id: missing.into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -969,6 +981,7 @@ async fn contract_not_found_for_missing_experiment() {
     let err = handler
         .get_interleaving_analysis(Request::new(GetInterleavingAnalysisRequest {
             experiment_id: missing.into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -978,6 +991,7 @@ async fn contract_not_found_for_missing_experiment() {
     let err = handler
         .get_novelty_analysis(Request::new(GetNoveltyAnalysisRequest {
             experiment_id: missing.into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -987,6 +1001,7 @@ async fn contract_not_found_for_missing_experiment() {
     let err = handler
         .get_interference_analysis(Request::new(GetInterferenceAnalysisRequest {
             experiment_id: missing.into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -1002,6 +1017,7 @@ async fn contract_empty_experiment_id_invalid_argument() {
     let err = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "".into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -1011,6 +1027,7 @@ async fn contract_empty_experiment_id_invalid_argument() {
     let err = handler
         .get_analysis_result(Request::new(GetAnalysisResultRequest {
             experiment_id: "".into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -1020,6 +1037,7 @@ async fn contract_empty_experiment_id_invalid_argument() {
     let err = handler
         .get_interleaving_analysis(Request::new(GetInterleavingAnalysisRequest {
             experiment_id: "".into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -1029,6 +1047,7 @@ async fn contract_empty_experiment_id_invalid_argument() {
     let err = handler
         .get_novelty_analysis(Request::new(GetNoveltyAnalysisRequest {
             experiment_id: "".into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -1038,6 +1057,7 @@ async fn contract_empty_experiment_id_invalid_argument() {
     let err = handler
         .get_interference_analysis(Request::new(GetInterferenceAnalysisRequest {
             experiment_id: "".into(),
+            ..Default::default()
         }))
         .await
         .unwrap_err();
@@ -1093,6 +1113,7 @@ async fn contract_cochran_q_heterogeneity() {
     let resp = handler
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -1123,6 +1144,7 @@ async fn contract_cochran_q_heterogeneity() {
     let resp2 = handler2
         .run_analysis(Request::new(RunAnalysisRequest {
             experiment_id: "exp-1".into(),
+            ..Default::default()
         }))
         .await
         .unwrap();
@@ -1132,5 +1154,155 @@ async fn contract_cochran_q_heterogeneity() {
         (result_no.cochran_q_p_value - 0.0).abs() < 1e-10,
         "no segments: cochran_q_p_value should be 0.0 (proto3 omits), got {}",
         result_no.cochran_q_p_value
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ADR-015: AVLM integration test — narrower CIs than mSPRT on golden-file data
+// ---------------------------------------------------------------------------
+//
+// Golden-file data: outcome Y strongly correlated with covariate X (θ ≈ 2.0,
+// R² ≈ 0.999). AVLM regression-adjusts away ~99% of outcome variance, producing
+// a confidence sequence much narrower than the unadjusted mSPRT CI.
+//
+// AVLM run:  covariates non-null → full regression adjustment → narrow CI
+// mSPRT run: same Y values, null covariates → x=0 → unadjusted mSPRT CS → wide CI
+//
+// Asserts:
+//   - AVLM CI width < mSPRT CI width (primary goal of ADR-015)
+//   - AVLM sequential_result.boundary_crossed == true (treatment effect = 1.0 detected)
+//   - AVLM variance_reduction_pct > 80% (confirms regression adjustment is effective)
+
+#[tokio::test]
+async fn test_avlm_narrower_ci_than_msprt_on_golden_data() {
+    // Golden-file data: Y = 2·X + treatment_effect + small_noise
+    // Control: 10 users, X in [3.0, 7.5], Y ≈ 2·X (residuals ~0.1)
+    // Treatment: 10 users, X in [3.0, 7.5], Y ≈ 2·X + 1.0
+    let exp_id = "exp-avlm-golden";
+
+    // Outcome values (Y)
+    let y_control = [6.1, 8.0, 10.1, 12.0, 14.1, 7.1, 9.0, 11.0, 13.0, 15.1_f64];
+    let y_treatment = [7.1, 9.0, 11.0, 13.1, 15.0, 8.0, 10.1, 12.0, 14.1, 16.0_f64];
+
+    // Covariate values (X) — same for both arms
+    let x = [3.0, 4.0, 5.0, 6.0, 7.0, 3.5, 4.5, 5.5, 6.5, 7.5_f64];
+
+    let n = y_control.len();
+    let exp_ids: Vec<&str> = vec![exp_id; 2 * n];
+    let user_ids: Vec<String> = (0..2 * n).map(|i| format!("u{}", i)).collect();
+    let user_id_refs: Vec<&str> = user_ids.iter().map(|s| s.as_str()).collect();
+    let metric_ids: Vec<&str> = vec!["watch_time"; 2 * n];
+
+    let mut variant_ids: Vec<&str> = vec!["control"; n];
+    variant_ids.extend(vec!["treatment"; n]);
+
+    let mut values: Vec<f64> = y_control.to_vec();
+    values.extend_from_slice(&y_treatment);
+
+    // AVLM run: non-null covariates (strong correlation)
+    let covariates_avlm: Vec<Option<f64>> = x.iter().map(|&v| Some(v))
+        .chain(x.iter().map(|&v| Some(v)))
+        .collect();
+
+    // mSPRT run: null covariates → AVLM falls back to unadjusted CS (= mSPRT)
+    let covariates_msprt: Vec<Option<f64>> = vec![None; 2 * n];
+
+    // Build Delta Lake tables in separate temp dirs.
+    let tmp_avlm = TempDir::new().unwrap();
+    let tmp_msprt = TempDir::new().unwrap();
+
+    let batch_avlm = make_analysis_data(
+        &exp_ids,
+        &user_id_refs,
+        &variant_ids,
+        &metric_ids,
+        &values,
+        &covariates_avlm,
+    );
+    write_table(tmp_avlm.path(), "metric_summaries", batch_avlm).await;
+
+    let batch_msprt = make_analysis_data(
+        &exp_ids,
+        &user_id_refs,
+        &variant_ids,
+        &metric_ids,
+        &values,
+        &covariates_msprt,
+    );
+    write_table(tmp_msprt.path(), "metric_summaries", batch_msprt).await;
+
+    let handler_avlm = test_handler(tmp_avlm.path().to_str().unwrap());
+    let handler_msprt = test_handler(tmp_msprt.path().to_str().unwrap());
+
+    // SEQUENTIAL_METHOD_AVLM = 4
+    let avlm_resp = handler_avlm
+        .run_analysis(Request::new(RunAnalysisRequest {
+            experiment_id: exp_id.into(),
+            sequential_method: 4,
+            tau_sq: 0.5,
+        }))
+        .await
+        .expect("AVLM RunAnalysis should succeed");
+
+    let msprt_resp = handler_msprt
+        .run_analysis(Request::new(RunAnalysisRequest {
+            experiment_id: exp_id.into(),
+            sequential_method: 4,
+            tau_sq: 0.5,
+        }))
+        .await
+        .expect("mSPRT (null covariates) RunAnalysis should succeed");
+
+    let avlm_result = avlm_resp.into_inner();
+    let msprt_result = msprt_resp.into_inner();
+
+    // Locate the treatment variant metric result for "watch_time".
+    let avlm_mr = avlm_result
+        .metric_results
+        .iter()
+        .find(|r| r.metric_id == "watch_time" && r.variant_id == "treatment")
+        .expect("AVLM: watch_time/treatment metric result missing");
+
+    let msprt_mr = msprt_result
+        .metric_results
+        .iter()
+        .find(|r| r.metric_id == "watch_time" && r.variant_id == "treatment")
+        .expect("mSPRT: watch_time/treatment metric result missing");
+
+    // AVLM CI is in cuped_ci_lower/upper (regression-adjusted confidence sequence).
+    let avlm_width = avlm_mr.cuped_ci_upper - avlm_mr.cuped_ci_lower;
+    let msprt_width = msprt_mr.cuped_ci_upper - msprt_mr.cuped_ci_lower;
+
+    assert_finite(avlm_width, "avlm_width");
+    assert_finite(msprt_width, "msprt_width");
+
+    assert!(
+        avlm_width > 0.0,
+        "AVLM CI width must be positive, got {avlm_width}"
+    );
+    assert!(
+        msprt_width > 0.0,
+        "mSPRT CI width must be positive, got {msprt_width}"
+    );
+    assert!(
+        avlm_width < msprt_width,
+        "AVLM CI (width={avlm_width:.4}) must be narrower than mSPRT CI (width={msprt_width:.4})"
+    );
+
+    // Variance reduction should exceed 80% for this strongly correlated covariate.
+    assert!(
+        avlm_mr.variance_reduction_pct > 80.0,
+        "expected variance reduction > 80%, got {:.1}%",
+        avlm_mr.variance_reduction_pct
+    );
+
+    // Treatment effect = 1.0 should be detected at this sample size.
+    let seq = avlm_mr
+        .sequential_result
+        .as_ref()
+        .expect("AVLM: sequential_result should be populated");
+    assert!(
+        seq.boundary_crossed,
+        "AVLM: confidence sequence should exclude 0 (treatment effect = 1.0 is large)"
     );
 }

--- a/docs/coordination/status/agent-4-status.md
+++ b/docs/coordination/status/agent-4-status.md
@@ -7,13 +7,29 @@
 
 Sprint: 5.0
 Focus: ADR-015 AVLM, ADR-017 TC/JIVE, ADR-018 E-values, ADR-014 Guardrail beta-correction, ADR-011 Multi-objective, ADR-012 LP constraints
-Branch: work/bright-platypus
+Branch: work/bright-bear
 
 ## In Progress
 
 - [ ] ADR-012 LP constraints
 
 ## Completed (Phase 5) — latest first
+
+- [x] **ADR-015 M4a integration — AVLM wired into RunAnalysis** (2026-03-23, work/bright-bear)
+  - `proto/experimentation/analysis/v1/analysis_service.proto`: extended `RunAnalysisRequest`
+    with `sequential_method` (field 2) and `tau_sq` (field 3) — AVLM now selectable per-call
+  - `crates/experimentation-analysis/src/config.rs`: added `default_tau_sq: f64` (env: `ANALYSIS_DEFAULT_TAU_SQ`, default 0.5)
+  - `crates/experimentation-analysis/src/grpc.rs`:
+    - Added `avlm` + `SequentialResult` imports; `SEQUENTIAL_METHOD_AVLM = 4` constant
+    - `compute_avlm_result()` helper: streams observations into `AvlmSequentialTest`, uses `cov.unwrap_or(0.0)` fallback (null covariate → unadjusted mSPRT CS)
+    - `compute_analysis()` branched: AVLM path when `sequential_method == 4`, CUPED path otherwise
+    - AVLM results placed in `cuped_adjusted_effect/cuped_ci_lower/cuped_ci_upper/variance_reduction_pct`; `sequential_result.boundary_crossed` = `is_significant`
+    - `run_analysis` handler now extracts `sequential_method` and `tau_sq` from request
+    - `get_analysis_result` passes (0, 0.0) → fixed-horizon, backward compatible
+  - `crates/experimentation-analysis/tests/m4a_m6_contract_test.rs`:
+    - `test_avlm_narrower_ci_than_msprt_on_golden_data`: 20-obs golden dataset (Y = 2X + effect + noise, R² ≈ 0.999); confirms AVLM CI narrower than mSPRT CI, variance reduction > 80%, boundary crossed
+    - All existing tests updated to `..Default::default()` for new `RunAnalysisRequest` fields
+  - All 52 analysis tests + 181 stats tests + full workspace green (0 failures)
 
 - [x] **ADR-021 — Feedback Loop Interference Detection** (2026-03-23, work/fancy-bear)
   - `crates/experimentation-stats/src/feedback_loop.rs`: `FeedbackLoopDetector`

--- a/proto/experimentation/analysis/v1/analysis_service.proto
+++ b/proto/experimentation/analysis/v1/analysis_service.proto
@@ -29,7 +29,15 @@ service AnalysisService {
   rpc GetSwitchbackAnalysis(GetSwitchbackAnalysisRequest) returns (SwitchbackAnalysisResult);
 }
 
-message RunAnalysisRequest { string experiment_id = 1; }
+message RunAnalysisRequest {
+  string experiment_id = 1;
+  // Optional: override sequential testing method for this run.
+  // SEQUENTIAL_METHOD_UNSPECIFIED (default) = fixed-horizon t-test only.
+  // SEQUENTIAL_METHOD_AVLM: anytime-valid LM with regression adjustment (ADR-015).
+  experimentation.common.v1.SequentialMethod sequential_method = 2;
+  // Mixing variance τ² for AVLM/mSPRT martingale. 0.0 = use service default (0.5).
+  double tau_sq = 3;
+}
 message GetAnalysisResultRequest { string experiment_id = 1; }
 message GetInterleavingAnalysisRequest { string experiment_id = 1; }
 message GetNoveltyAnalysisRequest { string experiment_id = 1; }


### PR DESCRIPTION
## Summary

- **Proto**: Extended `RunAnalysisRequest` with `sequential_method` (field 2) and `tau_sq` (field 3) so callers can select `SEQUENTIAL_METHOD_AVLM = 4` per-call with a configurable mixing variance
- **Config**: Added `default_tau_sq` field (`ANALYSIS_DEFAULT_TAU_SQ` env var, default 0.5) to `AnalysisConfig`
- **grpc.rs**: Added `compute_avlm_result()` helper that streams observations into `AvlmSequentialTest` in O(1) per observation; null covariate falls back to x=0 (unadjusted mSPRT CS). `compute_analysis` now branches on `sequential_method`: AVLM path places results in `cuped_ci_{lower,upper}` + `sequential_result.boundary_crossed`; CUPED path unchanged. `get_analysis_result` passes `(0, 0.0)` for backward compatibility.

## Integration Test

`test_avlm_narrower_ci_than_msprt_on_golden_data` (golden-file data):
- 20 observations, Y = 2·X + 1.0 + noise, R² ≈ 0.999
- AVLM run (non-null covariates): regression-adjusted CI, ~99% variance reduction → narrow CI
- mSPRT run (null covariates → x=0 fallback → unadjusted mSPRT CS) → wide CI
- Asserts: AVLM CI width < mSPRT CI width, variance_reduction_pct > 80%, boundary_crossed = true

## Test plan

- [x] `cargo test -p experimentation-analysis` — 52 passed, 0 failed (includes new AVLM test)
- [x] `cargo test --workspace` — all suites green, 0 failures
- [x] No credentials in diff

## Notes / opportunities

- `get_analysis_result` always uses fixed-horizon (0, 0.0); could optionally store the sequential config alongside cached results in a future PR
- `SequentialResult.adjusted_p_value` is left as 0.0 for AVLM (AVLM gives a CS, not a p-value); could compute implied p-value via CS inversion if needed by M6 UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
