### PR TITLE
feat(experimentation-stats,m5): ADR-020 adaptive sample size recalculation

### DIFF
--- a/crates/experimentation-stats/src/adaptive_n.rs
+++ b/crates/experimentation-stats/src/adaptive_n.rs
@@ -220,7 +220,7 @@ pub fn conditional_power(
     assert_finite(cp, "conditional_power");
 
     // Clamp to [0, 1] — numerical precision can produce tiny out-of-range values
-    Ok(cp.max(0.0).min(1.0))
+    Ok(cp.clamp(0.0, 1.0))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/experimentation-stats/src/adaptive_n.rs
+++ b/crates/experimentation-stats/src/adaptive_n.rs
@@ -1,0 +1,873 @@
+//! Adaptive Sample Size Recalculation (ADR-020).
+//!
+//! Implements the *promising-zone* adaptive design (Mehta & Pocock, 2011):
+//!
+//! 1. **Blinded pooled variance**: Variance re-estimation from combined
+//!    control + treatment observations *without* unmasking group assignments.
+//!    Based on Gould & Shih (1992). Conservative: overestimates within-group
+//!    variance when δ ≠ 0 (includes between-group component).
+//!
+//! 2. **Conditional power**: P(reject H₀ at final n_max | δ̂_observed, σ_B).
+//!    Two-sided Wald formula using the blinded σ_B as variance estimate.
+//!
+//! 3. **Zone classification** (Mehta & Pocock thresholds):
+//!    - Favorable:  CP ≥ 90% — experiment is on track, no action.
+//!    - Promising: 30% ≤ CP < 90% — extend to reclaim power.
+//!    - Futile:     CP < 30%  — early termination recommended.
+//!
+//! 4. **GST spending reallocation**: After extending to n_extended, the
+//!    remaining alpha budget is distributed across the new looks using the
+//!    same Lan-DeMets spending function as the original GST design.
+//!
+//! 5. **Required sample size**: Binary-search for n_max that achieves a
+//!    target conditional power level, given the blinded variance estimate.
+//!
+//! # Type I error guarantee
+//!
+//! Under H₀ the blinded pooled variance is independent of the (centred) test
+//! statistic, so the adaptive re-estimation step cannot inflate the false-
+//! positive rate. The GST boundary reallocation spends only `alpha_remaining`
+//! across the extended looks, preserving the overall α.
+//!
+//! Reference: Mehta & Pocock (2011) Stat Med 30:3267-3284.
+//! Reference: Gould & Shih (1992) Stat Med 11:1431-1441.
+//! Reference: Müller & Schäfer (2001) Biometrics 57:886-891.
+
+use experimentation_core::error::{assert_finite, Error, Result};
+use statrs::distribution::{ContinuousCDF, Normal};
+
+use crate::sequential::{gst_boundaries, SpendingFunction};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Zone classification for an adaptive sample size interim analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Zone {
+    /// Conditional power ≥ 90%. Experiment is well-powered; no extension needed.
+    Favorable,
+    /// Conditional power ∈ [30%, 90%). Extension is recommended.
+    Promising,
+    /// Conditional power < 30%. Experiment is unlikely to succeed; early
+    /// termination is recommended.
+    Futile,
+}
+
+impl std::fmt::Display for Zone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Zone::Favorable => write!(f, "favorable"),
+            Zone::Promising => write!(f, "promising"),
+            Zone::Futile => write!(f, "futile"),
+        }
+    }
+}
+
+/// Configurable zone thresholds.
+///
+/// Default values match Mehta & Pocock (2011) Table 1 recommendations.
+#[derive(Debug, Clone)]
+pub struct ZoneThresholds {
+    /// Minimum conditional power for the Favorable zone. Default: 0.90.
+    pub favorable: f64,
+    /// Minimum conditional power for the Promising zone. Default: 0.30.
+    pub promising: f64,
+}
+
+impl Default for ZoneThresholds {
+    fn default() -> Self {
+        Self {
+            favorable: 0.90,
+            promising: 0.30,
+        }
+    }
+}
+
+/// Full result of an adaptive-N interim analysis.
+#[derive(Debug, Clone)]
+pub struct AdaptiveNResult {
+    /// Blinded pooled variance σ²_B (per observation, within-group scale).
+    pub blinded_variance: f64,
+    /// Conditional power CP(δ̂, σ_B, n_max, α).
+    pub conditional_power: f64,
+    /// Zone classification.
+    pub zone: Zone,
+    /// For Promising zone: recommended extended n_max per arm to restore
+    /// conditional power to `target_power`. `None` for other zones.
+    pub recommended_n_max: Option<f64>,
+}
+
+// ---------------------------------------------------------------------------
+// Blinded pooled variance
+// ---------------------------------------------------------------------------
+
+/// Compute blinded pooled variance from the combined observations of both arms.
+///
+/// This is the Gould-Shih (1992) blinded estimator:
+///
+/// ```text
+/// σ²_B = (1/(N−1)) · Σᵢ (xᵢ − x̄)²
+/// ```
+///
+/// where `xᵢ` are all `N = n_control + n_treatment` observations (both groups
+/// combined) and `x̄` is the grand mean.
+///
+/// **Bias note**: Under H₀ (δ=0) this is an unbiased estimator of the common
+/// within-group σ². Under H₁ (δ≠0) it overestimates σ² by a term proportional
+/// to δ²/(variance), which gives a *conservative* (lower) power estimate.
+///
+/// # Errors
+/// Returns `Error::Validation` when fewer than 2 observations are supplied.
+pub fn blinded_pooled_variance(all_observations: &[f64]) -> Result<f64> {
+    let n = all_observations.len();
+    if n < 2 {
+        return Err(Error::Validation(
+            "blinded_pooled_variance requires at least 2 observations".into(),
+        ));
+    }
+
+    for (i, &x) in all_observations.iter().enumerate() {
+        assert_finite(x, &format!("all_observations[{i}]"));
+    }
+
+    let n_f = n as f64;
+    let mean = all_observations.iter().sum::<f64>() / n_f;
+    assert_finite(mean, "blinded grand mean");
+
+    let sum_sq = all_observations
+        .iter()
+        .map(|&x| (x - mean).powi(2))
+        .sum::<f64>();
+    assert_finite(sum_sq, "blinded sum of squares");
+
+    let variance = sum_sq / (n_f - 1.0);
+    assert_finite(variance, "blinded variance");
+
+    if variance < 0.0 {
+        return Err(Error::Numerical(
+            "blinded variance is negative (numerical underflow)".into(),
+        ));
+    }
+
+    Ok(variance)
+}
+
+// ---------------------------------------------------------------------------
+// Conditional power
+// ---------------------------------------------------------------------------
+
+/// Compute conditional power for a two-sided two-sample Wald test.
+///
+/// Treats `observed_effect` δ̂ as the "true" effect and `blinded_sigma_sq` σ²_B
+/// as the common within-group variance. Returns:
+///
+/// ```text
+/// CP = Φ(ncp − z_{α/2}) + Φ(−ncp − z_{α/2})
+/// ```
+///
+/// where the non-centrality parameter at the final sample size n_max per arm is
+///
+/// ```text
+/// ncp = δ̂ / SE_final = δ̂ · √(n_max/2) / σ_B
+/// ```
+///
+/// SE_final = σ_B · √(2/n_max) (pooled standard error of the mean difference).
+///
+/// # Arguments
+/// * `observed_effect` — Point estimate δ̂ = X̄_T − X̄_C at the current look.
+/// * `blinded_sigma_sq` — Blinded pooled variance σ²_B (positive).
+/// * `n_max_per_arm` — Final (or extended) per-arm target sample size.
+/// * `alpha` — Two-sided significance level.
+///
+/// # Errors
+/// Returns `Error::Validation` for non-positive inputs.
+pub fn conditional_power(
+    observed_effect: f64,
+    blinded_sigma_sq: f64,
+    n_max_per_arm: f64,
+    alpha: f64,
+) -> Result<f64> {
+    if blinded_sigma_sq <= 0.0 {
+        return Err(Error::Validation(
+            "blinded_sigma_sq must be positive".into(),
+        ));
+    }
+    if n_max_per_arm <= 0.0 {
+        return Err(Error::Validation("n_max_per_arm must be positive".into()));
+    }
+    if alpha <= 0.0 || alpha >= 1.0 {
+        return Err(Error::Validation("alpha must be in (0, 1)".into()));
+    }
+
+    assert_finite(observed_effect, "observed_effect");
+    assert_finite(blinded_sigma_sq, "blinded_sigma_sq");
+    assert_finite(n_max_per_arm, "n_max_per_arm");
+
+    let z = Normal::new(0.0, 1.0)
+        .map_err(|e| Error::Numerical(format!("failed to create Normal: {e}")))?;
+
+    let z_alpha_half = z.inverse_cdf(1.0 - alpha / 2.0);
+    assert_finite(z_alpha_half, "z_alpha_half");
+
+    // ncp = δ̂ / (σ_B * sqrt(2/n_max)) = δ̂ * sqrt(n_max/2) / σ_B
+    let sigma_b = blinded_sigma_sq.sqrt();
+    let ncp = observed_effect * (n_max_per_arm / 2.0).sqrt() / sigma_b;
+    assert_finite(ncp, "ncp");
+
+    // CP = Φ(ncp - z_{α/2}) + Φ(-ncp - z_{α/2})
+    let cp = z.cdf(ncp - z_alpha_half) + z.cdf(-ncp - z_alpha_half);
+    assert_finite(cp, "conditional_power");
+
+    // Clamp to [0, 1] — numerical precision can produce tiny out-of-range values
+    Ok(cp.max(0.0).min(1.0))
+}
+
+// ---------------------------------------------------------------------------
+// Zone classification
+// ---------------------------------------------------------------------------
+
+/// Classify conditional power into a zone.
+///
+/// Uses the configurable `thresholds` (default: favorable ≥ 0.90, promising ≥ 0.30).
+///
+/// # Arguments
+/// * `cp` — Conditional power value in [0, 1].
+/// * `thresholds` — Zone boundary thresholds.
+///
+/// # Panics
+/// Panics (fail-fast) if `cp` is NaN or infinite.
+pub fn zone_classify(cp: f64, thresholds: &ZoneThresholds) -> Zone {
+    assert_finite(cp, "conditional_power for zone_classify");
+    assert!(
+        thresholds.promising < thresholds.favorable,
+        "promising threshold ({}) must be < favorable threshold ({})",
+        thresholds.promising,
+        thresholds.favorable
+    );
+
+    if cp >= thresholds.favorable {
+        Zone::Favorable
+    } else if cp >= thresholds.promising {
+        Zone::Promising
+    } else {
+        Zone::Futile
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Required sample size for target power
+// ---------------------------------------------------------------------------
+
+/// Binary-search for the minimum per-arm n that achieves `target_power` CP.
+///
+/// Given the blinded variance estimate and observed effect, returns the
+/// smallest integer-valued `n_per_arm` in `[n_current_per_arm, n_max_allowed]`
+/// such that:
+///
+/// ```text
+/// conditional_power(δ̂, σ²_B, n_per_arm, α) ≥ target_power
+/// ```
+///
+/// If target power is already achieved at `n_current_per_arm`, returns
+/// `n_current_per_arm`. If target power cannot be achieved within the allowed
+/// range, returns `n_max_allowed`.
+///
+/// # Arguments
+/// * `observed_effect` — Observed treatment effect δ̂.
+/// * `blinded_sigma_sq` — Blinded pooled variance σ²_B.
+/// * `target_power` — Desired conditional power (e.g. 0.80).
+/// * `alpha` — Two-sided significance level.
+/// * `n_current_per_arm` — Lower bound for the search (current per-arm n).
+/// * `n_max_allowed` — Upper bound for the search.
+pub fn required_n_for_power(
+    observed_effect: f64,
+    blinded_sigma_sq: f64,
+    target_power: f64,
+    alpha: f64,
+    n_current_per_arm: f64,
+    n_max_allowed: f64,
+) -> Result<f64> {
+    if target_power <= 0.0 || target_power >= 1.0 {
+        return Err(Error::Validation("target_power must be in (0, 1)".into()));
+    }
+    if n_current_per_arm <= 0.0 {
+        return Err(Error::Validation(
+            "n_current_per_arm must be positive".into(),
+        ));
+    }
+    if n_max_allowed <= n_current_per_arm {
+        return Err(Error::Validation(
+            "n_max_allowed must be greater than n_current_per_arm".into(),
+        ));
+    }
+
+    assert_finite(observed_effect, "observed_effect");
+    assert_finite(blinded_sigma_sq, "blinded_sigma_sq");
+
+    // Check if target power is already achieved at n_current
+    let cp_current = conditional_power(
+        observed_effect,
+        blinded_sigma_sq,
+        n_current_per_arm,
+        alpha,
+    )?;
+    if cp_current >= target_power {
+        return Ok(n_current_per_arm);
+    }
+
+    // Check if target power can be achieved at n_max_allowed
+    let cp_max = conditional_power(
+        observed_effect,
+        blinded_sigma_sq,
+        n_max_allowed,
+        alpha,
+    )?;
+    if cp_max < target_power {
+        return Ok(n_max_allowed);
+    }
+
+    // Binary search for the crossover point
+    let mut lo = n_current_per_arm;
+    let mut hi = n_max_allowed;
+
+    for _ in 0..64 {
+        let mid = 0.5 * (lo + hi);
+        let cp_mid = conditional_power(observed_effect, blinded_sigma_sq, mid, alpha)?;
+        if cp_mid < target_power {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+        if (hi - lo) < 0.5 {
+            break;
+        }
+    }
+
+    // Round up to next integer sample size
+    Ok(hi.ceil())
+}
+
+// ---------------------------------------------------------------------------
+// GST spending reallocation for extended experiments
+// ---------------------------------------------------------------------------
+
+/// Compute new GST boundaries for the extended portion of an adaptive trial.
+///
+/// After deciding to extend at an interim look, the remaining alpha budget
+/// `alpha_remaining` is distributed across `additional_looks` new looks using
+/// the same Lan-DeMets spending function. The new information fractions are
+/// assumed to be equally spaced in the extended segment.
+///
+/// This delegates to [`gst_boundaries`] from the `sequential` module, which
+/// implements the Armitage-McPherson-Rowe recursive quadrature algorithm.
+///
+/// # Arguments
+/// * `alpha_remaining` — Alpha budget not yet spent (overall_alpha − alpha_spent).
+/// * `additional_looks` — Number of new looks in the extended segment (≥ 2).
+/// * `spending` — Spending function to use for the extended segment.
+///
+/// # Returns
+/// Critical z-values for each of the `additional_looks` new looks.
+///
+/// # Errors
+/// Returns `Error::Validation` for invalid arguments.
+pub fn gst_reallocate_spending(
+    alpha_remaining: f64,
+    additional_looks: u32,
+    spending: SpendingFunction,
+) -> Result<Vec<f64>> {
+    if alpha_remaining <= 0.0 || alpha_remaining >= 1.0 {
+        return Err(Error::Validation(
+            "alpha_remaining must be in (0, 1)".into(),
+        ));
+    }
+    if additional_looks < 2 {
+        return Err(Error::Validation(
+            "additional_looks must be at least 2 for GST reallocation".into(),
+        ));
+    }
+
+    assert_finite(alpha_remaining, "alpha_remaining");
+
+    // Delegate to the full recursive boundary computation from sequential.rs,
+    // using alpha_remaining as the budget for the extended segment.
+    gst_boundaries(additional_looks, alpha_remaining, spending)
+}
+
+// ---------------------------------------------------------------------------
+// Full interim analysis entry-point
+// ---------------------------------------------------------------------------
+
+/// Run a complete adaptive-N interim analysis.
+///
+/// Combines blinded variance estimation, conditional power computation, zone
+/// classification, and (for the Promising zone) extended n recommendation.
+///
+/// # Arguments
+/// * `all_interim_obs` — All observations (both arms) at the interim look.
+/// * `observed_effect` — Unblinded effect estimate δ̂ (only used for CP calc;
+///   does not affect blinded variance).
+/// * `n_max_per_arm` — Original planned per-arm sample size.
+/// * `alpha` — Two-sided significance level.
+/// * `thresholds` — Zone classification thresholds.
+/// * `target_power` — Desired power for the Promising zone extension (e.g. 0.80).
+/// * `n_max_allowed` — Maximum allowed per-arm n (extension ceiling).
+///
+/// # Returns
+/// [`AdaptiveNResult`] with all intermediate values for audit trail logging.
+#[allow(clippy::too_many_arguments)]
+pub fn run_interim_analysis(
+    all_interim_obs: &[f64],
+    observed_effect: f64,
+    n_max_per_arm: f64,
+    alpha: f64,
+    thresholds: &ZoneThresholds,
+    target_power: f64,
+    n_max_allowed: f64,
+) -> Result<AdaptiveNResult> {
+    let blinded_variance = blinded_pooled_variance(all_interim_obs)?;
+
+    let cp = conditional_power(observed_effect, blinded_variance, n_max_per_arm, alpha)?;
+
+    let zone = zone_classify(cp, thresholds);
+
+    let recommended_n_max = if zone == Zone::Promising {
+        let n_current_per_arm = (all_interim_obs.len() as f64) / 2.0;
+        let rec = required_n_for_power(
+            observed_effect,
+            blinded_variance,
+            target_power,
+            alpha,
+            n_current_per_arm.max(1.0),
+            n_max_allowed,
+        )?;
+        Some(rec)
+    } else {
+        None
+    };
+
+    Ok(AdaptiveNResult {
+        blinded_variance,
+        conditional_power: cp,
+        zone,
+        recommended_n_max,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand::SeedableRng;
+    use rand_distr::{Distribution, Normal as RandNormal};
+
+    // -----------------------------------------------------------------------
+    // blinded_pooled_variance
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_blinded_variance_known_distribution() {
+        // With a large enough sample from a single normal, blinded variance
+        // should approach the true σ² = 4.0.
+        let sigma_sq: f64 = 4.0;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(1);
+        let dist = RandNormal::new(0.0_f64, sigma_sq.sqrt()).unwrap();
+        let obs: Vec<f64> = (0..10_000).map(|_| dist.sample(&mut rng)).collect();
+        let bv = blinded_pooled_variance(&obs).unwrap();
+        assert!(
+            (bv - sigma_sq).abs() < 0.15,
+            "blinded variance {bv:.4} should be close to {sigma_sq}"
+        );
+    }
+
+    #[test]
+    fn test_blinded_variance_conservative_under_effect() {
+        // When there's a real treatment effect, blinded variance should be ≥ true σ².
+        let sigma_sq: f64 = 1.0;
+        let delta = 2.0_f64; // large effect
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+        let ctrl_dist = RandNormal::new(0.0_f64, sigma_sq.sqrt()).unwrap();
+        let trt_dist = RandNormal::new(delta, sigma_sq.sqrt()).unwrap();
+
+        let mut all: Vec<f64> = (0..5_000).map(|_| ctrl_dist.sample(&mut rng)).collect();
+        all.extend((0..5_000).map(|_| trt_dist.sample(&mut rng)));
+
+        let bv = blinded_pooled_variance(&all).unwrap();
+        // Blinded variance overestimates σ² when δ > 0 because the grand mean
+        // is between the two group means.
+        assert!(bv > sigma_sq, "blinded variance {bv:.4} should exceed σ²={sigma_sq}");
+    }
+
+    #[test]
+    fn test_blinded_variance_too_few_obs() {
+        assert!(blinded_pooled_variance(&[]).is_err());
+        assert!(blinded_pooled_variance(&[1.0]).is_err());
+    }
+
+    #[test]
+    fn test_blinded_variance_two_obs() {
+        let obs = [0.0_f64, 2.0];
+        let bv = blinded_pooled_variance(&obs).unwrap();
+        assert!((bv - 2.0).abs() < 1e-10, "variance of [0,2] should be 2.0, got {bv}");
+    }
+
+    // -----------------------------------------------------------------------
+    // conditional_power
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_cp_zero_effect_is_alpha() {
+        // With δ̂ = 0, CP = P(|Z| > z_{α/2}) = α (no non-centrality).
+        let cp = conditional_power(0.0, 1.0, 200.0, 0.05).unwrap();
+        assert!(
+            (cp - 0.05).abs() < 1e-6,
+            "CP with zero effect should equal alpha, got {cp:.6}"
+        );
+    }
+
+    #[test]
+    fn test_cp_large_effect_is_high() {
+        // With a very large effect, CP should be close to 1.0.
+        let cp = conditional_power(10.0, 1.0, 500.0, 0.05).unwrap();
+        assert!(cp > 0.999, "CP with huge effect should be ~1.0, got {cp:.4}");
+    }
+
+    #[test]
+    fn test_cp_increases_with_n_max() {
+        // For the same δ̂ and σ², larger n_max should give higher CP.
+        let cp_small = conditional_power(0.2, 1.0, 100.0, 0.05).unwrap();
+        let cp_large = conditional_power(0.2, 1.0, 1000.0, 0.05).unwrap();
+        assert!(cp_large > cp_small, "larger n_max should give higher CP");
+    }
+
+    #[test]
+    fn test_cp_decreases_with_larger_variance() {
+        // Same δ̂ and n, but larger σ² → lower CP.
+        let cp_low_var = conditional_power(0.5, 1.0, 200.0, 0.05).unwrap();
+        let cp_high_var = conditional_power(0.5, 4.0, 200.0, 0.05).unwrap();
+        assert!(cp_low_var > cp_high_var, "higher variance should give lower CP");
+    }
+
+    #[test]
+    fn test_cp_in_unit_interval() {
+        for &delta in &[-1.0, 0.0, 0.3, 1.0, 5.0] {
+            let cp = conditional_power(delta, 1.0, 200.0, 0.05).unwrap();
+            assert!(
+                (0.0..=1.0).contains(&cp),
+                "CP={cp} is out of [0,1] for delta={delta}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cp_validation_errors() {
+        assert!(conditional_power(0.5, 0.0, 200.0, 0.05).is_err()); // σ²=0
+        assert!(conditional_power(0.5, -1.0, 200.0, 0.05).is_err()); // σ²<0
+        assert!(conditional_power(0.5, 1.0, 0.0, 0.05).is_err()); // n=0
+        assert!(conditional_power(0.5, 1.0, 200.0, 0.0).is_err()); // α=0
+        assert!(conditional_power(0.5, 1.0, 200.0, 1.0).is_err()); // α=1
+    }
+
+    // -----------------------------------------------------------------------
+    // zone_classify
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_zone_boundaries() {
+        let th = ZoneThresholds::default(); // favorable=0.90, promising=0.30
+        assert_eq!(zone_classify(0.95, &th), Zone::Favorable);
+        assert_eq!(zone_classify(0.90, &th), Zone::Favorable); // boundary inclusive
+        assert_eq!(zone_classify(0.89, &th), Zone::Promising);
+        assert_eq!(zone_classify(0.30, &th), Zone::Promising); // boundary inclusive
+        assert_eq!(zone_classify(0.29, &th), Zone::Futile);
+        assert_eq!(zone_classify(0.00, &th), Zone::Futile);
+    }
+
+    #[test]
+    fn test_zone_custom_thresholds() {
+        let th = ZoneThresholds {
+            favorable: 0.80,
+            promising: 0.50,
+        };
+        assert_eq!(zone_classify(0.85, &th), Zone::Favorable);
+        assert_eq!(zone_classify(0.75, &th), Zone::Promising);
+        assert_eq!(zone_classify(0.45, &th), Zone::Futile);
+    }
+
+    // -----------------------------------------------------------------------
+    // required_n_for_power
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_required_n_achieves_target_power() {
+        let delta = 0.3;
+        let sigma_sq = 1.0;
+        let alpha = 0.05;
+        let target_power = 0.80;
+
+        let n_req = required_n_for_power(delta, sigma_sq, target_power, alpha, 50.0, 10_000.0)
+            .unwrap();
+
+        // Verify that the returned n actually achieves the target power.
+        let cp = conditional_power(delta, sigma_sq, n_req, alpha).unwrap();
+        assert!(
+            cp >= target_power - 1e-6,
+            "CP={cp:.4} should be >= target_power={target_power}"
+        );
+    }
+
+    #[test]
+    fn test_required_n_returns_current_if_already_powered() {
+        let n_req = required_n_for_power(2.0, 1.0, 0.80, 0.05, 100.0, 1000.0).unwrap();
+        // With such a large effect, n=100 should already exceed 80% power.
+        assert_eq!(n_req, 100.0, "should return n_current when already powered");
+    }
+
+    #[test]
+    fn test_required_n_caps_at_n_max_allowed() {
+        // With a tiny effect, we can't achieve 80% power within a limited range.
+        let n_req =
+            required_n_for_power(0.001, 1.0, 0.80, 0.05, 100.0, 500.0).unwrap();
+        assert_eq!(n_req, 500.0, "should cap at n_max_allowed");
+    }
+
+    #[test]
+    fn test_required_n_validation_errors() {
+        assert!(required_n_for_power(0.3, 1.0, 0.0, 0.05, 50.0, 1000.0).is_err());
+        assert!(required_n_for_power(0.3, 1.0, 1.0, 0.05, 50.0, 1000.0).is_err());
+        assert!(required_n_for_power(0.3, 1.0, 0.8, 0.05, 50.0, 40.0).is_err()); // max < current
+    }
+
+    // -----------------------------------------------------------------------
+    // gst_reallocate_spending
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_gst_reallocate_boundaries_decrease_obf() {
+        let bounds = gst_reallocate_spending(
+            0.03, // alpha_remaining
+            4,    // additional_looks
+            SpendingFunction::OBrienFleming,
+        )
+        .unwrap();
+        assert_eq!(bounds.len(), 4);
+        // OBF: boundaries should be non-increasing.
+        for i in 1..bounds.len() {
+            assert!(
+                bounds[i] <= bounds[i - 1] + 1e-6,
+                "OBF boundary {} > {} at looks {},{i}",
+                bounds[i],
+                bounds[i - 1],
+                i - 1
+            );
+        }
+    }
+
+    #[test]
+    fn test_gst_reallocate_uses_reduced_alpha() {
+        // Boundaries with alpha_remaining=0.02 should be larger than alpha=0.05.
+        let bounds_small =
+            gst_reallocate_spending(0.02, 3, SpendingFunction::OBrienFleming).unwrap();
+        let bounds_large =
+            gst_reallocate_spending(0.05, 3, SpendingFunction::OBrienFleming).unwrap();
+        // Smaller alpha → more conservative → larger critical values.
+        for (b_small, b_large) in bounds_small.iter().zip(bounds_large.iter()) {
+            assert!(
+                b_small > b_large,
+                "smaller remaining alpha should give larger boundary, got {b_small} <= {b_large}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gst_reallocate_validation_errors() {
+        // alpha_remaining out of range
+        assert!(gst_reallocate_spending(0.0, 3, SpendingFunction::OBrienFleming).is_err());
+        assert!(gst_reallocate_spending(1.0, 3, SpendingFunction::OBrienFleming).is_err());
+        // too few looks
+        assert!(gst_reallocate_spending(0.03, 1, SpendingFunction::OBrienFleming).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // run_interim_analysis
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_run_interim_analysis_promising_zone() {
+        // Generate an experiment where CP is in the promising range.
+        // δ̂ = 0.15, σ² ≈ 1.0, n_max = 200 → should be promising.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(99);
+        let dist = RandNormal::new(0.0_f64, 1.0).unwrap();
+        let mut obs: Vec<f64> = (0..200).map(|_| dist.sample(&mut rng)).collect();
+        // Add a small effect to treatment group (second 100 obs).
+        for x in obs[100..].iter_mut() {
+            *x += 0.15;
+        }
+        let thresholds = ZoneThresholds::default();
+        let result = run_interim_analysis(&obs, 0.15, 200.0, 0.05, &thresholds, 0.80, 1000.0)
+            .unwrap();
+        assert!(result.blinded_variance > 0.0);
+        assert!((0.0..=1.0).contains(&result.conditional_power));
+    }
+
+    #[test]
+    fn test_run_interim_analysis_favourable_no_extension() {
+        // Large effect → favorable → no recommended_n_max.
+        let obs: Vec<f64> = (0..200)
+            .map(|i| if i < 100 { 0.0 } else { 5.0 })
+            .collect();
+        let thresholds = ZoneThresholds::default();
+        let result =
+            run_interim_analysis(&obs, 5.0, 200.0, 0.05, &thresholds, 0.80, 1000.0).unwrap();
+        assert_eq!(result.zone, Zone::Favorable);
+        assert!(result.recommended_n_max.is_none());
+    }
+
+    #[test]
+    fn test_run_interim_analysis_futile_no_extension() {
+        // Near-zero effect → futile → no recommended_n_max.
+        // Use random-looking data with unit variance but essentially zero effect.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(77);
+        let dist = RandNormal::new(0.0_f64, 1.0).unwrap();
+        let obs: Vec<f64> = (0..200).map(|_| dist.sample(&mut rng)).collect();
+        let thresholds = ZoneThresholds::default();
+        // observed_effect = 0.0 → CP = 0.05 (=alpha) → Futile zone.
+        let result =
+            run_interim_analysis(&obs, 0.0, 200.0, 0.05, &thresholds, 0.80, 1000.0).unwrap();
+        assert_eq!(result.zone, Zone::Futile);
+        assert!(result.recommended_n_max.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Type I error control — 10K null simulations
+    // -----------------------------------------------------------------------
+
+    /// Verify that blinded variance re-estimation does not inflate type I error.
+    ///
+    /// Protocol:
+    ///   1. Under H₀ (δ=0), generate n_per_arm obs per arm.
+    ///   2. Compute blinded pooled variance on all 2·n observations.
+    ///   3. Use σ²_B (instead of true σ²) to compute the two-sample z-test.
+    ///   4. Count rejections. Must be ≤ α + 3·SE(α).
+    ///
+    /// The conservative bias of the blinded estimator (σ²_B ≥ σ² under H₀ only
+    /// when there is between-group variance) means using σ²_B in the SE makes
+    /// the test *at most as liberal* as the oracle test.
+    #[test]
+    fn test_type_i_error_blinded_reestimation_null_sims() {
+        const N_SIMS: usize = 10_000;
+        const ALPHA: f64 = 0.05;
+        const N_PER_ARM: usize = 200;
+        const SIGMA_SQ: f64 = 2.0;
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(20240101);
+        let dist = RandNormal::new(0.0_f64, SIGMA_SQ.sqrt()).unwrap();
+        let z_dist = Normal::new(0.0, 1.0).unwrap();
+        let z_crit = z_dist.inverse_cdf(1.0 - ALPHA / 2.0);
+
+        let mut rejections = 0usize;
+
+        for _ in 0..N_SIMS {
+            // Generate under H₀
+            let control: Vec<f64> = (0..N_PER_ARM).map(|_| dist.sample(&mut rng)).collect();
+            let treatment: Vec<f64> = (0..N_PER_ARM).map(|_| dist.sample(&mut rng)).collect();
+
+            // Blind the variance: combine both groups without revealing labels.
+            let mut all_obs = Vec::with_capacity(2 * N_PER_ARM);
+            all_obs.extend_from_slice(&control);
+            all_obs.extend_from_slice(&treatment);
+            let blinded_var = blinded_pooled_variance(&all_obs).unwrap();
+
+            // Two-sample test using blinded SE (conservative denominator).
+            let n = N_PER_ARM as f64;
+            let mean_c = control.iter().sum::<f64>() / n;
+            let mean_t = treatment.iter().sum::<f64>() / n;
+            let effect = mean_t - mean_c;
+            let se = (2.0 * blinded_var / n).sqrt();
+            if se > 0.0 {
+                let z = effect / se;
+                if z.abs() > z_crit {
+                    rejections += 1;
+                }
+            }
+        }
+
+        let empirical_alpha = rejections as f64 / N_SIMS as f64;
+        // Tolerance: alpha ± 3 standard deviations of the Binomial(N_SIMS, alpha)
+        let tolerance = 3.0 * (ALPHA * (1.0 - ALPHA) / N_SIMS as f64).sqrt();
+
+        assert!(
+            empirical_alpha <= ALPHA + tolerance,
+            "type I error {empirical_alpha:.4} exceeds alpha {ALPHA:.4} + 3*SE={:.4}",
+            ALPHA + tolerance
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // proptest invariants
+    // -----------------------------------------------------------------------
+
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Conditional power is always in [0, 1].
+        #[test]
+        fn prop_cp_in_unit_interval(
+            delta in -5.0f64..5.0f64,
+            sigma_sq in 0.1f64..10.0f64,
+            n_max in 10.0f64..1000.0f64,
+            alpha in 0.001f64..0.2f64,
+        ) {
+            let cp = conditional_power(delta, sigma_sq, n_max, alpha).unwrap();
+            prop_assert!((0.0..=1.0).contains(&cp),
+                "CP={cp} out of range for delta={delta}, sigma_sq={sigma_sq}");
+        }
+
+        /// Blinded variance is always positive for any two-or-more obs.
+        #[test]
+        fn prop_blinded_variance_positive(
+            obs in prop::collection::vec(-100.0f64..100.0f64, 2..200),
+        ) {
+            let bv = blinded_pooled_variance(&obs).unwrap();
+            prop_assert!(bv >= 0.0, "blinded variance {bv} was negative");
+        }
+
+        /// Conditional power is symmetric in delta (CP(δ̂) = CP(-δ̂)).
+        #[test]
+        fn prop_cp_symmetric(
+            delta in 0.01f64..5.0f64,
+            sigma_sq in 0.1f64..10.0f64,
+            n_max in 10.0f64..1000.0f64,
+            alpha in 0.001f64..0.2f64,
+        ) {
+            let cp_pos = conditional_power(delta, sigma_sq, n_max, alpha).unwrap();
+            let cp_neg = conditional_power(-delta, sigma_sq, n_max, alpha).unwrap();
+            prop_assert!((cp_pos - cp_neg).abs() < 1e-10,
+                "CP not symmetric: CP(+delta)={cp_pos} ≠ CP(-delta)={cp_neg}");
+        }
+
+        /// Required n is at least n_current and at most n_max_allowed.
+        #[test]
+        fn prop_required_n_in_bounds(
+            delta in 0.05f64..2.0f64,
+            sigma_sq in 0.5f64..5.0f64,
+            target_power in 0.5f64..0.95f64,
+            n_current in 20.0f64..200.0f64,
+        ) {
+            let n_max_allowed = n_current * 5.0;
+            let n_req = required_n_for_power(
+                delta, sigma_sq, target_power, 0.05,
+                n_current, n_max_allowed,
+            ).unwrap();
+            prop_assert!(n_req >= n_current,
+                "required n {n_req} < n_current {n_current}");
+            prop_assert!(n_req <= n_max_allowed,
+                "required n {n_req} > n_max_allowed {n_max_allowed}");
+        }
+    }
+}

--- a/crates/experimentation-stats/src/lib.rs
+++ b/crates/experimentation-stats/src/lib.rs
@@ -17,12 +17,14 @@
 //! - `avlm` — Anytime-Valid Linear Model (AVLM): regression-adjusted confidence sequences (ADR-015)
 //! - `sequential` — mSPRT and Group Sequential Tests
 //! - `evalue` — GROW martingale and AVLM e-values (ADR-018)
+//! - `adaptive_n` — Adaptive sample size: promising-zone design, GST reallocation (ADR-020)
 //! - `multiple_comparison` — Holm-Bonferroni, Benjamini-Hochberg
 //! - `novelty` — Exponential decay fitting for novelty effects
 //! - `interference` — Jensen-Shannon divergence, Jaccard, Gini
 //! - `feedback_loop` — Feedback loop detection: paired t-test, contamination correlation, bias correction (ADR-021)
 //! - `clustering` — Clustered standard errors for session-level experiments
 
+pub mod adaptive_n;
 pub mod avlm;
 pub mod bayesian;
 pub mod bootstrap;

--- a/docs/coordination/status/agent-5-status.md
+++ b/docs/coordination/status/agent-5-status.md
@@ -1,28 +1,34 @@
 # Agent-5 Status — Phase 5
 
 **Module**: M5 Management
-**Last updated**: [date]
+**Last updated**: 2026-03-23
 
 ## Current Sprint
 
-Sprint: 5.0
-Focus: ADR-013 META type, ADR-018 FDR controller, ADR-019 Portfolio, ADR-020 Adaptive N
-Branch: agent-5/feat/[current-work]
+Sprint: 5.2
+Focus: ADR-020 Adaptive Sample Size
+Branch: work/proud-bear
+PR: https://github.com/wunderkennd/kaizen-experimentation/pull/227
 
 ## In Progress
 
-- [ ] [Milestone description] (ADR-XXX)
-  - Blocked by: [none | Agent-M: description]
-  - ETA: [date]
+- [x] ADR-020 Adaptive Sample Size (PR #227, pending merge)
+  - Blocked by: Agent-4 — `ComputeConditionalPower` M4a RPC needed for live wiring
+  - Statistical math complete; M5 scheduler complete; M4a delegation interface defined
 
 ## Completed (Phase 5)
 
-_None yet._
+- [x] ADR-020 Phase 1 — Rust stats module + M5 scheduler (PR #227)
+  - `crates/experimentation-stats/src/adaptive_n.rs`: blinded_pooled_variance, conditional_power, zone_classify, gst_reallocate_spending, required_n_for_power, run_interim_analysis
+  - `sql/migrations/008_adaptive_sample_size_audit.sql`
+  - `services/management/internal/adaptive/`: Trigger, Processor, ConditionalPowerClient interface
 
 ## Blocked
 
-_None._
+- **Agent-4 dependency**: `ConditionalPowerClient` interface at `services/management/internal/adaptive/processor.go:62` needs a gRPC wrapper around M4a's `ComputeConditionalPower` RPC. The contract is defined in the interface — Agent-4 implements the server side.
 
 ## Next Up
 
-- [Next milestone] — depends on: [Agent-Proto schema | none]
+- ADR-013 META experiment type (M5 STARTING validation for MetaExperimentConfig)
+- ADR-018 Phase 2: e-LOND OnlineFdrController singleton + PostgreSQL persistence
+- ADR-019 Portfolio optimization: ExperimentLearning classification, traffic allocation optimizer

--- a/services/management/internal/adaptive/processor.go
+++ b/services/management/internal/adaptive/processor.go
@@ -1,0 +1,314 @@
+// Package adaptive implements the adaptive sample size (ADR-020) interim
+// trigger and zone-classification response logic for M5.
+//
+// # Architecture
+//
+// Statistical computation lives entirely in experimentation-stats (Rust).
+// M5 delegates to M4a via the ConditionalPowerClient interface, which wraps
+// the ComputeConditionalPower RPC (to be implemented by Agent-4). A no-op
+// stub implementation is provided for tests and deployments that do not yet
+// have M4a wired up.
+//
+// Zone responses:
+//   - Favorable  → no action; record in audit table.
+//   - Promising  → update experiment's recommended_n_max in type_config,
+//     insert adaptive_sample_size_audit row with extended=true.
+//   - Futile     → send early-termination recommendation to experiment owner
+//     via audit trail; does NOT auto-conclude.
+package adaptive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/org/experimentation-platform/services/management/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// ConditionalPowerClient — M4a delegation interface
+// ---------------------------------------------------------------------------
+
+// ConditionalPowerRequest is sent to M4a to compute conditional power using
+// the blinded variance estimate and current effect size.
+type ConditionalPowerRequest struct {
+	ExperimentID    string  `json:"experiment_id"`
+	ObservedEffect  float64 `json:"observed_effect"`
+	BlinderVariance float64 `json:"blinded_variance"` // σ²_B
+	NMaxPerArm      float64 `json:"n_max_per_arm"`
+	Alpha           float64 `json:"alpha"`
+}
+
+// ConditionalPowerResponse holds the zone classification returned by M4a.
+type ConditionalPowerResponse struct {
+	ConditionalPower float64 `json:"conditional_power"`
+	Zone             Zone    `json:"zone"` // "favorable" | "promising" | "futile"
+	RecommendedNMax  float64 `json:"recommended_n_max,omitempty"`
+	BlinderVariance  float64 `json:"blinded_variance"`
+}
+
+// Zone is the string tag used in the database and audit trail.
+type Zone string
+
+const (
+	ZoneFavorable Zone = "favorable"
+	ZonePromising Zone = "promising"
+	ZoneFutile    Zone = "futile"
+)
+
+// ConditionalPowerClient abstracts the M4a RPC call so that M5 tests can
+// inject a mock without spinning up a real gRPC server.
+type ConditionalPowerClient interface {
+	// ComputeZone requests conditional power and zone classification from M4a.
+	// Returns an error when M4a is unavailable; callers should treat that as a
+	// soft failure (skip the interim, retry next cycle).
+	ComputeZone(ctx context.Context, req ConditionalPowerRequest) (ConditionalPowerResponse, error)
+}
+
+// ---------------------------------------------------------------------------
+// Processor
+// ---------------------------------------------------------------------------
+
+// InterimTrigger describes a single adaptive-N interim check.
+type InterimTrigger struct {
+	ExperimentID    string
+	NInterimPerArm  float64
+	NMaxPerArm      float64
+	Alpha           float64
+	InterimFraction float64
+}
+
+// ProcessResult summarises the action taken for one interim trigger.
+type ProcessResult struct {
+	ExperimentID     string
+	Zone             Zone
+	ConditionalPower float64
+	RecommendedNMax  float64
+	Extended         bool
+	Skipped          bool
+	SkipReason       string
+}
+
+// Processor executes the zone-classification and side-effects for one
+// adaptive-N interim trigger.
+type Processor struct {
+	pool   *pgxpool.Pool
+	store  *store.ExperimentStore
+	audit  *store.AuditStore
+	client ConditionalPowerClient
+}
+
+// NewProcessor creates a Processor.
+func NewProcessor(
+	pool *pgxpool.Pool,
+	es *store.ExperimentStore,
+	as *store.AuditStore,
+	client ConditionalPowerClient,
+) *Processor {
+	return &Processor{pool: pool, store: es, audit: as, client: client}
+}
+
+// Process runs the full interim analysis for a single trigger.
+//
+// Steps:
+//  1. Read current metric summary from the experiment (blinded variance and
+//     effect estimate must be pre-computed by M3/M4a and stored in type_config
+//     or fetched from metric_results; this implementation reads them from the
+//     trigger payload for now).
+//  2. Delegate to M4a (ConditionalPowerClient) for zone classification.
+//  3. Act on zone: record audit row, optionally extend experiment.
+func (p *Processor) Process(ctx context.Context, trigger InterimTrigger, observedEffect, blindedVariance float64) (ProcessResult, error) {
+	log := slog.With(
+		"experiment_id", trigger.ExperimentID,
+		"n_interim", trigger.NInterimPerArm,
+		"n_max", trigger.NMaxPerArm,
+	)
+
+	// Guard: experiment must still be RUNNING.
+	exp, _, _, err := p.store.GetByID(ctx, trigger.ExperimentID)
+	if err != nil {
+		return skipResult(trigger.ExperimentID, "experiment not found"), nil
+	}
+	if exp.State != "RUNNING" {
+		log.Info("adaptive-N: experiment not RUNNING, skipping", "state", exp.State)
+		return skipResult(trigger.ExperimentID, "not RUNNING"), nil
+	}
+
+	// Delegate to M4a for conditional power and zone classification.
+	resp, err := p.client.ComputeZone(ctx, ConditionalPowerRequest{
+		ExperimentID:    trigger.ExperimentID,
+		ObservedEffect:  observedEffect,
+		BlinderVariance: blindedVariance,
+		NMaxPerArm:      trigger.NMaxPerArm,
+		Alpha:           trigger.Alpha,
+	})
+	if err != nil {
+		log.Error("adaptive-N: M4a delegation failed, skipping", "error", err)
+		return skipResult(trigger.ExperimentID, fmt.Sprintf("M4a unavailable: %v", err)), nil
+	}
+
+	log.Info("adaptive-N: zone classified",
+		"zone", resp.Zone,
+		"conditional_power", resp.ConditionalPower,
+		"recommended_n_max", resp.RecommendedNMax)
+
+	result := ProcessResult{
+		ExperimentID:     trigger.ExperimentID,
+		Zone:             resp.Zone,
+		ConditionalPower: resp.ConditionalPower,
+		RecommendedNMax:  resp.RecommendedNMax,
+	}
+
+	// Insert the audit record.
+	if dbErr := p.insertAuditRow(ctx, trigger, observedEffect, blindedVariance, resp); dbErr != nil {
+		log.Error("adaptive-N: failed to insert audit row", "error", dbErr)
+		// Non-fatal: continue with zone actions.
+	}
+
+	switch resp.Zone {
+	case ZoneFavorable:
+		if auditErr := p.recordAuditTrail(ctx, trigger.ExperimentID, "adaptive_n_favorable", nil); auditErr != nil {
+			log.Warn("adaptive-N: audit trail insert failed", "error", auditErr)
+		}
+
+	case ZonePromising:
+		extended, extErr := p.extendExperiment(ctx, exp, resp.RecommendedNMax)
+		if extErr != nil {
+			log.Error("adaptive-N: experiment extension failed", "error", extErr)
+		}
+		result.Extended = extended
+		details := map[string]any{
+			"zone":              "promising",
+			"conditional_power": resp.ConditionalPower,
+			"recommended_n_max": resp.RecommendedNMax,
+			"extended":          extended,
+		}
+		if auditErr := p.recordAuditTrail(ctx, trigger.ExperimentID, "adaptive_n_promising", details); auditErr != nil {
+			log.Warn("adaptive-N: audit trail insert failed", "error", auditErr)
+		}
+
+	case ZoneFutile:
+		details := map[string]any{
+			"zone":              "futile",
+			"conditional_power": resp.ConditionalPower,
+			"recommendation":    "early_termination",
+			"message":           "Conditional power below 30%. Consider stopping this experiment.",
+		}
+		if auditErr := p.recordAuditTrail(ctx, trigger.ExperimentID, "adaptive_n_futile", details); auditErr != nil {
+			log.Warn("adaptive-N: audit trail insert failed", "error", auditErr)
+		}
+	}
+
+	return result, nil
+}
+
+// extendExperiment records the recommended extension in the experiment's
+// type_config under the "adaptive_n_extension" key.
+//
+// Returns true if the extension was recorded successfully.
+func (p *Processor) extendExperiment(ctx context.Context, exp *store.ExperimentRow, recommendedNMax float64) (bool, error) {
+	if recommendedNMax <= 0 {
+		return false, nil
+	}
+
+	// Parse existing type_config.
+	var tc map[string]json.RawMessage
+	if len(exp.TypeConfig) > 0 {
+		if err := json.Unmarshal(exp.TypeConfig, &tc); err != nil {
+			return false, fmt.Errorf("unmarshal type_config: %w", err)
+		}
+	}
+	if tc == nil {
+		tc = make(map[string]json.RawMessage)
+	}
+
+	// Record extension under "adaptive_n_extension" key.
+	ext := map[string]any{
+		"recommended_n_max": recommendedNMax,
+		"extended_at":       time.Now().UTC().Format(time.RFC3339),
+	}
+	extJSON, err := json.Marshal(ext)
+	if err != nil {
+		return false, fmt.Errorf("marshal extension: %w", err)
+	}
+	tc["adaptive_n_extension"] = extJSON
+
+	newConfig, err := json.Marshal(tc)
+	if err != nil {
+		return false, fmt.Errorf("marshal type_config: %w", err)
+	}
+
+	_, err = p.pool.Exec(ctx,
+		`UPDATE experiments SET type_config = $1, updated_at = NOW() WHERE experiment_id = $2`,
+		newConfig, exp.ExperimentID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("update type_config: %w", err)
+	}
+
+	// Mark the audit row as extended.
+	_, _ = p.pool.Exec(ctx,
+		`UPDATE adaptive_sample_size_audit SET extended = TRUE
+		 WHERE experiment_id = $1
+		 ORDER BY triggered_at DESC LIMIT 1`,
+		exp.ExperimentID,
+	)
+
+	return true, nil
+}
+
+// insertAuditRow writes a row to the adaptive_sample_size_audit table.
+func (p *Processor) insertAuditRow(
+	ctx context.Context,
+	trigger InterimTrigger,
+	observedEffect, blindedVariance float64,
+	resp ConditionalPowerResponse,
+) error {
+	var recNMax *float64
+	if resp.RecommendedNMax > 0 {
+		recNMax = &resp.RecommendedNMax
+	}
+
+	_, err := p.pool.Exec(ctx, `
+		INSERT INTO adaptive_sample_size_audit
+			(experiment_id, interim_fraction, n_interim_per_arm, n_max_per_arm,
+			 observed_effect, blinded_variance, conditional_power, zone,
+			 recommended_n_max, actor)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'adaptive_n_scheduler')`,
+		trigger.ExperimentID,
+		trigger.InterimFraction,
+		trigger.NInterimPerArm,
+		trigger.NMaxPerArm,
+		observedEffect,
+		blindedVariance,
+		resp.ConditionalPower,
+		string(resp.Zone),
+		recNMax,
+	)
+	return err
+}
+
+// recordAuditTrail writes an entry to the existing audit_trail table.
+func (p *Processor) recordAuditTrail(ctx context.Context, experimentID, action string, details map[string]any) error {
+	detailsJSON, _ := json.Marshal(details)
+	return p.audit.Insert(ctx, nil, store.AuditEntry{
+		ExperimentID:  experimentID,
+		Action:        action,
+		ActorEmail:    "adaptive_n_scheduler",
+		PreviousState: "RUNNING",
+		NewState:      "RUNNING",
+		DetailsJSON:   detailsJSON,
+	})
+}
+
+func skipResult(experimentID, reason string) ProcessResult {
+	return ProcessResult{
+		ExperimentID: experimentID,
+		Skipped:      true,
+		SkipReason:   reason,
+	}
+}

--- a/services/management/internal/adaptive/processor.go
+++ b/services/management/internal/adaptive/processor.go
@@ -176,7 +176,7 @@ func (p *Processor) Process(ctx context.Context, trigger InterimTrigger, observe
 		}
 
 	case ZonePromising:
-		extended, extErr := p.extendExperiment(ctx, exp, resp.RecommendedNMax)
+		extended, extErr := p.extendExperiment(ctx, &exp, resp.RecommendedNMax)
 		if extErr != nil {
 			log.Error("adaptive-N: experiment extension failed", "error", extErr)
 		}

--- a/services/management/internal/adaptive/processor_test.go
+++ b/services/management/internal/adaptive/processor_test.go
@@ -1,0 +1,149 @@
+package adaptive_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/org/experimentation-platform/services/management/internal/adaptive"
+)
+
+// ---------------------------------------------------------------------------
+// Stub ConditionalPowerClient for unit tests
+// ---------------------------------------------------------------------------
+
+type stubCPClient struct {
+	resp adaptive.ConditionalPowerResponse
+	err  error
+}
+
+func (s *stubCPClient) ComputeZone(_ context.Context, _ adaptive.ConditionalPowerRequest) (adaptive.ConditionalPowerResponse, error) {
+	return s.resp, s.err
+}
+
+// ---------------------------------------------------------------------------
+// Zone constant validation
+// ---------------------------------------------------------------------------
+
+func TestZoneConstants(t *testing.T) {
+	zones := []adaptive.Zone{
+		adaptive.ZoneFavorable,
+		adaptive.ZonePromising,
+		adaptive.ZoneFutile,
+	}
+	expected := []string{"favorable", "promising", "futile"}
+	for i, z := range zones {
+		if string(z) != expected[i] {
+			t.Errorf("zone[%d] = %q, want %q", i, z, expected[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AdaptiveNConfig JSON round-trip
+// ---------------------------------------------------------------------------
+
+func TestAdaptiveNConfigRoundTrip(t *testing.T) {
+	cfg := map[string]any{
+		"adaptive_n_config": map[string]any{
+			"interim_fraction":         0.5,
+			"n_max_per_arm":            400.0,
+			"alpha":                    0.05,
+			"extension_ceiling":        2.0,
+			"planned_duration_seconds": 1_209_600.0, // 14 days
+			"interim_fired":            false,
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var tc map[string]json.RawMessage
+	if err := json.Unmarshal(data, &tc); err != nil {
+		t.Fatalf("unmarshal outer: %v", err)
+	}
+
+	raw, ok := tc["adaptive_n_config"]
+	if !ok {
+		t.Fatal("adaptive_n_config key missing")
+	}
+
+	type config struct {
+		InterimFraction        float64 `json:"interim_fraction"`
+		NMaxPerArm             float64 `json:"n_max_per_arm"`
+		Alpha                  float64 `json:"alpha"`
+		ExtensionCeiling       float64 `json:"extension_ceiling"`
+		PlannedDurationSeconds float64 `json:"planned_duration_seconds"`
+		InterimFired           bool    `json:"interim_fired"`
+	}
+	var parsed config
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal adaptive_n_config: %v", err)
+	}
+	if parsed.InterimFraction != 0.5 {
+		t.Errorf("interim_fraction = %v, want 0.5", parsed.InterimFraction)
+	}
+	if parsed.NMaxPerArm != 400.0 {
+		t.Errorf("n_max_per_arm = %v, want 400", parsed.NMaxPerArm)
+	}
+	if parsed.InterimFired {
+		t.Error("interim_fired should be false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ProcessResult skip path
+// ---------------------------------------------------------------------------
+
+func TestProcessResultSkipFields(t *testing.T) {
+	r := adaptive.ProcessResult{
+		ExperimentID: "exp-001",
+		Skipped:      true,
+		SkipReason:   "not RUNNING",
+	}
+	if !r.Skipped {
+		t.Error("expected Skipped=true")
+	}
+	if r.SkipReason == "" {
+		t.Error("SkipReason should be non-empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ConditionalPowerRequest field validation
+// ---------------------------------------------------------------------------
+
+func TestConditionalPowerRequestFields(t *testing.T) {
+	req := adaptive.ConditionalPowerRequest{
+		ExperimentID:    "exp-123",
+		ObservedEffect:  0.25,
+		BlinderVariance: 1.5,
+		NMaxPerArm:      400.0,
+		Alpha:           0.05,
+	}
+	if req.ExperimentID == "" {
+		t.Error("ExperimentID must be set")
+	}
+	if req.BlinderVariance <= 0 {
+		t.Error("BlinderVariance must be positive")
+	}
+	if req.Alpha <= 0 || req.Alpha >= 1 {
+		t.Error("Alpha must be in (0,1)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Zone constants are distinct
+// ---------------------------------------------------------------------------
+
+func TestZonesAreDistinct(t *testing.T) {
+	zones := map[adaptive.Zone]struct{}{
+		adaptive.ZoneFavorable: {},
+		adaptive.ZonePromising: {},
+		adaptive.ZoneFutile:    {},
+	}
+	if len(zones) != 3 {
+		t.Error("zone constants are not distinct")
+	}
+}

--- a/services/management/internal/adaptive/trigger.go
+++ b/services/management/internal/adaptive/trigger.go
@@ -1,0 +1,309 @@
+package adaptive
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/org/experimentation-platform/services/management/internal/store"
+)
+
+// AdaptiveNConfig is embedded in experiment.type_config["adaptive_n_config"].
+//
+// JSON key: "adaptive_n_config".
+type AdaptiveNConfig struct {
+	// Fraction of planned duration at which to fire the interim check.
+	// Must be in (0, 1). Typical values: 0.50 (half-way) or 0.67.
+	InterimFraction float64 `json:"interim_fraction"`
+
+	// Original planned per-arm sample size.
+	NMaxPerArm float64 `json:"n_max_per_arm"`
+
+	// Overall significance level for the experiment (typically == experiments.overall_alpha).
+	Alpha float64 `json:"alpha"`
+
+	// Maximum allowed extension factor (n_extended ≤ ExtensionCeiling × NMaxPerArm).
+	// Default: 2.0.
+	ExtensionCeiling float64 `json:"extension_ceiling,omitempty"`
+
+	// Planned duration in seconds. Used to compute the trigger time as
+	// started_at + interim_fraction × planned_duration_seconds.
+	PlannedDurationSeconds float64 `json:"planned_duration_seconds"`
+
+	// Internal: set to true once the interim has fired.
+	InterimFired bool `json:"interim_fired,omitempty"`
+}
+
+// Trigger polls the experiments table on a fixed interval and fires adaptive-N
+// interim analyses for RUNNING experiments that have reached their
+// interim_fraction × planned_duration wall-clock time.
+type Trigger struct {
+	pool      *pgxpool.Pool
+	store     *store.ExperimentStore
+	processor *Processor
+	interval  time.Duration
+	done      chan struct{}
+	cancel    context.CancelFunc
+}
+
+// NewTrigger creates a Trigger. `interval` controls how often the scheduler
+// polls for experiments that need an interim check (default: 1 minute).
+func NewTrigger(pool *pgxpool.Pool, es *store.ExperimentStore, processor *Processor, interval time.Duration) *Trigger {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &Trigger{
+		pool:      pool,
+		store:     es,
+		processor: processor,
+		interval:  interval,
+		done:      make(chan struct{}),
+	}
+}
+
+// Start begins the polling loop in a background goroutine.
+func (t *Trigger) Start(ctx context.Context) {
+	ctx, t.cancel = context.WithCancel(ctx)
+	go t.loop(ctx)
+}
+
+// Stop shuts down the polling loop and waits for it to exit.
+func (t *Trigger) Stop() {
+	if t.cancel != nil {
+		t.cancel()
+	}
+	<-t.done
+}
+
+func (t *Trigger) loop(ctx context.Context) {
+	defer close(t.done)
+	slog.Info("adaptive-N trigger: started", "interval", t.interval)
+
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("adaptive-N trigger: shutting down")
+			return
+		case <-ticker.C:
+			t.scanAndFire(ctx)
+		}
+	}
+}
+
+// scanAndFire queries for all RUNNING experiments with adaptive_n_config
+// set in type_config, then fires any whose interim time has arrived.
+func (t *Trigger) scanAndFire(ctx context.Context) {
+	// Query experiments that are RUNNING and have adaptive_n_config.
+	rows, err := t.pool.Query(ctx, `
+		SELECT experiment_id, type_config, started_at, overall_alpha
+		FROM experiments
+		WHERE state = 'RUNNING'
+		  AND type_config ? 'adaptive_n_config'
+		ORDER BY started_at ASC
+	`)
+	if err != nil {
+		slog.Error("adaptive-N trigger: query failed", "error", err)
+		return
+	}
+	defer rows.Close()
+
+	type candidateRow struct {
+		ExperimentID string
+		TypeConfig   json.RawMessage
+		StartedAt    *time.Time
+		OverallAlpha *float64
+	}
+
+	var candidates []candidateRow
+	for rows.Next() {
+		var r candidateRow
+		if err := rows.Scan(&r.ExperimentID, &r.TypeConfig, &r.StartedAt, &r.OverallAlpha); err != nil {
+			slog.Error("adaptive-N trigger: scan error", "error", err)
+			continue
+		}
+		candidates = append(candidates, r)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("adaptive-N trigger: rows error", "error", err)
+		return
+	}
+
+	now := time.Now().UTC()
+
+	for _, c := range candidates {
+		cfg, err := parseAdaptiveNConfig(c.TypeConfig)
+		if err != nil || cfg == nil {
+			continue
+		}
+
+		// Skip if already fired.
+		if cfg.InterimFired {
+			continue
+		}
+
+		// Compute trigger time: started_at + interim_fraction × planned_duration.
+		if c.StartedAt == nil || cfg.PlannedDurationSeconds <= 0 {
+			continue
+		}
+		triggerAt := c.StartedAt.Add(
+			time.Duration(cfg.InterimFraction*cfg.PlannedDurationSeconds) * time.Second,
+		)
+
+		if now.Before(triggerAt) {
+			continue // Not yet.
+		}
+
+		// Apply default alpha from experiment if not set.
+		alpha := cfg.Alpha
+		if alpha <= 0 && c.OverallAlpha != nil {
+			alpha = *c.OverallAlpha
+		}
+		if alpha <= 0 {
+			alpha = 0.05
+		}
+
+		// Apply default extension ceiling.
+		ceiling := cfg.ExtensionCeiling
+		if ceiling <= 0 {
+			ceiling = 2.0
+		}
+
+		nMaxPerArm := cfg.NMaxPerArm
+
+		trigger := InterimTrigger{
+			ExperimentID:    c.ExperimentID,
+			NInterimPerArm:  estimateCurrentN(c.TypeConfig),
+			NMaxPerArm:      nMaxPerArm,
+			Alpha:           alpha,
+			InterimFraction: cfg.InterimFraction,
+		}
+
+		// Fetch observed effect and blinded variance from the last metric result.
+		// In Sprint 5.2 M4a delegates the actual stats work; here we fall back to
+		// values stored in type_config by M3 metric computation.
+		observedEffect, blindedVariance := fetchMetricStats(c.TypeConfig)
+
+		slog.Info("adaptive-N trigger: firing interim",
+			"experiment_id", c.ExperimentID,
+			"interim_fraction", cfg.InterimFraction,
+			"trigger_at", triggerAt.Format(time.RFC3339),
+		)
+
+		result, err := t.processor.Process(ctx, trigger, observedEffect, blindedVariance)
+		if err != nil {
+			slog.Error("adaptive-N trigger: processor error",
+				"experiment_id", c.ExperimentID, "error", err)
+			continue
+		}
+
+		if result.Skipped {
+			slog.Info("adaptive-N trigger: skipped",
+				"experiment_id", c.ExperimentID, "reason", result.SkipReason)
+			continue
+		}
+
+		// Mark interim as fired so we don't repeat it.
+		if markErr := markInterimFired(ctx, t.pool, c.ExperimentID, c.TypeConfig); markErr != nil {
+			slog.Error("adaptive-N trigger: failed to mark interim fired",
+				"experiment_id", c.ExperimentID, "error", markErr)
+		}
+	}
+}
+
+// parseAdaptiveNConfig extracts the adaptive_n_config object from type_config.
+func parseAdaptiveNConfig(typeConfig json.RawMessage) (*AdaptiveNConfig, error) {
+	if len(typeConfig) == 0 {
+		return nil, nil
+	}
+	var tc map[string]json.RawMessage
+	if err := json.Unmarshal(typeConfig, &tc); err != nil {
+		return nil, err
+	}
+	raw, ok := tc["adaptive_n_config"]
+	if !ok {
+		return nil, nil
+	}
+	var cfg AdaptiveNConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// estimateCurrentN reads n_interim_per_arm from type_config["adaptive_n_current_n"]
+// if set; otherwise returns 0. M3/M4a should populate this before the interim fires.
+func estimateCurrentN(typeConfig json.RawMessage) float64 {
+	var tc map[string]json.RawMessage
+	if err := json.Unmarshal(typeConfig, &tc); err != nil {
+		return 0
+	}
+	raw, ok := tc["adaptive_n_current_n"]
+	if !ok {
+		return 0
+	}
+	var n float64
+	_ = json.Unmarshal(raw, &n)
+	return n
+}
+
+// fetchMetricStats reads the pre-computed observed_effect and blinded_variance
+// from type_config["adaptive_n_metric_stats"]. These are populated by M3/M4a
+// during their metric computation run; if absent, returns zeros which will
+// cause the processor to report to M4a for a real computation.
+func fetchMetricStats(typeConfig json.RawMessage) (observedEffect, blindedVariance float64) {
+	var tc map[string]json.RawMessage
+	if err := json.Unmarshal(typeConfig, &tc); err != nil {
+		return 0, 0
+	}
+	raw, ok := tc["adaptive_n_metric_stats"]
+	if !ok {
+		return 0, 0
+	}
+	var stats struct {
+		ObservedEffect  float64 `json:"observed_effect"`
+		BlinderVariance float64 `json:"blinded_variance"`
+	}
+	_ = json.Unmarshal(raw, &stats)
+	return stats.ObservedEffect, stats.BlinderVariance
+}
+
+// markInterimFired sets adaptive_n_config.interim_fired = true in type_config.
+func markInterimFired(ctx context.Context, pool *pgxpool.Pool, experimentID string, typeConfig json.RawMessage) error {
+	var tc map[string]json.RawMessage
+	if err := json.Unmarshal(typeConfig, &tc); err != nil {
+		return err
+	}
+
+	rawCfg, ok := tc["adaptive_n_config"]
+	if !ok {
+		return nil
+	}
+	var cfg AdaptiveNConfig
+	if err := json.Unmarshal(rawCfg, &cfg); err != nil {
+		return err
+	}
+	cfg.InterimFired = true
+
+	newCfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	tc["adaptive_n_config"] = newCfgJSON
+
+	newTypeConfig, err := json.Marshal(tc)
+	if err != nil {
+		return err
+	}
+
+	_, err = pool.Exec(ctx,
+		`UPDATE experiments SET type_config = $1, updated_at = NOW() WHERE experiment_id = $2`,
+		newTypeConfig, experimentID,
+	)
+	return err
+}

--- a/sql/migrations/008_adaptive_sample_size_audit.sql
+++ b/sql/migrations/008_adaptive_sample_size_audit.sql
@@ -1,0 +1,35 @@
+-- ============================================================================
+-- ADR-020: Adaptive Sample Size Recalculation
+--
+-- Tracks every interim analysis trigger and the resulting zone classification
+-- / extension decision. One row per trigger event (not per experiment).
+-- ============================================================================
+
+CREATE TABLE adaptive_sample_size_audit (
+    id                  BIGSERIAL PRIMARY KEY,
+    experiment_id       UUID    NOT NULL REFERENCES experiments(experiment_id) ON DELETE CASCADE,
+
+    -- When the interim check fired.
+    triggered_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Inputs to the conditional-power computation.
+    interim_fraction    DOUBLE PRECISION NOT NULL,
+    n_interim_per_arm   DOUBLE PRECISION NOT NULL,
+    n_max_per_arm       DOUBLE PRECISION NOT NULL,
+    observed_effect     DOUBLE PRECISION NOT NULL,
+    blinded_variance    DOUBLE PRECISION NOT NULL,
+
+    -- Outputs of the computation.
+    conditional_power   DOUBLE PRECISION NOT NULL CHECK (conditional_power BETWEEN 0 AND 1),
+    zone                TEXT NOT NULL CHECK (zone IN ('favorable', 'promising', 'futile')),
+
+    -- For promising zone: recommended extension.
+    recommended_n_max   DOUBLE PRECISION,   -- NULL when zone != 'promising'
+    extended            BOOLEAN NOT NULL DEFAULT FALSE,
+
+    -- Who/what triggered this (e.g. "adaptive_n_scheduler").
+    actor               TEXT NOT NULL DEFAULT 'adaptive_n_scheduler'
+);
+
+CREATE INDEX idx_adaptive_n_audit_experiment_id
+    ON adaptive_sample_size_audit (experiment_id, triggered_at DESC);


### PR DESCRIPTION
## Summary

- **`crates/experimentation-stats/src/adaptive_n.rs`** (new): Full promising-zone adaptive design implementation — blinded pooled variance (Gould-Shih 1992), conditional power (Mehta-Pocock 2011), zone classification (Favorable/Promising/Futile), required-n binary search, GST spending reallocation (Müller-Schäfer 2001).
- **`crates/experimentation-stats/src/lib.rs`**: Added `pub mod adaptive_n`.
- **`sql/migrations/008_adaptive_sample_size_audit.sql`** (new): Audit table for every interim trigger event.
- **`services/management/internal/adaptive/`** (new): M5 scheduler (`Trigger`) and zone-response handler (`Processor`) with `ConditionalPowerClient` interface for M4a delegation.

## Statistical Correctness

- **Type I error**: 10K null simulations confirm empirical α ≤ 0.05 + 3·SE (test: `test_type_i_error_blinded_reestimation_null_sims`).
- **Fail-fast**: All float paths use `assert_finite!()`.
- **Proptest invariants**: CP in [0,1]; blinded variance ≥ 0; CP symmetric; required-n bounded.
- **GST reallocation**: Delegates to existing recursive Armitage-McPherson-Rowe algorithm via `gst_boundaries(additional_looks, alpha_remaining, spending)`.

## Test Results

```
cargo test -p experimentation-stats adaptive_n
test result: ok. 27 passed; 0 failed; 0 ignored
```

Full workspace: `cargo test --workspace` — all green.

## Agent-4 Integration Point

`services/management/internal/adaptive/processor.go:ConditionalPowerClient` (line 62) needs a real gRPC wrapper around M4a's `ComputeConditionalPower` RPC. Contract:
- Request: `experiment_id`, `observed_effect`, `blinded_variance`, `n_max_per_arm`, `alpha`
- Response: `conditional_power`, `zone` (`"favorable"|"promising"|"futile"`), `recommended_n_max`

## Go Build Note

`gen/go/go.mod` is absent (pre-existing repo issue); Go syntax verified with `gofmt`. All Go files format cleanly.

## Test plan

- [x] `cargo test -p experimentation-stats adaptive_n` — 27/27 pass
- [x] `cargo test --workspace` — all green
- [x] `gofmt -l` on all Go files — no formatting issues
- [ ] Integration: requires `gen/go/go.mod` (pre-existing blocker)
- [ ] M4a `ComputeConditionalPower` RPC wiring (Agent-4 dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
