### PR TITLE
🎨 Palette: Standardize copy-to-clipboard UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,6 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2025-05-15 - [Distribute Evenly UX Win]
 **Learning:** Automating repetitive calculations (like equal traffic distribution) significantly reduces friction and errors in experiment setup. Users appreciate tools that handle precision and edge cases (like remainder distribution) for them.
 **Action:** Look for other manual calculation tasks in the UI, such as target sample size or duration estimation, and provide one-click solutions.
+## 2025-05-16 - Reusable Copy-to-Clipboard Component
+**Learning:** Standardizing common interactions like "copy-to-clipboard" with a reusable component ensures consistent accessibility (ARIA labels, focus states) and user feedback (toasts) across the entire application. It also reduces code duplication and prevents subtle UX regressions.
+**Action:** Use the `CopyButton` component from `@/components/copy-button` for all technical identifiers and code snippets.

--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -8,6 +8,7 @@ import { NavHeader } from '@/components/nav-header';
 import { QueryLogTable } from '@/components/query-log-table';
 import ExperimentListPage from '@/app/page';
 import ResultsPage from '@/app/experiments/[id]/results/page';
+import { ToastProvider } from '@/lib/toast-context';
 import { AuthProvider } from '@/lib/auth-context';
 import type { AuthUser } from '@/lib/auth-context';
 import type { QueryLogEntry } from '@/lib/types';
