### PR TITLE
feat(m6): ADR-021 feedback loop interference UI components

### DIFF
--- a/docs/coordination/status/agent-6-status.md
+++ b/docs/coordination/status/agent-6-status.md
@@ -1,45 +1,48 @@
 # Agent-6 Status — Phase 5
 
 **Module**: M6 UI
-**Last updated**: 2026-03-23
+**Last updated**: 2026-03-24
 
 ## Current Sprint
 
-Sprint: 5.1
-Focus: AVLM confidence sequence (ADR-015), Adaptive N zone badge (ADR-020), Feedback Loop analysis tab
-Branch: work/proud-eagle
+Sprint: 5.2
+Focus: Feedback Loop Interference UI (ADR-021), FeedbackLoopAlert banner, InterferenceTimelineChart
+Branch: work/proud-badger
 
 ## Completed (this PR)
 
-- [x] **AVLM confidence sequence boundary plot** (ADR-015)
-  - `ui/src/components/charts/avlm-boundary-plot.tsx`
-  - Recharts ComposedChart with Area (confidence sequence band) + dual Line (CUPED + raw estimate)
-  - ReferenceLine at H0=0; conclusive badge when CS excludes zero
-  - Dynamically imported; legacy alpha-spending chart preserved under details fold
-  - API: `getAvlmResult(experimentId, metricId)` → AnalysisService/GetAvlmResult
-  - Types: AvlmBoundaryPoint, AvlmResult
-  - Seed data: 2 metrics for 111... (CTR conclusive look 3, watch_time inconclusive)
+- [x] **FeedbackLoopAlert.tsx** (ADR-021)
+  - `ui/src/components/feedback-loop-alert.tsx`
+  - Self-fetching banner shown when feedback loop interference detected
+  - Severity: ERROR (red) when |bias| > 0.1, WARNING (yellow) otherwise
+  - Shows: contamination metric name, contamination %, estimated bias, time-since-last-retrain
+  - Uses `feedbackLoopDetected` backend flag when present; infers from `contaminationFraction > 0 && retrainingEvents.length > 0` otherwise
+  - Wired into results page after `SrmBanner` for MAB/CONTEXTUAL_BANDIT/AB experiments
+  - React.memo, TypeScript strict, no SSR issues
 
-- [x] **Adaptive N zone indicator badge** (ADR-020)
-  - `ui/src/components/adaptive-n-badge.tsx`
-  - Zones: FAVORABLE (green), PROMISING (blue), FUTILE (red), INCONCLUSIVE (gray)
-  - Mounted in experiment detail page header for RUNNING/CONCLUDED experiments
-  - API: `getAdaptiveN(experimentId)` → AnalysisService/GetAdaptiveN
+- [x] **InterferenceTimelineChart.tsx** (ADR-021)
+  - `ui/src/components/interference-timeline-chart.tsx`
+  - Recharts LineChart showing treatment effect (postEffect) over time
+  - Orange vertical ReferenceLine markers at each `ModelRetrainingEvent` timestamp
+  - Accessible: role="img" with aria-label
+  - Returns null when no data points
+  - React.memo, isAnimationActive=false
 
-- [x] **Extended timeline visualization** (ADR-020 PROMISING zone)
-  - `ui/src/components/adaptive-n-timeline.tsx`
-  - AreaChart with planned N and recommended N reference lines
-  - Only rendered when zone === PROMISING in results page overview tab
+- [x] **Wired into ExperimentResults page**
+  - `FeedbackLoopAlert` added to results page banner area (alongside SrmBanner)
+  - `InterferenceTimelineChart` added inside FeedbackLoopTab (gets data from existing fetch)
+  - Both visible without navigating to the feedback tab when interference is detected
 
