### PR TITLE
🎨 Palette: Add Variant IDs and Copy Buttons to VariantTable

### DIFF
--- a/ui/src/__tests__/experiment-detail.test.tsx
+++ b/ui/src/__tests__/experiment-detail.test.tsx
@@ -91,6 +91,7 @@ describe('Experiment Detail Page', () => {
     expect(screen.getByText('Control')).toBeInTheDocument();
     const variantsSection = screen.getByText('Variants').closest('section')!;
     expect(within(variantsSection).getAllByText('50.0%')).toHaveLength(2);
+    expect(within(variantsSection).getByText('ID')).toBeInTheDocument();
   });
 
   it('renders metadata fields', async () => {

--- a/ui/src/components/variant-table.tsx
+++ b/ui/src/components/variant-table.tsx
@@ -2,6 +2,7 @@
 
 import type { Variant } from '@/lib/types';
 import { formatPercent, truncateJson } from '@/lib/utils';
+import { CopyButton } from './copy-button';
 
 interface VariantTableProps {
   variants: Variant[];
@@ -15,6 +16,9 @@ export function VariantTable({ variants }: VariantTableProps) {
           <tr>
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
               Name
+            </th>
+            <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+              ID
             </th>
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
               Traffic
@@ -32,6 +36,18 @@ export function VariantTable({ variants }: VariantTableProps) {
             <tr key={v.variantId}>
               <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
                 {v.name}
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                <div className="flex items-center gap-2">
+                  <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+                    {v.variantId}
+                  </code>
+                  <CopyButton
+                    value={v.variantId}
+                    label="Copy variant ID"
+                    successMessage="Variant ID copied"
+                  />
+                </div>
               </td>
               <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
                 {formatPercent(v.trafficFraction)}


### PR DESCRIPTION
Added a new "ID" column to the `VariantTable` component in the Experiment Detail page. Each ID is displayed in a `<code>` tag and features a `CopyButton` for easier developer workflow. Updated relevant unit tests and verified the change visually.

---
*PR created automatically by Jules for task [75236485471911649](https://jules.google.com/task/75236485471911649) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