@@ -241,7 +242,11 @@ describe('Accessibility', () => {
 
   describe('Charts', () => {
     it('forest plot has role="img" with aria-label', async () => {
-      render(<ResultsPage />);
+      render(
+        <ToastProvider>
+          <ResultsPage />
+        </ToastProvider>,
+      );
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: 'Results Dashboard' })).toBeInTheDocument();
@@ -256,7 +261,11 @@ describe('Accessibility', () => {
 
   describe('Tab panels', () => {
     it('has role="tablist" on nav and role="tabpanel" on content', async () => {
-      render(<ResultsPage />);
+      render(
+        <ToastProvider>
+          <ResultsPage />
+        </ToastProvider>,
+      );
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: 'Results Dashboard' })).toBeInTheDocument();
@@ -288,7 +297,11 @@ describe('Accessibility', () => {
 
     it('SQL preview button has aria-expanded that toggles on click', async () => {
       const user = userEvent.setup();
-      render(<QueryLogTable entries={entries} onExport={() => {}} exporting={false} />);
+      render(
+        <ToastProvider>
+          <QueryLogTable entries={entries} onExport={() => {}} exporting={false} />
+        </ToastProvider>,
+      );
 
       const toggleButton = screen.getByRole('button', { name: /Toggle SQL preview/ });
       expect(toggleButton).toHaveAttribute('aria-expanded', 'false');

--- a/ui/src/__tests__/flag-pages.test.tsx
+++ b/ui/src/__tests__/flag-pages.test.tsx
@@ -8,6 +8,7 @@ import FlagDetailPage from '@/app/flags/[id]/page';
 import CreateFlagPage from '@/app/flags/new/page';
 import EditFlagPage from '@/app/flags/[id]/edit/page';
 import { AuthProvider } from '@/lib/auth-context';
+import { ToastProvider } from '@/lib/toast-context';
 import type { AuthUser } from '@/lib/auth-context';
 
 const FLAGS_SVC = '*/experimentation.flags.v1.FeatureFlagService';
@@ -190,7 +191,11 @@ describe('Flag Detail Page', () => {
   });
 
   async function renderAndWait() {
-    render(<FlagDetailPage />);
+    render(
+      <ToastProvider>
+        <FlagDetailPage />
+      </ToastProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('flag-name')).toBeInTheDocument();
     });
@@ -233,7 +238,11 @@ describe('Flag Detail Page', () => {
 
   it('renders variants table for multi-variant flag', async () => {
     mockFlagId = 'flag-string-ab';
-    render(<FlagDetailPage />);
+    render(
+      <ToastProvider>
+        <FlagDetailPage />
+      </ToastProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('flag-name')).toHaveTextContent('checkout_flow_variant');
     });

--- a/ui/src/__tests__/performance.test.tsx
+++ b/ui/src/__tests__/performance.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import ResultsPage from '@/app/experiments/[id]/results/page';
 import SqlPage from '@/app/experiments/[id]/sql/page';
+import { ToastProvider } from '@/lib/toast-context';
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ id: '11111111-1111-1111-1111-111111111111' }),
@@ -80,7 +81,11 @@ describe('Performance targets', () => {
 
   it('results dashboard renders within 1000ms', async () => {
     const start = performance.now();
-    render(<ResultsPage />);
+    render(
+      <ToastProvider>
+        <ResultsPage />
+      </ToastProvider>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Results Dashboard')).toBeInTheDocument();
@@ -92,7 +97,11 @@ describe('Performance targets', () => {
 
   it('tab switch renders within 1000ms', async () => {
     const user = userEvent.setup();
-    render(<ResultsPage />);
+    render(
+      <ToastProvider>
+        <ResultsPage />
+      </ToastProvider>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Results Dashboard')).toBeInTheDocument();
@@ -111,7 +120,11 @@ describe('Performance targets', () => {
 
   it('SQL page query log renders within 1000ms', async () => {
     const start = performance.now();
-    render(<SqlPage />);
+    render(
+      <ToastProvider>
+        <SqlPage />
+      </ToastProvider>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Query Log')).toBeInTheDocument();
@@ -123,7 +136,11 @@ describe('Performance targets', () => {
 
   it('SQL page expand shows SQL within 200ms', async () => {
     const user = userEvent.setup();
-    render(<SqlPage />);
+    render(
+      <ToastProvider>
+        <SqlPage />
+      </ToastProvider>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('click_through_rate')).toBeInTheDocument();
@@ -145,7 +162,11 @@ describe('Performance targets', () => {
 
   it('notebook export completes within 5000ms', async () => {
     const user = userEvent.setup();
-    render(<SqlPage />);
+    render(
+      <ToastProvider>
+        <SqlPage />
+      </ToastProvider>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Export Notebook')).toBeInTheDocument();

--- a/ui/src/__tests__/sql-page.test.tsx
+++ b/ui/src/__tests__/sql-page.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/__mocks__/server';
 import SqlPage from '@/app/experiments/[id]/sql/page';
+import { ToastProvider } from '@/lib/toast-context';
 
 let mockExperimentId = '11111111-1111-1111-1111-111111111111';
 
@@ -34,13 +35,21 @@ describe('SQL Page', () => {
     mockExperimentId = '11111111-1111-1111-1111-111111111111';
   });
 
+  function renderSqlPage() {
+    return render(
+      <ToastProvider>
+        <SqlPage />
+      </ToastProvider>,
+    );
+  }
+
   it('shows loading state initially', () => {
-    render(<SqlPage />);
+    renderSqlPage();
     expect(document.querySelector('.animate-spin')).toBeInTheDocument();
   });
 
   it('renders query log entries after load', async () => {
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText('click_through_rate')).toBeInTheDocument();
@@ -51,7 +60,7 @@ describe('SQL Page', () => {
   });
 
   it('shows metric ID for each entry', async () => {
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText('click_through_rate')).toBeInTheDocument();
@@ -62,7 +71,7 @@ describe('SQL Page', () => {
   });
 
   it('shows formatted duration and row count', async () => {
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText('3.2s')).toBeInTheDocument();
@@ -75,7 +84,7 @@ describe('SQL Page', () => {
 
   it('expands row to show full SQL text', async () => {
     const user = userEvent.setup();
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText('click_through_rate')).toBeInTheDocument();
@@ -93,7 +102,7 @@ describe('SQL Page', () => {
 
   it('shows empty state when no entries', async () => {
     mockExperimentId = '44444444-4444-4444-4444-444444444444';
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText('No query log entries found for this experiment.')).toBeInTheDocument();
@@ -101,7 +110,7 @@ describe('SQL Page', () => {
   });
 
   it('shows Export Notebook button', async () => {
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText('Export Notebook')).toBeInTheDocument();
@@ -118,7 +127,7 @@ describe('SQL Page', () => {
       }),
     );
 
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText(/Internal server error/)).toBeInTheDocument();
@@ -126,7 +135,7 @@ describe('SQL Page', () => {
   });
 
   it('renders breadcrumb navigation', async () => {
-    render(<SqlPage />);
+    renderSqlPage();
 
     await waitFor(() => {
       expect(screen.getByText('Query Log')).toBeInTheDocument();

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -14,6 +14,7 @@ import { StateBadge } from '@/components/state-badge';
 import { TypeBadge } from '@/components/type-badge';
 import { VariantTable } from '@/components/variant-table';
 import { VariantForm } from '@/components/variant-form';
+import { CopyButton } from '@/components/copy-button';
 import { StateActions } from '@/components/state-actions';
 import { StartingChecklist } from '@/components/starting-checklist';
 import { ConcludingProgress } from '@/components/concluding-progress';
@@ -74,12 +75,6 @@ export default function ExperimentDetailPage() {
     }
   }, [experiment, addToast]);
 
-  const handleCopyId = useCallback(() => {
-    if (!experiment) return;
-    navigator.clipboard.writeText(experiment.experimentId);
-    addToast('Experiment ID copied to clipboard', 'success');
-  }, [experiment, addToast]);
-
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
@@ -105,27 +100,11 @@ export default function ExperimentDetailPage() {
         <div>
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold text-gray-900">{experiment.name}</h1>
-            <button
-              type="button"
-              onClick={handleCopyId}
-              className="group relative flex h-6 w-6 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              aria-label="Copy experiment ID"
-              title="Copy experiment ID"
-            >
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
-                />
-              </svg>
-            </button>
+            <CopyButton
+              text={experiment.experimentId}
+              label="Copy experiment ID"
+              className="h-6 w-6"
+            />
             <StateBadge state={experiment.state} />
             <TypeBadge type={experiment.type} />
             {(experiment.state === 'RUNNING' || experiment.state === 'CONCLUDED') && (

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import type { Flag, FlagType, ExperimentType } from '@/lib/types';
 import { getFlag, promoteToExperiment } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
+import { CopyButton } from '@/components/copy-button';
 import { AuthProvider, useAuth } from '@/lib/auth-context';
 import { NavHeader } from '@/components/nav-header';
 
@@ -105,7 +106,10 @@ function FlagDetailContent() {
         <dl className="grid grid-cols-2 gap-x-8 gap-y-4 text-sm">
           <div>
             <dt className="font-medium text-gray-500">Flag ID</dt>
-            <dd className="text-gray-900"><code className="text-xs">{flag.flagId}</code></dd>
+            <dd className="flex items-center gap-2 text-gray-900">
+              <code className="text-xs">{flag.flagId}</code>
+              <CopyButton text={flag.flagId} label="Copy flag ID" className="h-5 w-5" />
+            </dd>
           </div>
           <div>
             <dt className="font-medium text-gray-500">Description</dt>

--- a/ui/src/components/copy-button.tsx
+++ b/ui/src/components/copy-button.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useToast } from '@/lib/toast-context';
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  className?: string;
+}
+
+export function CopyButton({ text, label = 'Copy to clipboard', className = '' }: CopyButtonProps) {
+  const { addToast } = useToast();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      addToast('Copied to clipboard', 'success');
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+      addToast('Failed to copy', 'error');
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`group relative flex items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${className}`}
+      aria-label={label}
+      title={label}
+    >
+      <svg
+        className="h-4 w-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/ui/src/components/sql-highlighter.tsx
+++ b/ui/src/components/sql-highlighter.tsx
@@ -1,35 +1,20 @@
 'use client';
 
-import { useState } from 'react';
 import { Highlight, themes } from 'prism-react-renderer';
+import { CopyButton } from './copy-button';
 
 interface SqlHighlighterProps {
   sql: string;
 }
 
 export function SqlHighlighter({ sql }: SqlHighlighterProps) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(sql);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy text: ', err);
-    }
-  };
-
   return (
     <div className="group relative">
-      <button
-        type="button"
-        onClick={handleCopy}
-        className="absolute right-2 top-4 z-10 rounded border border-gray-300 bg-white px-2 py-1 text-[10px] font-medium text-gray-600 opacity-0 shadow-sm transition-opacity hover:bg-gray-50 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        aria-label="Copy SQL to clipboard"
-      >
-        {copied ? 'Copied!' : 'Copy'}
-      </button>
+      <CopyButton
+        text={sql}
+        label="Copy SQL to clipboard"
+        className="absolute right-2 top-4 z-10 h-7 w-7 border border-gray-300 bg-white opacity-0 shadow-sm transition-opacity group-hover:opacity-100 focus:opacity-100"
+      />
       <Highlight theme={themes.github} code={sql} language="sql">
         {({ style, tokens, getLineProps, getTokenProps }) => (
           <pre


### PR DESCRIPTION
Standardize copy-to-clipboard interaction across the application with a reusable component. This improvement enhances accessibility and ensures consistent user feedback via toasts for technical identifiers like Experiment IDs, Flag IDs, and SQL snippets. Verified with Playwright screenshots and Vitest suite.

---
*PR created automatically by Jules for task [2948266697629330289](https://jules.google.com/task/2948266697629330289) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
