### PR TITLE
feat(m6): multi-objective bandit reward visualization (ADR-011, ADR-012)

### DIFF
--- a/docs/coordination/status/agent-6-status.md
+++ b/docs/coordination/status/agent-6-status.md
@@ -9,6 +9,9 @@ Sprint: 5.2
 Focus: Portfolio optimization dashboard (ADR-019) + Provider Health dashboard (ADR-014)
 Branch: work/gentle-panda, work/gentle-penguin
 
+Focus: ADR-011 multi-objective bandit reward visualization, ADR-012 LP constraint status table
+Branch: work/fancy-koala
+
 ## Completed (this sprint)
 
 - [x] **Portfolio optimization dashboard** (ADR-019)
@@ -36,35 +39,50 @@ Branch: work/gentle-panda, work/gentle-penguin
 
 ## Completed (previous PRs)
 
-- [x] **AVLM confidence sequence boundary plot** (ADR-015)
-  - `ui/src/components/charts/avlm-boundary-plot.tsx`
-  - Recharts ComposedChart with Area (confidence sequence band) + dual Line (CUPED + raw estimate)
-  - ReferenceLine at H0=0; conclusive badge when CS excludes zero
-  - Dynamically imported; legacy alpha-spending chart preserved under details fold
-  - API: `getAvlmResult(experimentId, metricId)` → AnalysisService/GetAvlmResult
-  - Types: AvlmBoundaryPoint, AvlmResult
-  - Seed data: 2 metrics for 111... (CTR conclusive look 3, watch_time inconclusive)
+- [x] **ADR-011 Multi-objective reward composition chart** (2026-03-24, work/fancy-koala)
+  - `ui/src/components/RewardCompositionChart.tsx`
+  - Stacked BarChart (recharts) showing each objective's weighted contribution per arm
+  - Color-coded segments: one per RewardObjective metricId
+  - Footer shows primary objective and all weights
+  - Empty state when no breakdowns or objectives provided
+  - `React.memo` wrapped, strict TypeScript
 
-- [x] **Adaptive N zone indicator badge** (ADR-020)
-  - `ui/src/components/adaptive-n-badge.tsx`
-  - Zones: FAVORABLE (green), PROMISING (blue), FUTILE (red), INCONCLUSIVE (gray)
-  - Mounted in experiment detail page header for RUNNING/CONCLUDED experiments
-  - API: `getAdaptiveN(experimentId)` → AnalysisService/GetAdaptiveN
+- [x] **ADR-012 LP constraint status table** (2026-03-24, work/fancy-koala)
+  - `ui/src/components/ConstraintStatusTable.tsx`
+  - Table: constraint name, current value, limit, SATISFIED/VIOLATED badge
+  - Red row highlight (`bg-red-50`) on VIOLATED rows
+  - Red badge and bold current value for violated constraints
+  - Empty state when no constraints configured
+  - `React.memo` wrapped, strict TypeScript
 
-- [x] **Extended timeline visualization** (ADR-020 PROMISING zone)
-  - `ui/src/components/adaptive-n-timeline.tsx`
-  - AreaChart with planned N and recommended N reference lines
-  - Only rendered when zone === PROMISING in results page overview tab
+- [x] **Wired into bandit dashboard page**
+  - `ui/src/app/experiments/[id]/bandit/page.tsx` updated
+  - `RewardCompositionChart` and `ConstraintStatusTable` sections rendered
+  - Conditional: only shown when `banditExperimentConfig.rewardObjectives?.length > 0`
+  - `ConstraintStatusTable` additionally guarded by `constraintStatuses?.length > 0`
 
