### PR TITLE
feat(contract-tests): Phase 5 cross-module contract tests (ADR-016/019/021)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-test",
  "tonic",
  "tonic-web",

--- a/crates/experimentation-analysis/Cargo.toml
+++ b/crates/experimentation-analysis/Cargo.toml
@@ -34,4 +34,5 @@ uuid = { workspace = true }
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-stream = { workspace = true }
 deltalake = { workspace = true }

--- a/crates/experimentation-analysis/src/grpc.rs
+++ b/crates/experimentation-analysis/src/grpc.rs
@@ -11,6 +11,7 @@ use experimentation_proto::experimentation::analysis::v1::analysis_service_serve
 use experimentation_proto::experimentation::analysis::v1::{
     AlgorithmStrength as ProtoAlgorithmStrength, AnalysisResult, GetAnalysisResultRequest,
     GetInterferenceAnalysisRequest, GetInterleavingAnalysisRequest, GetNoveltyAnalysisRequest,
+    GetPortfolioAllocationRequest, GetPortfolioAllocationResponse,
     GetSwitchbackAnalysisRequest, GetSyntheticControlAnalysisRequest, InterferenceAnalysisResult,
     InterleavingAnalysisResult, IpwResult as ProtoIpwResult, MetricResult, NoveltyAnalysisResult,
     PositionAnalysis as ProtoPositionAnalysis, RunAnalysisRequest, SegmentResult,
@@ -824,6 +825,18 @@ impl AnalysisService for AnalysisServiceHandler {
     ) -> Result<Response<SwitchbackAnalysisResult>, Status> {
         Err(Status::unimplemented(
             "GetSwitchbackAnalysis not yet implemented (ADR-022)",
+        ))
+    }
+
+    async fn get_portfolio_allocation(
+        &self,
+        _request: Request<GetPortfolioAllocationRequest>,
+    ) -> Result<Response<GetPortfolioAllocationResponse>, Status> {
+        // ADR-019: Full portfolio optimization requires power-curve analysis.
+        // Contract is defined; implementation is Phase 5 work.
+        // The contract test exercises a test-specific implementation for wire-format validation.
+        Err(Status::unimplemented(
+            "GetPortfolioAllocation not yet implemented (ADR-019)",
         ))
     }
 }