-- [x] **Feedback loop analysis tab**
-  - `ui/src/components/feedback-loop-tab.tsx`
-  - Sections: retraining timeline, pre/post comparison chart, contamination bar chart,
-    bias-corrected estimate highlight, mitigation recommendation matrix (HIGH/MEDIUM/LOW)
-  - Visible for AB/MAB/CONTEXTUAL_BANDIT experiments
-  - API: `getFeedbackLoopAnalysis(experimentId)` → AnalysisService/GetFeedbackLoopAnalysis
+- [x] **Type update**
+  - Added optional `feedbackLoopDetected?: boolean` field to `FeedbackLoopResult` in `types.ts`
 
-- [x] Tests: 14 new tests all passing, 0 regressions (499 total, 6 pre-existing skips)
-- [x] Updated recharts mocks in analysis-tabs, results-dashboard, performance test files (Area/AreaChart)
+- [x] **Tests**: 15 new tests all passing, 0 regressions
+  - `ui/src/__tests__/feedback-loop-interference.test.tsx`
+  - FeedbackLoopAlert: 10 tests (WARNING/ERROR severity, metric name, contamination, bias, retrain date, 404 handling, zero contamination, explicit flag suppression, fallback label)
+  - InterferenceTimelineChart: 5 tests (title, a11y container, retrain count, empty data, singular event)
+  - Updated recharts mocks in `avlm-adaptive-n.test.tsx`, `analysis-tabs.test.tsx`, `results-dashboard.test.tsx` to include `LineChart`
+
+- [x] Build: `npm run build` passes cleanly
 
 ## Blocked
 
@@ -55,6 +58,18 @@ None.
 
 - [x] /portfolio/provider-health page (ADR-014)
   - Time series charts, provider filter, MSW mock, 8 tests
+
+- [x] AVLM confidence sequence boundary plot (ADR-015)
+  - `ui/src/components/charts/avlm-boundary-plot.tsx`
+
+- [x] Adaptive N zone indicator badge (ADR-020)
+  - `ui/src/components/adaptive-n-badge.tsx`
+
+- [x] Extended timeline visualization (ADR-020 PROMISING zone)
+  - `ui/src/components/adaptive-n-timeline.tsx`
+
+- [x] Feedback loop analysis tab
+  - `ui/src/components/feedback-loop-tab.tsx`
 
 ## Dependencies (wire-ready, awaiting backend)
 

