### PR TITLE
🎨 Palette: Standardize copy-to-clipboard for identifiers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,3 +14,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2025-05-15 - [Distribute Evenly UX Win]
 **Learning:** Automating repetitive calculations (like equal traffic distribution) significantly reduces friction and errors in experiment setup. Users appreciate tools that handle precision and edge cases (like remainder distribution) for them.
 **Action:** Look for other manual calculation tasks in the UI, such as target sample size or duration estimation, and provide one-click solutions.
+
+## 2026-03-28 - Reusable Copy Components and Toast Testing
+**Learning:** Standardizing technical identifier copy interactions into a reusable `CopyButton` prevents logic duplication and ensures consistent visual feedback (e.g., checkmark transition). Unit testing components that use `useToast` requires explicit wrapping in `ToastProvider` because RTL `render` does not include the root layout's context.
+**Action:** Always wrap identifier copy targets with the `CopyButton`. Ensure tests for these components include `ToastProvider`.

--- a/ui/src/__tests__/copy-button.test.tsx
+++ b/ui/src/__tests__/copy-button.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CopyButton } from '@/components/copy-button';
+import { ToastProvider } from '@/lib/toast-context';
+import { describe, it, expect, vi } from 'vitest';
+
+// Wrap with ToastProvider since CopyButton uses useToast
+const renderWithToast = (ui: React.ReactElement) => {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+};
+
+describe('CopyButton', () => {
+  it('renders correctly with default label', () => {
+    renderWithToast(<CopyButton text="test-text" />);
+    const button = screen.getByRole('button', { name: /copy to clipboard/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('renders with custom label', () => {
+    renderWithToast(<CopyButton text="test-text" label="Custom Copy" />);
+    const button = screen.getByRole('button', { name: /custom copy/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('copies text to clipboard and shows success state', async () => {
+    const textToCopy = 'secret-id-123';
+    renderWithToast(<CopyButton text={textToCopy} />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    // Verify clipboard call
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(textToCopy);
+
+    // Verify visual feedback (SVG change)
+    await waitFor(() => {
+      // The checkmark SVG has path d="M5 13l4 4L19 7"
+      const checkIcon = screen.getByRole('button').querySelector('path[d="M5 13l4 4L19 7"]');
+      expect(checkIcon).toBeInTheDocument();
+    });
+  });
+
+  it('resets state after timeout', async () => {
+    vi.useFakeTimers();
+    renderWithToast(<CopyButton text="test" />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    // Fast-forward 2.5s to ensure all effects/timeouts run
+    vi.advanceTimersByTime(2500);
+
+    // Check it reverted back to copy icon
+    expect(screen.getByRole('button').querySelector('path[d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"]')).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+});

--- a/ui/src/__tests__/flag-pages.test.tsx
+++ b/ui/src/__tests__/flag-pages.test.tsx
@@ -8,6 +8,7 @@ import FlagDetailPage from '@/app/flags/[id]/page';
 import CreateFlagPage from '@/app/flags/new/page';
 import EditFlagPage from '@/app/flags/[id]/edit/page';
 import { AuthProvider } from '@/lib/auth-context';
+import { ToastProvider } from '@/lib/toast-context';
 import type { AuthUser } from '@/lib/auth-context';
 
 const FLAGS_SVC = '*/experimentation.flags.v1.FeatureFlagService';
@@ -190,14 +191,22 @@ describe('Flag Detail Page', () => {
   });
 
   async function renderAndWait() {
-    render(<FlagDetailPage />);
+    render(
+      <ToastProvider>
+        <FlagDetailPage />
+      </ToastProvider>
+    );
     await waitFor(() => {
       expect(screen.getByTestId('flag-name')).toBeInTheDocument();
     });
   }
 
   it('shows loading spinner initially', () => {
-    render(<FlagDetailPage />);
+    render(
+      <ToastProvider>
+        <FlagDetailPage />
+      </ToastProvider>
+    );
     expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
 
@@ -225,7 +234,11 @@ describe('Flag Detail Page', () => {
 
   it('renders 404 error for nonexistent flag', async () => {
     mockFlagId = 'nonexistent-flag';
-    render(<FlagDetailPage />);
+    render(
+      <ToastProvider>
+        <FlagDetailPage />
+      </ToastProvider>
+    );
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
     });
@@ -233,7 +246,11 @@ describe('Flag Detail Page', () => {
 
   it('renders variants table for multi-variant flag', async () => {
     mockFlagId = 'flag-string-ab';
-    render(<FlagDetailPage />);
+    render(
+      <ToastProvider>
+        <FlagDetailPage />
+      </ToastProvider>
+    );
     await waitFor(() => {
       expect(screen.getByTestId('flag-name')).toHaveTextContent('checkout_flow_variant');
     });

--- a/ui/src/__tests__/setup.ts
+++ b/ui/src/__tests__/setup.ts
@@ -2,7 +2,16 @@ import '@testing-library/jest-dom/vitest';
 import { server } from '@/__mocks__/server';
 import { resetSeedData } from '@/__mocks__/seed-data';
 import { clearApiCache } from '@/lib/api';
-import { beforeAll, afterEach, afterAll } from 'vitest';
+import { beforeAll, afterEach, afterAll, vi } from 'vitest';
+
+if (typeof window !== 'undefined') {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      writeText: vi.fn().mockImplementation(() => Promise.resolve()),
+    },
+    configurable: true,
+  });
+}
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -15,6 +15,7 @@ import { TypeBadge } from '@/components/type-badge';
 import { VariantTable } from '@/components/variant-table';
 import { VariantForm } from '@/components/variant-form';
 import { StateActions } from '@/components/state-actions';
+import { CopyButton } from '@/components/copy-button';
 import { StartingChecklist } from '@/components/starting-checklist';
 import { ConcludingProgress } from '@/components/concluding-progress';
 import { LayerAllocationChart } from '@/components/layer-allocation-chart';
@@ -74,12 +75,6 @@ export default function ExperimentDetailPage() {
     }
   }, [experiment, addToast]);
 
-  const handleCopyId = useCallback(() => {
-    if (!experiment) return;
-    navigator.clipboard.writeText(experiment.experimentId);
-    addToast('Experiment ID copied to clipboard', 'success');
-  }, [experiment, addToast]);
-
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
@@ -105,27 +100,7 @@ export default function ExperimentDetailPage() {
         <div>
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold text-gray-900">{experiment.name}</h1>
-            <button
-              type="button"
-              onClick={handleCopyId}
-              className="group relative flex h-6 w-6 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              aria-label="Copy experiment ID"
-              title="Copy experiment ID"
-            >
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
-                />
-              </svg>
-            </button>
+            <CopyButton text={experiment.experimentId} label="Copy experiment ID" />
             <StateBadge state={experiment.state} />
             <TypeBadge type={experiment.type} />
             {(experiment.state === 'RUNNING' || experiment.state === 'CONCLUDED') && (

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import type { Flag, FlagType, ExperimentType } from '@/lib/types';
 import { getFlag, promoteToExperiment } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
+import { CopyButton } from '@/components/copy-button';
 import { AuthProvider, useAuth } from '@/lib/auth-context';
 import { NavHeader } from '@/components/nav-header';
 
@@ -105,7 +106,10 @@ function FlagDetailContent() {
         <dl className="grid grid-cols-2 gap-x-8 gap-y-4 text-sm">
           <div>
             <dt className="font-medium text-gray-500">Flag ID</dt>
-            <dd className="text-gray-900"><code className="text-xs">{flag.flagId}</code></dd>
+            <dd className="flex items-center gap-2 text-gray-900">
+              <code className="text-xs">{flag.flagId}</code>
+              <CopyButton text={flag.flagId} label="Copy flag ID" />
+            </dd>
           </div>
           <div>
             <dt className="font-medium text-gray-500">Description</dt>

--- a/ui/src/components/copy-button.tsx
+++ b/ui/src/components/copy-button.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { useToast } from '@/lib/toast-context';
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  className?: string;
+}
+
+export function CopyButton({ text, label = 'Copy to clipboard', className = '' }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    if (!copied) return;
+    const timeout = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timeout);
+  }, [copied]);
+
+  const handleCopy = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      addToast('Copied to clipboard', 'success');
+    } catch (err) {
+      addToast('Failed to copy to clipboard', 'error');
+      console.error('Failed to copy:', err);
+    }
+  }, [text, addToast]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`group relative flex h-6 w-6 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${className}`}
+      aria-label={label}
+      title={label}
+    >
+      {copied ? (
+        <svg
+          className="h-4 w-4 text-green-600"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+      ) : (
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
💡 **What**: Added a reusable `CopyButton` component and applied it to technical identifiers across the platform.

🎯 **Why**: Previously, copying the Experiment ID provided no visual feedback beyond a toast, and the Flag ID wasn't copyable at all. This change standardizes the interaction and improves developer productivity.

📸 **Before/After**: 
- **Experiment Detail**: Replaced manual copy logic with `CopyButton`. Now shows a checkmark icon on success.
- **Flag Detail**: Added a new `CopyButton` next to the Flag ID.

♿ **Accessibility**: 
- Added `aria-label` to all copy buttons.
- Ensured focus states are visible (`focus:ring-2`).
- Added immediate visual feedback for screen readers via the toast system.

---
*PR created automatically by Jules for task [8673424865095731269](https://jules.google.com/task/8673424865095731269) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