--- a/crates/experimentation-analysis/tests/m5m4a_portfolio_contract_test.rs
+++ b/crates/experimentation-analysis/tests/m5m4a_portfolio_contract_test.rs
@@ -1,0 +1,680 @@
+//! M5 ↔ M4a GetPortfolioAllocation Contract Tests (ADR-019)
+//!
+//! These tests verify the wire-format contract between M5's portfolio optimization
+//! requests and M4a's `GetPortfolioAllocation` RPC. M5 submits a set of running
+//! experiment IDs and a total traffic budget; M4a returns optimal per-experiment
+//! traffic allocations and conclusion signals.
+//!
+//! Contract points verified:
+//! 1. Response has exactly one ExperimentAllocation per requested experiment_id
+//! 2. Each allocation's experiment_id matches one from the request
+//! 3. All allocated_fraction values are in [0.0, 1.0] and finite
+//! 4. sum(allocated_fraction) <= total_traffic_budget
+//! 5. estimated_power is in [0.0, 1.0] and finite for each allocation
+//! 6. computed_at timestamp is populated
+//! 7. total_allocated matches sum of individual allocated_fractions
+//! 8. Empty experiment_ids returns empty allocations (not an error)
+//! 9. Invalid total_traffic_budget (> 1.0 or <= 0) returns INVALID_ARGUMENT
+//! 10. Allocations respect budget even under high-traffic experiments
+//! 11. can_conclude flag is set when sample size exceeds stopping rule
+
+use experimentation_proto::experimentation::analysis::v1::{
+    analysis_service_server::{AnalysisService, AnalysisServiceServer},
+    AnalysisResult, ExperimentAllocation, GetAnalysisResultRequest,
+    GetInterferenceAnalysisRequest, GetInterleavingAnalysisRequest, GetNoveltyAnalysisRequest,
+    GetPortfolioAllocationRequest, GetPortfolioAllocationResponse, GetSwitchbackAnalysisRequest,
+    GetSyntheticControlAnalysisRequest, InterleavingAnalysisResult, InterferenceAnalysisResult,
+    NoveltyAnalysisResult, RunAnalysisRequest, SwitchbackAnalysisResult,
+    SyntheticControlAnalysisResult,
+};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use tonic::{Request, Response, Status};
+
+// ---------------------------------------------------------------------------
+// Test M4a implementation for portfolio allocation
+// ---------------------------------------------------------------------------
+
+/// Per-experiment metadata tracked by the test service.
+struct ExpInfo {
+    /// Sample size accumulated so far (simulates M4a reading from Delta Lake).
+    sample_size: u64,
+    /// Target sample size for full power (from power calculation at design time).
+    target_sample_size: u64,
+    /// Observed effect size (absolute, in effect units).
+    observed_effect: f64,
+    /// Minimum detectable effect (from experiment design).
+    mde: f64,
+}
+
+/// Test implementation of M4a's AnalysisService for portfolio allocation.
+struct PortfolioTestService {
+    /// Registered experiment metadata (simulates Delta Lake reads).
+    experiments: HashMap<String, ExpInfo>,
+}
+
+impl PortfolioTestService {
+    fn new() -> Self {
+        let mut exps = HashMap::new();
+
+        // Mature experiment: has 90% of target sample, borderline concludable.
+        exps.insert(
+            "exp-mature".to_string(),
+            ExpInfo {
+                sample_size: 9000,
+                target_sample_size: 10_000,
+                observed_effect: 0.05,
+                mde: 0.03,
+            },
+        );
+
+        // Ready-to-conclude: has 120% of target, effect > MDE, high power.
+        exps.insert(
+            "exp-ready-conclude".to_string(),
+            ExpInfo {
+                sample_size: 12_000,
+                target_sample_size: 10_000,
+                observed_effect: 0.08,
+                mde: 0.03,
+            },
+        );
+
+        // Early-stage: only 20% of target sample size, needs more traffic.
+        exps.insert(
+            "exp-early".to_string(),
+            ExpInfo {
+                sample_size: 2_000,
+                target_sample_size: 10_000,
+                observed_effect: 0.01,
+                mde: 0.03,
+            },
+        );
+
+        // High-traffic incumbent: large ongoing experiment.
+        exps.insert(
+            "exp-incumbent".to_string(),
+            ExpInfo {
+                sample_size: 50_000,
+                target_sample_size: 50_000,
+                observed_effect: 0.02,
+                mde: 0.01,
+            },
+        );
+
+        Self { experiments: exps }
+    }
+
+    /// Portfolio optimizer: maximizes information gain within the traffic budget.
+    ///
+    /// Simple heuristic that mirrors the ADR-019 objective: prioritize experiments
+    /// with the lowest completion ratio (most room to gain information).
+    fn compute_portfolio_allocation(
+        &self,
+        experiment_ids: &[String],
+        total_budget: f64,
+    ) -> Result<GetPortfolioAllocationResponse, Status> {
+        if experiment_ids.is_empty() {
+            return Ok(GetPortfolioAllocationResponse {
+                allocations: vec![],
+                total_allocated: 0.0,
+                computed_at: Some(now_timestamp()),
+            });
+        }
+
+        // Validate all experiments exist.
+        for exp_id in experiment_ids {
+            if !self.experiments.contains_key(exp_id.as_str()) {
+                return Err(Status::not_found(format!(
+                    "experiment '{exp_id}' not found in M4a analysis store"
+                )));
+            }
+        }
+
+        // Compute completion ratio and target allocation for each experiment.
+        // Lower completion → higher priority for traffic allocation.
+        let mut weights: Vec<(usize, f64)> = experiment_ids
+            .iter()
+            .enumerate()
+            .map(|(i, exp_id)| {
+                let info = &self.experiments[exp_id.as_str()];
+                let completion = (info.sample_size as f64 / info.target_sample_size as f64).min(1.0);
+                // Experiments closer to target get less additional traffic.
+                let weight = (1.0 - completion).max(0.05); // min 5% weight to avoid starvation
+                (i, weight)
+            })
+            .collect();
+
+        // Normalize weights to sum to 1.0, then scale by total_budget.
+        let total_weight: f64 = weights.iter().map(|(_, w)| w).sum();
+        for (_, w) in &mut weights {
+            *w = (*w / total_weight) * total_budget;
+        }
+
+        let mut allocations = vec![
+            ExperimentAllocation {
+                experiment_id: String::new(),
+                allocated_fraction: 0.0,
+                can_conclude: false,
+                estimated_power: 0.0,
+            };
+            experiment_ids.len()
+        ];
+
+        let mut total_allocated = 0.0;
+        for (i, fraction) in weights {
+            let exp_id = &experiment_ids[i];
+            let info = &self.experiments[exp_id.as_str()];
+
+            // Statistical power estimate: Cohen's power approximation.
+            // Power ≈ Φ(|effect| / mde × √(sample/target) − z_alpha/2)
+            // Simplified: clamp completion × (effect/mde) to [0, 1].
+            let completion = (info.sample_size as f64 / info.target_sample_size as f64).min(1.0);
+            let effect_ratio = if info.mde > 0.0 {
+                (info.observed_effect.abs() / info.mde).min(2.0)
+            } else {
+                0.0
+            };
+            let estimated_power = (completion * effect_ratio * 0.9).clamp(0.0, 1.0);
+
+            // Experiment is concludable if: sample >= target AND effect > MDE.
+            let can_conclude =
+                info.sample_size >= info.target_sample_size && info.observed_effect.abs() > info.mde;
+
+            allocations[i] = ExperimentAllocation {
+                experiment_id: exp_id.clone(),
+                allocated_fraction: fraction,
+                can_conclude,
+                estimated_power,
+            };
+            total_allocated += fraction;
+        }
+
+        Ok(GetPortfolioAllocationResponse {
+            allocations,
+            total_allocated,
+            computed_at: Some(now_timestamp()),
+        })
+    }
+}
+
+fn now_timestamp() -> prost_types::Timestamp {
+    let now = chrono::Utc::now();
+    prost_types::Timestamp {
+        seconds: now.timestamp(),
+        nanos: now.timestamp_subsec_nanos() as i32,
+    }
+}
+
+#[tonic::async_trait]
+impl AnalysisService for PortfolioTestService {
+    async fn run_analysis(
+        &self,
+        _r: Request<RunAnalysisRequest>,
+    ) -> Result<Response<AnalysisResult>, Status> {
+        Err(Status::unimplemented("not used in portfolio contract tests"))
+    }
+
+    async fn get_analysis_result(
+        &self,
+        _r: Request<GetAnalysisResultRequest>,
+    ) -> Result<Response<AnalysisResult>, Status> {
+        Err(Status::unimplemented("not used in portfolio contract tests"))
+    }
+
+    async fn get_interleaving_analysis(
+        &self,
+        _r: Request<GetInterleavingAnalysisRequest>,
+    ) -> Result<Response<InterleavingAnalysisResult>, Status> {
+        Err(Status::unimplemented("not used in portfolio contract tests"))
+    }
+
+    async fn get_novelty_analysis(
+        &self,
+        _r: Request<GetNoveltyAnalysisRequest>,
+    ) -> Result<Response<NoveltyAnalysisResult>, Status> {
+        Err(Status::unimplemented("not used in portfolio contract tests"))
+    }
+
+    async fn get_interference_analysis(
+        &self,
+        _r: Request<GetInterferenceAnalysisRequest>,
+    ) -> Result<Response<InterferenceAnalysisResult>, Status> {
+        Err(Status::unimplemented("not used in portfolio contract tests"))
+    }
+
+    async fn get_synthetic_control_analysis(
+        &self,
+        _r: Request<GetSyntheticControlAnalysisRequest>,
+    ) -> Result<Response<SyntheticControlAnalysisResult>, Status> {
+        Err(Status::unimplemented("not used in portfolio contract tests"))
+    }
+
+    async fn get_switchback_analysis(
+        &self,
+        _r: Request<GetSwitchbackAnalysisRequest>,
+    ) -> Result<Response<SwitchbackAnalysisResult>, Status> {
+        Err(Status::unimplemented("not used in portfolio contract tests"))
+    }
+
+    async fn get_portfolio_allocation(
+        &self,
+        request: Request<GetPortfolioAllocationRequest>,
+    ) -> Result<Response<GetPortfolioAllocationResponse>, Status> {
+        let req = request.into_inner();
+
+        // Validate budget: must be in (0.0, 1.0].
+        if req.total_traffic_budget <= 0.0 || req.total_traffic_budget > 1.0 {
+            return Err(Status::invalid_argument(format!(
+                "total_traffic_budget must be in (0.0, 1.0], got {}",
+                req.total_traffic_budget
+            )));
+        }
+
+        let resp = self
+            .compute_portfolio_allocation(&req.experiment_ids, req.total_traffic_budget)?;
+
+        Ok(Response::new(resp))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+type PortfolioClient =
+    experimentation_proto::experimentation::analysis::v1::analysis_service_client::AnalysisServiceClient<
+        tonic::transport::Channel,
+    >;
+
+async fn start_portfolio_server() -> (PortfolioClient, SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("[::1]:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let service = PortfolioTestService::new();
+    let handle = tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        tonic::transport::Server::builder()
+            .add_service(AnalysisServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let channel = tonic::transport::Channel::from_shared(format!("http://[::1]:{}", addr.port()))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+
+    let client = experimentation_proto::experimentation::analysis::v1::analysis_service_client::AnalysisServiceClient::new(channel);
+
+    (client, addr, handle)
+}
+
+// ---------------------------------------------------------------------------
+// Contract Tests
+// ---------------------------------------------------------------------------
+
+/// 1. Response has exactly one ExperimentAllocation per requested experiment_id.
+#[tokio::test]
+async fn contract_portfolio_one_allocation_per_experiment() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let exp_ids = vec![
+        "exp-mature".to_string(),
+        "exp-early".to_string(),
+        "exp-ready-conclude".to_string(),
+    ];
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: exp_ids.clone(),
+            total_traffic_budget: 0.6,
+        })
+        .await
+        .expect("GetPortfolioAllocation should succeed")
+        .into_inner();
+
+    assert_eq!(
+        resp.allocations.len(),
+        exp_ids.len(),
+        "should have one allocation per requested experiment"
+    );
+
+    // Each allocation's experiment_id must be in the request set.
+    let request_ids: std::collections::HashSet<_> = exp_ids.iter().collect();
+    for alloc in &resp.allocations {
+        assert!(
+            request_ids.contains(&alloc.experiment_id),
+            "allocation for unknown experiment_id '{}'",
+            alloc.experiment_id
+        );
+    }
+
+    handle.abort();
+}
+
+/// 2. All allocated_fraction values are in [0.0, 1.0] and finite.
+#[tokio::test]
+async fn contract_portfolio_allocated_fractions_valid() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec![
+                "exp-mature".to_string(),
+                "exp-early".to_string(),
+                "exp-ready-conclude".to_string(),
+                "exp-incumbent".to_string(),
+            ],
+            total_traffic_budget: 0.8,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    for alloc in &resp.allocations {
+        assert!(
+            alloc.allocated_fraction >= 0.0,
+            "allocated_fraction for '{}' must be >= 0, got {}",
+            alloc.experiment_id,
+            alloc.allocated_fraction
+        );
+        assert!(
+            alloc.allocated_fraction <= 1.0,
+            "allocated_fraction for '{}' must be <= 1.0, got {}",
+            alloc.experiment_id,
+            alloc.allocated_fraction
+        );
+        assert!(
+            alloc.allocated_fraction.is_finite(),
+            "allocated_fraction for '{}' must be finite",
+            alloc.experiment_id
+        );
+    }
+
+    handle.abort();
+}
+
+/// 3. sum(allocated_fraction) <= total_traffic_budget.
+#[tokio::test]
+async fn contract_portfolio_total_within_budget() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let budget = 0.5;
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec![
+                "exp-mature".to_string(),
+                "exp-early".to_string(),
+                "exp-ready-conclude".to_string(),
+            ],
+            total_traffic_budget: budget,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let sum: f64 = resp.allocations.iter().map(|a| a.allocated_fraction).sum();
+    assert!(
+        sum <= budget + 1e-9,
+        "sum of allocated_fractions {:.4} exceeds total_traffic_budget {:.4}",
+        sum,
+        budget
+    );
+
+    handle.abort();
+}
+
+/// 4. total_allocated field matches sum of individual allocated_fractions.
+#[tokio::test]
+async fn contract_portfolio_total_allocated_matches_sum() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec!["exp-mature".to_string(), "exp-early".to_string()],
+            total_traffic_budget: 0.4,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let expected_total: f64 = resp.allocations.iter().map(|a| a.allocated_fraction).sum();
+    assert!(
+        (resp.total_allocated - expected_total).abs() < 1e-9,
+        "total_allocated {:.6} != sum of fractions {:.6}",
+        resp.total_allocated,
+        expected_total
+    );
+
+    handle.abort();
+}
+
+/// 5. estimated_power is in [0.0, 1.0] and finite for each allocation.
+#[tokio::test]
+async fn contract_portfolio_estimated_power_valid() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec![
+                "exp-mature".to_string(),
+                "exp-ready-conclude".to_string(),
+                "exp-early".to_string(),
+            ],
+            total_traffic_budget: 0.6,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    for alloc in &resp.allocations {
+        assert!(
+            alloc.estimated_power >= 0.0 && alloc.estimated_power <= 1.0,
+            "estimated_power for '{}' must be in [0,1], got {}",
+            alloc.experiment_id,
+            alloc.estimated_power
+        );
+        assert!(
+            alloc.estimated_power.is_finite(),
+            "estimated_power for '{}' must be finite",
+            alloc.experiment_id
+        );
+    }
+
+    handle.abort();
+}
+
+/// 6. computed_at timestamp is populated.
+#[tokio::test]
+async fn contract_portfolio_computed_at_present() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec!["exp-mature".to_string()],
+            total_traffic_budget: 0.3,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(
+        resp.computed_at.is_some(),
+        "computed_at must be present in GetPortfolioAllocationResponse"
+    );
+
+    let ts = resp.computed_at.unwrap();
+    // timestamp must be a recent epoch (after year 2020).
+    assert!(
+        ts.seconds > 1_580_000_000,
+        "computed_at.seconds looks wrong: {}",
+        ts.seconds
+    );
+
+    handle.abort();
+}
+
+/// 7. Empty experiment_ids returns empty allocations without error.
+#[tokio::test]
+async fn contract_portfolio_empty_request_returns_empty() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec![],
+            total_traffic_budget: 0.5,
+        })
+        .await
+        .expect("empty experiment_ids should not error")
+        .into_inner();
+
+    assert!(
+        resp.allocations.is_empty(),
+        "empty request should produce empty allocations"
+    );
+    assert!(
+        (resp.total_allocated - 0.0).abs() < 1e-9,
+        "total_allocated should be 0.0 for empty request"
+    );
+
+    handle.abort();
+}
+
+/// 8. total_traffic_budget > 1.0 returns INVALID_ARGUMENT.
+#[tokio::test]
+async fn contract_portfolio_budget_above_one_rejected() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let err = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec!["exp-mature".to_string()],
+            total_traffic_budget: 1.5,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.code(),
+        tonic::Code::InvalidArgument,
+        "budget > 1.0 must return INVALID_ARGUMENT, got: {:?}",
+        err.code()
+    );
+
+    handle.abort();
+}
+
+/// 9. total_traffic_budget <= 0 returns INVALID_ARGUMENT.
+#[tokio::test]
+async fn contract_portfolio_budget_zero_rejected() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let err = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec!["exp-mature".to_string()],
+            total_traffic_budget: 0.0,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.code(),
+        tonic::Code::InvalidArgument,
+        "budget = 0 must return INVALID_ARGUMENT, got: {:?}",
+        err.code()
+    );
+
+    handle.abort();
+}
+
+/// 10. Unknown experiment returns NOT_FOUND.
+#[tokio::test]
+async fn contract_portfolio_unknown_experiment_not_found() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let err = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec!["exp-mature".to_string(), "nonexistent-exp".to_string()],
+            total_traffic_budget: 0.5,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.code(),
+        tonic::Code::NotFound,
+        "unknown experiment must return NOT_FOUND, got: {:?}",
+        err.code()
+    );
+
+    handle.abort();
+}
+
+/// 11. can_conclude is true for the experiment that has met all stopping criteria.
+#[tokio::test]
+async fn contract_portfolio_can_conclude_signal() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec![
+                "exp-ready-conclude".to_string(), // should be concludable
+                "exp-early".to_string(),          // should NOT be concludable
+                "exp-mature".to_string(),         // borderline — not concludable (9000 < 10000)
+            ],
+            total_traffic_budget: 0.6,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let allocs: HashMap<&str, &ExperimentAllocation> = resp
+        .allocations
+        .iter()
+        .map(|a| (a.experiment_id.as_str(), a))
+        .collect();
+
+    assert!(
+        allocs["exp-ready-conclude"].can_conclude,
+        "exp-ready-conclude should have can_conclude=true (sample=12000>target=10000, effect=0.08>mde=0.03)",
+    );
+    assert!(
+        !allocs["exp-early"].can_conclude,
+        "exp-early should have can_conclude=false (sample=2000 << target=10000)"
+    );
+    assert!(
+        !allocs["exp-mature"].can_conclude,
+        "exp-mature should have can_conclude=false (sample=9000 < target=10000)"
+    );
+
+    handle.abort();
+}
+
+/// 12. Single experiment request works correctly.
+#[tokio::test]
+async fn contract_portfolio_single_experiment() {
+    let (mut client, _, handle) = start_portfolio_server().await;
+
+    let resp = client
+        .get_portfolio_allocation(GetPortfolioAllocationRequest {
+            experiment_ids: vec!["exp-incumbent".to_string()],
+            total_traffic_budget: 0.3,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.allocations.len(), 1);
+    assert_eq!(resp.allocations[0].experiment_id, "exp-incumbent");
+    // Single experiment gets the full budget allocated.
+    assert!(
+        (resp.allocations[0].allocated_fraction - 0.3).abs() < 1e-9,
+        "single experiment should receive full budget, got: {}",
+        resp.allocations[0].allocated_fraction
+    );
+
+    handle.abort();
+}

--- a/crates/experimentation-assignment/tests/assignment_test.rs
+++ b/crates/experimentation-assignment/tests/assignment_test.rs
@@ -14,7 +14,7 @@ use experimentation_proto::experimentation::bandit::v1::bandit_policy_service_se
 use experimentation_proto::experimentation::bandit::v1::{
     CreateColdStartBanditRequest, CreateColdStartBanditResponse, ExportAffinityScoresRequest,
     ExportAffinityScoresResponse, GetPolicySnapshotRequest, RollbackPolicyRequest,
-    SelectArmRequest, SlateAssignmentRequest, SlateAssignmentResponse,
+    GetSlateAssignmentRequest, SelectArmRequest, SlateAssignmentResponse,
 };
 use experimentation_proto::experimentation::common::v1::{ArmSelection, PolicySnapshot};
 
@@ -1375,7 +1375,7 @@ impl BanditPolicyService for MockBanditService {
 
     async fn get_slate_assignment(
         &self,
-        _request: tonic::Request<SlateAssignmentRequest>,
+        _request: tonic::Request<GetSlateAssignmentRequest>,
     ) -> Result<tonic::Response<SlateAssignmentResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented("not needed for assignment_test mock"))
     }

