### PR TITLE
feat(experimentation-stats): ADR-018 Phase 1 — e-value computation with proptest invariants

### DIFF
--- a/crates/experimentation-stats/src/evalue.rs
+++ b/crates/experimentation-stats/src/evalue.rs
@@ -358,6 +358,8 @@ pub fn e_value_avlm(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(test)]
+    use proptest::prelude::*;
 
     // --- e_value_grow -------------------------------------------------------
 
@@ -529,5 +531,93 @@ mod tests {
         let x2 = vec![0.0; 2];
         assert!(e_value_avlm(&y3, &y3, &x2, &x3, 1.0, 0.05).is_err(), "ctrl_x mismatch");
         assert!(e_value_avlm(&y3, &y3, &x3, &x2, 1.0, 0.05).is_err(), "trt_x mismatch");
+    }
+
+    // --- proptest invariants -------------------------------------------------
+
+    proptest! {
+        /// e_value_grow always returns a finite, nonnegative e-value and a
+        /// trajectory whose length matches the observation count.
+        #[test]
+        fn grow_outputs_always_finite(
+            obs in proptest::collection::vec(-5.0f64..5.0, 1..20),
+            sigma_sq in 0.1f64..10.0,
+        ) {
+            let result = e_value_grow(&obs, sigma_sq, 0.05).unwrap();
+            prop_assert!(result.e_value.is_finite(), "e_value not finite: {}", result.e_value);
+            prop_assert!(result.e_value >= 0.0, "e_value negative: {}", result.e_value);
+            prop_assert!(result.log_e_value.is_finite(), "log_e_value not finite");
+            prop_assert_eq!(result.log_wealth_trajectory.len(), obs.len());
+            for &w in &result.log_wealth_trajectory {
+                prop_assert!(w.is_finite(), "trajectory entry not finite: {w}");
+            }
+        }
+
+        /// reject is consistent: reject iff e_value > 1/alpha.
+        #[test]
+        fn grow_reject_consistent_with_threshold(
+            obs in proptest::collection::vec(-3.0f64..3.0, 1..15),
+            sigma_sq in 0.5f64..5.0,
+            alpha in 0.01f64..0.5,
+        ) {
+            let result = e_value_grow(&obs, sigma_sq, alpha).unwrap();
+            let threshold = 1.0 / alpha;
+            if result.reject {
+                prop_assert!(result.e_value > threshold,
+                    "reject=true but e_value={} <= threshold={}", result.e_value, threshold);
+            } else {
+                prop_assert!(result.e_value <= threshold,
+                    "reject=false but e_value={} > threshold={}", result.e_value, threshold);
+            }
+        }
+
+        /// e_value_avlm always returns a finite, positive e-value and an empty
+        /// trajectory (batch method).
+        #[test]
+        fn avlm_outputs_always_finite(
+            ctrl in proptest::collection::vec(-5.0f64..5.0, 2..10),
+            trt in proptest::collection::vec(-5.0f64..5.0, 2..10),
+            tau_sq in 0.01f64..5.0,
+        ) {
+            let n_c = ctrl.len();
+            let n_t = trt.len();
+            let ctrl_x = vec![0.0f64; n_c];
+            let trt_x = vec![0.0f64; n_t];
+            match e_value_avlm(&ctrl, &trt, &ctrl_x, &trt_x, tau_sq, 0.05) {
+                Ok(result) => {
+                    prop_assert!(result.e_value.is_finite(), "e_value not finite");
+                    prop_assert!(result.e_value >= 0.0, "e_value negative: {}", result.e_value);
+                    prop_assert!(result.log_e_value.is_finite(), "log_e_value not finite");
+                    prop_assert!(result.log_wealth_trajectory.is_empty(), "batch: trajectory must be empty");
+                }
+                Err(_) => {
+                    // Degenerate (zero-variance) data may yield an error; that is valid.
+                }
+            }
+        }
+
+        /// AVLM reject is consistent: reject iff e_value > 1/alpha.
+        #[test]
+        fn avlm_reject_consistent_with_threshold(
+            ctrl in proptest::collection::vec(-3.0f64..3.0, 2..8),
+            trt in proptest::collection::vec(-3.0f64..3.0, 2..8),
+            tau_sq in 0.1f64..3.0,
+            alpha in 0.01f64..0.5,
+        ) {
+            let n_c = ctrl.len();
+            let n_t = trt.len();
+            let cx = vec![0.0f64; n_c];
+            let tx = vec![0.0f64; n_t];
+            if let Ok(result) = e_value_avlm(&ctrl, &trt, &cx, &tx, tau_sq, alpha) {
+                let threshold = 1.0 / alpha;
+                if result.reject {
+                    prop_assert!(result.e_value > threshold,
+                        "reject=true but e_value={} <= threshold={}", result.e_value, threshold);
+                } else {
+                    prop_assert!(result.e_value <= threshold,
+                        "reject=false but e_value={} > threshold={}", result.e_value, threshold);
+                }
+            }
+        }
     }
 }

