### PR TITLE
docs(agent-4): ADR-017 TC/JIVE Phase 1 verification pass

### DIFF
--- a/docs/coordination/status/agent-4-status.md
+++ b/docs/coordination/status/agent-4-status.md
@@ -1,19 +1,26 @@
 # Agent-4 Status — Phase 5
 
 **Module**: M4a Analysis + M4b Bandit
-**Last updated**: 2026-03-23
+**Last updated**: 2026-03-24
 
 ## Current Sprint
 
 Sprint: 5.0
 Focus: ADR-015 AVLM, ADR-017 TC/JIVE, ADR-018 E-values, ADR-014 Guardrail beta-correction, ADR-011 Multi-objective, ADR-012 LP constraints
-Branch: work/bright-bear
+Branch: work/clever-koala (verification pass)
 
 ## In Progress
 
 - [ ] ADR-012 LP constraints
 
 ## Completed (Phase 5) — latest first
+
+- [x] **ADR-017 Phase 1 — TC/JIVE verification pass** (2026-03-24, work/clever-koala)
+  - Verified `kfold_iv_calibrate()` in `crates/experimentation-stats/src/orl.rs` is fully operational
+  - All 3 Netflix KDD 2024 Table 2 golden tests pass (`orl_golden.rs`): no-confounding, confounded, weak-instrument
+  - Proptest invariants `iv_result_all_finite` and `bias_correction_sign_with_positive_confounder` confirmed green
+  - Full `experimentation-stats` test suite: 0 failures
+  - No code changes required — implementation landed in PR #198
 
 - [x] **ADR-015 M4a integration — AVLM wired into RunAnalysis** (2026-03-23, work/bright-bear)
   - `proto/experimentation/analysis/v1/analysis_service.proto`: extended `RunAnalysisRequest`


### PR DESCRIPTION
## Summary

- Verified `kfold_iv_calibrate()` in `crates/experimentation-stats/src/orl.rs` is fully operational (PR #198)
- All 3 Netflix KDD 2024 Table 2 golden tests pass (`orl_golden.rs`)
- Updated `docs/coordination/status/agent-4-status.md` to reflect verification by `work/clever-koala`

## What was verified

**ADR-017 Phase 1 — TC/JIVE surrogate calibration fix** (already merged in PR #198):

| Component | Status |
|---|---|
| `orl.rs` — `kfold_iv_calibrate()` K-fold IV estimation | ✅ complete |
| `orl.rs` — `InstrumentStrength` enum (Stock-Yogo F > 10 threshold) | ✅ complete |
| `orl.rs` — HC0 sandwich SE + OLS bias-correction reporting | ✅ complete |
| Golden: Scenario A no-confounding → JIVE = OLS = γ = 0.3 (exact) | ✅ pass |
| Golden: Scenario B confounded → OLS biased up, JIVE corrects | ✅ pass |
| Golden: Scenario C weak instrument → `InstrumentStrength::Weak` detected | ✅ pass |
| Proptest: `iv_result_all_finite` | ✅ pass |
| Proptest: `bias_correction_sign_with_positive_confounder` | ✅ pass |
| Full `experimentation-stats` test suite | ✅ 0 failures |

## Test plan

- [x] `cargo test -p experimentation-stats --test orl_golden` — 3 golden tests pass
- [x] `cargo test -p experimentation-stats` — full suite clean

## Notes / Opportunities

- ADR-017 Phase 2 (doubly-robust offline RL policy evaluation) is unstarted — next logical task for M4a
- The `surrogate.rs` R²-based calibrator coexists with the new IV calibrator; a future task could add a migration path or deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
