### PR TITLE
🎨 Palette: Standardize clipboard interactions for technical identifiers

### DIFF
--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -180,7 +180,14 @@ export default function ExperimentDetailPage() {
         </div>
         <div>
           <dt className="text-xs font-medium uppercase text-gray-500">Primary Metric</dt>
-          <dd className="mt-1 text-sm text-gray-900">{experiment.primaryMetricId}</dd>
+          <dd className="mt-1 flex items-center gap-2 text-sm text-gray-900">
+            {experiment.primaryMetricId}
+            <CopyButton
+              value={experiment.primaryMetricId}
+              label="Copy primary metric ID"
+              successMessage="Primary metric ID copied to clipboard"
+            />
+          </dd>
         </div>
         <div>
           <dt className="text-xs font-medium uppercase text-gray-500">Created</dt>

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import type { MetricDefinition, MetricType } from '@/lib/types';
+import { CopyButton } from '@/components/copy-button';
 import { listMetricDefinitions } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 
@@ -41,7 +42,14 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
           <span className="font-medium text-gray-900">{metric.name}</span>
         </td>
         <td className="px-4 py-3">
-          <code className="text-xs text-gray-500">{metric.metricId}</code>
+          <div className="flex items-center gap-2">
+            <code className="text-xs text-gray-500">{metric.metricId}</code>
+            <CopyButton
+              value={metric.metricId}
+              label="Copy metric ID"
+              successMessage="Metric ID copied to clipboard"
+            />
+          </div>
         </td>
         <td className="px-4 py-3">
           <span
@@ -120,13 +128,27 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
               {metric.cupedCovariateMetricId && (
                 <div>
                   <dt className="font-medium text-gray-500">CUPED Covariate</dt>
-                  <dd className="text-gray-900"><code className="text-xs">{metric.cupedCovariateMetricId}</code></dd>
+                  <dd className="flex items-center gap-2 text-gray-900">
+                    <code className="text-xs">{metric.cupedCovariateMetricId}</code>
+                    <CopyButton
+                      value={metric.cupedCovariateMetricId}
+                      label="Copy covariate metric ID"
+                      successMessage="Metric ID copied to clipboard"
+                    />
+                  </dd>
                 </div>
               )}
               {metric.surrogateTargetMetricId && (
                 <div>
                   <dt className="font-medium text-gray-500">Surrogate Target</dt>
-                  <dd className="text-gray-900"><code className="text-xs">{metric.surrogateTargetMetricId}</code></dd>
+                  <dd className="flex items-center gap-2 text-gray-900">
+                    <code className="text-xs">{metric.surrogateTargetMetricId}</code>
+                    <CopyButton
+                      value={metric.surrogateTargetMetricId}
+                      label="Copy surrogate target metric ID"
+                      successMessage="Metric ID copied to clipboard"
+                    />
+                  </dd>
                 </div>
               )}
             </dl>

--- a/ui/src/components/variant-table.tsx
+++ b/ui/src/components/variant-table.tsx
@@ -2,6 +2,7 @@
 
 import type { Variant } from '@/lib/types';
 import { formatPercent, truncateJson } from '@/lib/utils';
+import { CopyButton } from './copy-button';
 
 interface VariantTableProps {
   variants: Variant[];
@@ -15,6 +16,9 @@ export function VariantTable({ variants }: VariantTableProps) {
           <tr>
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
               Name
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              Variant ID
             </th>
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
               Traffic
@@ -32,6 +36,16 @@ export function VariantTable({ variants }: VariantTableProps) {
             <tr key={v.variantId}>
               <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
                 {v.name}
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm font-mono text-gray-500">
+                <div className="flex items-center gap-2">
+                  <code className="text-xs">{v.variantId}</code>
+                  <CopyButton
+                    value={v.variantId}
+                    label={`Copy variant ID ${v.variantId}`}
+                    successMessage="Variant ID copied to clipboard"
+                  />
+                </div>
               </td>
               <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
                 {formatPercent(v.trafficFraction)}


### PR DESCRIPTION
This PR standardizes the "Copy to Clipboard" pattern across the platform for technical identifiers, making it easier for users to grab IDs for CLI tools or API calls.

### 💡 What:
- **Experiment Detail Page:** Added a `CopyButton` next to the Primary Metric ID in the metadata grid.
- **Variant Table:** Introduced a new "Variant ID" column (the second column) displaying the technical ID and a `CopyButton`.
- **Metric Browser:** Added `CopyButton` to the Metric ID column in the main table, as well as to CUPED Covariate and Surrogate Target IDs in the expanded detail view.

### 🎯 Why:
Users frequently need to copy these technical identifiers for use in other parts of their workflow (e.g., querying data, configuring SDKs). Providing a consistent, accessible, and discoverable "Copy" interaction reduces friction.

### ♿ Accessibility:
- Each `CopyButton` includes a descriptive `aria-label` (e.g., "Copy primary metric ID").
- Focus states and hover effects are preserved for keyboard navigability.
- Visual feedback is provided via an icon change and a "Copied!" tooltip/toast.

### 📸 Before/After:
*Refer to the attached screenshots in the verification section.*

---
*PR created automatically by Jules for task [3233012312544726575](https://jules.google.com/task/3233012312544726575) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
