### PR TITLE
fix(experimentation-stats): adaptive_n proptest ceiling comparison

### DIFF
--- a/crates/experimentation-stats/src/adaptive_n.rs
+++ b/crates/experimentation-stats/src/adaptive_n.rs
@@ -866,8 +866,8 @@ mod tests {
             ).unwrap();
             prop_assert!(n_req >= n_current,
                 "required n {n_req} < n_current {n_current}");
-            prop_assert!(n_req <= n_max_allowed,
-                "required n {n_req} > n_max_allowed {n_max_allowed}");
+            prop_assert!(n_req <= n_max_allowed.ceil(),
+                "required n {n_req} > n_max_allowed.ceil() {}", n_max_allowed.ceil());
         }
     }
 }


### PR DESCRIPTION
## Root Cause

`required_n_for_power` returns `hi.ceil()` — an integer-valued `f64`. However, `n_max_allowed` in the proptest is `n_current * 5.0`, which is a non-integer float (e.g. `37.3 * 5.0 = 186.5`). The binary search converges and returns the ceiling of its `hi` value, which can be `187.0 > 186.5`, causing `prop_required_n_in_bounds` to fail intermittently across every branch that runs this proptest.

This is the systemic failure making every new worktree branch go RED on CI.

## Fix

**One line change** in `crates/experimentation-stats/src/adaptive_n.rs:869`:

```rust
// Before
prop_assert!(n_req <= n_max_allowed, ...)

// After
prop_assert!(n_req <= n_max_allowed.ceil(), ...)
```

The comparison is now between two integer-valued quantities (both are ceilings), which is the semantically correct invariant: the required sample size (an integer) must not exceed the ceiling of the maximum allowed (the next representable integer upper bound).

## Verification

```
cargo test -p experimentation-stats -- adaptive_n
```

All 27 adaptive_n tests pass including `prop_required_n_in_bounds`.

## Scope

- **1 file changed, 2 lines changed** (assertion + error message)
- No logic changes to `required_n_for_power` or any other function
- Unblocks all future branches from CI failures caused by this flaky proptest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
