### PR TITLE
🎨 Palette: Add "Distribute Evenly" to Experiment Wizard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,6 +14,9 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2025-05-15 - [Distribute Evenly UX Win]
 **Learning:** Automating repetitive calculations (like equal traffic distribution) significantly reduces friction and errors in experiment setup. Users appreciate tools that handle precision and edge cases (like remainder distribution) for them.
 **Action:** Look for other manual calculation tasks in the UI, such as target sample size or duration estimation, and provide one-click solutions.
+## 2026-03-31 - Automating Traffic Distribution in Wizard
+**Learning:** Manual traffic distribution in multi-variant experiments is error-prone and tedious for users. Automating this with a "Distribute Evenly" button that handles rounding remainders (e.g., 33.3%, 33.3%, 33.4%) significantly improves the experiment setup UX.
+**Action:** Implement "Distribute Evenly" for any multi-input resource allocation UI. Ensure it is accessible via keyboard and provides immediate visual feedback on the total sum.
 ## 2026-03-24 - Standardizing Clipboard Interactions
 **Learning:** A reusable `CopyButton` component provides a consistent and accessible way for users to copy technical identifiers. Standardizing this pattern across Experiment IDs, Flag IDs, and SQL blocks improves the overall discoverability and reliability of the feature.
 **Action:** Use the `CopyButton` component for all technical identifiers. Ensure it includes an `aria-label` for screen readers and provides both visual (icon change) and toast feedback. Wrap tests for pages using this component in `ToastProvider` to avoid context errors.

--- a/ui/src/__tests__/experiment-wizard.test.tsx
+++ b/ui/src/__tests__/experiment-wizard.test.tsx
@@ -187,4 +187,27 @@ describe('Experiment Creation Wizard', () => {
     expect(screen.getByText('Rebuffer Ratio')).toBeInTheDocument();
     expect(screen.getByText('Time to First Frame (ms)')).toBeInTheDocument();
   });
+
+  it('distributes traffic evenly when "Distribute Evenly" is clicked in the wizard', async () => {
+    const user = userEvent.setup();
+    renderNewPage();
+
+    await fillBasicsAndAdvance(user); // Step 1 -> 2
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Step 2 -> 3 (Variants)
+
+    // Add a third variant
+    await user.click(screen.getByRole('button', { name: 'Add Variant' }));
+
+    // Initially: 0.5, 0.5, 0 -> 1.0 (defaults + 1 new)
+    expect(screen.getByText('Total traffic: 100.0%')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Distribute Evenly'));
+
+    // Should be 0.333, 0.333, 0.334
+    const trafficInputs = screen.getAllByRole('spinbutton', { name: /traffic/i });
+    expect(trafficInputs[0]).toHaveValue(0.333);
+    expect(trafficInputs[1]).toHaveValue(0.333);
+    expect(trafficInputs[2]).toHaveValue(0.334);
+    expect(screen.getByText('Total traffic: 100.0%')).toBeInTheDocument();
+  });
 });

--- a/ui/src/components/wizard/steps/variants-step.tsx
+++ b/ui/src/components/wizard/steps/variants-step.tsx
@@ -88,13 +88,23 @@ export function VariantsStep() {
         <span className={`text-sm font-medium ${trafficSumValid ? 'text-green-700' : 'text-red-700'}`}>
           Total traffic: {formatPercent(trafficSum)}
         </span>
-        <button
-          type="button"
-          onClick={() => dispatch({ type: 'ADD_VARIANT' })}
-          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
-        >
-          Add Variant
-        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'DISTRIBUTE_VARIANTS' })}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            aria-label="Distribute traffic evenly across all variants"
+          >
+            Distribute Evenly
+          </button>
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'ADD_VARIANT' })}
+            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Add Variant
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/ui/src/components/wizard/wizard-context.tsx
+++ b/ui/src/components/wizard/wizard-context.tsx
@@ -108,6 +108,7 @@ export type WizardAction =
   | { type: 'SET_FIELD'; field: string; value: unknown }
   | { type: 'SET_STEP'; step: number }
   | { type: 'ADD_VARIANT' }
+  | { type: 'DISTRIBUTE_VARIANTS' }
   | { type: 'REMOVE_VARIANT'; index: number }
   | { type: 'UPDATE_VARIANT'; index: number; field: keyof Variant; value: string | number | boolean }
   | { type: 'ADD_GUARDRAIL' }
@@ -132,6 +133,23 @@ function wizardReducer(state: WizardState, action: WizardAction): WizardState {
           { variantId: generateVariantId(), name: '', trafficFraction: 0, isControl: false, payloadJson: '{}' },
         ],
       };
+
+    case 'DISTRIBUTE_VARIANTS': {
+      const count = state.variants.length;
+      if (count === 0) return state;
+      const equalTraffic = Math.floor((1.0 / count) * 1000) / 1000;
+      const remainder = Math.round((1.0 - equalTraffic * count) * 1000) / 1000;
+
+      const variants = state.variants.map((v, i) => ({
+        ...v,
+        trafficFraction: i === count - 1 ? Math.round((equalTraffic + remainder) * 1000) / 1000 : equalTraffic,
+      }));
+      return {
+        ...state,
+        variants,
+        stepErrors: { ...state.stepErrors, [state.currentStep]: null },
+      };
+    }
 
     case 'REMOVE_VARIANT':
       return { ...state, variants: state.variants.filter((_, i) => i !== action.index) };


### PR DESCRIPTION
Added "Distribute Evenly" button to the experiment creation wizard to automate traffic allocation and reduce manual errors. Includes state management, UI, and test coverage.

---
*PR created automatically by Jules for task [14642128890161592046](https://jules.google.com/task/14642128890161592046) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