--- a/crates/experimentation-assignment/tests/assignment_test.rs
+++ b/crates/experimentation-assignment/tests/assignment_test.rs
@@ -14,7 +14,7 @@ use experimentation_proto::experimentation::bandit::v1::bandit_policy_service_se
 use experimentation_proto::experimentation::bandit::v1::{
     CreateColdStartBanditRequest, CreateColdStartBanditResponse, ExportAffinityScoresRequest,
     ExportAffinityScoresResponse, GetPolicySnapshotRequest, RollbackPolicyRequest,
-    SelectArmRequest,
+    SelectArmRequest, SlateAssignmentRequest, SlateAssignmentResponse,
 };
 use experimentation_proto::experimentation::common::v1::{ArmSelection, PolicySnapshot};
 
@@ -1371,6 +1371,13 @@ impl BanditPolicyService for MockBanditService {
             assignment_probability: self.probability,
             all_arm_probabilities: all_probs,
         }))
+    }
+
+    async fn get_slate_assignment(
+        &self,
+        _request: tonic::Request<SlateAssignmentRequest>,
+    ) -> Result<tonic::Response<SlateAssignmentResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented("not needed for assignment_test mock"))
     }
 
     async fn create_cold_start_bandit(

--- a/crates/experimentation-assignment/tests/m1m4b_contract_test.rs
+++ b/crates/experimentation-assignment/tests/m1m4b_contract_test.rs
@@ -25,7 +25,7 @@ use experimentation_bandit::thompson::BetaArm;
 use experimentation_proto::experimentation::bandit::v1::{
     self as proto,
     bandit_policy_service_server::{BanditPolicyService, BanditPolicyServiceServer},
-    CreateColdStartBanditResponse, ExportAffinityScoresResponse,
+    CreateColdStartBanditResponse, ExportAffinityScoresResponse, SlateAssignmentResponse,
 };
 use experimentation_proto::experimentation::common::v1::{
     ArmSelection as ProtoArmSelection, PolicySnapshot as ProtoPolicySnapshot,
@@ -178,6 +178,14 @@ impl BanditPolicyService for RealBanditService {
         Err(Status::not_found(format!(
             "experiment '{experiment_id}' not found"
         )))
+    }
+
+    async fn get_slate_assignment(
+        &self,
+        _request: Request<proto::SlateAssignmentRequest>,
+    ) -> Result<Response<SlateAssignmentResponse>, Status> {
+        // Slate assignment is covered by m1m4b_slate_contract_test.rs.
+        Err(Status::unimplemented("use m1m4b_slate_contract_test for slate tests"))
     }
 
     async fn create_cold_start_bandit(

--- a/crates/experimentation-assignment/tests/m1m4b_contract_test.rs
+++ b/crates/experimentation-assignment/tests/m1m4b_contract_test.rs
@@ -182,7 +182,7 @@ impl BanditPolicyService for RealBanditService {
 
     async fn get_slate_assignment(
         &self,
-        _request: Request<proto::SlateAssignmentRequest>,
+        _request: Request<proto::GetSlateAssignmentRequest>,
     ) -> Result<Response<SlateAssignmentResponse>, Status> {
         // Slate assignment is covered by m1m4b_slate_contract_test.rs.
         Err(Status::unimplemented("use m1m4b_slate_contract_test for slate tests"))

--- a/crates/experimentation-assignment/tests/m1m4b_slate_contract_test.rs
+++ b/crates/experimentation-assignment/tests/m1m4b_slate_contract_test.rs
@@ -6,7 +6,7 @@
 //! rather than a single arm.
 //!
 //! Contract points verified:
-//! 1. SlateAssignmentRequest fields round-trip: experiment_id, user_id, context_features, num_slots
+//! 1. GetSlateAssignmentRequest fields round-trip: experiment_id, user_id, context_features, num_slots
 //! 2. SlateAssignmentResponse: arm_ids length equals num_slots, all unique, all valid candidates
 //! 3. slot_probabilities: length equals num_slots, all positive and finite
 //! 4. joint_probability: positive, finite, approximately product of slot_probabilities
@@ -145,7 +145,7 @@ impl BanditPolicyService for SlateTestService {
 
     async fn get_slate_assignment(
         &self,
-        request: Request<proto::SlateAssignmentRequest>,
+        request: Request<proto::GetSlateAssignmentRequest>,
     ) -> Result<Response<SlateAssignmentResponse>, Status> {
         let req = request.into_inner();
 
@@ -263,7 +263,7 @@ async fn contract_slate_arm_ids_length_and_uniqueness() {
     let (mut client, _, handle) = start_slate_server().await;
 
     let resp = client
-        .get_slate_assignment(proto::SlateAssignmentRequest {
+        .get_slate_assignment(proto::GetSlateAssignmentRequest {
             experiment_id: "slate-content-3slot".into(),
             user_id: "user-slate-1".into(),
             context_features: HashMap::new(),
@@ -309,7 +309,7 @@ async fn contract_slate_slot_probabilities_valid() {
     let (mut client, _, handle) = start_slate_server().await;
 
     let resp = client
-        .get_slate_assignment(proto::SlateAssignmentRequest {
+        .get_slate_assignment(proto::GetSlateAssignmentRequest {
             experiment_id: "slate-content-3slot".into(),
             user_id: "user-slate-prob".into(),
             context_features: HashMap::new(),
@@ -349,7 +349,7 @@ async fn contract_slate_joint_probability_valid() {
     let (mut client, _, handle) = start_slate_server().await;
 
     let resp = client
-        .get_slate_assignment(proto::SlateAssignmentRequest {
+        .get_slate_assignment(proto::GetSlateAssignmentRequest {
             experiment_id: "slate-content-3slot".into(),
             user_id: "user-joint-prob".into(),
             context_features: HashMap::new(),
@@ -389,7 +389,7 @@ async fn contract_slate_joint_probability_valid() {
 async fn contract_slate_deterministic_for_same_user() {
     let (mut client, _, handle) = start_slate_server().await;
 
-    let req = || proto::SlateAssignmentRequest {
+    let req = || proto::GetSlateAssignmentRequest {
         experiment_id: "slate-content-3slot".into(),
         user_id: "stable-slate-user-42".into(),
         context_features: HashMap::new(),
@@ -422,7 +422,7 @@ async fn contract_slate_distribution_across_users() {
     let mut top_arm_counts: HashMap<String, u32> = HashMap::new();
     for i in 0..200u32 {
         let resp = client
-            .get_slate_assignment(proto::SlateAssignmentRequest {
+            .get_slate_assignment(proto::GetSlateAssignmentRequest {
                 experiment_id: "slate-content-3slot".into(),
                 user_id: format!("dist-slate-user-{i}"),
                 context_features: HashMap::new(),
@@ -452,7 +452,7 @@ async fn contract_slate_unknown_experiment_not_found() {
     let (mut client, _, handle) = start_slate_server().await;
 
     let err = client
-        .get_slate_assignment(proto::SlateAssignmentRequest {
+        .get_slate_assignment(proto::GetSlateAssignmentRequest {
             experiment_id: "nonexistent-slate-exp".into(),
             user_id: "user-1".into(),
             context_features: HashMap::new(),
@@ -477,7 +477,7 @@ async fn contract_slate_num_slots_zero_uses_default() {
     let (mut client, _, handle) = start_slate_server().await;
 
     let resp = client
-        .get_slate_assignment(proto::SlateAssignmentRequest {
+        .get_slate_assignment(proto::GetSlateAssignmentRequest {
             experiment_id: "slate-hero-2slot".into(),
             user_id: "user-default-slots".into(),
             context_features: HashMap::new(),
@@ -505,7 +505,7 @@ async fn contract_slate_num_slots_capped_at_pool_size() {
     // "slate-small-pool" has 2 candidates but default_slots=5.
     // Requesting 10 slots should return only 2 (pool size).
     let resp = client
-        .get_slate_assignment(proto::SlateAssignmentRequest {
+        .get_slate_assignment(proto::GetSlateAssignmentRequest {
             experiment_id: "slate-small-pool".into(),
             user_id: "user-overflow-slots".into(),
             context_features: HashMap::new(),
@@ -544,7 +544,7 @@ async fn contract_slate_with_context_features_accepted() {
     .collect();
 
     let resp = client
-        .get_slate_assignment(proto::SlateAssignmentRequest {
+        .get_slate_assignment(proto::GetSlateAssignmentRequest {
             experiment_id: "slate-content-3slot".into(),
             user_id: "contextual-user-1".into(),
             context_features: context,
@@ -577,7 +577,7 @@ async fn contract_slate_concurrent_requests() {
         let mut c = client.clone();
         handles.push(tokio::spawn(async move {
             tokio::time::timeout(per_task_timeout, async move {
-                c.get_slate_assignment(proto::SlateAssignmentRequest {
+                c.get_slate_assignment(proto::GetSlateAssignmentRequest {
                     experiment_id: "slate-content-3slot".into(),
                     user_id: format!("concurrent-slate-{i}"),
                     context_features: HashMap::new(),
@@ -633,7 +633,7 @@ async fn contract_slate_all_probabilities_finite() {
 
     for i in 0..20u32 {
         let resp = client
-            .get_slate_assignment(proto::SlateAssignmentRequest {
+            .get_slate_assignment(proto::GetSlateAssignmentRequest {
                 experiment_id: "slate-content-3slot".into(),
                 user_id: format!("finite-check-slate-{i}"),
                 context_features: HashMap::new(),

--- a/crates/experimentation-assignment/tests/m1m4b_slate_contract_test.rs
+++ b/crates/experimentation-assignment/tests/m1m4b_slate_contract_test.rs
@@ -1,0 +1,659 @@
+//! M1 ↔ M4b GetSlateAssignment Contract Tests (ADR-016)
+//!
+//! These tests verify the wire-format contract between M1's slate assignment path
+//! and M4b's new `GetSlateAssignment` RPC. The slate interface supports
+//! SLATE_FACTORIZED_TS experiments where M4b returns an ordered list of arm IDs
+//! rather than a single arm.
+//!
+//! Contract points verified:
+//! 1. SlateAssignmentRequest fields round-trip: experiment_id, user_id, context_features, num_slots
+//! 2. SlateAssignmentResponse: arm_ids length equals num_slots, all unique, all valid candidates
+//! 3. slot_probabilities: length equals num_slots, all positive and finite
+//! 4. joint_probability: positive, finite, approximately product of slot_probabilities
+//! 5. Different users produce different orderings (distribution check)
+//! 6. Same user + same experiment produces the same slate (deterministic)
+//! 7. Unknown experiment returns NOT_FOUND
+//! 8. Slate with context_features (contextual variant)
+//! 9. num_slots > candidate pool → capped at pool size
+//! 10. Concurrent slate requests — valid results under load
+
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use experimentation_bandit::thompson::BetaArm;
+use experimentation_proto::experimentation::bandit::v1::{
+    self as proto,
+    bandit_policy_service_server::{BanditPolicyService, BanditPolicyServiceServer},
+    CreateColdStartBanditResponse, ExportAffinityScoresResponse, SlateAssignmentResponse,
+};
+use experimentation_proto::experimentation::common::v1::{
+    ArmSelection as ProtoArmSelection, PolicySnapshot as ProtoPolicySnapshot,
+};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use tonic::{Request, Response, Status};
+
+// ---------------------------------------------------------------------------
+// Test M4b implementation with real slate selection (factorized Thompson)
+// ---------------------------------------------------------------------------
+
+/// Slate experiment config used by the test service.
+struct SlateExperiment {
+    /// Candidate arm IDs (all eligible items).
+    candidates: Vec<BetaArm>,
+    /// Default number of slots if num_slots == 0 in request.
+    default_slots: usize,
+}
+
+struct SlateTestService {
+    experiments: Arc<Mutex<HashMap<String, SlateExperiment>>>,
+}
+
+impl SlateTestService {
+    fn new() -> Self {
+        let mut exps = HashMap::new();
+
+        // 6-candidate, 3-slot slate: content ranking experiment
+        exps.insert(
+            "slate-content-3slot".to_string(),
+            SlateExperiment {
+                candidates: vec![
+                    BetaArm::new("drama_series".into()),
+                    BetaArm::new("comedy_film".into()),
+                    BetaArm::new("documentary".into()),
+                    BetaArm::new("action_blockbuster".into()),
+                    BetaArm::new("kids_animation".into()),
+                    BetaArm::new("thriller".into()),
+                ],
+                default_slots: 3,
+            },
+        );
+
+        // 4-candidate, 2-slot slate: homepage hero banners
+        exps.insert(
+            "slate-hero-2slot".to_string(),
+            SlateExperiment {
+                candidates: vec![
+                    BetaArm::new("hero_a".into()),
+                    BetaArm::new("hero_b".into()),
+                    BetaArm::new("hero_c".into()),
+                    BetaArm::new("hero_d".into()),
+                ],
+                default_slots: 2,
+            },
+        );
+
+        // Small pool for the "num_slots > pool" test
+        exps.insert(
+            "slate-small-pool".to_string(),
+            SlateExperiment {
+                candidates: vec![
+                    BetaArm::new("item_x".into()),
+                    BetaArm::new("item_y".into()),
+                ],
+                default_slots: 5, // exceeds pool size of 2
+            },
+        );
+
+        Self {
+            experiments: Arc::new(Mutex::new(exps)),
+        }
+    }
+}
+
+/// Factorized Thompson Sampling slate selection.
+///
+/// For each slot, sample from the remaining candidates using Thompson's Beta
+/// sampling, remove the selected arm, and recurse. Returns (arm_ids, per_slot_probs).
+fn select_slate_factorized(
+    candidates: &[BetaArm],
+    num_slots: usize,
+    rng: &mut StdRng,
+) -> (Vec<String>, Vec<f64>) {
+    let actual_slots = num_slots.min(candidates.len());
+    let mut remaining: Vec<BetaArm> = candidates.to_vec();
+    let mut arm_ids = Vec::with_capacity(actual_slots);
+    let mut slot_probs = Vec::with_capacity(actual_slots);
+
+    for _ in 0..actual_slots {
+        if remaining.is_empty() {
+            break;
+        }
+        let selection = experimentation_bandit::thompson::select_arm(&remaining, rng);
+        let prob = selection.assignment_probability;
+        let arm_id = selection.arm_id.clone();
+
+        // Per-slot probability: marginal probability of this arm at this slot
+        // given the remaining candidate pool.
+        slot_probs.push(prob.max(1e-9)); // avoid exact zero for IPW stability
+        arm_ids.push(arm_id.clone());
+        remaining.retain(|a| a.arm_id != arm_id);
+    }
+
+    (arm_ids, slot_probs)
+}
+
+#[tonic::async_trait]
+impl BanditPolicyService for SlateTestService {
+    async fn select_arm(
+        &self,
+        _request: Request<proto::SelectArmRequest>,
+    ) -> Result<Response<ProtoArmSelection>, Status> {
+        Err(Status::unimplemented("use GetSlateAssignment for slate tests"))
+    }
+
+    async fn get_slate_assignment(
+        &self,
+        request: Request<proto::SlateAssignmentRequest>,
+    ) -> Result<Response<SlateAssignmentResponse>, Status> {
+        let req = request.into_inner();
+
+        if req.experiment_id.is_empty() {
+            return Err(Status::invalid_argument("experiment_id is required"));
+        }
+        if req.user_id.is_empty() {
+            return Err(Status::invalid_argument("user_id is required"));
+        }
+
+        let (candidates, default_slots) = {
+            let exps = self.experiments.lock().unwrap();
+            let exp = exps.get(&req.experiment_id).ok_or_else(|| {
+                Status::not_found(format!("experiment '{}' not found", req.experiment_id))
+            })?;
+            (exp.candidates.clone(), exp.default_slots)
+        };
+
+        let num_slots = if req.num_slots > 0 {
+            req.num_slots as usize
+        } else {
+            default_slots
+        };
+
+        // Seed RNG deterministically per (user_id, experiment_id) for reproducibility.
+        let seed = experimentation_hash::murmur3::murmurhash3_x86_32(
+            format!("{}:{}", req.user_id, req.experiment_id).as_bytes(),
+            0,
+        ) as u64;
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let (arm_ids, slot_probs) = select_slate_factorized(&candidates, num_slots, &mut rng);
+
+        // Joint probability: product of per-slot marginals (factorized model approximation).
+        let joint_probability: f64 = slot_probs.iter().product();
+
+        Ok(Response::new(SlateAssignmentResponse {
+            arm_ids,
+            slot_probabilities: slot_probs,
+            joint_probability,
+        }))
+    }
+
+    async fn create_cold_start_bandit(
+        &self,
+        _request: Request<proto::CreateColdStartBanditRequest>,
+    ) -> Result<Response<CreateColdStartBanditResponse>, Status> {
+        Err(Status::unimplemented("not used in slate contract tests"))
+    }
+
+    async fn export_affinity_scores(
+        &self,
+        _request: Request<proto::ExportAffinityScoresRequest>,
+    ) -> Result<Response<ExportAffinityScoresResponse>, Status> {
+        Err(Status::unimplemented("not used in slate contract tests"))
+    }
+
+    async fn get_policy_snapshot(
+        &self,
+        _request: Request<proto::GetPolicySnapshotRequest>,
+    ) -> Result<Response<ProtoPolicySnapshot>, Status> {
+        Err(Status::unimplemented("not used in slate contract tests"))
+    }
+
+    async fn rollback_policy(
+        &self,
+        _request: Request<proto::RollbackPolicyRequest>,
+    ) -> Result<Response<ProtoPolicySnapshot>, Status> {
+        Err(Status::unimplemented("not used in slate contract tests"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+type SlateClient =
+    proto::bandit_policy_service_client::BanditPolicyServiceClient<tonic::transport::Channel>;
+
+async fn start_slate_server() -> (SlateClient, SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("[::1]:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let service = SlateTestService::new();
+    let handle = tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        tonic::transport::Server::builder()
+            .add_service(BanditPolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let channel = tonic::transport::Channel::from_shared(format!("http://[::1]:{}", addr.port()))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+
+    let client =
+        proto::bandit_policy_service_client::BanditPolicyServiceClient::new(channel);
+
+    (client, addr, handle)
+}
+
+// ---------------------------------------------------------------------------
+// Contract Tests
+// ---------------------------------------------------------------------------
+
+/// 1. Basic slate: arm_ids.len == num_slots, all arms are unique, all from candidate pool.
+#[tokio::test]
+async fn contract_slate_arm_ids_length_and_uniqueness() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    let resp = client
+        .get_slate_assignment(proto::SlateAssignmentRequest {
+            experiment_id: "slate-content-3slot".into(),
+            user_id: "user-slate-1".into(),
+            context_features: HashMap::new(),
+            num_slots: 3,
+        })
+        .await
+        .expect("GetSlateAssignment should succeed")
+        .into_inner();
+
+    assert_eq!(resp.arm_ids.len(), 3, "expected exactly 3 arm_ids");
+
+    // All arm IDs must be unique within the slate.
+    let unique: HashSet<_> = resp.arm_ids.iter().collect();
+    assert_eq!(
+        unique.len(),
+        resp.arm_ids.len(),
+        "slate must not repeat arm IDs: {:?}",
+        resp.arm_ids
+    );
+
+    // All arm IDs must be from the known candidate pool.
+    let valid_candidates = [
+        "drama_series",
+        "comedy_film",
+        "documentary",
+        "action_blockbuster",
+        "kids_animation",
+        "thriller",
+    ];
+    for arm_id in &resp.arm_ids {
+        assert!(
+            valid_candidates.contains(&arm_id.as_str()),
+            "unknown arm_id '{arm_id}' not in candidate pool"
+        );
+    }
+
+    handle.abort();
+}
+
+/// 2. slot_probabilities: len == num_slots, all positive and finite.
+#[tokio::test]
+async fn contract_slate_slot_probabilities_valid() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    let resp = client
+        .get_slate_assignment(proto::SlateAssignmentRequest {
+            experiment_id: "slate-content-3slot".into(),
+            user_id: "user-slate-prob".into(),
+            context_features: HashMap::new(),
+            num_slots: 3,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.slot_probabilities.len(),
+        resp.arm_ids.len(),
+        "slot_probabilities length must equal arm_ids length"
+    );
+
+    for (i, &prob) in resp.slot_probabilities.iter().enumerate() {
+        assert!(
+            prob > 0.0,
+            "slot_probabilities[{i}] must be positive, got {prob}"
+        );
+        assert!(
+            prob.is_finite(),
+            "slot_probabilities[{i}] must be finite, got {prob}"
+        );
+        assert!(
+            prob <= 1.0,
+            "slot_probabilities[{i}] must be <= 1.0, got {prob}"
+        );
+    }
+
+    handle.abort();
+}
+
+/// 3. joint_probability is positive, finite, and approximately the product of slot probs.
+#[tokio::test]
+async fn contract_slate_joint_probability_valid() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    let resp = client
+        .get_slate_assignment(proto::SlateAssignmentRequest {
+            experiment_id: "slate-content-3slot".into(),
+            user_id: "user-joint-prob".into(),
+            context_features: HashMap::new(),
+            num_slots: 3,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(
+        resp.joint_probability > 0.0,
+        "joint_probability must be positive"
+    );
+    assert!(
+        resp.joint_probability.is_finite(),
+        "joint_probability must be finite"
+    );
+    assert!(
+        resp.joint_probability <= 1.0,
+        "joint_probability must be <= 1.0"
+    );
+
+    // Joint probability must equal product of per-slot marginals (factorized model).
+    let expected_joint: f64 = resp.slot_probabilities.iter().product();
+    assert!(
+        (resp.joint_probability - expected_joint).abs() < 1e-9,
+        "joint_probability {:.6} != product of slot_probs {:.6}",
+        resp.joint_probability,
+        expected_joint
+    );
+
+    handle.abort();
+}
+
+/// 4. Deterministic: same user + experiment produces the same slate.
+#[tokio::test]
+async fn contract_slate_deterministic_for_same_user() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    let req = || proto::SlateAssignmentRequest {
+        experiment_id: "slate-content-3slot".into(),
+        user_id: "stable-slate-user-42".into(),
+        context_features: HashMap::new(),
+        num_slots: 3,
+    };
+
+    let r1 = client.get_slate_assignment(req()).await.unwrap().into_inner();
+    let r2 = client.get_slate_assignment(req()).await.unwrap().into_inner();
+
+    assert_eq!(
+        r1.arm_ids, r2.arm_ids,
+        "same user must get the same slate ordering"
+    );
+    for (p1, p2) in r1.slot_probabilities.iter().zip(&r2.slot_probabilities) {
+        assert!(
+            (p1 - p2).abs() < f64::EPSILON,
+            "same user must get the same slot probabilities"
+        );
+    }
+
+    handle.abort();
+}
+
+/// 5. Different users produce different orderings (distribution check).
+#[tokio::test]
+async fn contract_slate_distribution_across_users() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    // Collect top-position arm choices across many users.
+    let mut top_arm_counts: HashMap<String, u32> = HashMap::new();
+    for i in 0..200u32 {
+        let resp = client
+            .get_slate_assignment(proto::SlateAssignmentRequest {
+                experiment_id: "slate-content-3slot".into(),
+                user_id: format!("dist-slate-user-{i}"),
+                context_features: HashMap::new(),
+                num_slots: 3,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        let top_arm = resp.arm_ids.first().unwrap().clone();
+        *top_arm_counts.entry(top_arm).or_default() += 1;
+    }
+
+    // With uniform Thompson priors, multiple arms should reach the top position.
+    assert!(
+        top_arm_counts.len() >= 3,
+        "at least 3 different arms should appear at position 0 across 200 users, \
+         got: {top_arm_counts:?}"
+    );
+
+    handle.abort();
+}
+
+/// 6. Unknown experiment returns NOT_FOUND.
+#[tokio::test]
+async fn contract_slate_unknown_experiment_not_found() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    let err = client
+        .get_slate_assignment(proto::SlateAssignmentRequest {
+            experiment_id: "nonexistent-slate-exp".into(),
+            user_id: "user-1".into(),
+            context_features: HashMap::new(),
+            num_slots: 3,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.code(),
+        tonic::Code::NotFound,
+        "unknown experiment must return NOT_FOUND, got: {:?}",
+        err.code()
+    );
+
+    handle.abort();
+}
+
+/// 7. num_slots=0 falls back to experiment default.
+#[tokio::test]
+async fn contract_slate_num_slots_zero_uses_default() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    let resp = client
+        .get_slate_assignment(proto::SlateAssignmentRequest {
+            experiment_id: "slate-hero-2slot".into(),
+            user_id: "user-default-slots".into(),
+            context_features: HashMap::new(),
+            num_slots: 0, // should use experiment default of 2
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.arm_ids.len(),
+        2,
+        "num_slots=0 should use experiment default (2), got: {:?}",
+        resp.arm_ids
+    );
+
+    handle.abort();
+}
+
+/// 8. num_slots > candidate pool is capped at pool size.
+#[tokio::test]
+async fn contract_slate_num_slots_capped_at_pool_size() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    // "slate-small-pool" has 2 candidates but default_slots=5.
+    // Requesting 10 slots should return only 2 (pool size).
+    let resp = client
+        .get_slate_assignment(proto::SlateAssignmentRequest {
+            experiment_id: "slate-small-pool".into(),
+            user_id: "user-overflow-slots".into(),
+            context_features: HashMap::new(),
+            num_slots: 10,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.arm_ids.len(),
+        2,
+        "num_slots must be capped at pool size (2), got: {:?}",
+        resp.arm_ids
+    );
+    assert_eq!(
+        resp.slot_probabilities.len(),
+        resp.arm_ids.len(),
+        "slot_probabilities length must match arm_ids length"
+    );
+
+    handle.abort();
+}
+
+/// 9. Context features are accepted without error (contextual variant path).
+#[tokio::test]
+async fn contract_slate_with_context_features_accepted() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    let context: HashMap<String, f64> = [
+        ("user_age_bucket".into(), 3.0),
+        ("watch_history_len".into(), 150.0),
+        ("subscription_tier".into(), 2.0),
+    ]
+    .into_iter()
+    .collect();
+
+    let resp = client
+        .get_slate_assignment(proto::SlateAssignmentRequest {
+            experiment_id: "slate-content-3slot".into(),
+            user_id: "contextual-user-1".into(),
+            context_features: context,
+            num_slots: 3,
+        })
+        .await
+        .expect("GetSlateAssignment with context should succeed")
+        .into_inner();
+
+    assert_eq!(resp.arm_ids.len(), 3);
+    assert_eq!(resp.slot_probabilities.len(), 3);
+    assert!(resp.joint_probability > 0.0);
+
+    handle.abort();
+}
+
+/// 10. Concurrent slate requests return valid results under load.
+#[tokio::test]
+async fn contract_slate_concurrent_requests() {
+    let (client, _, handle) = start_slate_server().await;
+
+    let per_task_timeout = if std::env::var("CI").is_ok() {
+        std::time::Duration::from_secs(30)
+    } else {
+        std::time::Duration::from_secs(10)
+    };
+
+    let mut handles = Vec::new();
+    for i in 0..30u32 {
+        let mut c = client.clone();
+        handles.push(tokio::spawn(async move {
+            tokio::time::timeout(per_task_timeout, async move {
+                c.get_slate_assignment(proto::SlateAssignmentRequest {
+                    experiment_id: "slate-content-3slot".into(),
+                    user_id: format!("concurrent-slate-{i}"),
+                    context_features: HashMap::new(),
+                    num_slots: 3,
+                })
+                .await
+            })
+            .await
+            .expect("concurrent GetSlateAssignment timed out")
+        }));
+    }
+
+    let valid_candidates: HashSet<&str> = [
+        "drama_series",
+        "comedy_film",
+        "documentary",
+        "action_blockbuster",
+        "kids_animation",
+        "thriller",
+    ]
+    .into_iter()
+    .collect();
+
+    for h in handles {
+        let resp = h
+            .await
+            .unwrap()
+            .expect("concurrent GetSlateAssignment should succeed")
+            .into_inner();
+
+        assert_eq!(resp.arm_ids.len(), 3);
+        assert_eq!(resp.slot_probabilities.len(), 3);
+        assert!(resp.joint_probability > 0.0 && resp.joint_probability.is_finite());
+
+        let unique: HashSet<_> = resp.arm_ids.iter().collect();
+        assert_eq!(unique.len(), 3, "concurrent slate must have unique arm IDs");
+
+        for arm_id in &resp.arm_ids {
+            assert!(
+                valid_candidates.contains(arm_id.as_str()),
+                "concurrent: unknown arm_id '{arm_id}'"
+            );
+        }
+    }
+
+    handle.abort();
+}
+
+/// 11. All returned slot_probabilities are finite across many users (fail-fast contract).
+#[tokio::test]
+async fn contract_slate_all_probabilities_finite() {
+    let (mut client, _, handle) = start_slate_server().await;
+
+    for i in 0..20u32 {
+        let resp = client
+            .get_slate_assignment(proto::SlateAssignmentRequest {
+                experiment_id: "slate-content-3slot".into(),
+                user_id: format!("finite-check-slate-{i}"),
+                context_features: HashMap::new(),
+                num_slots: 3,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        for (j, &prob) in resp.slot_probabilities.iter().enumerate() {
+            assert!(
+                prob.is_finite(),
+                "user {i}, slot {j}: probability is not finite: {prob}"
+            );
+        }
+        assert!(
+            resp.joint_probability.is_finite(),
+            "user {i}: joint_probability is not finite"
+        );
+    }
+
+    handle.abort();
+}

--- a/crates/experimentation-ingest/tests/m2m3_kafka_contract_test.rs
+++ b/crates/experimentation-ingest/tests/m2m3_kafka_contract_test.rs
@@ -1,0 +1,379 @@
+//! M2 → M3 ModelRetrainingEvent Kafka Contract Tests (ADR-021)
+//!
+//! These tests verify the proto wire-format contract for `ModelRetrainingEvent`
+//! between M2 (Event Ingestion, producer) and M3 (Metrics, consumer).
+//!
+//! M2 validates events via `validate_model_retraining_event`, then serializes
+//! them to proto bytes for the `model_retraining_events` Kafka topic.
+//! M3 deserializes those bytes and joins them with exposure data to compute
+//! training data contamination fractions for feedback loop analysis.
+//!
+//! Since Kafka transport is tested separately, these tests use prost encode/decode
+//! directly to verify the wire format without requiring a running Kafka cluster.
+//!
+//! Contract points verified:
+//! 1. All required fields survive proto roundtrip: event_id, model_id, timestamps
+//! 2. active_experiment_ids list is preserved (including empty and multi-element)
+//! 3. treatment_contamination_fraction round-trips without precision loss
+//! 4. training_data_start and training_data_end timestamps are encoded correctly
+//! 5. retrained_at timestamp is optional and preserved when set
+//! 6. M2's validation layer rejects missing required fields (consumer expectations)
+//! 7. M2's validation rejects training_data_end <= training_data_start (window sanity)
+//! 8. treatment_contamination_fraction=0.0 is a valid proto zero-value (not dropped)
+//! 9. Large active_experiment_ids lists are preserved without truncation
+//! 10. Proto field ordering contract: field numbers are stable across encode/decode
+
+use experimentation_ingest::validation::validate_model_retraining_event;
+use experimentation_proto::common::ModelRetrainingEvent;
+use prost::Message;
+
+// ---------------------------------------------------------------------------
+// Helper builders
+// ---------------------------------------------------------------------------
+
+fn past_timestamp(offset_hours: i64) -> Option<prost_types::Timestamp> {
+    let epoch_secs = chrono::Utc::now().timestamp() - offset_hours * 3600;
+    Some(prost_types::Timestamp {
+        seconds: epoch_secs,
+        nanos: 0,
+    })
+}
+
+/// Build a valid ModelRetrainingEvent that M2 would accept.
+fn valid_retraining_event() -> ModelRetrainingEvent {
+    ModelRetrainingEvent {
+        event_id: "mre-contract-001".into(),
+        model_id: "rec-model-v42".into(),
+        training_data_start: past_timestamp(72),  // 3 days ago
+        training_data_end: past_timestamp(24),    // 1 day ago
+        retrained_at: past_timestamp(1),           // 1 hour ago (recent, use past_timestamp with small value)
+        active_experiment_ids: vec![
+            "exp-001".into(),
+            "exp-002".into(),
+            "exp-003".into(),
+        ],
+        treatment_contamination_fraction: 0.23,
+    }
+}
+
+/// Encode a ModelRetrainingEvent to bytes and decode it back (simulates Kafka roundtrip).
+fn kafka_roundtrip(event: &ModelRetrainingEvent) -> ModelRetrainingEvent {
+    let mut buf = Vec::new();
+    event.encode(&mut buf).expect("proto encode should not fail");
+    ModelRetrainingEvent::decode(buf.as_slice()).expect("proto decode should not fail")
+}
+
+// ---------------------------------------------------------------------------
+// Contract Tests
+// ---------------------------------------------------------------------------
+
+/// 1. Required fields survive proto roundtrip.
+#[test]
+fn contract_required_fields_roundtrip() {
+    let original = valid_retraining_event();
+    validate_model_retraining_event(&original).expect("valid event should pass M2 validation");
+
+    let decoded = kafka_roundtrip(&original);
+
+    assert_eq!(
+        decoded.event_id, original.event_id,
+        "event_id must survive proto roundtrip"
+    );
+    assert_eq!(
+        decoded.model_id, original.model_id,
+        "model_id must survive proto roundtrip"
+    );
+}
+
+/// 2. training_data_start and training_data_end timestamps are encoded correctly.
+#[test]
+fn contract_training_window_timestamps_roundtrip() {
+    let original = valid_retraining_event();
+    let decoded = kafka_roundtrip(&original);
+
+    let orig_start = original.training_data_start.as_ref().unwrap();
+    let dec_start = decoded
+        .training_data_start
+        .as_ref()
+        .expect("training_data_start must be present after decode");
+
+    assert_eq!(
+        dec_start.seconds, orig_start.seconds,
+        "training_data_start.seconds must survive roundtrip"
+    );
+    assert_eq!(
+        dec_start.nanos, orig_start.nanos,
+        "training_data_start.nanos must survive roundtrip"
+    );
+
+    let orig_end = original.training_data_end.as_ref().unwrap();
+    let dec_end = decoded
+        .training_data_end
+        .as_ref()
+        .expect("training_data_end must be present after decode");
+
+    assert_eq!(
+        dec_end.seconds, orig_end.seconds,
+        "training_data_end.seconds must survive roundtrip"
+    );
+
+    // M3 contract: end must be after start in decoded message.
+    assert!(
+        dec_end.seconds > dec_start.seconds,
+        "training_data_end ({}) must be after training_data_start ({}) after decode",
+        dec_end.seconds,
+        dec_start.seconds
+    );
+}
+
+/// 3. retrained_at timestamp is optional; preserved when set.
+#[test]
+fn contract_retrained_at_optional_preserved() {
+    // With retrained_at set.
+    let original = valid_retraining_event();
+    let decoded = kafka_roundtrip(&original);
+
+    let orig_ts = original.retrained_at.as_ref().unwrap();
+    let dec_ts = decoded
+        .retrained_at
+        .as_ref()
+        .expect("retrained_at should be present after decode");
+    assert_eq!(dec_ts.seconds, orig_ts.seconds, "retrained_at.seconds must survive roundtrip");
+
+    // Without retrained_at (proto3 zero-value → omitted).
+    let mut no_ts = valid_retraining_event();
+    no_ts.retrained_at = None;
+    let decoded_no_ts = kafka_roundtrip(&no_ts);
+    assert!(
+        decoded_no_ts.retrained_at.is_none(),
+        "retrained_at=None should remain None after roundtrip (proto3 optional semantics)"
+    );
+}
+
+/// 4. active_experiment_ids list is preserved exactly (including order).
+#[test]
+fn contract_active_experiment_ids_roundtrip() {
+    let original = valid_retraining_event();
+    let decoded = kafka_roundtrip(&original);
+
+    assert_eq!(
+        decoded.active_experiment_ids, original.active_experiment_ids,
+        "active_experiment_ids must be preserved exactly after proto roundtrip"
+    );
+    assert_eq!(
+        decoded.active_experiment_ids.len(),
+        3,
+        "all 3 active_experiment_ids must survive encode/decode"
+    );
+}
+
+/// 5. Empty active_experiment_ids is valid (proto3 zero-value).
+#[test]
+fn contract_active_experiment_ids_empty_valid() {
+    let mut event = valid_retraining_event();
+    event.active_experiment_ids = vec![];
+
+    validate_model_retraining_event(&event).expect("empty active_experiment_ids is valid for M2");
+
+    let decoded = kafka_roundtrip(&event);
+    assert!(
+        decoded.active_experiment_ids.is_empty(),
+        "empty active_experiment_ids must survive roundtrip as empty (not None)"
+    );
+}
+
+/// 6. Large active_experiment_ids list is preserved without truncation.
+#[test]
+fn contract_large_active_experiment_ids_no_truncation() {
+    let mut event = valid_retraining_event();
+    event.active_experiment_ids = (0..500).map(|i| format!("exp-{i:04}")).collect();
+
+    let decoded = kafka_roundtrip(&event);
+
+    assert_eq!(
+        decoded.active_experiment_ids.len(),
+        500,
+        "500 active_experiment_ids must survive roundtrip without truncation"
+    );
+    // Spot-check a few entries.
+    assert_eq!(decoded.active_experiment_ids[0], "exp-0000");
+    assert_eq!(decoded.active_experiment_ids[499], "exp-0499");
+}
+
+/// 7. treatment_contamination_fraction survives roundtrip without precision loss.
+#[test]
+fn contract_contamination_fraction_roundtrip() {
+    let fractions = [0.0, 0.001, 0.123456789, 0.5, 0.999, 1.0];
+
+    for &fraction in &fractions {
+        let mut event = valid_retraining_event();
+        event.treatment_contamination_fraction = fraction;
+
+        let decoded = kafka_roundtrip(&event);
+
+        // f64 proto encoding is exact (IEEE 754 double).
+        assert_eq!(
+            decoded.treatment_contamination_fraction, fraction,
+            "treatment_contamination_fraction {fraction} must survive roundtrip exactly"
+        );
+    }
+}
+
+/// 8. treatment_contamination_fraction=0.0 is not dropped (proto3 zero-value).
+///
+/// M3 uses this field for contamination analysis. If M2 sets it to 0.0
+/// (no contamination) and proto3 drops it, M3 would also see 0.0 (the default),
+/// so the wire format is correct — but we validate the behavior explicitly.
+#[test]
+fn contract_zero_contamination_fraction_preserved() {
+    let mut event = valid_retraining_event();
+    event.treatment_contamination_fraction = 0.0;
+
+    let decoded = kafka_roundtrip(&event);
+
+    // Proto3: 0.0 is the default for double fields; the field is not written
+    // to the wire, and the decoder will return 0.0 (the default). This is
+    // correct behavior — M3 sees 0.0 as expected.
+    assert_eq!(
+        decoded.treatment_contamination_fraction,
+        0.0,
+        "zero contamination fraction must decode to 0.0 (proto3 default behavior)"
+    );
+}
+
+/// 9. M2 validation rejects missing event_id (consumer expectation).
+#[test]
+fn contract_m2_rejects_missing_event_id() {
+    let mut event = valid_retraining_event();
+    event.event_id = String::new();
+
+    let err = validate_model_retraining_event(&event).unwrap_err();
+    assert!(
+        err.to_string().contains("event_id is required"),
+        "M2 must reject missing event_id: {err}"
+    );
+}
+
+/// 10. M2 validation rejects missing model_id.
+#[test]
+fn contract_m2_rejects_missing_model_id() {
+    let mut event = valid_retraining_event();
+    event.model_id = String::new();
+
+    let err = validate_model_retraining_event(&event).unwrap_err();
+    assert!(
+        err.to_string().contains("model_id is required"),
+        "M2 must reject missing model_id: {err}"
+    );
+}
+
+/// 11. M2 validation rejects missing training_data_start.
+#[test]
+fn contract_m2_rejects_missing_training_data_start() {
+    let mut event = valid_retraining_event();
+    event.training_data_start = None;
+
+    let err = validate_model_retraining_event(&event).unwrap_err();
+    assert!(
+        err.to_string().contains("training_data_start is required"),
+        "M2 must reject missing training_data_start: {err}"
+    );
+}
+
+/// 12. M2 validation rejects missing training_data_end.
+#[test]
+fn contract_m2_rejects_missing_training_data_end() {
+    let mut event = valid_retraining_event();
+    event.training_data_end = None;
+
+    let err = validate_model_retraining_event(&event).unwrap_err();
+    assert!(
+        err.to_string().contains("training_data_end is required"),
+        "M2 must reject missing training_data_end: {err}"
+    );
+}
+
+/// 13. M2 validation rejects training_data_end <= training_data_start.
+///
+/// M3 uses the training window for temporal joins. An invalid window (end before start)
+/// would produce empty joins or incorrect contamination fractions.
+#[test]
+fn contract_m2_rejects_inverted_training_window() {
+    let mut event = valid_retraining_event();
+    // Swap: end is older than start.
+    event.training_data_start = past_timestamp(24);
+    event.training_data_end = past_timestamp(72); // older than start
+
+    let err = validate_model_retraining_event(&event).unwrap_err();
+    assert!(
+        err.to_string().contains("training_data_end must be after"),
+        "M2 must reject inverted training window: {err}"
+    );
+}
+
+/// 14. Historical training windows (> 24h ago) are valid for M2.
+///
+/// M3 frequently joins against historical exposure data. Training windows
+/// can reference ranges weeks or months in the past — they are NOT subject
+/// to the ±24h validation applied to ExposureEvent timestamps.
+#[test]
+fn contract_historical_training_window_accepted_by_m2() {
+    let event = ModelRetrainingEvent {
+        event_id: "mre-historical".into(),
+        model_id: "rec-model-v1".into(),
+        training_data_start: past_timestamp(30 * 24),  // 30 days ago
+        training_data_end: past_timestamp(7 * 24),     // 7 days ago
+        retrained_at: past_timestamp(1),
+        active_experiment_ids: vec!["exp-historical".into()],
+        treatment_contamination_fraction: 0.15,
+    };
+
+    validate_model_retraining_event(&event)
+        .expect("historical training window must be valid for M2 (no ±24h restriction on retraining timestamps)");
+
+    let decoded = kafka_roundtrip(&event);
+    assert_eq!(decoded.event_id, event.event_id);
+    assert_eq!(
+        decoded.treatment_contamination_fraction,
+        event.treatment_contamination_fraction
+    );
+}
+
+/// 15. Wire size is reasonable: encoding a typical event produces < 1KB.
+///
+/// Kafka has a default max message size of 1MB; this sanity-checks that a
+/// typical ModelRetrainingEvent with ~10 experiment IDs doesn't grow unexpectedly.
+#[test]
+fn contract_wire_size_typical_event() {
+    let mut event = valid_retraining_event();
+    event.active_experiment_ids = (0..10).map(|i| format!("exp-{i:03}")).collect();
+    event.treatment_contamination_fraction = 0.12;
+
+    let mut buf = Vec::new();
+    event.encode(&mut buf).unwrap();
+
+    assert!(
+        buf.len() < 1024,
+        "typical ModelRetrainingEvent should serialize to < 1KB, got {} bytes",
+        buf.len()
+    );
+}
+
+/// 16. Multiple encode/decode cycles produce identical bytes (idempotent serialization).
+#[test]
+fn contract_serialization_idempotent() {
+    let original = valid_retraining_event();
+
+    let mut buf1 = Vec::new();
+    original.encode(&mut buf1).unwrap();
+
+    let decoded = ModelRetrainingEvent::decode(buf1.as_slice()).unwrap();
+
+    let mut buf2 = Vec::new();
+    decoded.encode(&mut buf2).unwrap();
+
+    assert_eq!(
+        buf1, buf2,
+        "two encode cycles of the same event must produce identical bytes"
+    );
+}

--- a/crates/experimentation-policy/src/grpc.rs
+++ b/crates/experimentation-policy/src/grpc.rs
@@ -116,6 +116,18 @@ impl BanditPolicyService for BanditPolicyServiceHandler {
         }))
     }
 
+    async fn get_slate_assignment(
+        &self,
+        _request: Request<proto::SlateAssignmentRequest>,
+    ) -> Result<Response<proto::SlateAssignmentResponse>, Status> {
+        // ADR-016: Full slate bandit implementation is in-progress.
+        // The contract is defined; the PolicyCore integration is Phase 5 work.
+        Err(Status::unimplemented(
+            "GetSlateAssignment is not yet wired to PolicyCore; \
+             use the contract test service for wire-format validation",
+        ))
+    }
+
     async fn create_cold_start_bandit(
         &self,
         request: Request<proto::CreateColdStartBanditRequest>,

--- a/crates/experimentation-policy/src/grpc.rs
+++ b/crates/experimentation-policy/src/grpc.rs
@@ -118,7 +118,7 @@ impl BanditPolicyService for BanditPolicyServiceHandler {
 
     async fn get_slate_assignment(
         &self,
-        _request: Request<proto::SlateAssignmentRequest>,
+        _request: Request<proto::GetSlateAssignmentRequest>,
     ) -> Result<Response<proto::SlateAssignmentResponse>, Status> {
         // ADR-016: Full slate bandit implementation is in-progress.
         // The contract is defined; the PolicyCore integration is Phase 5 work.

--- a/docs/coordination/status/agent-1-status.md
+++ b/docs/coordination/status/agent-1-status.md
@@ -1,28 +1,41 @@
 # Agent-1 Status — Phase 5
 
 **Module**: M1 Assignment
-**Last updated**: [date]
+**Last updated**: 2026-03-24
 
 ## Current Sprint
 
 Sprint: 5.0
-Focus: ADR-016 GetSlateAssignment, ADR-022 Switchback assignment, ADR-013 META routing
-Branch: agent-1/feat/[current-work]
+Focus: ADR-016 GetSlateAssignment contract tests, ADR-019 portfolio contract tests, ADR-021 M2→M3 Kafka contract tests
+Branch: work/nice-bear
 
 ## In Progress
 
-- [ ] [Milestone description] (ADR-XXX)
-  - Blocked by: [none | Agent-M: description]
-  - ETA: [date]
+_None._
 
 ## Completed (Phase 5)
 
-_None yet._
+- [x] Phase 5 cross-module contract tests (consumer-side) — PR pending
+  - M1→M4b: `GetSlateAssignment` contract test (11 tests) — `crates/experimentation-assignment/tests/m1m4b_slate_contract_test.rs`
+  - M5→M4a: `GetPortfolioAllocation` contract test (12 tests) — `crates/experimentation-analysis/tests/m5m4a_portfolio_contract_test.rs`
+  - M2→M3: `ModelRetrainingEvent` Kafka wire-format contract test (16 tests) — `crates/experimentation-ingest/tests/m2m3_kafka_contract_test.rs`
+  - Proto additions: `GetSlateAssignment` RPC + messages (ADR-016), `GetPortfolioAllocation` RPC + messages (ADR-019)
+  - Stubs added to `BanditPolicyServiceHandler` (policy/grpc.rs) and `AnalysisServiceHandler` (analysis/grpc.rs)
+  - `cargo test --workspace`: all 0 failures
 
 ## Blocked
 
 _None._
 
+## Dependencies for Other Agents
+
+- **Agent-4 (M4b)**: `GetSlateAssignment` proto RPC now defined — impl can begin using the contract test as the acceptance spec.
+- **Agent-4 (M4a)**: `GetPortfolioAllocation` proto RPC defined — stub returns `unimplemented`, real impl needed.
+- **Agent-5 (M5)**: `GetPortfolioAllocation` contract spec available; M5 Go client generation needed.
+- **Agent-2 (M2/M3)**: `ModelRetrainingEvent` Kafka wire format validated — M3 consume path can reference test for field expectations.
+
 ## Next Up
 
-- [Next milestone] — depends on: [Agent-Proto schema | none]
+- ADR-016 GetSlateAssignment: wire up `SlateTestService` logic into real `BanditPolicyServiceHandler` on LMAX thread
+- ADR-022 Switchback assignment: M1 needs to assign users based on (current_time, block_duration, cluster_attribute)
+- ADR-013 META routing: M1 hashes user to variant; each variant uses different reward objective

--- a/proto/experimentation/analysis/v1/analysis_service.proto
+++ b/proto/experimentation/analysis/v1/analysis_service.proto
@@ -27,6 +27,10 @@ service AnalysisService {
   rpc GetSyntheticControlAnalysis(GetSyntheticControlAnalysisRequest) returns (SyntheticControlAnalysisResult);
   // Get switchback temporal analysis for SWITCHBACK experiments (ADR-022).
   rpc GetSwitchbackAnalysis(GetSwitchbackAnalysisRequest) returns (SwitchbackAnalysisResult);
+  // Get optimal traffic allocation across a portfolio of running experiments (ADR-019).
+  // Called by M5 to maximize portfolio-level information gain within a traffic budget.
+  // M4a uses power curves and accumulated effect estimates for portfolio optimization.
+  rpc GetPortfolioAllocation(GetPortfolioAllocationRequest) returns (GetPortfolioAllocationResponse);
 }
 
 message RunAnalysisRequest {
@@ -258,4 +262,36 @@ message SwitchbackAnalysisResult {
   double carryover_p_value = 8;
   bool carryover_detected = 9;
   google.protobuf.Timestamp computed_at = 10;
+}
+
+// GetPortfolioAllocationRequest — sent by M5 to M4a (ADR-019).
+// M5 submits the set of running experiments; M4a returns optimal traffic splits.
+message GetPortfolioAllocationRequest {
+  // Experiment IDs to optimize allocation across. Must be non-empty.
+  repeated string experiment_ids = 1;
+  // Total traffic budget as a fraction [0.0, 1.0].
+  // Sum of returned allocated_fraction values will be <= total_traffic_budget.
+  double total_traffic_budget = 2;
+}
+
+// ExperimentAllocation is one entry in GetPortfolioAllocationResponse.
+message ExperimentAllocation {
+  string experiment_id = 1;
+  // Optimal traffic allocation fraction for this experiment. In [0.0, 1.0].
+  double allocated_fraction = 2;
+  // Whether M4a estimates sufficient evidence has accumulated to conclude this experiment.
+  // M5 uses this signal to trigger the CONCLUDING lifecycle transition.
+  bool can_conclude = 3;
+  // Estimated statistical power at the allocated traffic level and current sample size.
+  // In [0.0, 1.0]. M6 UI displays this per experiment.
+  double estimated_power = 4;
+}
+
+// GetPortfolioAllocationResponse — returned by M4a to M5 (ADR-019).
+message GetPortfolioAllocationResponse {
+  // One ExperimentAllocation per experiment_id in the request, in request order.
+  repeated ExperimentAllocation allocations = 1;
+  // Sum of all allocated_fraction values. Will be <= total_traffic_budget.
+  double total_allocated = 2;
+  google.protobuf.Timestamp computed_at = 3;
 }

--- a/proto/experimentation/bandit/v1/bandit_service.proto
+++ b/proto/experimentation/bandit/v1/bandit_service.proto
@@ -13,6 +13,11 @@ service BanditPolicyService {
   // Select an arm for a user. Called by M1 Assignment Service.
   // p99 < 15ms at 10K rps.
   rpc SelectArm(SelectArmRequest) returns (experimentation.common.v1.ArmSelection);
+  // Get an ordered slate assignment for slate-level bandit experiments (ADR-016).
+  // Called by M1 for SLATE_FACTORIZED_TS and SLATE_GENERATIVE experiment types.
+  // Factorized Thompson Sampling: per-slot posterior sampling, O(L × K) for L slots, K candidates.
+  // p99 < 20ms at 5K rps.
+  rpc GetSlateAssignment(SlateAssignmentRequest) returns (SlateAssignmentResponse);
   // Create a cold-start bandit for new content.
   // Auto-creates experiment, arms, and begins exploration.
   rpc CreateColdStartBandit(CreateColdStartBanditRequest) returns (CreateColdStartBanditResponse);
@@ -52,6 +57,28 @@ message ExportAffinityScoresResponse {
   map<string, double> segment_affinity_scores = 2;
   // Optimal placement per segment (arm with highest reward).
   map<string, string> optimal_placements = 3;
+}
+
+message SlateAssignmentRequest {
+  string experiment_id = 1;
+  string user_id = 2;
+  // Context features for contextual slate bandits.
+  map<string, double> context_features = 3;
+  // Number of slots to fill. 0 = use SlateConfig.num_slots from experiment config.
+  int32 num_slots = 4;
+}
+
+message SlateAssignmentResponse {
+  // Ordered slate: arm_ids[0] is the top position (rank 1).
+  // Length equals the num_slots resolved for this request.
+  repeated string arm_ids = 1;
+  // Per-slot selection probabilities (for IPW computation in M4a).
+  // slot_probabilities[i] = marginal probability that arm_ids[i] was selected at slot i.
+  // Length equals arm_ids length.
+  repeated double slot_probabilities = 2;
+  // Joint slate selection probability under the factorized model.
+  // Used by M4a for slate-level IPW adjustment.
+  double joint_probability = 3;
 }
 
 message GetPolicySnapshotRequest { string experiment_id = 1; }

--- a/proto/experimentation/bandit/v1/bandit_service.proto
+++ b/proto/experimentation/bandit/v1/bandit_service.proto
@@ -17,7 +17,7 @@ service BanditPolicyService {
   // Called by M1 for SLATE_FACTORIZED_TS and SLATE_GENERATIVE experiment types.
   // Factorized Thompson Sampling: per-slot posterior sampling, O(L × K) for L slots, K candidates.
   // p99 < 20ms at 5K rps.
-  rpc GetSlateAssignment(SlateAssignmentRequest) returns (SlateAssignmentResponse);
+  rpc GetSlateAssignment(GetSlateAssignmentRequest) returns (SlateAssignmentResponse);
   // Create a cold-start bandit for new content.
   // Auto-creates experiment, arms, and begins exploration.
   rpc CreateColdStartBandit(CreateColdStartBanditRequest) returns (CreateColdStartBanditResponse);
@@ -59,7 +59,7 @@ message ExportAffinityScoresResponse {
   map<string, string> optimal_placements = 3;
 }
 
-message SlateAssignmentRequest {
+message GetSlateAssignmentRequest {
   string experiment_id = 1;
   string user_id = 2;
   // Context features for contextual slate bandits.


### PR DESCRIPTION
## Summary

Adds consumer-side wire-format contract tests for three Phase 5 new interfaces. Per CLAUDE.md policy: _contract tests are written by the consumer agent_.

- **39 new tests** across 3 files, all green (`cargo test --workspace` passes)
- **2 proto RPCs added** with full message definitions
- **2 service stubs** added (return `unimplemented` until full ADR impls land)

### Interface 1: M1→M4b GetSlateAssignment (ADR-016)

**File**: `crates/experimentation-assignment/tests/m1m4b_slate_contract_test.rs` — 11 tests

Test service uses real factorized Thompson Sampling (without replacement, per-slot) to validate:
- `arm_ids` length == `num_slots`, all unique, all from candidate pool
- `slot_probabilities` finite/positive, `joint_probability` = exact product of slot probs
- Deterministic per (user_id, experiment_id), distribution across users (≥3 arms at position 0)
- `num_slots=0` falls back to experiment default; overflow capped at pool size
- NOT_FOUND for unknown experiments; context features accepted; concurrency (30 concurrent)

Proto: `SlateAssignmentRequest` / `SlateAssignmentResponse` added to `bandit_service.proto`.

### Interface 2: M5→M4a GetPortfolioAllocation (ADR-019)

**File**: `crates/experimentation-analysis/tests/m5m4a_portfolio_contract_test.rs` — 12 tests

Test service uses a power-curve heuristic (completion × effect/MDE) to validate:
- One `ExperimentAllocation` per requested `experiment_id`
- `allocated_fraction` in [0,1], finite; sum ≤ `total_traffic_budget`
- `total_allocated` == sum of fractions (wire-field consistency)
- `estimated_power` in [0,1], finite; `computed_at` present and valid
- Empty request → empty response (not an error)
- `total_traffic_budget` ∈ (0,1] enforced (0.0 and 1.5 → INVALID_ARGUMENT)
- `can_conclude=true` for exp-ready-conclude (sample=12K > target=10K, effect > MDE)
- NOT_FOUND when any experiment_id is unknown

Proto: `GetPortfolioAllocationRequest` / `GetPortfolioAllocationResponse` / `ExperimentAllocation` added to `analysis_service.proto`.

### Interface 3: M2→M3 ModelRetrainingEvent Kafka (ADR-021)

**File**: `crates/experimentation-ingest/tests/m2m3_kafka_contract_test.rs` — 16 tests

Uses `prost::Message` encode/decode directly (no Kafka broker needed) to validate:
- All required fields survive roundtrip: `event_id`, `model_id`, timestamps
- `training_data_start` < `training_data_end` maintained in decoded message
- `retrained_at` optional (None preserved); `active_experiment_ids` exact (including 500-element)
- `treatment_contamination_fraction` exact f64 roundtrip across [0.0, 0.001, 0.5, 1.0]
- Zero-value `0.0` behavior documented (proto3 default, correct for M3)
- M2 validation rejects: missing `event_id`/`model_id`/timestamps, inverted training window
- Historical windows (30 days ago) accepted — no ±24h restriction on retraining timestamps
- Wire size < 1KB for typical event; two encode cycles produce identical bytes

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p experimentation-assignment --test m1m4b_slate_contract_test` — 11/11
- [x] `cargo test -p experimentation-analysis --test m5m4a_portfolio_contract_test` — 12/12
- [x] `cargo test -p experimentation-ingest --test m2m3_kafka_contract_test` — 16/16
- [x] `cargo test --workspace` — all passing, 0 failures

## Opportunities (not implemented)

- `GetSlateAssignment` in `BanditPolicyServiceHandler` stub returns `unimplemented` — full LMAX integration is ADR-016 scope
- `GetPortfolioAllocation` in `AnalysisServiceHandler` stub returns `unimplemented` — power-curve optimizer is ADR-019 scope
- M5 Go client stub for `GetPortfolioAllocation` needed (Agent-5 scope)
- M3 Go consumer validation for `ModelRetrainingEvent` field mapping (Agent-3 scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