--- a/ui/src/__tests__/analysis-tabs.test.tsx
+++ b/ui/src/__tests__/analysis-tabs.test.tsx
@@ -40,6 +40,7 @@ vi.mock('recharts', async () => {
     ComposedChart: Passthrough,
     BarChart: Passthrough,
     AreaChart: Passthrough,
+    LineChart: Passthrough,
     Area: Noop,
     Bar: Noop,
     Line: Noop,

--- a/ui/src/__tests__/avlm-adaptive-n.test.tsx
+++ b/ui/src/__tests__/avlm-adaptive-n.test.tsx
@@ -26,6 +26,7 @@ vi.mock('recharts', async () => {
     ComposedChart: Passthrough,
     AreaChart: Passthrough,
     BarChart: Passthrough,
+    LineChart: Passthrough,
     Area: Noop,
     Line: Noop,
     Bar: Noop,

--- a/ui/src/__tests__/feedback-loop-interference.test.tsx
+++ b/ui/src/__tests__/feedback-loop-interference.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Tests for ADR-021 feedback loop interference UI components.
+ *
+ * Coverage:
+ *   - FeedbackLoopAlert: WARNING severity for bias ≤ 0.1, ERROR for bias > 0.1
+ *   - FeedbackLoopAlert: shows contamination metric, estimated bias, last retrain date
+ *   - FeedbackLoopAlert: hidden when no feedback loop data (404)
+ *   - FeedbackLoopAlert: hidden when contamination fraction is 0
+ *   - InterferenceTimelineChart: renders chart section with retrain markers copy
+ *   - InterferenceTimelineChart: returns null when no data points
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import type { FeedbackLoopResult } from '@/lib/types';
+
+vi.mock('recharts', async () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="recharts-wrapper">{children}</div>
+  );
+  const Noop = () => null;
+  return {
+    ResponsiveContainer: Passthrough,
+    LineChart: Passthrough,
+    ComposedChart: Passthrough,
+    AreaChart: Passthrough,
+    BarChart: Passthrough,
+    Area: Noop,
+    Line: Noop,
+    Bar: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    Tooltip: Noop,
+    Legend: Noop,
+    ReferenceLine: Noop,
+    Scatter: Noop,
+    Cell: Noop,
+  };
+});
+
+import { FeedbackLoopAlert } from '@/components/feedback-loop-alert';
+import { InterferenceTimelineChart } from '@/components/interference-timeline-chart';
+
+const ANALYSIS_SVC = '*/experimentation.analysis.v1.AnalysisService';
+
+// Shared base result (bias = 0.001 < 0.1 → WARNING)
+const BASE_RESULT: FeedbackLoopResult = {
+  experimentId: '11111111-1111-1111-1111-111111111111',
+  retrainingEvents: [
+    {
+      eventId: 're-001',
+      retrainedAt: '2026-02-22T02:00:00Z',
+      triggerReason: 'Scheduled weekly retrain',
+      modelVersion: 'neural_cf_v2.1',
+    },
+    {
+      eventId: 're-002',
+      retrainedAt: '2026-03-01T02:00:00Z',
+      triggerReason: 'Scheduled weekly retrain',
+      modelVersion: 'neural_cf_v2.2',
+    },
+  ],
+  prePostComparison: [
+    { date: '2026-02-20', preEffect: 0.011, postEffect: 0.014 },
+    { date: '2026-02-22', preEffect: 0.013, postEffect: 0.014 },
+    { date: '2026-03-01', preEffect: 0.014, postEffect: 0.016 },
+    { date: '2026-03-03', preEffect: 0.014, postEffect: 0.014 },
+  ],
+  contaminationTimeline: [
+    { date: '2026-02-22', contaminationFraction: 0.0 },
+    { date: '2026-02-24', contaminationFraction: 0.15 },
+  ],
+  rawEstimate: 0.014,
+  biasCorrectedEstimate: 0.013,
+  biasCorrectedCiLower: 0.004,
+  biasCorrectedCiUpper: 0.022,
+  contaminationFraction: 0.20,
+  recommendations: [],
+  computedAt: '2026-03-05T14:30:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// FeedbackLoopAlert
+// ---------------------------------------------------------------------------
+describe('FeedbackLoopAlert', () => {
+  it('renders WARNING banner for seeded experiment (bias = 0.001 < 0.1)', async () => {
+    render(
+      <FeedbackLoopAlert
+        experimentId="11111111-1111-1111-1111-111111111111"
+        primaryMetricId="click_through_rate"
+      />,
+    );
+    const alert = await screen.findByTestId('feedback-loop-alert');
+    expect(alert).toHaveAttribute('data-severity', 'WARNING');
+    expect(alert).toHaveTextContent(/Feedback Loop Interference Detected/);
+  });
+
+  it('shows contamination metric name', async () => {
+    render(
+      <FeedbackLoopAlert
+        experimentId="11111111-1111-1111-1111-111111111111"
+        primaryMetricId="click_through_rate"
+      />,
+    );
+    const metricEl = await screen.findByTestId('alert-metric-name');
+    expect(metricEl).toHaveTextContent('click_through_rate');
+  });
+
+  it('shows contamination percentage', async () => {
+    render(
+      <FeedbackLoopAlert experimentId="11111111-1111-1111-1111-111111111111" />,
+    );
+    const el = await screen.findByTestId('alert-contamination');
+    expect(el).toHaveTextContent('20.0%');
+  });
+
+  it('shows estimated bias value', async () => {
+    render(
+      <FeedbackLoopAlert experimentId="11111111-1111-1111-1111-111111111111" />,
+    );
+    const el = await screen.findByTestId('alert-bias');
+    // |0.014 - 0.013| = 0.001
+    expect(el).toHaveTextContent('0.0010');
+  });
+
+  it('shows last retrain date', async () => {
+    render(
+      <FeedbackLoopAlert experimentId="11111111-1111-1111-1111-111111111111" />,
+    );
+    const el = await screen.findByTestId('alert-retrain-time');
+    // Most recent event: 2026-03-01
+    expect(el.textContent).toMatch(/Mar 1, 2026/);
+  });
+
+  it('renders ERROR severity when bias > 0.1', async () => {
+    server.use(
+      http.post(`${ANALYSIS_SVC}/GetFeedbackLoopAnalysis`, () =>
+        HttpResponse.json({
+          ...BASE_RESULT,
+          rawEstimate: 0.5,
+          biasCorrectedEstimate: 0.1, // bias = 0.4 > 0.1
+        }),
+      ),
+    );
+    render(
+      <FeedbackLoopAlert experimentId="11111111-1111-1111-1111-111111111111" />,
+    );
+    const alert = await screen.findByTestId('feedback-loop-alert');
+    expect(alert).toHaveAttribute('data-severity', 'ERROR');
+  });
+
+  it('renders nothing when server returns 404', async () => {
+    server.use(
+      http.post(`${ANALYSIS_SVC}/GetFeedbackLoopAnalysis`, () =>
+        HttpResponse.json({ code: 'not_found' }, { status: 404 }),
+      ),
+    );
+    const { container } = render(
+      <FeedbackLoopAlert experimentId="00000000-0000-0000-0000-000000000000" />,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when contamination fraction is 0', async () => {
+    server.use(
+      http.post(`${ANALYSIS_SVC}/GetFeedbackLoopAnalysis`, () =>
+        HttpResponse.json({ ...BASE_RESULT, contaminationFraction: 0 }),
+      ),
+    );
+    const { container } = render(
+      <FeedbackLoopAlert experimentId="11111111-1111-1111-1111-111111111111" />,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('uses explicit feedbackLoopDetected=false to suppress banner', async () => {
+    server.use(
+      http.post(`${ANALYSIS_SVC}/GetFeedbackLoopAnalysis`, () =>
+        HttpResponse.json({ ...BASE_RESULT, feedbackLoopDetected: false }),
+      ),
+    );
+    const { container } = render(
+      <FeedbackLoopAlert experimentId="11111111-1111-1111-1111-111111111111" />,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('falls back to "primary metric" label when no primaryMetricId given', async () => {
+    render(<FeedbackLoopAlert experimentId="11111111-1111-1111-1111-111111111111" />);
+    const el = await screen.findByTestId('alert-metric-name');
+    expect(el).toHaveTextContent('primary metric');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// InterferenceTimelineChart
+// ---------------------------------------------------------------------------
+describe('InterferenceTimelineChart', () => {
+  it('renders chart title and description', () => {
+    render(<InterferenceTimelineChart result={BASE_RESULT} />);
+    expect(screen.getByText('Treatment Effect Timeline')).toBeInTheDocument();
+    expect(screen.getByText(/Treatment effect over time/)).toBeInTheDocument();
+  });
+
+  it('renders the accessible chart container', () => {
+    render(<InterferenceTimelineChart result={BASE_RESULT} />);
+    expect(
+      screen.getByRole('img', { name: /Treatment effect over time with model retraining events/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows retrain event count footer', () => {
+    render(<InterferenceTimelineChart result={BASE_RESULT} />);
+    expect(screen.getByText(/2 retraining events marked/)).toBeInTheDocument();
+  });
+
+  it('returns null when prePostComparison is empty', () => {
+    const emptyResult: FeedbackLoopResult = {
+      ...BASE_RESULT,
+      prePostComparison: [],
+    };
+    const { container } = render(<InterferenceTimelineChart result={emptyResult} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows singular "event" for one retrain', () => {
+    const oneEvent: FeedbackLoopResult = {
+      ...BASE_RESULT,
+      retrainingEvents: [BASE_RESULT.retrainingEvents[0]],
+    };
+    render(<InterferenceTimelineChart result={oneEvent} />);
+    expect(screen.getByText(/1 retraining event marked/)).toBeInTheDocument();
+  });
+});

--- a/ui/src/__tests__/results-dashboard.test.tsx
+++ b/ui/src/__tests__/results-dashboard.test.tsx
@@ -40,6 +40,7 @@ vi.mock('recharts', async () => {
     ComposedChart: Passthrough,
     BarChart: Passthrough,
     AreaChart: Passthrough,
+    LineChart: Passthrough,
     Area: Noop,
     Bar: Noop,
     Line: Noop,

--- a/ui/src/app/experiments/[id]/results/page.tsx
+++ b/ui/src/app/experiments/[id]/results/page.tsx
@@ -9,6 +9,7 @@ import type { AdaptiveNResult } from '@/lib/types';
 import { RetryableError } from '@/components/retryable-error';
 import { Breadcrumb } from '@/components/breadcrumb';
 import { SrmBanner } from '@/components/srm-banner';
+import { FeedbackLoopAlert } from '@/components/feedback-loop-alert';
 import { ResultsSummary } from '@/components/results-summary';
 import { CupedToggle } from '@/components/cuped-toggle';
 import { IpwToggle } from '@/components/ipw-toggle';
@@ -263,6 +264,14 @@ export default function ResultsPage() {
 
       {/* SRM Banner */}
       <SrmBanner srmResult={analysisResult.srmResult} />
+
+      {/* Feedback Loop Interference Alert (ADR-021) */}
+      {(experiment.type === 'MAB' || experiment.type === 'CONTEXTUAL_BANDIT' || experiment.type === 'AB') && (
+        <FeedbackLoopAlert
+          experimentId={params.id}
+          primaryMetricId={experiment.primaryMetricId}
+        />
+      )}
 
       {/* Summary */}
       <ResultsSummary analysisResult={analysisResult} experiment={experiment} />

--- a/ui/src/components/feedback-loop-alert.tsx
+++ b/ui/src/components/feedback-loop-alert.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { memo, useEffect, useState } from 'react';
+import type { FeedbackLoopResult } from '@/lib/types';
+import { getFeedbackLoopAnalysis, RpcError } from '@/lib/api';
+import { formatDate } from '@/lib/utils';
+
+interface FeedbackLoopAlertProps {
+  experimentId: string;
+  primaryMetricId?: string;
+}
+
+function FeedbackLoopAlertInner({ experimentId, primaryMetricId }: FeedbackLoopAlertProps) {
+  const [result, setResult] = useState<FeedbackLoopResult | null>(null);
+
+  useEffect(() => {
+    getFeedbackLoopAnalysis(experimentId)
+      .then(setResult)
+      .catch((err) => {
+        if (!(err instanceof RpcError && err.status === 404)) {
+          // Best-effort: banner is non-blocking; suppress but don't crash
+        }
+      });
+  }, [experimentId]);
+
+  if (!result) return null;
+
+  // Use explicit backend flag when available; infer from data otherwise
+  const feedbackLoopDetected =
+    result.feedbackLoopDetected ?? (result.retrainingEvents.length > 0 && result.contaminationFraction > 0);
+
+  if (!feedbackLoopDetected) return null;
+
+  const estimatedBias = Math.abs(result.rawEstimate - result.biasCorrectedEstimate);
+  const isError = estimatedBias > 0.1;
+  const severity = isError ? 'ERROR' : 'WARNING';
+
+  const sortedEvents = [...result.retrainingEvents].sort(
+    (a, b) => new Date(b.retrainedAt).getTime() - new Date(a.retrainedAt).getTime(),
+  );
+  const mostRecent = sortedEvents[0];
+
+  let timeSinceRetrain = '';
+  if (mostRecent) {
+    const diffDays = Math.floor(
+      (Date.now() - new Date(mostRecent.retrainedAt).getTime()) / (1000 * 60 * 60 * 24),
+    );
+    timeSinceRetrain = diffDays === 0 ? 'today' : `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
+  }
+
+  const metricLabel = primaryMetricId ?? 'primary metric';
+  const contaminationPct = (result.contaminationFraction * 100).toFixed(1);
+
+  const colorSet = isError
+    ? { banner: 'bg-red-50 border-red-300', heading: 'text-red-800', text: 'text-red-700' }
+    : { banner: 'bg-yellow-50 border-yellow-300', heading: 'text-yellow-800', text: 'text-yellow-700' };
+
+  return (
+    <div
+      className={`mb-4 rounded-lg border p-4 ${colorSet.banner}`}
+      role="alert"
+      aria-live="polite"
+      data-testid="feedback-loop-alert"
+      data-severity={severity}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-lg leading-none" aria-hidden="true">&#9888;</span>
+        <div className="flex-1">
+          <h3 className={`font-semibold ${colorSet.heading}`}>
+            {severity}: Feedback Loop Interference Detected
+          </h3>
+          <p className={`mt-1 text-sm ${colorSet.text}`}>
+            Model retraining has contaminated the primary metric estimate.
+            Use the bias-corrected estimate for decisions.
+          </p>
+          <p className={`mt-2 text-sm ${colorSet.text}`}>
+            <span data-testid="alert-metric-name">Metric: {metricLabel}</span>
+            {' · '}
+            <span data-testid="alert-contamination">Contamination: {contaminationPct}%</span>
+            {' · '}
+            <span data-testid="alert-bias">Bias: {estimatedBias.toFixed(4)}</span>
+            {mostRecent && (
+              <>
+                {' · '}
+                <span data-testid="alert-retrain-time">
+                  Last retrain: {formatDate(mostRecent.retrainedAt)} ({timeSinceRetrain})
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const FeedbackLoopAlert = memo(FeedbackLoopAlertInner);

--- a/ui/src/components/feedback-loop-tab.tsx
+++ b/ui/src/components/feedback-loop-tab.tsx
@@ -8,6 +8,7 @@ import {
 import type { FeedbackLoopResult, MitigationSeverity } from '@/lib/types';
 import { getFeedbackLoopAnalysis, RpcError } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
+import { InterferenceTimelineChart } from '@/components/interference-timeline-chart';
 import { formatDate } from '@/lib/utils';
 
 interface FeedbackLoopTabProps {
@@ -166,6 +167,9 @@ export function FeedbackLoopTab({ experimentId }: FeedbackLoopTabProps) {
           </table>
         </div>
       </div>
+
+      {/* Treatment effect timeline with retrain markers */}
+      <InterferenceTimelineChart result={result} />
 
       {/* Pre/post comparison chart */}
       <div className="rounded-lg border border-gray-200 bg-white p-4">

--- a/ui/src/components/interference-timeline-chart.tsx
+++ b/ui/src/components/interference-timeline-chart.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { memo } from 'react';
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer, ReferenceLine, Legend,
+} from 'recharts';
+import type { FeedbackLoopResult } from '@/lib/types';
+
+interface InterferenceTimelineChartProps {
+  result: FeedbackLoopResult;
+}
+
+function InterferenceTimelineChartInner({ result }: InterferenceTimelineChartProps) {
+  const chartData = result.prePostComparison.map((p) => ({
+    date: p.date.slice(5), // MM-DD
+    effect: p.postEffect,
+  }));
+
+  if (chartData.length === 0) return null;
+
+  // Retrain dates in MM-DD format, deduplicated
+  const retrainDates = [
+    ...new Set(result.retrainingEvents.map((e) => e.retrainedAt.slice(5, 10))),
+  ];
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <h4 className="mb-1 text-sm font-semibold text-gray-900">Treatment Effect Timeline</h4>
+      <p className="mb-3 text-xs text-gray-500">
+        Treatment effect over time. Orange vertical lines mark model retraining events.
+        Abrupt shifts after retraining indicate feedback loop contamination.
+      </p>
+      <div role="img" aria-label="Treatment effect over time with model retraining events">
+        <ResponsiveContainer width="100%" height={240}>
+          <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 30 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+            <YAxis
+              tick={{ fontSize: 11 }}
+              tickFormatter={(v: number) => v.toFixed(3)}
+              label={{ value: 'Effect', angle: -90, position: 'insideLeft', fontSize: 12 }}
+            />
+            <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="4 4" />
+            {retrainDates.map((d) => (
+              <ReferenceLine
+                key={d}
+                x={d}
+                stroke="#f97316"
+                strokeWidth={2}
+                label={{ value: 'Retrain', position: 'top', fontSize: 9, fill: '#f97316' }}
+              />
+            ))}
+            <Tooltip
+              formatter={(value: number) => [value.toFixed(4), 'Treatment effect']}
+              labelFormatter={(label: string) => `Date: ${label}`}
+            />
+            <Legend
+              formatter={(value: string) =>
+                value === 'effect' ? 'Treatment effect' : value
+              }
+            />
+            <Line
+              type="monotone"
+              dataKey="effect"
+              stroke="#6366f1"
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              isAnimationActive={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      {result.retrainingEvents.length > 0 && (
+        <p className="mt-2 text-xs text-gray-400">
+          {result.retrainingEvents.length} retraining event
+          {result.retrainingEvents.length !== 1 ? 's' : ''} marked.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export const InterferenceTimelineChart = memo(InterferenceTimelineChartInner);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -650,6 +650,7 @@ export interface MitigationRecommendation {
 
 export interface FeedbackLoopResult {
   experimentId: string;
+  feedbackLoopDetected?: boolean;
   retrainingEvents: RetrainingEvent[];
   prePostComparison: FeedbackLoopPrePost[];
   contaminationTimeline: ContaminationPoint[];


### PR DESCRIPTION
## Summary

- **FeedbackLoopAlert.tsx** — warning banner shown when feedback loop interference is detected on the ExperimentResults page (alongside `SrmBanner`). ERROR severity when `|bias| > 0.1`, WARNING otherwise. Displays contamination metric name, contamination %, estimated bias, and time-since-last-retrain. Self-fetching component (`useEffect` + best-effort 404 suppression), `React.memo`.
- **InterferenceTimelineChart.tsx** — Recharts `LineChart` showing treatment effect (`postEffect`) over time with orange vertical `ReferenceLine` markers at each `ModelRetrainingEvent` timestamp. Wired into `FeedbackLoopTab`. Returns null for empty data. `React.memo`, `isAnimationActive=false`.
- **Type**: Added optional `feedbackLoopDetected?: boolean` to `FeedbackLoopResult` — used by alert when set by backend; infers from `contaminationFraction > 0 && retrainingEvents.length > 0` otherwise.
- **Wiring**: `FeedbackLoopAlert` in `results/page.tsx` after `SrmBanner` for MAB/CONTEXTUAL_BANDIT/AB experiments. `InterferenceTimelineChart` inside `FeedbackLoopTab` (reuses existing data fetch).

## Test plan

- [x] 15 new tests in `feedback-loop-interference.test.tsx` — all passing
- [x] `FeedbackLoopAlert`: WARNING/ERROR severity thresholds, metric name display, contamination %, bias value, last retrain date, 404 suppression, zero-contamination suppression, explicit `feedbackLoopDetected=false`, fallback label
- [x] `InterferenceTimelineChart`: title, accessible chart container, retrain count footer, null for empty data, singular "event" text
- [x] Updated recharts mocks in 3 existing test files (`avlm-adaptive-n`, `analysis-tabs`, `results-dashboard`) to add `LineChart`
- [x] 0 regressions in affected test files (57 tests in modified files all pass)
- [x] `npm run build` passes cleanly

## Notes for next agent

- `analysis-tabs.test.tsx > Novelty Tab > shows novelty detection banner` was using `getByText('click_through_rate')` and broke when `FeedbackLoopAlert` added the metric name as standalone text. Fixed by embedding metric name within labelled `<span>` text ("Metric: click_through_rate") so exact `getByText` query doesn't match.
- Pre-existing flaky timeouts in `experiment-form`, `experiment-wizard`, `performance`, `cate-lifecycle` in the full combined suite run — these pass in isolation and are unrelated to ADR-021 work.
- Opportunities: `FeedbackLoopAlert` could also fire for `MULTIVARIATE` and `SESSION_LEVEL` types once backend supports those experiment types.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