-- [x] **Feedback loop analysis tab**
-  - `ui/src/components/feedback-loop-tab.tsx`
-  - Sections: retraining timeline, pre/post comparison chart, contamination bar chart,
-    bias-corrected estimate highlight, mitigation recommendation matrix (HIGH/MEDIUM/LOW)
-  - Visible for AB/MAB/CONTEXTUAL_BANDIT experiments
-  - API: `getFeedbackLoopAnalysis(experimentId)` → AnalysisService/GetFeedbackLoopAnalysis
+- [x] **Types extended** (`ui/src/lib/types.ts`)
+  - `RewardCompositionMethod` (WEIGHTED_SCALARIZATION | EPSILON_CONSTRAINT | TCHEBYCHEFF)
+  - `RewardObjective` (metricId, weight, floor, isPrimary)
+  - `BanditArmConstraint` (armId, minFraction, maxFraction)
+  - `BanditGlobalConstraint` (label, coefficients, rhs)
+  - `ArmObjectiveBreakdown` (armId, armName, objectiveContributions, composedReward)
+  - `ConstraintStatus` (label, currentValue, limit, isSatisfied)
+  - `BanditExperimentConfig` extended with optional: rewardObjectives, compositionMethod, armConstraints, globalConstraints
+  - `BanditDashboardResult` extended with optional: objectiveBreakdowns, constraintStatuses
 
-- [x] Tests: 14 new tests all passing, 0 regressions (499 total, 6 pre-existing skips)
-- [x] Updated recharts mocks in analysis-tabs, results-dashboard, performance test files (Area/AreaChart)
+- [x] **Seed data updated** (`ui/src/__mocks__/seed-data.ts`)
+  - cold_start_bandit (444...) banditExperimentConfig: 3 rewardObjectives, WEIGHTED_SCALARIZATION, 2 globalConstraints
+  - BanditDashboardResult: objectiveBreakdowns for all 4 arms, 2 constraintStatuses (1 satisfied, 1 violated)
+
+- [x] **Tests: 15 new tests, all passing** (26 total in bandit-dashboard.test.tsx)
+  - 5 integration tests on bandit dashboard page (multi-objective sections, constraint badges)
+  - 4 unit tests for RewardCompositionChart (empty states, aria label, footer)
+  - 6 unit tests for ConstraintStatusTable (badges, red highlight, empty state, columns)
+  - Pre-existing test isolation failures (performance, chaos-resilience, MSW state bleed) unchanged
+
+- [x] `npm run build` passes
+- [x] 26 / 26 bandit dashboard tests pass
 
 ## Blocked
 
@@ -77,6 +95,12 @@ None.
 
 ## Completed (Phase 5 — prior sprints)
 
+- [x] AVLM confidence sequence boundary plot (ADR-015)
+  - `ui/src/components/charts/avlm-boundary-plot.tsx`
+- [x] Adaptive N zone indicator badge + timeline (ADR-020)
+  - `ui/src/components/adaptive-n-badge.tsx`, `adaptive-n-timeline.tsx`
+- [x] Feedback loop analysis tab (ADR-021)
+  - `ui/src/components/feedback-loop-tab.tsx`
 - [x] /portfolio/provider-health page (ADR-014)
   - Time series charts, provider filter, MSW mock, 8 tests
 - [x] AVLM confidence sequence boundary plot (ADR-015)
@@ -89,5 +113,6 @@ None.
   - Request: `{}` (empty)
   - Response: `{ experiments: PortfolioExperiment[], totalAllocatedPct: float, computedAt: timestamp }`
   - `PortfolioExperiment` fields: `experiment_id`, `name`, `effect_size`, `variance`, `allocated_traffic_pct`, `priority_score`, `user_segments`
+
+- Agent-4: BanditPolicyService objectiveBreakdowns and constraintStatuses in GetBanditDashboard response
 - Agent-4: AnalysisService/GetAvlmResult, GetAdaptiveN, GetFeedbackLoopAnalysis
