### PR TITLE
feat(m5,fdr): ADR-018 Phase 2 e-LOND OnlineFdrController

### DIFF
--- a/docs/coordination/status/agent-5-status.md
+++ b/docs/coordination/status/agent-5-status.md
@@ -5,16 +5,21 @@
 
 ## Current Sprint
 
-Sprint: 5.2
-Focus: ADR-020 Adaptive Sample Size
-Branch: work/proud-bear
-PR: https://github.com/wunderkennd/kaizen-experimentation/pull/227
+Sprint: 5.3
+Focus: ADR-018 Phase 2 — e-LOND OnlineFdrController
+Branch: work/witty-badger
+PR: (pending)
 
 ## In Progress
 
-- [x] ADR-020 Adaptive Sample Size (PR #227, pending merge)
-  - Blocked by: Agent-4 — `ComputeConditionalPower` M4a RPC needed for live wiring
-  - Statistical math complete; M5 scheduler complete; M4a delegation interface defined
+- [x] ADR-018 Phase 2 — e-LOND OnlineFdrController (this PR)
+  - `sql/migrations/009_online_fdr_controller_state.sql`
+  - `services/management/internal/fdr/controller.go` — Controller singleton
+  - `services/management/internal/fdr/controller_test.go` — 11 unit tests
+  - `services/management/internal/handlers/service.go` — WithPool, WithFdrController options
+  - `services/management/internal/handlers/conclude.go` — submitFdrDecision (best-effort)
+  - `services/management/internal/handlers/lifecycle.go` — wire into concludeByID
+  - `services/management/cmd/main.go` — ONLINE_FDR_ENABLED env var gate
 
 ## Completed (Phase 5)
 
@@ -23,12 +28,21 @@ PR: https://github.com/wunderkennd/kaizen-experimentation/pull/227
   - `sql/migrations/008_adaptive_sample_size_audit.sql`
   - `services/management/internal/adaptive/`: Trigger, Processor, ConditionalPowerClient interface
 
+- [x] ADR-018 Phase 2 — e-LOND OnlineFdrController (this PR)
+  - Platform-level singleton persisted in PostgreSQL (migration 009)
+  - e-LOND geometric-decay alpha wealth management
+  - SELECT FOR UPDATE serializes concurrent conclude calls
+  - Best-effort integration at CONCLUDED transition; never blocks conclusion
+  - Opt-in via ONLINE_FDR_ENABLED=true environment variable
+
 ## Blocked
 
-- **Agent-4 dependency**: `ConditionalPowerClient` interface at `services/management/internal/adaptive/processor.go:62` needs a gRPC wrapper around M4a's `ComputeConditionalPower` RPC. The contract is defined in the interface — Agent-4 implements the server side.
+- **Agent-4 dependency**: `ConditionalPowerClient` interface at
+  `services/management/internal/adaptive/processor.go:62` needs a gRPC
+  wrapper around M4a's `ComputeConditionalPower` RPC. The contract is
+  defined in the interface — Agent-4 implements the server side.
 
 ## Next Up
 
 - ADR-013 META experiment type (M5 STARTING validation for MetaExperimentConfig)
-- ADR-018 Phase 2: e-LOND OnlineFdrController singleton + PostgreSQL persistence
 - ADR-019 Portfolio optimization: ExperimentLearning classification, traffic allocation optimizer

--- a/services/management/cmd/main.go
+++ b/services/management/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
 
 	"github.com/org/experimentation-platform/services/management/internal/auth"
+	"github.com/org/experimentation-platform/services/management/internal/fdr"
 	"github.com/org/experimentation-platform/services/management/internal/guardrail"
 	"github.com/org/experimentation-platform/services/management/internal/handlers"
 	"github.com/org/experimentation-platform/services/management/internal/metrics"
@@ -98,6 +99,15 @@ func main() {
 		slog.Info("surrogate recalibration publisher configured", "topic", surrogate.Topic)
 	}
 	defer surrogatePub.Close()
+
+	// e-LOND Online FDR controller (ADR-018 Phase 2).
+	// Enabled when ONLINE_FDR_ENABLED=true. The migration 009 must be applied.
+	if os.Getenv("ONLINE_FDR_ENABLED") == "true" {
+		fdrController := fdr.NewController(pool)
+		serviceOpts = append(serviceOpts, handlers.WithFdrController(fdrController))
+		serviceOpts = append(serviceOpts, handlers.WithPool(pool))
+		slog.Info("e-LOND Online FDR controller enabled (ADR-018 Phase 2)")
+	}
 
 	// Service handlers (created before consumers because sequential consumer uses expSvc as Concluder).
 	expSvc := handlers.NewExperimentService(experimentStore, auditStore, layerStore, metricStore, targetingStore, surrogateStore, notifier, serviceOpts...)

--- a/services/management/internal/fdr/controller.go
+++ b/services/management/internal/fdr/controller.go
@@ -1,0 +1,221 @@
+// Package fdr implements the e-LOND Online FDR Controller (ADR-018 Phase 2).
+//
+// # Algorithm
+//
+// e-LOND (Xu and Ramdas, AISTATS 2024) controls the false discovery rate across
+// a stream of experiments under arbitrary dependence. The controller is a
+// platform-level singleton: every time an experiment concludes, its primary
+// metric's e-value is submitted via [Controller.Test], which returns a
+// reject / don't-reject decision while maintaining FDR ≤ alpha.
+//
+// # Wealth Management
+//
+// Alpha wealth W_t tracks the remaining budget for future rejections:
+//
+//	W_0 = alpha  (initial wealth)
+//	W_t = W_{t-1} − alpha_t + alpha · 1[reject_t]
+//
+// At each step t the allocation is:
+//
+//	gamma_t    = (1 − gamma_decay) · gamma_decay^(t−1)
+//	alpha_t    = W_{t-1} · gamma_t
+//
+// Rejection rule: reject H_t when E_t ≥ 1/alpha_t.
+//
+// gamma_t is a geometric sequence that sums to 1 over all t. Alpha wealth
+// decays toward 0 without rejections and recovers by +alpha per rejection.
+// Setting gamma_decay close to 1 (e.g. 0.90) gives a slow decay suitable
+// for platforms running many experiments.
+//
+// # Persistence
+//
+// State is persisted in the online_fdr_controller_state table (migration 009).
+// Each [Controller.Test] call wraps the read-modify-write in a transaction
+// with SELECT FOR UPDATE, serializing concurrent conclude operations. Each
+// decision is also appended to fdr_decisions for auditability.
+package fdr
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Decision is the output of [Controller.Test].
+type Decision struct {
+	// Rejected is true when the e-value crossed the rejection threshold:
+	// E_t >= 1/alpha_allocated.
+	Rejected bool
+
+	// AlphaAllocated is the level alpha_t used for this test.
+	// Zero if alpha wealth was depleted before this call.
+	AlphaAllocated float64
+
+	// WealthBefore is the alpha wealth before this test.
+	WealthBefore float64
+
+	// WealthAfter is the alpha wealth after this test (and any replenishment).
+	WealthAfter float64
+
+	// NumTested is the total number of hypotheses tested after this call.
+	NumTested int64
+
+	// NumRejected is the total number of rejections after this call.
+	NumRejected int64
+}
+
+// State mirrors the persistent row in online_fdr_controller_state.
+type State struct {
+	Alpha       float64
+	GammaDecay  float64
+	NumTested   int64
+	NumRejected int64
+	AlphaWealth float64
+}
+
+// Controller is the platform-level e-LOND Online FDR controller.
+// It is backed by the online_fdr_controller_state singleton in PostgreSQL.
+//
+// Use [NewController] to create a Controller. The migration 009 must have
+// been applied before any call to [Controller.Test].
+type Controller struct {
+	pool *pgxpool.Pool
+}
+
+// NewController creates a Controller backed by the given connection pool.
+func NewController(pool *pgxpool.Pool) *Controller {
+	return &Controller{pool: pool}
+}
+
+// Test submits an e-value for a concluded experiment and returns the FDR
+// decision. The call is fully transactional:
+//  1. SELECT FOR UPDATE on the singleton state row.
+//  2. Compute geometric-decay allocation alpha_t.
+//  3. Reject when e_value >= 1/alpha_t.
+//  4. Checkpoint updated state back to the singleton row.
+//  5. Append a row to fdr_decisions.
+//  6. Commit.
+//
+// If alpha_wealth is effectively zero (< 1e-15), the test is recorded with
+// Rejected=false and AlphaAllocated=0 to avoid division-by-zero.
+func (c *Controller) Test(ctx context.Context, experimentID string, eValue float64) (Decision, error) {
+	tx, err := c.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return Decision{}, fmt.Errorf("fdr: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Load and lock the singleton row.
+	var s State
+	err = tx.QueryRow(ctx, `
+		SELECT alpha, gamma_decay, num_tested, num_rejected, alpha_wealth
+		FROM online_fdr_controller_state
+		WHERE id = 1
+		FOR UPDATE
+	`).Scan(&s.Alpha, &s.GammaDecay, &s.NumTested, &s.NumRejected, &s.AlphaWealth)
+	if err != nil {
+		return Decision{}, fmt.Errorf("fdr: load state: %w", err)
+	}
+
+	wealthBefore := s.AlphaWealth
+
+	var alphaAllocated float64
+	var rejected bool
+
+	if s.AlphaWealth >= 1e-15 {
+		// Geometric-decay allocation:
+		//   t          = num_tested + 1  (1-indexed step)
+		//   gamma_t    = (1 − gamma_decay) · gamma_decay^(t−1)
+		//   alpha_t    = alpha_wealth · gamma_t
+		t := s.NumTested + 1
+		gammaT := (1.0 - s.GammaDecay) * math.Pow(s.GammaDecay, float64(t-1))
+		alphaAllocated = s.AlphaWealth * gammaT
+
+		// Rejection rule: reject when E_t >= 1 / alpha_t.
+		rejected = alphaAllocated > 1e-300 && eValue >= 1.0/alphaAllocated
+	} else {
+		slog.Warn("fdr: alpha wealth depleted, skipping test",
+			"experiment_id", experimentID,
+			"num_tested", s.NumTested,
+		)
+	}
+
+	// Update state.
+	s.NumTested++
+	s.AlphaWealth -= alphaAllocated
+	if rejected {
+		s.NumRejected++
+		s.AlphaWealth += s.Alpha // replenish on rejection
+	}
+	// Clamp to prevent floating-point drift below zero.
+	if s.AlphaWealth < 0 {
+		s.AlphaWealth = 0
+	}
+
+	// Checkpoint singleton state.
+	_, err = tx.Exec(ctx, `
+		UPDATE online_fdr_controller_state
+		SET num_tested   = $1,
+		    num_rejected = $2,
+		    alpha_wealth = $3,
+		    updated_at   = NOW()
+		WHERE id = 1
+	`, s.NumTested, s.NumRejected, s.AlphaWealth)
+	if err != nil {
+		return Decision{}, fmt.Errorf("fdr: checkpoint state: %w", err)
+	}
+
+	// Record the per-experiment decision.
+	_, err = tx.Exec(ctx, `
+		INSERT INTO fdr_decisions
+			(experiment_id, e_value, alpha_allocated, rejected,
+			 wealth_before, wealth_after, num_tested_at, num_rejected_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, experimentID, eValue, alphaAllocated, rejected,
+		wealthBefore, s.AlphaWealth, s.NumTested, s.NumRejected)
+	if err != nil {
+		return Decision{}, fmt.Errorf("fdr: record decision: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Decision{}, fmt.Errorf("fdr: commit: %w", err)
+	}
+
+	slog.Info("fdr: decision",
+		"experiment_id", experimentID,
+		"e_value", eValue,
+		"alpha_allocated", alphaAllocated,
+		"rejected", rejected,
+		"wealth_before", wealthBefore,
+		"wealth_after", s.AlphaWealth,
+		"num_tested", s.NumTested,
+		"num_rejected", s.NumRejected,
+	)
+
+	return Decision{
+		Rejected:       rejected,
+		AlphaAllocated: alphaAllocated,
+		WealthBefore:   wealthBefore,
+		WealthAfter:    s.AlphaWealth,
+		NumTested:      s.NumTested,
+		NumRejected:    s.NumRejected,
+	}, nil
+}
+
+// GetState returns a snapshot of the current controller state (no lock).
+func (c *Controller) GetState(ctx context.Context) (State, error) {
+	var s State
+	err := c.pool.QueryRow(ctx, `
+		SELECT alpha, gamma_decay, num_tested, num_rejected, alpha_wealth
+		FROM online_fdr_controller_state
+		WHERE id = 1
+	`).Scan(&s.Alpha, &s.GammaDecay, &s.NumTested, &s.NumRejected, &s.AlphaWealth)
+	if err != nil {
+		return State{}, fmt.Errorf("fdr: get state: %w", err)
+	}
+	return s, nil
+}

--- a/services/management/internal/fdr/controller.go
+++ b/services/management/internal/fdr/controller.go
@@ -37,6 +37,7 @@ package fdr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -103,6 +104,13 @@ func NewController(pool *pgxpool.Pool) *Controller {
 // If alpha_wealth is effectively zero (< 1e-15), the test is recorded with
 // Rejected=false and AlphaAllocated=0 to avoid division-by-zero.
 func (c *Controller) Test(ctx context.Context, experimentID string, eValue float64) (Decision, error) {
+	// E-values must be finite and non-negative. They are likelihood ratios and
+	// are undefined (or degenerate) outside [0, +∞). Reject NaN/Inf/-Inf early
+	// to avoid silent mis-classification or division anomalies inside the tx.
+	if math.IsNaN(eValue) || math.IsInf(eValue, -1) || eValue < 0 {
+		return Decision{}, fmt.Errorf("fdr: invalid e-value %v: must be finite and non-negative", eValue)
+	}
+
 	tx, err := c.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return Decision{}, fmt.Errorf("fdr: begin tx: %w", err)
@@ -118,6 +126,9 @@ func (c *Controller) Test(ctx context.Context, experimentID string, eValue float
 		FOR UPDATE
 	`).Scan(&s.Alpha, &s.GammaDecay, &s.NumTested, &s.NumRejected, &s.AlphaWealth)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Decision{}, fmt.Errorf("fdr: controller state row not found — has migration 009 been applied?")
+		}
 		return Decision{}, fmt.Errorf("fdr: load state: %w", err)
 	}
 
@@ -215,6 +226,9 @@ func (c *Controller) GetState(ctx context.Context) (State, error) {
 		WHERE id = 1
 	`).Scan(&s.Alpha, &s.GammaDecay, &s.NumTested, &s.NumRejected, &s.AlphaWealth)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return State{}, fmt.Errorf("fdr: controller state row not found — has migration 009 been applied?")
+		}
 		return State{}, fmt.Errorf("fdr: get state: %w", err)
 	}
 	return s, nil

--- a/services/management/internal/fdr/controller_test.go
+++ b/services/management/internal/fdr/controller_test.go
@@ -1,0 +1,229 @@
+package fdr_test
+
+import (
+	"math"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Pure-logic unit tests (no database required).
+//
+// These tests exercise the e-LOND allocation and rejection math by replicating
+// the Controller.Test logic in plain Go, so they run without a real PostgreSQL
+// instance.
+// ---------------------------------------------------------------------------
+
+// elondStep models one step of the e-LOND controller (mirrors Controller.Test).
+type elondStep struct {
+	alpha      float64
+	gammaDecay float64
+}
+
+func (e elondStep) allocate(numTested int64, wealth float64) float64 {
+	if wealth < 1e-15 {
+		return 0
+	}
+	t := numTested + 1
+	gammaT := (1.0 - e.gammaDecay) * math.Pow(e.gammaDecay, float64(t-1))
+	return wealth * gammaT
+}
+
+func (e elondStep) reject(eValue, alphaAllocated float64) bool {
+	return alphaAllocated > 1e-300 && eValue >= 1.0/alphaAllocated
+}
+
+func (e elondStep) updateWealth(wealth, alphaAllocated float64, rejected bool) float64 {
+	wealth -= alphaAllocated
+	if rejected {
+		wealth += e.alpha
+	}
+	if wealth < 0 {
+		wealth = 0
+	}
+	return wealth
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestELond_InitialAllocation(t *testing.T) {
+	// With default alpha=0.05, gamma_decay=0.9, num_tested=0, wealth=0.05:
+	//   t = 1
+	//   gamma_1 = (1 - 0.9) * 0.9^0 = 0.1
+	//   alpha_1 = 0.05 * 0.1 = 0.005
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	got := e.allocate(0, 0.05)
+	want := 0.005
+	if math.Abs(got-want) > 1e-12 {
+		t.Fatalf("allocate(t=1): got %v, want %v", got, want)
+	}
+}
+
+func TestELond_RejectionThreshold(t *testing.T) {
+	// alpha_1 = 0.005, so rejection threshold = 1/0.005 = 200.
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	alloc := e.allocate(0, 0.05)
+	threshold := 1.0 / alloc // = 200
+
+	if e.reject(threshold-1e-9, alloc) {
+		t.Error("should not reject below threshold")
+	}
+	if !e.reject(threshold, alloc) {
+		t.Error("should reject at threshold")
+	}
+	if !e.reject(threshold+1, alloc) {
+		t.Error("should reject above threshold")
+	}
+}
+
+func TestELond_WealthDecreasesOnNonRejection(t *testing.T) {
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	wealth := 0.05
+	alloc := e.allocate(0, wealth)
+	newWealth := e.updateWealth(wealth, alloc, false)
+
+	if newWealth >= wealth {
+		t.Fatalf("wealth should decrease: before=%v after=%v", wealth, newWealth)
+	}
+	want := wealth - alloc
+	if math.Abs(newWealth-want) > 1e-12 {
+		t.Fatalf("wealth after non-rejection: got %v want %v", newWealth, want)
+	}
+}
+
+func TestELond_WealthReplenishedOnRejection(t *testing.T) {
+	// On rejection, wealth decreases by alpha_t but gains alpha back.
+	// Net change = alpha - alpha_t (positive when alpha_t < alpha).
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	wealth := 0.05
+	alloc := e.allocate(0, wealth) // 0.005 < alpha(0.05)
+	newWealth := e.updateWealth(wealth, alloc, true)
+
+	want := wealth - alloc + e.alpha // = 0.05 - 0.005 + 0.05 = 0.095
+	if math.Abs(newWealth-want) > 1e-12 {
+		t.Fatalf("wealth after rejection: got %v want %v", newWealth, want)
+	}
+	if newWealth <= wealth {
+		t.Errorf("wealth should increase on rejection when alloc < alpha: before=%v after=%v", wealth, newWealth)
+	}
+}
+
+func TestELond_GeometricDecayAcrossSteps(t *testing.T) {
+	// Allocations should follow geometric decay: alpha_t = W_{t-1} * (1-r) * r^(t-1)
+	// where W_{t-1} is the wealth before step t.
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	wealth := 0.05
+
+	// Simulate 3 consecutive non-rejections.
+	allocs := make([]float64, 3)
+	for i := int64(0); i < 3; i++ {
+		alloc := e.allocate(i, wealth)
+		allocs[i] = alloc
+		wealth = e.updateWealth(wealth, alloc, false)
+	}
+
+	// gamma_1=0.1, gamma_2=0.09, gamma_3=0.081 — ratio between gammas = 0.9.
+	// But allocations also depend on declining wealth, so the exact ratio differs.
+	// Just verify they are all positive and decreasing.
+	for i := 1; i < 3; i++ {
+		if allocs[i] >= allocs[i-1] {
+			t.Errorf("allocation should decrease: allocs[%d]=%v >= allocs[%d]=%v",
+				i, allocs[i], i-1, allocs[i-1])
+		}
+	}
+}
+
+func TestELond_DepletedWealthSkipsTest(t *testing.T) {
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	alloc := e.allocate(0, 0) // wealth=0
+	if alloc != 0 {
+		t.Errorf("allocate with zero wealth: got %v want 0", alloc)
+	}
+	// Should not reject if alpha_allocated=0.
+	if e.reject(1e30, 0) {
+		t.Error("should not reject when alpha_allocated=0")
+	}
+}
+
+func TestELond_HighEValueEventuallyRejects(t *testing.T) {
+	// An e-value of 1000 should trigger rejection at the first step
+	// when alpha_1 = 0.005 and threshold = 200.
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	alloc := e.allocate(0, 0.05)
+	if !e.reject(1000, alloc) {
+		t.Errorf("e_value=1000 should reject (threshold=%.1f)", 1.0/alloc)
+	}
+}
+
+func TestELond_FdrControl_ManyNonRejections(t *testing.T) {
+	// After many non-rejections, wealth decreases monotonically and converges
+	// to a positive limit (it does NOT go to zero). With gamma_decay=0.9:
+	//   W_t = W_{t-1} * (1 - gamma_t)
+	//   prod_{t→∞}(1 - gamma_t) converges to a positive value because
+	//   sum(gamma_t) < ∞ (geometric series). Empirically, W_∞ ≈ 0.36 * W_0.
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	wealth := 0.05
+	prev := wealth
+	for i := int64(0); i < 200; i++ {
+		alloc := e.allocate(i, wealth)
+		wealth = e.updateWealth(wealth, alloc, false)
+		if wealth < 0 {
+			t.Fatalf("wealth went negative at step %d: %v", i, wealth)
+		}
+		if wealth > prev {
+			t.Fatalf("wealth increased without rejection at step %d: prev=%v cur=%v", i, prev, wealth)
+		}
+		prev = wealth
+	}
+	// After 200 steps, wealth should have converged (changed < 1e-10 between steps 199 and 200).
+	alloc200 := e.allocate(200, wealth)
+	change := alloc200 / wealth
+	if change > 1e-10 {
+		// Still measurable change — that's ok, just verify it's positive.
+	}
+	if wealth <= 0 {
+		t.Errorf("wealth should remain positive after 200 non-rejections, got %v", wealth)
+	}
+}
+
+func TestELond_WealthBoundedAboveByAlphaMultiple(t *testing.T) {
+	// With many rejections, wealth grows but should never be negative.
+	// Verify non-negativity invariant.
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	wealth := 0.05
+	for i := int64(0); i < 50; i++ {
+		alloc := e.allocate(i, wealth)
+		// Simulate rejection every step (best-case scenario).
+		wealth = e.updateWealth(wealth, alloc, true)
+		if wealth < 0 {
+			t.Fatalf("wealth negative at step %d: %v", i, wealth)
+		}
+	}
+}
+
+func TestELond_AllocateStepOne_Manual(t *testing.T) {
+	// Manual: alpha=0.05, gamma_decay=0.5, t=1
+	//   gamma_1 = (1-0.5)*0.5^0 = 0.5
+	//   alpha_1 = 0.05 * 0.5 = 0.025
+	e := elondStep{alpha: 0.05, gammaDecay: 0.5}
+	got := e.allocate(0, 0.05)
+	want := 0.025
+	if math.Abs(got-want) > 1e-12 {
+		t.Fatalf("gamma_decay=0.5 step 1: got %v want %v", got, want)
+	}
+}
+
+func TestELond_AllocateStepTwo_Manual(t *testing.T) {
+	// Manual: alpha=0.05, gamma_decay=0.5, t=2, wealth after step 1 (no rejection)
+	//   alloc_1 = 0.025 → wealth_1 = 0.05 - 0.025 = 0.025
+	//   gamma_2 = (1-0.5)*0.5^1 = 0.25
+	//   alpha_2 = 0.025 * 0.25 = 0.00625
+	e := elondStep{alpha: 0.05, gammaDecay: 0.5}
+	wealth1 := e.updateWealth(0.05, 0.025, false) // = 0.025
+	got := e.allocate(1, wealth1)
+	want := 0.00625
+	if math.Abs(got-want) > 1e-12 {
+		t.Fatalf("gamma_decay=0.5 step 2: got %v want %v", got, want)
+	}
+}

--- a/services/management/internal/fdr/controller_test.go
+++ b/services/management/internal/fdr/controller_test.go
@@ -227,3 +227,41 @@ func TestELond_AllocateStepTwo_Manual(t *testing.T) {
 		t.Fatalf("gamma_decay=0.5 step 2: got %v want %v", got, want)
 	}
 }
+
+func TestELond_NegativeEValueDoesNotReject(t *testing.T) {
+	// E-values are non-negative by definition (they are likelihood ratios).
+	// A negative e-value must never trigger a rejection — the comparison
+	// eValue >= 1/alphaAllocated is false for any negative input when the
+	// threshold is positive (as it always is when alphaAllocated > 0).
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	alloc := e.allocate(0, 0.05) // > 0
+	if e.reject(-1.0, alloc) {
+		t.Error("negative e-value must not trigger rejection")
+	}
+	if e.reject(-1e10, alloc) {
+		t.Error("large negative e-value must not trigger rejection")
+	}
+}
+
+func TestELond_NaNEValueDoesNotReject(t *testing.T) {
+	// NaN comparisons always return false in Go, so a NaN e-value never
+	// crosses the threshold. Controller.Test() now rejects NaN inputs with
+	// an error before reaching the DB, but the pure reject() logic is also
+	// safe (documents the invariant).
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	alloc := e.allocate(0, 0.05)
+	if e.reject(math.NaN(), alloc) {
+		t.Error("NaN e-value must not trigger rejection")
+	}
+}
+
+func TestELond_PositiveInfEValueRejects(t *testing.T) {
+	// +Inf is a valid (extreme) e-value — an infinite likelihood ratio is a
+	// certain rejection. Controller.Test() permits +Inf because e-values in
+	// [0, +∞] are mathematically valid; the rejection rule correctly fires.
+	e := elondStep{alpha: 0.05, gammaDecay: 0.9}
+	alloc := e.allocate(0, 0.05) // threshold = 1/0.005 = 200
+	if !e.reject(math.Inf(1), alloc) {
+		t.Error("+Inf e-value should trigger rejection")
+	}
+}

--- a/services/management/internal/handlers/conclude.go
+++ b/services/management/internal/handlers/conclude.go
@@ -13,6 +13,60 @@ import (
 	"github.com/org/experimentation-platform/services/management/internal/store"
 )
 
+// submitFdrDecision reads the primary metric's e-value from metric_results and
+// submits it to the e-LOND Online FDR controller (ADR-018 Phase 2).
+//
+// The call is best-effort: any error is logged and silently dropped so that
+// experiment conclusion is never blocked by FDR controller failures.
+func (s *ExperimentService) submitFdrDecision(ctx context.Context, experimentID, primaryMetricID string) {
+	if s.fdrController == nil || s.pool == nil {
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	// Read the most-recently computed e-value for the primary metric.
+	// M4a stores results in metric_results after RunAnalysis completes.
+	var eValue float64
+	err := s.pool.QueryRow(callCtx, `
+		SELECT e_value
+		FROM   metric_results
+		WHERE  experiment_id = $1
+		  AND  metric_id     = $2
+		  AND  e_value IS NOT NULL
+		ORDER  BY computed_at DESC
+		LIMIT  1
+	`, experimentID, primaryMetricID).Scan(&eValue)
+	if err != nil {
+		slog.Warn("fdr: primary metric e-value not available, skipping FDR submission",
+			"experiment_id", experimentID,
+			"metric_id", primaryMetricID,
+			"error", err,
+		)
+		return
+	}
+
+	decision, err := s.fdrController.Test(callCtx, experimentID, eValue)
+	if err != nil {
+		slog.Error("fdr: controller.Test failed",
+			"experiment_id", experimentID,
+			"e_value", eValue,
+			"error", err,
+		)
+		return
+	}
+
+	slog.Info("fdr: experiment submitted to e-LOND controller",
+		"experiment_id", experimentID,
+		"e_value", eValue,
+		"rejected", decision.Rejected,
+		"alpha_allocated", decision.AlphaAllocated,
+		"wealth_after", decision.WealthAfter,
+		"num_tested", decision.NumTested,
+	)
+}
+
 // analysisTypeForExperiment maps experiment type to the analysis method used at conclude time.
 func analysisTypeForExperiment(expType string) string {
 	switch expType {

--- a/services/management/internal/handlers/lifecycle.go
+++ b/services/management/internal/handlers/lifecycle.go
@@ -289,6 +289,10 @@ func (s *ExperimentService) concludeByID(ctx context.Context, id, actor string, 
 		for k, v := range concludeDetails {
 			extraDetails[k] = v
 		}
+
+		// Submit primary metric e-value to the e-LOND Online FDR controller
+		// (ADR-018 Phase 2). Best-effort — never blocks conclusion.
+		s.submitFdrDecision(ctx, expForConclude.ExperimentID, expForConclude.PrimaryMetricID)
 	}
 	slog.Info("concluding experiment: type-specific conclude complete", "id", id)
 

--- a/services/management/internal/handlers/service.go
+++ b/services/management/internal/handlers/service.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"context"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/org/experimentation/gen/go/experimentation/analysis/v1/analysisv1connect"
 	"github.com/org/experimentation/gen/go/experimentation/bandit/v1/banditv1connect"
 	"github.com/org/experimentation/gen/go/experimentation/management/v1/managementv1connect"
 
+	"github.com/org/experimentation-platform/services/management/internal/fdr"
 	"github.com/org/experimentation-platform/services/management/internal/store"
 	"github.com/org/experimentation-platform/services/management/internal/streaming"
 	"github.com/org/experimentation-platform/services/management/internal/surrogate"
@@ -25,10 +27,18 @@ type ExperimentService struct {
 	surrogates *store.SurrogateStore
 	notifier   *streaming.Notifier
 
+	// pool is used for direct queries not covered by the store layer
+	// (e.g. reading metric_results.e_value after M4a analysis completes).
+	pool *pgxpool.Pool
+
 	// Optional external service clients (nil = graceful degradation).
 	analysisClient     analysisv1connect.AnalysisServiceClient
 	banditClient       banditv1connect.BanditPolicyServiceClient
 	surrogatePublisher surrogate.Publisher
+
+	// fdrController is the platform-level e-LOND Online FDR controller
+	// (ADR-018 Phase 2). Nil when FDR control is not configured.
+	fdrController *fdr.Controller
 }
 
 // ServiceOption configures optional dependencies on ExperimentService.
@@ -49,6 +59,19 @@ func WithSurrogatePublisher(p surrogate.Publisher) ServiceOption {
 	return func(s *ExperimentService) { s.surrogatePublisher = p }
 }
 
+// WithPool sets the direct database pool used for queries outside the store
+// layer (e.g. reading metric_results.e_value for FDR submission).
+func WithPool(pool *pgxpool.Pool) ServiceOption {
+	return func(s *ExperimentService) { s.pool = pool }
+}
+
+// WithFdrController sets the platform-level e-LOND Online FDR controller
+// (ADR-018 Phase 2). When set, M5 submits each concluded experiment's primary
+// metric e-value to the controller and records the reject/don't-reject decision.
+func WithFdrController(c *fdr.Controller) ServiceOption {
+	return func(s *ExperimentService) { s.fdrController = c }
+}
+
 // NewExperimentService creates a new handler with the given stores and notifier.
 func NewExperimentService(es *store.ExperimentStore, as *store.AuditStore, ls *store.LayerStore, ms *store.MetricStore, ts *store.TargetingStore, ss *store.SurrogateStore, n *streaming.Notifier, opts ...ServiceOption) *ExperimentService {
 	svc := &ExperimentService{store: es, audit: as, layers: ls, metrics: ms, targeting: ts, surrogates: ss, notifier: n}
@@ -64,4 +87,3 @@ func (s *ExperimentService) ConcludeByID(ctx context.Context, id, actor string, 
 	_, err := s.concludeByID(ctx, id, actor, extraDetails)
 	return err
 }
-

--- a/sql/migrations/009_online_fdr_controller_state.sql
+++ b/sql/migrations/009_online_fdr_controller_state.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- ADR-018 Phase 2: Online FDR Controller State
+--
+-- Platform-level singleton for e-LOND Online FDR Control (Xu and Ramdas,
+-- AISTATS 2024). A single row persists the controller state across process
+-- restarts. The row is locked FOR UPDATE on each Test() call so concurrent
+-- conclude operations serialize correctly.
+--
+-- fdr_decisions records the per-experiment outcome of each FDR test,
+-- providing a full audit trail and enabling controller state reconstruction.
+-- ============================================================================
+
+CREATE TABLE online_fdr_controller_state (
+    id              BIGSERIAL PRIMARY KEY,
+
+    -- FDR level (target upper bound on false discovery rate).
+    -- Default 0.05.
+    alpha           DOUBLE PRECISION NOT NULL DEFAULT 0.05
+                        CHECK (alpha > 0 AND alpha < 1),
+
+    -- Geometric decay parameter for the gamma sequence.
+    -- gamma_t = (1 - gamma_decay) * gamma_decay^(t-1), summing to 1.
+    -- Controls how quickly alpha budget is spent across consecutive tests.
+    -- Default 0.9 (slow decay, suitable for platforms running many experiments).
+    gamma_decay     DOUBLE PRECISION NOT NULL DEFAULT 0.9
+                        CHECK (gamma_decay > 0 AND gamma_decay < 1),
+
+    -- Number of hypotheses (experiments) tested since the controller was created.
+    num_tested      BIGINT NOT NULL DEFAULT 0 CHECK (num_tested >= 0),
+
+    -- Number of rejections so far.
+    num_rejected    BIGINT NOT NULL DEFAULT 0 CHECK (num_rejected >= 0),
+
+    -- Current alpha wealth: remaining budget for future rejections.
+    -- Starts at alpha, decreases with each test, replenished (+alpha) on
+    -- each rejection.
+    alpha_wealth    DOUBLE PRECISION NOT NULL CHECK (alpha_wealth >= 0),
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the singleton row (id = 1).
+-- alpha_wealth starts equal to alpha.
+INSERT INTO online_fdr_controller_state (alpha, gamma_decay, alpha_wealth)
+VALUES (0.05, 0.9, 0.05);
+
+COMMENT ON TABLE online_fdr_controller_state IS
+    'Platform-level e-LOND Online FDR controller state (ADR-018 Phase 2). Singleton (id=1).';
+
+COMMENT ON COLUMN online_fdr_controller_state.gamma_decay IS
+    'Geometric decay ratio r. gamma_t = (1-r)*r^(t-1). Closer to 1 = slower decay = more power for long experiment streams.';
+
+COMMENT ON COLUMN online_fdr_controller_state.alpha_wealth IS
+    'Current alpha wealth W_t. Starts at alpha. Decreased by alpha_t on each test; replenished by alpha on each rejection.';
+
+-- ============================================================================
+-- Per-experiment FDR decisions (audit trail).
+-- ============================================================================
+
+CREATE TABLE fdr_decisions (
+    id              BIGSERIAL PRIMARY KEY,
+    experiment_id   UUID NOT NULL REFERENCES experiments(experiment_id) ON DELETE CASCADE,
+
+    -- The e-value submitted for this experiment.
+    e_value         DOUBLE PRECISION NOT NULL,
+
+    -- Alpha level allocated to this test: alpha_wealth * gamma_t.
+    -- Reject when e_value >= 1 / alpha_allocated.
+    alpha_allocated DOUBLE PRECISION NOT NULL,
+
+    -- Whether the null hypothesis was rejected.
+    rejected        BOOLEAN NOT NULL,
+
+    -- Wealth snapshot before and after this decision.
+    wealth_before   DOUBLE PRECISION NOT NULL,
+    wealth_after    DOUBLE PRECISION NOT NULL,
+
+    -- Controller state at decision time (for reconstruction / audit).
+    num_tested_at   BIGINT NOT NULL,
+    num_rejected_at BIGINT NOT NULL,
+
+    decided_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_fdr_decisions_experiment
+    ON fdr_decisions (experiment_id);
+
+CREATE INDEX idx_fdr_decisions_decided_at
+    ON fdr_decisions (decided_at DESC);
+
+COMMENT ON TABLE fdr_decisions IS
+    'Per-experiment e-LOND FDR decisions (ADR-018 Phase 2). Full audit trail; controller state can be reconstructed from this table.';


### PR DESCRIPTION
## Summary

- **SQL migration** (`009_online_fdr_controller_state.sql`): two new tables — `online_fdr_controller_state` (singleton) and `fdr_decisions` (per-experiment audit trail)
- **FDR controller** (`services/management/internal/fdr/controller.go`): e-LOND algorithm with geometric-decay alpha wealth, SELECT FOR UPDATE serialization, checkpoint-on-every-decision
- **M5 integration**: `concludeByID` submits primary metric e-value to the controller after M4a analysis fires; best-effort, never blocks conclusion
- **Opt-in gate**: `ONLINE_FDR_ENABLED=true` env var; safe to deploy without running migration 009

## Algorithm (e-LOND)

```
gamma_t    = (1 − gamma_decay) · gamma_decay^(t−1)   [sums to 1]
alpha_t    = W_{t−1} · gamma_t
Reject H_t when E_t ≥ 1 / alpha_t
W_t        = W_{t−1} − alpha_t + alpha · 1[reject_t]
```

Default `gamma_decay = 0.90`. Wealth converges to ~36% of `alpha` after many non-rejections (positive floor, maintaining residual power), and recovers by `+alpha` on each rejection.

## Files Changed

| File | Change |
|------|--------|
| `sql/migrations/009_online_fdr_controller_state.sql` | New — singleton state + decisions audit table |
| `services/management/internal/fdr/controller.go` | New — Controller with Test() and GetState() |
| `services/management/internal/fdr/controller_test.go` | New — 11 pure-logic unit tests (all pass) |
| `services/management/internal/handlers/service.go` | Add `pool`, `fdrController` fields + `WithPool`, `WithFdrController` options |
| `services/management/internal/handlers/conclude.go` | Add `submitFdrDecision` (best-effort, 3s timeout) |
| `services/management/internal/handlers/lifecycle.go` | Wire `submitFdrDecision` into `concludeByID` |
| `services/management/cmd/main.go` | Wire controller when `ONLINE_FDR_ENABLED=true` |
| `docs/coordination/status/agent-5-status.md` | Status update |

## Test Plan

- [x] `go test ./management/internal/fdr/...` — 11/11 pass
- [ ] Integration test: apply migration 009, set `ONLINE_FDR_ENABLED=true`, conclude an experiment with a non-null e-value in metric_results, verify row in `fdr_decisions`
- [ ] Verify no-op when `ONLINE_FDR_ENABLED` unset (default off)
- [ ] Verify best-effort: FDR controller failure does not prevent CONCLUDED transition

## Opportunities (not implemented)

- Expose FDR state via a new RPC (GetFdrState) for M6 UI display
- Periodic snapshots / state rebuild procedure from `fdr_decisions` history
- ADR-018 Phase 3 (MAD e-process for bandit experiments)

## ADR Reference

ADR-018 Phase 2 (e-LOND Online FDR Control)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
