### PR TITLE
feat(m6): ADR-016 slate bandit UI components

### DIFF
--- a/docs/coordination/status/agent-6-status.md
+++ b/docs/coordination/status/agent-6-status.md
@@ -11,6 +11,9 @@ Branch: work/fancy-platypus
 Sprint: 5.2
 Focus: Portfolio optimization dashboard (ADR-019) + Provider Health dashboard (ADR-014)
 Branch: work/gentle-panda, work/gentle-penguin
+Sprint: 5.4
+Focus: Slate Bandit UI components (ADR-016)
+Branch: work/silly-deer
 
 Focus: ADR-011 multi-objective bandit reward visualization, ADR-012 LP constraint status table
 Branch: work/fancy-koala
@@ -67,6 +70,63 @@ None.
 - Portfolio index page /portfolio (ADR-019)
 - Enhanced bandit dashboard (ADR-016 slate bandit visualization)
 
+## Completed (this sprint)
+
+- [x] **SlateResultsPanel** (ADR-016)
+  - `ui/src/components/slate/SlateResultsPanel.tsx`
+  - Ranked ordered list with position badges (1..n) and per-slot probability badges
+  - Color-coded probability bands: green ≥80%, blue ≥60%, indigo ≥40%, purple ≥20%, gray <20%
+  - Shows overall slate probability in scientific notation (slateProbability)
+  - `React.memo` wrapped
+
+- [x] **SlatePositionBiasChart** (ADR-016)
+  - `ui/src/components/slate/SlatePositionBiasChart.tsx`
+  - Recharts BarChart showing per-position CTR from LIPS OPE estimate
+  - Fetches `getSlateOpe(experimentId)` from AnalysisService/GetSlateOpe
+  - Position opacity gradient (deeper positions appear fainter)
+  - Shows policy value estimate from LIPS
+  - `React.memo` wrapped, dynamically imported in experiment detail page
+
+- [x] **SlateAssignmentForm** (ADR-016)
+  - `ui/src/components/slate/SlateAssignmentForm.tsx`
+  - Candidate item picker (textarea, comma-separated)
+  - n_slots selector (1–20)
+  - User ID field
+  - Submit → calls AssignmentService/GetSlateAssignment
+  - Renders SlateResultsPanel on successful response
+  - Client-side validation: empty candidates, n_slots > candidate count
+  - `React.memo` wrapped
+
+- [x] **Slate tab on experiment detail page**
+  - `ui/src/app/experiments/[id]/page.tsx` — Slate section added
+  - Only visible when `experiment.type === 'SLATE'`
+  - Tab label "Slate" with tab-nav chrome
+  - Two-column layout: SlateAssignmentForm | SlatePositionBiasChart
+  - Both components code-split via `next/dynamic`
+
+- [x] **New types** (ADR-016)
+  - `SlateAssignmentResponse`, `SlatePositionBiasPoint`, `SlateOpeResult` in `types.ts`
+  - Added `SLATE` to `ExperimentType` union
+  - Added `SLATE: 'Slate Bandit'` to `TYPE_LABELS` in `utils.ts`
+
+- [x] **API functions** (ADR-016)
+  - `getSlateAssignment()` → AssignmentService/GetSlateAssignment
+  - `getSlateOpe()` → AnalysisService/GetSlateOpe
+  - New `ASSIGNMENT_URL` / `ASSIGNMENT_SVC` constants
+
+- [x] **Seed data and MSW handlers**
+  - Seed experiment `cccccccc-cccc-cccc-cccc-cccccccccccc` (homepage_slate_v1, RUNNING)
+  - `SEED_SLATE_OPE_RESULTS` with 10-position cascade bias data
+  - MSW handlers: `GetSlateOpe` (ANALYSIS_SVC), `GetSlateAssignment` (ASSIGNMENT_SVC)
+
+- [x] **Tests** (17 new tests, 0 regressions)
+  - `ui/src/__tests__/slate-bandit.test.tsx`
+  - SlateResultsPanel: 5 tests (items, positions, probability badges, overall prob, testid)
+  - SlatePositionBiasChart: 4 tests (loading, chart, policy value, no-data message)
+  - SlateAssignmentForm: 5 tests (form fields, testid, submit success, validation errors)
+  - ExperimentDetailPage integration: 3 tests (tab visible for SLATE, hidden for AB)
+  - Fixed 4 affected tests in proto-wire-format, experiment-list, monitoring
+
 ## Completed (Phase 5 — previous PRs)
 
 - [x] **AVLM confidence sequence boundary plot** (ADR-015)
@@ -76,7 +136,6 @@ None.
   - Dynamically imported; legacy alpha-spending chart preserved under details fold
   - API: `getAvlmResult(experimentId, metricId)` → AnalysisService/GetAvlmResult
   - Types: AvlmBoundaryPoint, AvlmResult
-## Completed (this sprint)
 
 - [x] **Portfolio optimization dashboard** (ADR-019)
   - `ui/src/app/portfolio/page.tsx` — `PortfolioDashboard` page with code-split, data fetch, error/loading states
@@ -108,7 +167,6 @@ None.
   - `ui/src/components/feedback-loop-tab.tsx`
   - Visible for AB/MAB/CONTEXTUAL_BANDIT experiments
   - API: `getFeedbackLoopAnalysis(experimentId)` → AnalysisService/GetFeedbackLoopAnalysis