-- Agent-2: Feedback loop retraining event data flow

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -192,6 +192,16 @@ const INITIAL_EXPERIMENTS: Experiment[] = [
       contextFeatureKeys: ['content_genre', 'user_tenure_days', 'device_type'],
       minExplorationFraction: 0.1,
       warmupObservations: 200,
+      rewardObjectives: [
+        { metricId: 'play_through_rate', weight: 0.6, floor: 0.0, isPrimary: true },
+        { metricId: 'provider_diversity_score', weight: 0.25, floor: 0.3, isPrimary: false },
+        { metricId: 'add_to_watchlist_rate', weight: 0.15, floor: 0.0, isPrimary: false },
+      ],
+      compositionMethod: 'WEIGHTED_SCALARIZATION',
+      globalConstraints: [
+        { label: 'max_single_provider_share', coefficients: { 'v4-arm1': 1.0, 'v4-arm2': 0.0, 'v4-arm3': 0.0, 'v4-arm4': 0.0 }, rhs: 0.5 },
+        { label: 'min_diversity_floor', coefficients: { 'v4-arm1': -0.25, 'v4-arm2': -0.25, 'v4-arm3': -0.25, 'v4-arm4': -0.25 }, rhs: -0.2 },
+      ],
     },
     createdAt: '2026-03-02T16:45:00Z',
   },
@@ -968,6 +978,32 @@ const INITIAL_BANDIT_RESULTS: Record<string, BanditDashboardResult> = {
       { timestamp: '2026-03-05T00:00:00Z', armId: 'genre_row', cumulativeReward: 196, cumulativeSelections: 980 },
       { timestamp: '2026-03-05T00:00:00Z', armId: 'trending_section', cumulativeReward: 224, cumulativeSelections: 860 },
       { timestamp: '2026-03-05T00:00:00Z', armId: 'personalized_row', cumulativeReward: 144, cumulativeSelections: 802 },
+    ],
+    objectiveBreakdowns: [
+      {
+        armId: 'v4-arm1', armName: 'top_carousel',
+        objectiveContributions: { play_through_rate: 0.156, provider_diversity_score: 0.112, add_to_watchlist_rate: 0.052 },
+        composedReward: 0.320,
+      },
+      {
+        armId: 'v4-arm2', armName: 'genre_row',
+        objectiveContributions: { play_through_rate: 0.120, provider_diversity_score: 0.178, add_to_watchlist_rate: 0.039 },
+        composedReward: 0.337,
+      },
+      {
+        armId: 'v4-arm3', armName: 'trending_section',
+        objectiveContributions: { play_through_rate: 0.149, provider_diversity_score: 0.095, add_to_watchlist_rate: 0.048 },
+        composedReward: 0.292,
+      },
+      {
+        armId: 'v4-arm4', armName: 'personalized_row',
+        objectiveContributions: { play_through_rate: 0.108, provider_diversity_score: 0.140, add_to_watchlist_rate: 0.031 },
+        composedReward: 0.279,
+      },
+    ],
+    constraintStatuses: [
+      { label: 'max_single_provider_share', currentValue: 0.3500, limit: 0.5000, isSatisfied: true },
+      { label: 'min_diversity_floor', currentValue: -0.2550, limit: -0.2000, isSatisfied: false },
     ],
   },
 };

--- a/ui/src/__tests__/bandit-dashboard.test.tsx
+++ b/ui/src/__tests__/bandit-dashboard.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import BanditDashboardPage from '@/app/experiments/[id]/bandit/page';
+import { RewardCompositionChart } from '@/components/RewardCompositionChart';
+import { ConstraintStatusTable } from '@/components/ConstraintStatusTable';
+import type { ArmObjectiveBreakdown, RewardObjective, ConstraintStatus } from '@/lib/types';
 
 let mockExperimentId = '44444444-4444-4444-4444-444444444444';
 
