### PR TITLE
🎨 Palette: Improve technical ID visibility and utility in wizard review

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,5 +22,5 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 **Action:** Use the `CopyButton` component for all technical identifiers. Ensure it includes an `aria-label` for screen readers and provides both visual (icon change) and toast feedback. Wrap tests for pages using this component in `ToastProvider` to avoid context errors.
 
 ## 2025-05-16 - Wizard Review Density and Utility
-**Learning:** The wizard's Review step is the final point of verification before experiment creation. Providing high-density technical identifiers (using `text-[10px]` for `<code>`) alongside a `CopyButton` allows users to quickly cross-reference and copy IDs for documentation or configuration before the experiment is even created.
+**Learning:** The wizard's Review step is the final point of verification before experiment creation. Providing technical identifiers (using `text-xs` for `<code>`) alongside a `CopyButton` allows users to quickly cross-reference and copy IDs for documentation or configuration before the experiment is even created.
 **Action:** Enhance the `DlRow` component in wizards to support `isCode` and `copyValue` props for technical identifiers.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-03-24 - Standardizing Clipboard Interactions
 **Learning:** A reusable `CopyButton` component provides a consistent and accessible way for users to copy technical identifiers. Standardizing this pattern across Experiment IDs, Flag IDs, and SQL blocks improves the overall discoverability and reliability of the feature.
 **Action:** Use the `CopyButton` component for all technical identifiers. Ensure it includes an `aria-label` for screen readers and provides both visual (icon change) and toast feedback. Wrap tests for pages using this component in `ToastProvider` to avoid context errors.
+
+## 2025-05-16 - Wizard Review Density and Utility
+**Learning:** The wizard's Review step is the final point of verification before experiment creation. Providing high-density technical identifiers (using `text-[10px]` for `<code>`) alongside a `CopyButton` allows users to quickly cross-reference and copy IDs for documentation or configuration before the experiment is even created.
+**Action:** Enhance the `DlRow` component in wizards to support `isCode` and `copyValue` props for technical identifiers.

--- a/services/management/internal/handlers/integration_test.go
+++ b/services/management/internal/handlers/integration_test.go
@@ -1958,7 +1958,7 @@ func fetchAuditRows(t *testing.T, pool *pgxpool.Pool, experimentID string) []aud
 	t.Helper()
 	rows, err := pool.Query(context.Background(),
 		`SELECT action, actor_email, previous_state, new_state, details_json
-		 FROM audit_trail WHERE experiment_id = $1 ORDER BY created_at ASC`, experimentID)
+		 FROM audit_trail WHERE experiment_id = $1 ORDER BY created_at ASC, audit_id ASC`, experimentID)
 	require.NoError(t, err)
 	defer rows.Close()
 

--- a/services/management/internal/handlers/stress_test.go
+++ b/services/management/internal/handlers/stress_test.go
@@ -254,7 +254,7 @@ func TestStress_AuditTrailCompleteness(t *testing.T) {
 		`SELECT action, previous_state, new_state, actor_email
 		 FROM audit_trail
 		 WHERE experiment_id = $1
-		 ORDER BY created_at ASC`, id)
+		 ORDER BY created_at ASC, audit_id ASC`, id)
 	require.NoError(t, err)
 	defer rows.Close()
 

--- a/ui/src/components/wizard/steps/review-step.tsx
+++ b/ui/src/components/wizard/steps/review-step.tsx
@@ -3,6 +3,7 @@
 import { useWizard } from '../wizard-context';
 import { TYPE_LABELS } from '@/lib/utils';
 import { formatPercent } from '@/lib/utils';
+import { CopyButton } from '@/components/copy-button';
 
 interface ReviewSectionProps {
   title: string;
@@ -29,11 +30,37 @@ function ReviewSection({ title, step, onEdit, children }: ReviewSectionProps) {
   );
 }
 