--- a/docs/coordination/status/agent-4-status.md
+++ b/docs/coordination/status/agent-4-status.md
@@ -1,13 +1,13 @@
 # Agent-4 Status — Phase 5
 
 **Module**: M4a Analysis + M4b Bandit
-**Last updated**: 2026-03-23
+**Last updated**: 2026-03-24
 
 ## Current Sprint
 
 Sprint: 5.0
 Focus: ADR-015 AVLM, ADR-017 TC/JIVE, ADR-018 E-values, ADR-014 Guardrail beta-correction, ADR-011 Multi-objective, ADR-012 LP constraints
-Branch: work/bright-bear
+Branch: work/eager-bear
 
 ## In Progress
 
@@ -151,12 +151,17 @@ Branch: work/bright-bear
   - PR #198 merged
 
 - [x] **Proto schema extensions** (PR #196 merged) — All Phase 5 proto additions, buf lint + breaking clean.
-- [x] ADR-018 Phase 1 — E-value computation (PR open 2026-03-23)
-  - `e_value_grow()`: Sequential GROW martingale (plug-in betting, valid e-process)
-  - `e_value_avlm()`: CUPED-adjusted Gaussian mixture e-value
-  - SQL migration 006_evalue_columns.sql: `e_value` + `log_e_value` on metric_results
-  - 8 golden-file tests (GROW: 4 analytic; AVLM: 4 formula-validated to 6dp)
-  - All 144+ workspace tests green
+- [x] **ADR-018 Phase 1 — E-value computation** (2026-03-24, work/eager-bear)
+  - `crates/experimentation-stats/src/evalue.rs`:
+    - `e_value_grow()`: Sequential GROW martingale (causal plug-in λ_t = μ̂_{t-1}/σ², safe-start λ_1=0)
+    - `e_value_avlm()`: CUPED-adjusted Gaussian mixture e-value (Ramdas & Wang §3.1)
+    - `EValueResult`: e_value, log_e_value, reject, log_wealth_trajectory
+  - `sql/migrations/006_evalue_columns.sql`: ALTER TABLE metric_results ADD COLUMN e_value, log_e_value
+  - `crates/experimentation-stats/tests/evalue_golden.rs`: 8 golden-file tests (6dp tolerance)
+  - 8 golden JSON files in tests/golden/: 4 GROW (analytic), 4 AVLM (formula-validated to 6dp)
+  - 4 proptest invariants: grow_outputs_always_finite, grow_reject_consistent, avlm_outputs_always_finite, avlm_reject_consistent
+  - 12 unit tests in evalue.rs
+  - All 144+ experimentation-stats tests green (0 failures)
 
 ### Proto changes landed:
 


### PR DESCRIPTION
## Summary

Completes ADR-018 Phase 1: e-value computation for online testing and FDR control.

- **`e_value_grow()`** — Sequential GROW martingale for iid Gaussian observations. Causal plug-in betting strategy λ_t = μ̂_{t-1}/σ² with safe start (λ_1=0). Valid e-process: E_{H0}[E_n] ≤ 1.
- **`e_value_avlm()`** — CUPED-adjusted Gaussian mixture e-value (two-sample, batch). Implements Ramdas & Wang (2024) §3.1 formula: log E = ½·log(se²/(se²+τ²)) + Δ²·τ²/(2·se²·(se²+τ²)).
- **SQL migration** `006_evalue_columns.sql` — `ADD COLUMN e_value, log_e_value DOUBLE PRECISION` to `metric_results`.
- **Golden files** — 8 JSON test vectors (4 GROW analytic, 4 AVLM formula-validated) to 6 decimal places against Ramdas & Wang monograph examples.
- **Proptest invariants** (4) — outputs always finite, reject ↔ e_value > 1/α for both functions.

## Files Changed

| File | Change |
|------|--------|
| `crates/experimentation-stats/src/evalue.rs` | +4 proptest invariants (GROW + AVLM) |
| `docs/coordination/status/agent-4-status.md` | Updated to reflect completion |

The implementation, golden test harness, SQL migration, and golden JSON files were already present in repo. This PR adds the missing proptest invariants required by CLAUDE.md critical rules.

## Test Plan

- [x] `cargo test -p experimentation-stats` — all 144+ tests pass, 0 failures
- [x] `cargo test -p experimentation-stats --test evalue_golden` — 8 golden tests pass at 1e-6 tolerance
- [x] Unit tests cover: null effect, safe start, analytic trajectory, negative signal, validation errors, covariate variance reduction
- [x] Proptest: 4 invariants covering both public functions

## Notes for Continuation

- ADR-018 Phase 2 (online FDR control via e-BH procedure) is not yet implemented — separate ADR scope.
- The `e_value_avlm` function diagnostics (theta, delta_adj, se_sq_adj) are stored in golden JSON but not returned in `EValueResult` — could be exposed as debug fields if needed downstream.
- Proto fields `e_value` (field 19) and `log_e_value` (field 20) on `MetricResult` are already defined (landed in proto PR #196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