@@ -148,6 +151,127 @@ describe('Bandit Dashboard - cold_start_bandit (experiment 444...)', () => {
 
     const detailLinks = screen.getAllByText('Detail');
     expect(detailLinks[0].closest('a')).toHaveAttribute('href', '/experiments/44444444-4444-4444-4444-444444444444');
+  });
+});
+
+describe('Bandit Dashboard - multi-objective reward composition (ADR-011)', () => {
+  beforeEach(() => {
+    mockExperimentId = '44444444-4444-4444-4444-444444444444';
+  });
+
+  it('renders reward composition section when objectives present', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Reward Composition per Arm')).toBeInTheDocument();
+    });
+  });
+
+  it('renders LP constraint status section', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('LP Constraint Status')).toBeInTheDocument();
+    });
+  });
+
+  it('shows VIOLATED constraint with red badge', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('VIOLATED')).toBeInTheDocument();
+    });
+  });
+
+  it('shows SATISFIED constraint badge', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('SATISFIED')).toBeInTheDocument();
+    });
+  });
+
+  it('shows constraint labels from seed data', async () => {
+    render(<BanditDashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('max_single_provider_share')).toBeInTheDocument();
+    });
+    expect(screen.getByText('min_diversity_floor')).toBeInTheDocument();
+  });
+});
+
+describe('RewardCompositionChart unit tests', () => {
+  const objectives: RewardObjective[] = [
+    { metricId: 'engagement', weight: 0.6, floor: 0.0, isPrimary: true },
+    { metricId: 'diversity', weight: 0.4, floor: 0.3, isPrimary: false },
+  ];
+
+  const breakdowns: ArmObjectiveBreakdown[] = [
+    { armId: 'arm-1', armName: 'Arm A', objectiveContributions: { engagement: 0.3, diversity: 0.2 }, composedReward: 0.5 },
+    { armId: 'arm-2', armName: 'Arm B', objectiveContributions: { engagement: 0.2, diversity: 0.3 }, composedReward: 0.5 },
+  ];
+
+  it('renders chart container with objectives and breakdowns', () => {
+    render(<RewardCompositionChart breakdowns={breakdowns} objectives={objectives} />);
+    expect(screen.getByRole('img', { name: /multi-objective reward composition/i })).toBeInTheDocument();
+  });
+
+  it('shows primary objective label in footer', () => {
+    render(<RewardCompositionChart breakdowns={breakdowns} objectives={objectives} />);
+    expect(screen.getByText(/Primary objective/)).toBeInTheDocument();
+    expect(screen.getAllByText(/engagement/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders empty state when breakdowns is empty', () => {
+    render(<RewardCompositionChart breakdowns={[]} objectives={objectives} />);
+    expect(screen.getByText(/No objective breakdown data/)).toBeInTheDocument();
+  });
+
+  it('renders empty state when objectives is empty', () => {
+    render(<RewardCompositionChart breakdowns={breakdowns} objectives={[]} />);
+    expect(screen.getByText(/No objective breakdown data/)).toBeInTheDocument();
+  });
+});
+
+describe('ConstraintStatusTable unit tests', () => {
+  const constraints: ConstraintStatus[] = [
+    { label: 'provider_cap', currentValue: 0.3, limit: 0.5, isSatisfied: true },
+    { label: 'diversity_floor', currentValue: 0.15, limit: 0.2, isSatisfied: false },
+  ];
+
+  it('renders constraint labels and values', () => {
+    render(<ConstraintStatusTable constraints={constraints} />);
+    expect(screen.getByText('provider_cap')).toBeInTheDocument();
+    expect(screen.getByText('diversity_floor')).toBeInTheDocument();
+  });
+
+  it('shows SATISFIED badge for satisfied constraints', () => {
+    render(<ConstraintStatusTable constraints={constraints} />);
+    expect(screen.getByText('SATISFIED')).toBeInTheDocument();
+  });
+
+  it('shows VIOLATED badge for violated constraints', () => {
+    render(<ConstraintStatusTable constraints={constraints} />);
+    expect(screen.getByText('VIOLATED')).toBeInTheDocument();
+  });
+
+  it('applies red row highlight on violated row', () => {
+    const { container } = render(<ConstraintStatusTable constraints={constraints} />);
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows[0]).not.toHaveClass('bg-red-50');
+    expect(rows[1]).toHaveClass('bg-red-50');
+  });
+
+  it('renders empty state when no constraints', () => {
+    render(<ConstraintStatusTable constraints={[]} />);
+    expect(screen.getByText(/No LP constraints configured/)).toBeInTheDocument();
+  });
+
+  it('shows current value and limit columns', () => {
+    render(<ConstraintStatusTable constraints={constraints} />);
+    expect(screen.getByText('Current Value')).toBeInTheDocument();
+    expect(screen.getByText('Limit')).toBeInTheDocument();
   });
 });
 

--- a/ui/src/app/experiments/[id]/bandit/page.tsx
+++ b/ui/src/app/experiments/[id]/bandit/page.tsx
@@ -18,6 +18,8 @@ import { getExperiment, getBanditDashboard } from '@/lib/api';
 import { formatDate } from '@/lib/utils';
 import { RetryableError } from '@/components/retryable-error';
 import { Breadcrumb } from '@/components/breadcrumb';
+import { RewardCompositionChart } from '@/components/RewardCompositionChart';
+import { ConstraintStatusTable } from '@/components/ConstraintStatusTable';
 
 const ARM_COLORS = ['#4f46e5', '#0891b2', '#059669', '#d97706', '#dc2626', '#7c3aed'];
 
@@ -207,6 +209,28 @@ export default function BanditDashboardPage() {
             </div>
           </div>
         </section>
+      )}
+
+      {/* Multi-objective reward composition (ADR-011) — only when reward_objectives non-empty */}
+      {(experiment.banditExperimentConfig?.rewardObjectives?.length ?? 0) > 0 && (
+        <>
+          <section className="mb-6">
+            <h2 className="mb-3 text-lg font-semibold text-gray-900">Reward Composition per Arm</h2>
+            <div className="rounded-lg border border-gray-200 bg-white p-4">
+              <RewardCompositionChart
+                breakdowns={dashboard.objectiveBreakdowns ?? []}
+                objectives={experiment.banditExperimentConfig!.rewardObjectives!}
+              />
+            </div>
+          </section>
+
+          {(dashboard.constraintStatuses?.length ?? 0) > 0 && (
+            <section className="mb-6">
+              <h2 className="mb-3 text-lg font-semibold text-gray-900">LP Constraint Status</h2>
+              <ConstraintStatusTable constraints={dashboard.constraintStatuses!} />
+            </section>
+          )}
+        </>
       )}
 
       {/* Arm stats table */}