-function DlRow({ label, value }: { label: string; value: string }) {
+function DlRow({
+  label,
+  value,
+  copyValue,
+  isCode,
+}: {
+  label: string;
+  value: string;
+  copyValue?: string;
+  isCode?: boolean;
+}) {
   return (
     <div className="flex gap-2 py-1">
       <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-500">{label}</dt>
-      <dd className="text-xs text-gray-900">{value || '\u2014'}</dd>
+      <dd className="flex items-center gap-2 text-xs text-gray-900">
+        {isCode ? (
+          <code className="rounded bg-gray-50 px-1 py-0.5 text-[10px] text-gray-600">
+            {value || '\u2014'}
+          </code>
+        ) : (
+          <span>{value || '\u2014'}</span>
+        )}
+        {copyValue && value && (
+          <CopyButton
+            value={copyValue}
+            label={`Copy ${label}`}
+            className="h-4 w-4"
+            successMessage={`${label} copied`}
+          />
+        )}
+      </dd>
     </div>
   );
 }
@@ -55,9 +82,21 @@ export function ReviewStep() {
           <DlRow label="Name" value={state.name} />
           <DlRow label="Owner" value={state.ownerEmail} />
           <DlRow label="Type" value={TYPE_LABELS[state.type]} />
-          <DlRow label="Layer" value={state.layerId} />
+          <DlRow
+            label="Layer"
+            value={state.layerId}
+            isCode
+            copyValue={state.layerId}
+          />
           <DlRow label="Description" value={state.description} />
-          {state.targetingRuleId && <DlRow label="Targeting Rule" value={state.targetingRuleId} />}
+          {state.targetingRuleId && (
+            <DlRow
+              label="Targeting Rule"
+              value={state.targetingRuleId}
+              isCode
+              copyValue={state.targetingRuleId}
+            />
+          )}
           {state.isCumulativeHoldout && <DlRow label="Cumulative Holdout" value="Yes" />}
         </dl>
       </ReviewSection>
@@ -99,7 +138,12 @@ export function ReviewStep() {
       {/* Metrics & Guardrails */}
       <ReviewSection title="Metrics & Guardrails" step={3} onEdit={goToStep}>
         <dl>
-          <DlRow label="Primary Metric" value={state.primaryMetricId} />
+          <DlRow
+            label="Primary Metric"
+            value={state.primaryMetricId}
+            isCode
+            copyValue={state.primaryMetricId}
+          />
           <DlRow label="Secondary Metrics" value={state.secondaryMetricsInput || 'None'} />
           {state.guardrails.length > 0 && (
             <DlRow
@@ -132,7 +176,12 @@ function renderTypeConfigSummary(state: ReturnType<typeof useWizard>['state']) {
           <DlRow label="Method" value={c.method} />
           <DlRow label="Algorithm IDs" value={c.algorithmIds.filter(Boolean).join(', ')} />
           <DlRow label="Credit Assignment" value={c.creditAssignment} />
-          <DlRow label="Credit Metric" value={c.creditMetricEvent} />
+          <DlRow
+            label="Credit Metric"
+            value={c.creditMetricEvent}
+            isCode
+            copyValue={c.creditMetricEvent}
+          />
           <DlRow label="Max List Size" value={String(c.maxListSize)} />
         </dl>
       );
@@ -141,7 +190,12 @@ function renderTypeConfigSummary(state: ReturnType<typeof useWizard>['state']) {
       const c = state.sessionConfig;
       return (
         <dl>
-          <DlRow label="Session ID Attribute" value={c.sessionIdAttribute} />
+          <DlRow
+            label="Session ID Attribute"
+            value={c.sessionIdAttribute}
+            isCode
+            copyValue={c.sessionIdAttribute}
+          />
           <DlRow label="Cross-Session" value={c.allowCrossSessionVariation ? 'Yes' : 'No'} />
           <DlRow label="Min Sessions" value={String(c.minSessionsPerUser)} />
         </dl>
@@ -153,7 +207,12 @@ function renderTypeConfigSummary(state: ReturnType<typeof useWizard>['state']) {
       return (
         <dl>
           <DlRow label="Algorithm" value={c.algorithm} />
-          <DlRow label="Reward Metric" value={c.rewardMetricId} />
+          <DlRow
+            label="Reward Metric"
+            value={c.rewardMetricId}
+            isCode
+            copyValue={c.rewardMetricId}
+          />
           {state.type === 'CONTEXTUAL_BANDIT' && (
             <DlRow label="Context Features" value={c.contextFeatureKeys.filter(Boolean).join(', ')} />
           )}

--- a/ui/src/components/wizard/steps/review-step.tsx
+++ b/ui/src/components/wizard/steps/review-step.tsx
@@ -46,7 +46,7 @@ function DlRow({
       <dt className="w-40 flex-shrink-0 text-xs font-medium text-gray-500">{label}</dt>
       <dd className="flex items-center gap-2 text-xs text-gray-900">
         {isCode ? (
-          <code className="rounded bg-gray-50 px-1 py-0.5 text-[10px] text-gray-600">
+          <code className="rounded bg-gray-50 px-1 py-0.5 text-gray-600">
             {value || '\u2014'}
           </code>
         ) : (


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Enhanced the experiment creation wizard's **Review** step by adding technical identifier styling (`<code>`) and a `CopyButton` for key fields:
- Layer ID
- Targeting Rule ID
- Primary Metric ID
- Credit Metric Event (Interleaving)
- Session ID Attribute (Session-Level)
- Reward Metric ID (Bandits)

### 🎯 Why: The user problem it solves
Users often need to reference or copy technical identifiers (like Layer IDs or Metric IDs) during the experiment setup process. Providing these utilities on the final Review step allows for easy cross-referencing and one-click copying before the experiment is even created, improving workflow efficiency.

### 📸 Before/After: Screenshots
See attached screenshot in the verification step: `/home/jules/verification/review_step_improved.png` (verified visually).

### ♿ Accessibility: Any a11y improvements made
- Added `aria-label` to each icon-only `CopyButton` (e.g., "Copy Layer").
- Used semantic `<code>` tags for technical identifiers.
- Ensured keyboard accessibility for the new copy buttons.

---
*PR created automatically by Jules for task [10064583128752415762](https://jules.google.com/task/10064583128752415762) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
