### PR TITLE
🎨 Palette: Add copy-to-clipboard for technical identifiers in Wizard Review

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-03-24 - Standardizing Clipboard Interactions
 **Learning:** A reusable `CopyButton` component provides a consistent and accessible way for users to copy technical identifiers. Standardizing this pattern across Experiment IDs, Flag IDs, and SQL blocks improves the overall discoverability and reliability of the feature.
 **Action:** Use the `CopyButton` component for all technical identifiers. Ensure it includes an `aria-label` for screen readers and provides both visual (icon change) and toast feedback. Wrap tests for pages using this component in `ToastProvider` to avoid context errors.
+
+## 2026-04-05 - Copy-to-Clipboard in Wizard Review
+**Learning:** Technical identifiers (like Layer IDs or primary metrics) in the final review step of a creation wizard are high-value copy targets for users who need to document the setup before clicking "Create". When placing these buttons in dense description lists, ensuring vertical alignment with `flex items-center gap-2` maintains visual hierarchy without disrupting the layout.
+**Action:** Extend description list helpers (like `DlRow`) to support optional copy functionality for identifiers. Always use a smaller button size (e.g., `h-4 w-4`) to fit within single-line list items.

--- a/ui/src/components/wizard/steps/review-step.tsx
+++ b/ui/src/components/wizard/steps/review-step.tsx
@@ -3,6 +3,7 @@
 import { useWizard } from '../wizard-context';
 import { TYPE_LABELS } from '@/lib/utils';
 import { formatPercent } from '@/lib/utils';
+import { CopyButton } from '@/components/copy-button';
 
 interface ReviewSectionProps {
   title: string;
@@ -29,11 +30,21 @@ function ReviewSection({ title, step, onEdit, children }: ReviewSectionProps) {
   );
 }
 
-function DlRow({ label, value }: { label: string; value: string }) {
+function DlRow({ label, value, copyValue }: { label: string; value: string; copyValue?: string }) {
   return (
     <div className="flex gap-2 py-1">
       <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-500">{label}</dt>
-      <dd className="text-xs text-gray-900">{value || '\u2014'}</dd>
+      <dd className="flex items-center gap-2 text-xs text-gray-900">
+        <span>{value || '\u2014'}</span>
+        {copyValue && (
+          <CopyButton
+            value={copyValue}
+            label={`Copy ${label.toLowerCase()}`}
+            successMessage={`${label} copied`}
+            className="h-4 w-4"
+          />
+        )}
+      </dd>
     </div>
   );
 }
@@ -52,12 +63,18 @@ export function ReviewStep() {
       {/* Basics */}
       <ReviewSection title="Basic Information" step={0} onEdit={goToStep}>
         <dl>
-          <DlRow label="Name" value={state.name} />
-          <DlRow label="Owner" value={state.ownerEmail} />
+          <DlRow label="Name" value={state.name} copyValue={state.name} />
+          <DlRow label="Owner" value={state.ownerEmail} copyValue={state.ownerEmail} />
           <DlRow label="Type" value={TYPE_LABELS[state.type]} />
-          <DlRow label="Layer" value={state.layerId} />
+          <DlRow label="Layer" value={state.layerId} copyValue={state.layerId} />
           <DlRow label="Description" value={state.description} />
-          {state.targetingRuleId && <DlRow label="Targeting Rule" value={state.targetingRuleId} />}
+          {state.targetingRuleId && (
+            <DlRow
+              label="Targeting Rule"
+              value={state.targetingRuleId}
+              copyValue={state.targetingRuleId}
+            />
+          )}
           {state.isCumulativeHoldout && <DlRow label="Cumulative Holdout" value="Yes" />}
         </dl>
       </ReviewSection>
@@ -99,7 +116,11 @@ export function ReviewStep() {
       {/* Metrics & Guardrails */}
       <ReviewSection title="Metrics & Guardrails" step={3} onEdit={goToStep}>
         <dl>
-          <DlRow label="Primary Metric" value={state.primaryMetricId} />
+          <DlRow
+            label="Primary Metric"
+            value={state.primaryMetricId}
+            copyValue={state.primaryMetricId}
+          />
           <DlRow label="Secondary Metrics" value={state.secondaryMetricsInput || 'None'} />
           {state.guardrails.length > 0 && (
             <DlRow


### PR DESCRIPTION
Standardized technical identifier copying in the Experiment Wizard Review step. Added `CopyButton` to Name, Owner, Layer ID, Targeting Rule ID, and Primary Metric fields for improved UX.

---
*PR created automatically by Jules for task [13105790628714355535](https://jules.google.com/task/13105790628714355535) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