--- a/ui/src/components/ConstraintStatusTable.tsx
+++ b/ui/src/components/ConstraintStatusTable.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { memo } from 'react';
+import type { ConstraintStatus } from '@/lib/types';
+
+interface ConstraintStatusTableProps {
+  constraints: ConstraintStatus[];
+}
+
+function ConstraintStatusTableInner({ constraints }: ConstraintStatusTableProps) {
+  if (constraints.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-gray-500">No LP constraints configured.</p>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Constraint
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+              Current Value
+            </th>
+            <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+              Limit
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {constraints.map((c) => (
+            <tr
+              key={c.label}
+              className={c.isSatisfied ? '' : 'bg-red-50'}
+            >
+              <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                {c.label}
+              </td>
+              <td className={`whitespace-nowrap px-4 py-3 text-right text-sm ${c.isSatisfied ? 'text-gray-600' : 'font-semibold text-red-700'}`}>
+                {c.currentValue.toFixed(4)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-600">
+                {c.limit.toFixed(4)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm">
+                {c.isSatisfied ? (
+                  <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
+                    SATISFIED
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">
+                    VIOLATED
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export const ConstraintStatusTable = memo(ConstraintStatusTableInner);

--- a/ui/src/components/RewardCompositionChart.tsx
+++ b/ui/src/components/RewardCompositionChart.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { memo } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { ArmObjectiveBreakdown, RewardObjective } from '@/lib/types';
+
+const OBJECTIVE_COLORS = [
+  '#4f46e5', // indigo
+  '#0891b2', // cyan
+  '#059669', // emerald
+  '#d97706', // amber
+  '#dc2626', // red
+  '#7c3aed', // violet
+  '#0284c7', // sky
+  '#65a30d', // lime
+];
+
+interface RewardCompositionChartProps {
+  breakdowns: ArmObjectiveBreakdown[];
+  objectives: RewardObjective[];
+}
+
+function RewardCompositionChartInner({ breakdowns, objectives }: RewardCompositionChartProps) {
+  if (breakdowns.length === 0 || objectives.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-gray-500">No objective breakdown data available.</p>
+    );
+  }
+
+  // Build recharts data: one object per arm with one key per objective metricId
+  const chartData = breakdowns.map((bd) => {
+    const row: Record<string, string | number> = { arm: bd.armName };
+    for (const obj of objectives) {
+      row[obj.metricId] = bd.objectiveContributions[obj.metricId] ?? 0;
+    }
+    return row;
+  });
+
+  const compositionLabel = objectives.find((o) => o.isPrimary)?.metricId ?? 'Composed';
+
+  return (
+    <div>
+      <div role="img" aria-label="Multi-objective reward composition per arm">
+        <ResponsiveContainer width="100%" height={260}>
+          <BarChart data={chartData} margin={{ left: 20, right: 20, top: 10, bottom: 10 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="arm" tick={{ fontSize: 12 }} />
+            <YAxis
+              domain={[0, 1]}
+              tickFormatter={(v: number) => v.toFixed(2)}
+              label={{ value: 'Weighted Contribution', angle: -90, position: 'insideLeft', offset: -5, style: { fontSize: 11 } }}
+            />
+            <Tooltip formatter={(v: number) => v.toFixed(4)} />
+            <Legend />
+            {objectives.map((obj, i) => (
+              <Bar
+                key={obj.metricId}
+                dataKey={obj.metricId}
+                stackId="reward"
+                fill={OBJECTIVE_COLORS[i % OBJECTIVE_COLORS.length]}
+                name={`${obj.metricId}${obj.isPrimary ? ' (primary)' : ''}`}
+                isAnimationActive={false}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-2 text-xs text-gray-500">
+        Primary objective: <span className="font-medium">{compositionLabel}</span>
+        {' · '}
+        Weights: {objectives.map((o) => `${o.metricId} ×${o.weight.toFixed(2)}`).join(', ')}
+      </p>
+    </div>
+  );
+}
+
+export const RewardCompositionChart = memo(RewardCompositionChartInner);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -496,12 +496,46 @@ export interface SessionConfig {
   minSessionsPerUser: number;
 }
 
+export type RewardCompositionMethod =
+  | 'WEIGHTED_SCALARIZATION'
+  | 'EPSILON_CONSTRAINT'
+  | 'TCHEBYCHEFF';
+
+export interface RewardObjective {
+  metricId: string;
+  weight: number;
+  /** Floor constraint for EPSILON_CONSTRAINT (minimum normalized value). */
+  floor: number;
+  isPrimary: boolean;
+}
+
+export interface BanditArmConstraint {
+  armId: string;
+  minFraction: number;
+  maxFraction: number;
+}
+
+export interface BanditGlobalConstraint {
+  label: string;
+  /** Coefficient for each arm keyed by armId. */
+  coefficients: Record<string, number>;
+  /** Right-hand side: Σ(coeff_i × p_i) <= rhs. */
+  rhs: number;
+}
+
 export interface BanditExperimentConfig {
   algorithm: BanditAlgorithm;
   rewardMetricId: string;
   contextFeatureKeys: string[];
   minExplorationFraction: number;
   warmupObservations: number;
+  /** Multi-objective reward objectives (ADR-011). When non-empty, rewardMetricId is ignored. */
+  rewardObjectives?: RewardObjective[];
+  compositionMethod?: RewardCompositionMethod;
+  /** Per-arm traffic bounds for LP post-processing layer (ADR-012). */
+  armConstraints?: BanditArmConstraint[];
+  /** General linear constraints across arms (ADR-012). */
+  globalConstraints?: BanditGlobalConstraint[];
 }
 
 export interface QoeConfig {
@@ -560,6 +594,23 @@ export interface RewardHistoryPoint {
   cumulativeSelections: number;
 }
 
+/** Per-arm per-objective weighted contribution for stacked bar chart (ADR-011). */
+export interface ArmObjectiveBreakdown {
+  armId: string;
+  armName: string;
+  /** metricId → weighted normalized contribution (weight × normalized_reward). */
+  objectiveContributions: Record<string, number>;
+  composedReward: number;
+}
+
+/** LP constraint current status row for ConstraintStatusTable (ADR-012). */
+export interface ConstraintStatus {
+  label: string;
+  currentValue: number;
+  limit: number;
+  isSatisfied: boolean;
+}
+
 export interface BanditDashboardResult {
   experimentId: string;
   algorithm: BanditAlgorithm;
@@ -570,6 +621,10 @@ export interface BanditDashboardResult {
   warmupObservations: number;
   minExplorationFraction: number;
   rewardHistory: RewardHistoryPoint[];
+  /** Multi-objective reward breakdown per arm (ADR-011). Present when reward_objectives non-empty. */
+  objectiveBreakdowns?: ArmObjectiveBreakdown[];
+  /** LP constraint current statuses (ADR-012). Present when global_constraints non-empty. */
+  constraintStatuses?: ConstraintStatus[];
 }
 
 // --- AVLM Confidence Sequence (ADR-015) ---


### PR DESCRIPTION
## Summary

- **RewardCompositionChart** (`ui/src/components/RewardCompositionChart.tsx`): Stacked bar chart showing each objective's weighted contribution to the composed reward per arm. One color-coded segment per `RewardObjective`. Renders primary objective label and all weights in footer. `React.memo`, TypeScript strict.
- **ConstraintStatusTable** (`ui/src/components/ConstraintStatusTable.tsx`): Table showing LP constraints with name, current value, limit, and SATISFIED/VIOLATED badge. Red row highlight (`bg-red-50`) on violated rows, red bold text on violated current values. `React.memo`, TypeScript strict.
- **Bandit dashboard wired**: Both components injected into `bandit/page.tsx`, guarded by `banditExperimentConfig.rewardObjectives?.length > 0`. ConstraintStatusTable additionally guarded by `constraintStatuses?.length > 0`.
- **Types added** to `ui/src/lib/types.ts`: `RewardCompositionMethod`, `RewardObjective`, `BanditArmConstraint`, `BanditGlobalConstraint`, `ArmObjectiveBreakdown`, `ConstraintStatus`. `BanditExperimentConfig` and `BanditDashboardResult` extended with optional Phase 5 fields.
- **Seed data**: cold_start_bandit (444...) updated with 3 reward objectives, WEIGHTED_SCALARIZATION method, 2 global constraints. `BanditDashboardResult` gets `objectiveBreakdowns` for all 4 arms and `constraintStatuses` (1 satisfied, 1 violated for demo coverage).

## Test plan

- [x] 26/26 bandit-dashboard tests pass (15 new)
  - Integration: reward composition section renders, LP constraint section renders, VIOLATED/SATISFIED badges visible, constraint labels shown
  - Unit (RewardCompositionChart): aria label, primary objective footer, empty states for empty breakdowns / empty objectives
  - Unit (ConstraintStatusTable): labels, SATISFIED badge, VIOLATED badge, red row highlight on violated, empty state, column headers
- [x] `npm run build` passes (no TypeScript errors)
- [x] Pre-existing test isolation failures in performance/chaos/list tests are unrelated to this PR (confirmed by running isolated)

## Notes for continuation

- `objectiveBreakdowns` and `constraintStatuses` fields in `BanditDashboardResult` are optional — MSW mock is populated, wire-format integration awaits Agent-4 extending `GetBanditDashboard` RPC response.
- Opportunity: `RewardCompositionChart` could add a tooltip showing exact normalized objective value (not just weighted contribution) — deferred to future PR.
- Opportunity: arm constraint visualization (per-arm min/max bars) from `BanditArmConstraint` — deferred to slate bandit PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