-## Completed (previous PRs)
 
 - [x] **ADR-011 Multi-objective reward composition chart** (2026-03-24, work/fancy-koala)
   - `ui/src/components/RewardCompositionChart.tsx`
@@ -162,7 +220,6 @@ None.
 ## Next Up
 
 - E-value display (ADR-018) — pending Agent-4 GetEvalueResult endpoint
-- Enhanced bandit dashboard (ADR-016 slate bandit visualization)
 
 ## Completed (Phase 5 — prior sprints)
 
@@ -174,18 +231,14 @@ None.
   - `ui/src/components/feedback-loop-tab.tsx`
 - [x] /portfolio/provider-health page (ADR-014)
   - Time series charts, provider filter, MSW mock, 8 tests
-- [x] AVLM confidence sequence boundary plot (ADR-015)
-- [x] Adaptive N zone indicator badge + extended timeline (ADR-020)
-- [x] Feedback loop analysis tab (ADR-019 interference)
 
 ## Dependencies (wire-ready, awaiting backend)
 
-- Agent-4: AnalysisService/GetAvlmResult, GetAdaptiveN, GetFeedbackLoopAnalysis, GetOnlineFdrState
+- Agent-4: AnalysisService/GetAvlmResult, GetAdaptiveN, GetFeedbackLoopAnalysis, GetOnlineFdrState, GetSlateOpe
+- Agent-1: AssignmentService/GetSlateAssignment
 - Agent-2: Feedback loop retraining event data flow
 - Agent-5: `ExperimentManagementService/GetPortfolioAllocation` gRPC endpoint
   - Request: `{}` (empty)
   - Response: `{ experiments: PortfolioExperiment[], totalAllocatedPct: float, computedAt: timestamp }`
   - `PortfolioExperiment` fields: `experiment_id`, `name`, `effect_size`, `variance`, `allocated_traffic_pct`, `priority_score`, `user_segments`
-
 - Agent-4: BanditPolicyService objectiveBreakdowns and constraintStatuses in GetBanditDashboard response
-- Agent-4: AnalysisService/GetAvlmResult, GetAdaptiveN, GetFeedbackLoopAnalysis

--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -8,6 +8,7 @@ import {
   SEED_AVLM_RESULTS, SEED_ADAPTIVE_N_RESULTS, SEED_FEEDBACK_LOOP_RESULTS,
   SEED_ONLINE_FDR_STATES,
   SEED_PORTFOLIO_ALLOCATION,
+  SEED_SLATE_OPE_RESULTS,
 } from './seed-data';
 import type { UserRole } from '@/lib/auth';
 import { hasAtLeast, isValidRole } from '@/lib/auth';
@@ -17,6 +18,7 @@ const METRICS_SVC = '*/experimentation.metrics.v1.MetricComputationService';
 const ANALYSIS_SVC = '*/experimentation.analysis.v1.AnalysisService';
 const BANDIT_SVC = '*/experimentation.bandit.v1.BanditPolicyService';
 const FLAGS_SVC = '*/experimentation.flags.v1.FeatureFlagService';
+const ASSIGNMENT_SVC = '*/experimentation.assignment.v1.AssignmentService';
 
 // --- Mock auth enforcement ---
 let _mockAuthEnabled = false;
@@ -839,8 +841,37 @@ export const handlers = [
     return HttpResponse.json(result);
   }),
 
+  // GetSlateOpe (ADR-016)
+  http.post(`${ANALYSIS_SVC}/GetSlateOpe`, async ({ request }) => {
+    const body = await request.json() as { experimentId: string };
+    const result = SEED_SLATE_OPE_RESULTS.find((r) => r.experimentId === body.experimentId);
+    if (!result) {
+      return HttpResponse.json(
+        { code: 'not_found', message: 'No slate OPE result found' },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(result);
+  }),
+
   // GetPortfolioAllocation (ADR-019)
   http.post(`${MGMT_SVC}/GetPortfolioAllocation`, () => {
     return HttpResponse.json(SEED_PORTFOLIO_ALLOCATION);
+  }),
+
+  // GetSlateAssignment (ADR-016) — on Assignment service
+  http.post(`${ASSIGNMENT_SVC}/GetSlateAssignment`, async ({ request }) => {
+    const body = await request.json() as {
+      experimentId: string;
+      userId: string;
+      candidateItemIds: string[];
+    };
+    const { candidateItemIds } = body;
+    const nSlots = Math.min(10, candidateItemIds.length);
+    // Deterministic mock: pick first nSlots items, assign geometric probabilities
+    const slateItemIds = candidateItemIds.slice(0, nSlots);
+    const slotProbabilities = slateItemIds.map((_, i) => parseFloat((0.9 ** i * 0.8).toFixed(4)));
+    const slateProbability = slotProbabilities.reduce((acc, p) => acc * p, 1);
+    return HttpResponse.json({ slateItemIds, slotProbabilities, slateProbability });
   }),
 ];

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -6,6 +6,7 @@ import type {
   AuditLogEntry, Flag, ProviderHealthResult,
   AvlmResult, AdaptiveNResult, FeedbackLoopResult, OnlineFdrState,
   PortfolioAllocationResult,
+  SlateOpeResult,
 } from '@/lib/types';
 
 const INITIAL_EXPERIMENTS: Experiment[] = [
@@ -434,6 +435,38 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
     createdAt: '2025-11-15T09:00:00Z',
     startedAt: '2025-11-16T06:00:00Z',
     concludedAt: '2025-12-20T18:00:00Z',
+  },
+  // Slate bandit experiment (ADR-016)
+  {
+    experimentId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    name: 'homepage_slate_v1',
+    description: 'Slot-wise factorized Thompson Sampling for homepage recommendation slate',
+    ownerEmail: 'grace@streamco.com',
+    type: 'SLATE',
+    state: 'RUNNING',
+    variants: [],
+    layerId: 'layer-homepage',
+    hashSalt: 'salt-homepage-slate-v1',
+    primaryMetricId: 'click_through_rate',
+    secondaryMetricIds: ['watch_time_per_session', 'completion_rate'],
+    guardrailConfigs: [
+      {
+        metricId: 'bounce_rate',
+        threshold: 0.45,
+        consecutiveBreachesRequired: 2,
+      },
+    ],
+    guardrailAction: 'ALERT_ONLY',
+    isCumulativeHoldout: false,
+    banditExperimentConfig: {
+      algorithm: 'THOMPSON_SAMPLING',
+      rewardMetricId: 'click_through_rate',
+      contextFeatureKeys: ['user_tenure_days', 'device_type', 'content_genre'],
+      minExplorationFraction: 0.05,
+      warmupObservations: 10000,
+    },
+    createdAt: '2026-03-20T08:00:00Z',
+    startedAt: '2026-03-21T06:00:00Z',
   },
 ];
 
@@ -2007,6 +2040,31 @@ const INITIAL_PORTFOLIO_ALLOCATION: PortfolioAllocationResult = {
 };
 
 export let SEED_PORTFOLIO_ALLOCATION: PortfolioAllocationResult = structuredClone(INITIAL_PORTFOLIO_ALLOCATION);
+
+// --- Slate OPE Seed Data (ADR-016) ---
+
+const INITIAL_SLATE_OPE_RESULTS: SlateOpeResult[] = [
+  {
+    experimentId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    positionBias: [
+      { position: 1, ctr: 0.28, lipsWeight: 1.0 },
+      { position: 2, ctr: 0.19, lipsWeight: 0.82 },
+      { position: 3, ctr: 0.14, lipsWeight: 0.68 },
+      { position: 4, ctr: 0.10, lipsWeight: 0.57 },
+      { position: 5, ctr: 0.07, lipsWeight: 0.48 },
+      { position: 6, ctr: 0.05, lipsWeight: 0.40 },
+      { position: 7, ctr: 0.04, lipsWeight: 0.34 },
+      { position: 8, ctr: 0.03, lipsWeight: 0.29 },
+      { position: 9, ctr: 0.02, lipsWeight: 0.25 },
+      { position: 10, ctr: 0.02, lipsWeight: 0.21 },
+    ],
+    estimatedValue: 0.1423,
+    computedAt: '2026-03-23T12:00:00Z',
+  },
+];
+
+export let SEED_SLATE_OPE_RESULTS: SlateOpeResult[] = structuredClone(INITIAL_SLATE_OPE_RESULTS);
+
 /** Reset seed data to initial state. Call in afterEach for test isolation. */
 export function resetSeedData(): void {
   SEED_FLAGS = structuredClone(INITIAL_FLAGS);
@@ -2032,4 +2090,5 @@ export function resetSeedData(): void {
   SEED_FEEDBACK_LOOP_RESULTS = structuredClone(INITIAL_FEEDBACK_LOOP_RESULTS);
   SEED_ONLINE_FDR_STATES = structuredClone(INITIAL_ONLINE_FDR_STATES);
   SEED_PORTFOLIO_ALLOCATION = structuredClone(INITIAL_PORTFOLIO_ALLOCATION);
+  SEED_SLATE_OPE_RESULTS = structuredClone(INITIAL_SLATE_OPE_RESULTS);
 }

--- a/ui/src/__tests__/experiment-list.test.tsx
+++ b/ui/src/__tests__/experiment-list.test.tsx
@@ -52,9 +52,9 @@ describe('Experiment List Page', () => {
     await renderAndWait();
 
     // State labels appear in both filter dropdown and table badges.
-    // Table badges: 3 RUNNING, 2 DRAFT, 1 STARTING, 1 CONCLUDING, 2 CONCLUDED, 1 ARCHIVED
-    // Dropdown options add 1 of each. So Running = 3+1=4, Draft = 2+1=3, etc.
-    expect(screen.getAllByText('Running').length).toBe(4);
+    // Table badges: 4 RUNNING, 2 DRAFT, 1 STARTING, 1 CONCLUDING, 2 CONCLUDED, 1 ARCHIVED
+    // Dropdown options add 1 of each. So Running = 4+1=5, Draft = 2+1=3, etc.
+    expect(screen.getAllByText('Running').length).toBe(5);
     expect(screen.getAllByText('Draft').length).toBe(3);
     expect(screen.getAllByText('Starting').length).toBe(2);
     expect(screen.getAllByText('Concluding').length).toBe(2);
@@ -187,7 +187,7 @@ describe('Experiment List Page', () => {
     await renderAndWait();
 
     const count = screen.getByTestId('filter-count');
-    expect(count).toHaveTextContent('Showing 10 of 10 experiments');
+    expect(count).toHaveTextContent('Showing 11 of 11 experiments');
   });
 
   it('no-match empty state displays with clear button', async () => {
@@ -225,11 +225,10 @@ describe('Experiment List Page', () => {
     await renderAndWait();
 
     const rows = screen.getAllByRole('row');
-    // Most recent createdAt is onboarding_flow_v2 (2026-03-03) or cold_start_bandit (2026-03-02)
-    // Actually: adaptive_bitrate_v3 is 2026-03-01, cold_start_bandit is 2026-03-02, onboarding_flow_v2 is 2026-03-03
-    // So descending: onboarding_flow_v2 should be first
+    // Most recent createdAt is homepage_slate_v1 (2026-03-20), then onboarding_flow_v2 (2026-03-03)
+    // So descending: homepage_slate_v1 should be first
     const firstDataRow = rows[1];
-    expect(within(firstDataRow).getByText('onboarding_flow_v2')).toBeInTheDocument();
+    expect(within(firstDataRow).getByText('homepage_slate_v1')).toBeInTheDocument();
   });
 
   // --- Results link tests ---

--- a/ui/src/__tests__/monitoring.test.tsx
+++ b/ui/src/__tests__/monitoring.test.tsx
@@ -51,9 +51,9 @@ describe('Monitoring Page', () => {
   it('shows summary cards with experiment counts by state', async () => {
     await renderAndWait();
 
-    // Seed data: 3 RUNNING, 2 DRAFT, 1 STARTING, 1 CONCLUDING, 2 CONCLUDED, 1 ARCHIVED
+    // Seed data: 4 RUNNING, 2 DRAFT, 1 STARTING, 1 CONCLUDING, 2 CONCLUDED, 1 ARCHIVED
     const runningCard = screen.getByTestId('summary-card-RUNNING');
-    expect(within(runningCard).getByTestId('count-RUNNING')).toHaveTextContent('3');
+    expect(within(runningCard).getByTestId('count-RUNNING')).toHaveTextContent('4');
 
     const draftCard = screen.getByTestId('summary-card-DRAFT');
     expect(within(draftCard).getByTestId('count-DRAFT')).toHaveTextContent('2');

--- a/ui/src/__tests__/proto-wire-format.test.ts
+++ b/ui/src/__tests__/proto-wire-format.test.ts
@@ -660,7 +660,7 @@ describe('Proto wire format — ListExperiments server-side filters', () => {
 
   it('returns all when no filters provided', async () => {
     const res = await listExperiments();
-    expect(res.experiments.length).toBe(10); // 10 seed experiments
+    expect(res.experiments.length).toBe(11); // 11 seed experiments (includes slate)
   });
 
   it('supports pagination with pageSize and pageToken', async () => {
@@ -673,7 +673,7 @@ describe('Proto wire format — ListExperiments server-side filters', () => {
     expect(second.nextPageToken).toBeTruthy();
 
     const third = await listExperiments({ pageSize: 4, pageToken: second.nextPageToken });
-    expect(third.experiments).toHaveLength(2);
+    expect(third.experiments).toHaveLength(3);
     expect(third.nextPageToken).toBe('');
   });
 });

--- a/ui/src/__tests__/slate-bandit.test.tsx
+++ b/ui/src/__tests__/slate-bandit.test.tsx
@@ -1,0 +1,239 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthProvider } from '@/lib/auth-context';
+import type { AuthUser } from '@/lib/auth-context';
+
+const SLATE_EXP_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const NON_SLATE_EXP_ID = '11111111-1111-1111-1111-111111111111';
+
+let mockExperimentId = SLATE_EXP_ID;
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: mockExperimentId }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/lib/toast-context', () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn(), toasts: [] }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock next/dynamic to eagerly resolve dynamic imports in tests
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<{ default: React.ComponentType<unknown> }>) => {
+    let Comp: React.ComponentType<unknown> | null = null;
+    loader().then((mod) => { Comp = mod.default; });
+    return function DynamicMock(props: Record<string, unknown>) {
+      return Comp ? <Comp {...props} /> : null;
+    };
+  },
+}));
+
+// Mock recharts
+vi.mock('recharts', async () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  );
+  const Noop = () => null;
+
+  return {
+    ResponsiveContainer: Passthrough,
+    BarChart: Passthrough,
+    Bar: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    Tooltip: Noop,
+    Cell: Noop,
+    Legend: Noop,
+  };
+});
+
+import ExperimentDetailPage from '@/app/experiments/[id]/page';
+import { SlateResultsPanel } from '@/components/slate/SlateResultsPanel';
+import { SlateAssignmentForm } from '@/components/slate/SlateAssignmentForm';
+import { SlatePositionBiasChart } from '@/components/slate/SlatePositionBiasChart';
+
+const defaultUser: AuthUser = { email: 'test@streamco.com', role: 'admin' };
+
+function renderDetail(user: AuthUser = defaultUser) {
+  return render(
+    <AuthProvider initialUser={user}>
+      <ExperimentDetailPage />
+    </AuthProvider>,
+  );
+}
+
+// ── SlateResultsPanel ──────────────────────────────────────────────────────
+
+describe('SlateResultsPanel', () => {
+  const mockResponse = {
+    slateItemIds: ['item-a', 'item-b', 'item-c'],
+    slotProbabilities: [0.85, 0.60, 0.35],
+    slateProbability: 0.1785,
+  };
+
+  it('renders ranked list of slate items', () => {
+    render(<SlateResultsPanel response={mockResponse} />);
+    expect(screen.getByText('item-a')).toBeInTheDocument();
+    expect(screen.getByText('item-b')).toBeInTheDocument();
+    expect(screen.getByText('item-c')).toBeInTheDocument();
+  });
+
+  it('shows position badges 1, 2, 3', () => {
+    render(<SlateResultsPanel response={mockResponse} />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('shows probability badges for each slot', () => {
+    render(<SlateResultsPanel response={mockResponse} />);
+    expect(screen.getByText('85.0%')).toBeInTheDocument();
+    expect(screen.getByText('60.0%')).toBeInTheDocument();
+    expect(screen.getByText('35.0%')).toBeInTheDocument();
+  });
+
+  it('shows overall slate probability', () => {
+    render(<SlateResultsPanel response={mockResponse} />);
+    expect(screen.getByText(/overall slate probability/i)).toBeInTheDocument();
+  });
+
+  it('renders testid', () => {
+    render(<SlateResultsPanel response={mockResponse} />);
+    expect(screen.getByTestId('slate-results-panel')).toBeInTheDocument();
+  });
+});
+
+// ── SlatePositionBiasChart ─────────────────────────────────────────────────
+
+describe('SlatePositionBiasChart', () => {
+  it('shows loading state initially', async () => {
+    render(<SlatePositionBiasChart experimentId={SLATE_EXP_ID} />);
+    expect(screen.getByRole('status', { name: /loading position bias/i })).toBeInTheDocument();
+  });
+
+  it('renders chart after data loads', async () => {
+    render(<SlatePositionBiasChart experimentId={SLATE_EXP_ID} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('slate-position-bias-chart')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/per-position ctr/i)).toBeInTheDocument();
+  });
+
+  it('shows estimated policy value from LIPS OPE', async () => {
+    render(<SlatePositionBiasChart experimentId={SLATE_EXP_ID} />);
+    await waitFor(() => {
+      expect(screen.getByText(/policy value/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/0\.1423/)).toBeInTheDocument();
+  });
+
+  it('shows no-data message for unknown experiment', async () => {
+    render(<SlatePositionBiasChart experimentId="00000000-0000-0000-0000-000000000000" />);
+    await waitFor(() => {
+      expect(screen.getByText(/no lips ope data/i)).toBeInTheDocument();
+    });
+  });
+});
+
+// ── SlateAssignmentForm ────────────────────────────────────────────────────
+
+describe('SlateAssignmentForm', () => {
+  it('renders form fields', () => {
+    render(<SlateAssignmentForm experimentId={SLATE_EXP_ID} />);
+    expect(screen.getByLabelText(/user id/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/number of slots/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/candidate item ids/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /get slate assignment/i })).toBeInTheDocument();
+  });
+
+  it('renders testid', () => {
+    render(<SlateAssignmentForm experimentId={SLATE_EXP_ID} />);
+    expect(screen.getByTestId('slate-assignment-form')).toBeInTheDocument();
+  });
+
+  it('submits and renders SlateResultsPanel on success', async () => {
+    render(<SlateAssignmentForm experimentId={SLATE_EXP_ID} />);
+    fireEvent.click(screen.getByRole('button', { name: /get slate assignment/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('slate-results-panel')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when n_slots exceeds candidates', async () => {
+    render(<SlateAssignmentForm experimentId={SLATE_EXP_ID} />);
+    const nSlotsInput = screen.getByLabelText(/number of slots/i);
+    fireEvent.change(nSlotsInput, { target: { value: '20' } });
+
+    const candidatesArea = screen.getByLabelText(/candidate item ids/i);
+    fireEvent.change(candidatesArea, { target: { value: 'item-a, item-b' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /get slate assignment/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('alert').textContent).toMatch(/n_slots.*cannot exceed/i);
+  });
+
+  it('shows error when no candidates provided', async () => {
+    render(<SlateAssignmentForm experimentId={SLATE_EXP_ID} />);
+    const candidatesArea = screen.getByLabelText(/candidate item ids/i);
+    fireEvent.change(candidatesArea, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /get slate assignment/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('alert').textContent).toMatch(/at least one candidate/i);
+  });
+});
+
+// ── ExperimentDetailPage — Slate tab ──────────────────────────────────────
+
+describe('ExperimentDetailPage — Slate tab visibility', () => {
+  beforeEach(() => {
+    mockExperimentId = SLATE_EXP_ID;
+  });
+
+  it('shows Slate tab section for SLATE experiment type', async () => {
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('slate-tab')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Slate" tab label', async () => {
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Slate')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ExperimentDetailPage — Slate tab hidden for non-SLATE', () => {
+  beforeEach(() => {
+    mockExperimentId = NON_SLATE_EXP_ID;
+  });
+
+  it('does not show Slate tab for AB experiment', async () => {
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('homepage_recs_v2').length).toBeGreaterThan(0);
+    });
+
+    expect(screen.queryByTestId('slate-tab')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import dynamic from 'next/dynamic';
 import type { Experiment, Variant } from '@/lib/types';
 import { getExperiment, updateExperiment, startExperiment, concludeExperiment, archiveExperiment, isPermissionDenied } from '@/lib/api';
 import { formatDate } from '@/lib/utils';
@@ -20,6 +21,15 @@ import { ConcludingProgress } from '@/components/concluding-progress';
 import { LayerAllocationChart } from '@/components/layer-allocation-chart';
 import { AdaptiveNBadge } from '@/components/adaptive-n-badge';
 import { CopyButton } from '@/components/copy-button';
+
+const SlateAssignmentForm = dynamic(
+  () => import('@/components/slate/SlateAssignmentForm').then((m) => ({ default: m.SlateAssignmentForm })),
+  { ssr: false },
+);
+const SlatePositionBiasChart = dynamic(
+  () => import('@/components/slate/SlatePositionBiasChart').then((m) => ({ default: m.SlatePositionBiasChart })),
+  { ssr: false },
+);
 
 export default function ExperimentDetailPage() {
   const params = useParams<{ id: string }>();
@@ -252,6 +262,29 @@ export default function ExperimentDetailPage() {
                 ))}
               </tbody>
             </table>
+          </div>
+        </section>
+      )}
+
+      {/* Slate Tab — only shown for SLATE experiment type */}
+      {experiment.type === 'SLATE' && (
+        <section className="mb-6" data-testid="slate-tab">
+          <div className="mb-3 border-b border-gray-200">
+            <nav className="-mb-px flex">
+              <span className="border-b-2 border-indigo-600 px-4 py-2 text-sm font-medium text-indigo-600">
+                Slate
+              </span>
+            </nav>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div className="rounded-lg border border-gray-200 bg-white p-4">
+              <SlateAssignmentForm experimentId={experiment.experimentId} />
+            </div>
+
+            <div className="rounded-lg border border-gray-200 bg-white p-4">
+              <SlatePositionBiasChart experimentId={experiment.experimentId} />
+            </div>
           </div>
         </section>
       )}

--- a/ui/src/components/slate/SlateAssignmentForm.tsx
+++ b/ui/src/components/slate/SlateAssignmentForm.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { memo, useState, useCallback } from 'react';
+import { getSlateAssignment } from '@/lib/api';
+import type { SlateAssignmentResponse } from '@/lib/types';
+import { SlateResultsPanel } from './SlateResultsPanel';
+
+interface SlateAssignmentFormProps {
+  experimentId: string;
+}
+
+const DEFAULT_CANDIDATES = [
+  'item-action-001',
+  'item-comedy-002',
+  'item-drama-003',
+  'item-thriller-004',
+  'item-scifi-005',
+  'item-docs-006',
+  'item-animation-007',
+  'item-romance-008',
+  'item-horror-009',
+  'item-family-010',
+  'item-crime-011',
+  'item-mystery-012',
+].join(', ');
+
+export const SlateAssignmentForm = memo(function SlateAssignmentForm({
+  experimentId,
+}: SlateAssignmentFormProps) {
+  const [candidateText, setCandidateText] = useState(DEFAULT_CANDIDATES);
+  const [nSlots, setNSlots] = useState(5);
+  const [userId, setUserId] = useState('test-user-001');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<SlateAssignmentResponse | null>(null);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    const candidateItemIds = candidateText
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (candidateItemIds.length === 0) {
+      setError('Enter at least one candidate item ID.');
+      return;
+    }
+    if (nSlots > candidateItemIds.length) {
+      setError(`n_slots (${nSlots}) cannot exceed number of candidates (${candidateItemIds.length}).`);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await getSlateAssignment(experimentId, userId, candidateItemIds);
+      setResult(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'GetSlateAssignment failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [experimentId, userId, candidateText, nSlots]);
+
+  return (
+    <div data-testid="slate-assignment-form">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="slate-user-id" className="block text-xs font-medium text-gray-700">
+            User ID
+          </label>
+          <input
+            id="slate-user-id"
+            type="text"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            placeholder="user-id"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="slate-n-slots" className="block text-xs font-medium text-gray-700">
+            Number of Slots (n_slots)
+          </label>
+          <input
+            id="slate-n-slots"
+            type="number"
+            min={1}
+            max={20}
+            value={nSlots}
+            onChange={(e) => setNSlots(Math.max(1, Math.min(20, Number(e.target.value))))}
+            className="mt-1 block w-32 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="slate-candidates" className="block text-xs font-medium text-gray-700">
+            Candidate Item IDs{' '}
+            <span className="font-normal text-gray-500">(comma-separated)</span>
+          </label>
+          <textarea
+            id="slate-candidates"
+            value={candidateText}
+            onChange={(e) => setCandidateText(e.target.value)}
+            rows={3}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 font-mono text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            placeholder="item-001, item-002, item-003"
+          />
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {loading ? 'Requesting…' : 'Get Slate Assignment'}
+        </button>
+      </form>
+
+      {result && (
+        <div className="mt-6">
+          <SlateResultsPanel response={result} />
+        </div>
+      )}
+    </div>
+  );
+});

--- a/ui/src/components/slate/SlatePositionBiasChart.tsx
+++ b/ui/src/components/slate/SlatePositionBiasChart.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { memo, useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import { getSlateOpe } from '@/lib/api';
+import type { SlateOpeResult } from '@/lib/types';
+
+interface SlatePositionBiasChartProps {
+  experimentId: string;
+}
+
+const POSITION_COLOR = '#4f46e5';
+
+export const SlatePositionBiasChart = memo(function SlatePositionBiasChart({
+  experimentId,
+}: SlatePositionBiasChartProps) {
+  const [result, setResult] = useState<SlateOpeResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getSlateOpe(experimentId)
+      .then(setResult)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [experimentId]);
+
+  if (loading) {
+    return (
+      <div className="flex h-40 items-center justify-center" role="status" aria-label="Loading position bias">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+        <span className="sr-only">Loading</span>
+      </div>
+    );
+  }
+
+  if (error || !result) {
+    return (
+      <p className="text-sm text-gray-500">
+        No LIPS OPE data available for this experiment.
+      </p>
+    );
+  }
+
+  const chartData = result.positionBias.map((p) => ({
+    position: `Pos ${p.position}`,
+    ctr: p.ctr,
+    lipsWeight: p.lipsWeight,
+  }));
+
+  return (
+    <div data-testid="slate-position-bias-chart">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900">Per-Position CTR (LIPS OPE)</h3>
+        <span className="text-xs text-gray-500">
+          Policy value: {result.estimatedValue.toFixed(4)}
+        </span>
+      </div>
+      <div role="img" aria-label="Per-position click-through rates from LIPS OPE estimate">
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart data={chartData} margin={{ left: 10, right: 10, top: 10, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="position" tick={{ fontSize: 11 }} />
+            <YAxis
+              tickFormatter={(v: number) => `${(v * 100).toFixed(0)}%`}
+              domain={[0, 'auto']}
+            />
+            <Tooltip
+              formatter={(v: number) => `${(v * 100).toFixed(2)}%`}
+              labelFormatter={(label) => `${label}`}
+            />
+            <Bar dataKey="ctr" isAnimationActive={false} name="CTR">
+              {chartData.map((_, i) => (
+                <Cell key={`cell-${i}`} fill={POSITION_COLOR} fillOpacity={1 - i * 0.06} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-1 text-xs text-gray-500">
+        Bars show click-through rate at each slate position, importance-weighted by LIPS abstraction.
+      </p>
+    </div>
+  );
+});

--- a/ui/src/components/slate/SlateResultsPanel.tsx
+++ b/ui/src/components/slate/SlateResultsPanel.tsx
@@ -1,0 +1,58 @@
+import { memo } from 'react';
+import type { SlateAssignmentResponse } from '@/lib/types';
+
+interface SlateResultsPanelProps {
+  response: SlateAssignmentResponse;
+}
+
+const PROB_COLORS = [
+  'bg-green-100 text-green-800',
+  'bg-blue-100 text-blue-800',
+  'bg-indigo-100 text-indigo-800',
+  'bg-purple-100 text-purple-800',
+  'bg-gray-100 text-gray-700',
+];
+
+function probColor(prob: number): string {
+  if (prob >= 0.8) return PROB_COLORS[0];
+  if (prob >= 0.6) return PROB_COLORS[1];
+  if (prob >= 0.4) return PROB_COLORS[2];
+  if (prob >= 0.2) return PROB_COLORS[3];
+  return PROB_COLORS[4];
+}
+
+export const SlateResultsPanel = memo(function SlateResultsPanel({ response }: SlateResultsPanelProps) {
+  const { slateItemIds, slotProbabilities, slateProbability } = response;
+
+  return (
+    <div data-testid="slate-results-panel">
+      <h3 className="mb-3 text-sm font-semibold text-gray-900">Slate Assignment</h3>
+      <ol className="space-y-2">
+        {slateItemIds.map((itemId, i) => {
+          const prob = slotProbabilities[i] ?? 0;
+          return (
+            <li
+              key={`${itemId}-${i}`}
+              className="flex items-center gap-3 rounded-md border border-gray-200 bg-white px-3 py-2"
+            >
+              <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-bold text-white">
+                {i + 1}
+              </span>
+              <span className="flex-1 truncate font-mono text-sm text-gray-800">{itemId}</span>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${probColor(prob)}`}
+                title={`Slot probability: ${(prob * 100).toFixed(1)}%`}
+              >
+                {(prob * 100).toFixed(1)}%
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+      <p className="mt-3 text-xs text-gray-500">
+        Overall slate probability:{' '}
+        <span className="font-medium text-gray-700">{slateProbability.toExponential(3)}</span>
+      </p>
+    </div>
+  );
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   AvlmResult, AdaptiveNResult, FeedbackLoopResult,
   OnlineFdrState,
   PortfolioAllocationResult,
+  SlateAssignmentResponse, SlateOpeResult,
 } from './types';
 import type { ExperimentState, ExperimentType, MetricType, LifecycleSegment } from './types';
 
@@ -32,6 +33,9 @@ const BANDIT_SVC = 'experimentation.bandit.v1.BanditPolicyService';
 
 const FLAGS_URL = process.env.NEXT_PUBLIC_FLAGS_URL || '/api/rpc/flags';
 const FLAGS_SVC = 'experimentation.flags.v1.FeatureFlagService';
+
+const ASSIGNMENT_URL = process.env.NEXT_PUBLIC_ASSIGNMENT_URL || '/api/rpc/assignment';
+const ASSIGNMENT_SVC = 'experimentation.assignment.v1.AssignmentService';
 
 // --- Auth header injection ---
 let _authEmail = '';
@@ -750,5 +754,31 @@ export async function getOnlineFdrState(experimentId: string): Promise<OnlineFdr
 export async function getPortfolioAllocation(): Promise<PortfolioAllocationResult> {
   return callRpc<Record<string, never>, PortfolioAllocationResult>(
     MGMT_URL, MGMT_SVC, 'GetPortfolioAllocation', {},
+  );
+}
+
+// --- Slate Bandit (ADR-016) ---
+
+export async function getSlateAssignment(
+  experimentId: string,
+  userId: string,
+  candidateItemIds: string[],
+  contextFeatures: Record<string, number> = {},
+): Promise<SlateAssignmentResponse> {
+  return callRpc<{
+    experimentId: string;
+    userId: string;
+    candidateItemIds: string[];
+    contextFeatures: Record<string, number>;
+  }, SlateAssignmentResponse>(
+    ASSIGNMENT_URL, ASSIGNMENT_SVC, 'GetSlateAssignment',
+    { experimentId, userId, candidateItemIds, contextFeatures },
+    { skipCache: true },
+  );
+}
+
+export async function getSlateOpe(experimentId: string): Promise<SlateOpeResult> {
+  return callRpc<{ experimentId: string }, SlateOpeResult>(
+    ANALYSIS_URL, ANALYSIS_SVC, 'GetSlateOpe', { experimentId },
   );
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -18,7 +18,8 @@ export type ExperimentType =
   | 'PLAYBACK_QOE'
   | 'MAB'
   | 'CONTEXTUAL_BANDIT'
-  | 'CUMULATIVE_HOLDOUT';
+  | 'CUMULATIVE_HOLDOUT'
+  | 'SLATE';
 
 export type GuardrailAction = 'AUTO_PAUSE' | 'ALERT_ONLY';
 
@@ -771,6 +772,27 @@ export interface PortfolioExperiment {
 export interface PortfolioAllocationResult {
   experiments: PortfolioExperiment[];
   totalAllocatedPct: number;
+  computedAt: string;
+}
+
+// --- Slate Bandit (ADR-016) ---
+
+export interface SlateAssignmentResponse {
+  slateItemIds: string[];
+  slotProbabilities: number[];
+  slateProbability: number;
+}
+
+export interface SlatePositionBiasPoint {
+  position: number;
+  ctr: number;
+  lipsWeight: number;
+}
+
+export interface SlateOpeResult {
+  experimentId: string;
+  positionBias: SlatePositionBiasPoint[];
+  estimatedValue: number;
   computedAt: string;
 }
 

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -69,6 +69,7 @@ export const TYPE_LABELS: Record<ExperimentType, string> = {
   MAB: 'Multi-Armed Bandit',
   CONTEXTUAL_BANDIT: 'Contextual Bandit',
   CUMULATIVE_HOLDOUT: 'Cumulative Holdout',
+  SLATE: 'Slate Bandit',
 };
 
 export function formatDate(iso: string): string {


### PR DESCRIPTION
## Summary

- **SlateResultsPanel**: ordered slate ranked list with position badges and per-slot probability color-coded badges (green≥80%, blue≥60%, indigo≥40%, purple≥20%, gray<20%), shows overall slate probability
- **SlatePositionBiasChart**: Recharts BarChart displaying per-position CTR weighted by LIPS importance weights; fetches `GetSlateOpe` from AnalysisService; shows estimated policy value
- **SlateAssignmentForm**: candidate item picker (textarea), n_slots selector (1–20), userId field; on submit calls `AssignmentService/GetSlateAssignment`; renders SlateResultsPanel on response; client-side validation
- **Slate tab on experiment detail page**: conditionally renders only for `experiment.type === 'SLATE'`; two-column layout (form | chart); both components code-split via `next/dynamic`

## Type / API changes

- Added `SLATE` to `ExperimentType` union and `TYPE_LABELS`
- New types: `SlateAssignmentResponse`, `SlatePositionBiasPoint`, `SlateOpeResult`
- New API: `getSlateAssignment()` → `AssignmentService/GetSlateAssignment`, `getSlateOpe()` → `AnalysisService/GetSlateOpe`
- New constants: `ASSIGNMENT_URL`, `ASSIGNMENT_SVC`

## Test plan

- [x] 17 new tests in `slate-bandit.test.tsx` (all passing)
  - SlateResultsPanel: items render, position badges, probability badges, overall probability
  - SlatePositionBiasChart: loading state, chart renders, policy value, no-data fallback
  - SlateAssignmentForm: form fields, submit success → SlateResultsPanel, validation errors
  - ExperimentDetailPage: Slate tab visible for SLATE, hidden for AB
- [x] Updated 4 affected tests: proto-wire-format (11 seeds), experiment-list (RUNNING count, sort, total), monitoring (RUNNING count)
- [x] Full suite: 516 passing, 6 pre-existing skips, 0 failures

## Notes / Opportunities

- `GetSlateOpe` and `GetSlateAssignment` are mocked via MSW; backend (Agent-4 + Agent-1) must implement these RPCs for production use
- SlatePositionBiasChart currently shows `error`→fallback silently; could add retry UX when Agent-4 endpoint is live
- GeMS generative approach (ADR-016 optional path) not yet surfaced in UI — deferred until `gpu` feature flag + Agent-4 support

Implements ADR-016 M6 UI section (Sprint 5.4).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
