### PR TITLE
feat(M6): E-value UI + FDR badge + optimal alpha (ADR-018)

### DIFF
--- a/ui/src/__mocks__/handlers.ts
+++ b/ui/src/__mocks__/handlers.ts
@@ -6,7 +6,7 @@ import {
   SEED_GST_RESULTS, SEED_CATE_RESULTS, SEED_LAYERS, SEED_LAYER_ALLOCATIONS,
   SEED_METRIC_DEFINITIONS, SEED_AUDIT_LOG, SEED_FLAGS, SEED_PROVIDER_HEALTH,
   SEED_AVLM_RESULTS, SEED_ADAPTIVE_N_RESULTS, SEED_FEEDBACK_LOOP_RESULTS,
-  SEED_ONLINE_FDR_STATES,
+  SEED_ONLINE_FDR_STATES, SEED_OPTIMAL_ALPHA,
   SEED_PORTFOLIO_ALLOCATION, SEED_PORTFOLIO_METRICS, SEED_PARETO_FRONTIER,
   SEED_META_EXPERIMENT_RESULTS,
   SEED_SLATE_OPE_RESULTS, SEED_SLATE_HEATMAP_RESULTS,
@@ -841,6 +841,17 @@ export const handlers = [
       );
     }
     return HttpResponse.json(result);
+  }),
+
+  // GetOptimalAlpha (ADR-019)
+  http.post(`${ANALYSIS_SVC}/GetOptimalAlpha`, async () => {
+    if (SEED_OPTIMAL_ALPHA.length === 0) {
+      return HttpResponse.json(
+        { code: 'not_found', message: 'No optimal alpha recommendation found' },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json(SEED_OPTIMAL_ALPHA[0]);
   }),
 
   // GetSlateOpe (ADR-016)

--- a/ui/src/__mocks__/seed-data.ts
+++ b/ui/src/__mocks__/seed-data.ts
@@ -4,7 +4,7 @@ import type {
   BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult, QoeDashboardResult,
   GstTrajectoryResult, CateAnalysisResult, Layer, LayerAllocation, MetricDefinition,
   AuditLogEntry, Flag, ProviderHealthResult,
-  AvlmResult, AdaptiveNResult, FeedbackLoopResult, OnlineFdrState,
+  AvlmResult, AdaptiveNResult, FeedbackLoopResult, OnlineFdrState, OptimalAlphaRecommendation,
   PortfolioAllocationResult, PortfolioMetricsResult, ParetoFrontierResult, MetaExperimentResult,
   SlateOpeResult, SlateHeatmapResult,
   SwitchbackResult, SyntheticControlResult,
@@ -2159,6 +2159,18 @@ const INITIAL_ONLINE_FDR_STATES: OnlineFdrState[] = [
 
 export let SEED_ONLINE_FDR_STATES: OnlineFdrState[] = structuredClone(INITIAL_ONLINE_FDR_STATES);
 
+// --- Optimal Alpha Recommendation (ADR-019) ---
+
+const INITIAL_OPTIMAL_ALPHA: OptimalAlphaRecommendation[] = [
+  {
+    optimalAlpha: 0.10,
+    expectedPortfolioFdr: 0.042,
+    computedAt: '2026-03-24T10:00:00Z',
+  },
+];
+
+export let SEED_OPTIMAL_ALPHA: OptimalAlphaRecommendation[] = structuredClone(INITIAL_OPTIMAL_ALPHA);
+
 // --- Portfolio Optimization (ADR-019) ---
 
 const INITIAL_PORTFOLIO_ALLOCATION: PortfolioAllocationResult = {
@@ -2556,6 +2568,7 @@ export function resetSeedData(): void {
   SEED_ADAPTIVE_N_RESULTS = structuredClone(INITIAL_ADAPTIVE_N_RESULTS);
   SEED_FEEDBACK_LOOP_RESULTS = structuredClone(INITIAL_FEEDBACK_LOOP_RESULTS);
   SEED_ONLINE_FDR_STATES = structuredClone(INITIAL_ONLINE_FDR_STATES);
+  SEED_OPTIMAL_ALPHA = structuredClone(INITIAL_OPTIMAL_ALPHA);
   SEED_PORTFOLIO_ALLOCATION = structuredClone(INITIAL_PORTFOLIO_ALLOCATION);
   SEED_SLATE_OPE_RESULTS = structuredClone(INITIAL_SLATE_OPE_RESULTS);
   SEED_SWITCHBACK_RESULTS = structuredClone(INITIAL_SWITCHBACK_RESULTS);

--- a/ui/src/__tests__/evalue-fdr.test.tsx
+++ b/ui/src/__tests__/evalue-fdr.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TreatmentEffectsTable } from '@/components/treatment-effects-table';
+import { FdrDecisionBadge } from '@/components/fdr-decision-badge';
+import { OptimalAlphaWidget } from '@/components/optimal-alpha-widget';
+import type { MetricResult, EValueResult, OnlineFdrState } from '@/lib/types';
+
+// --- Fixtures ---
+
+const METRIC_RESULTS: MetricResult[] = [
+  {
+    metricId: 'click_through_rate',
+    variantId: 'treatment_a',
+    controlMean: 0.085,
+    treatmentMean: 0.099,
+    absoluteEffect: 0.014,
+    relativeEffect: 0.1647,
+    ciLower: 0.003,
+    ciUpper: 0.025,
+    pValue: 0.012,
+    isSignificant: true,
+    cupedAdjustedEffect: 0.013,
+    cupedCiLower: 0.004,
+    cupedCiUpper: 0.022,
+    varianceReductionPct: 0.28,
+  },
+];
+
+const E_VALUE_REJECTING: EValueResult = {
+  eValue: 25.0,
+  logEValue: Math.log(25.0),
+  impliedLevel: 1 / 25.0,
+  reject: true,
+  alpha: 0.05,
+};
+
+const E_VALUE_NOT_REJECTING: EValueResult = {
+  eValue: 12.5,
+  logEValue: Math.log(12.5),
+  impliedLevel: 1 / 12.5,
+  reject: false,
+  alpha: 0.05,
+};
+
+const FDR_STATE_CONTROLLED: OnlineFdrState = {
+  experimentId: '11111111-1111-1111-1111-111111111111',
+  alphaWealth: 0.032,
+  initialWealth: 0.05,
+  numTested: 15,
+  numRejected: 3,
+  currentFdr: 0.04,
+  computedAt: '2026-03-24T10:00:00Z',
+};
+
+const FDR_STATE_OVER_BUDGET: OnlineFdrState = {
+  experimentId: '11111111-1111-1111-1111-111111111111',
+  alphaWealth: 0.001,
+  initialWealth: 0.05,
+  numTested: 20,
+  numRejected: 8,
+  currentFdr: 0.08,
+  computedAt: '2026-03-24T10:00:00Z',
+};
+
+// --- Treatment Effects Table: E-value column ---
+
+describe('TreatmentEffectsTable with e-value', () => {
+  it('shows e-value and implied p columns when eValueResult is provided', () => {
+    render(
+      <TreatmentEffectsTable
+        metricResults={METRIC_RESULTS}
+        showCuped={false}
+        eValueResult={E_VALUE_REJECTING}
+      />,
+    );
+
+    expect(screen.getByTestId('evalue-header')).toBeInTheDocument();
+    expect(screen.getByText('Implied p')).toBeInTheDocument();
+  });
+
+  it('does not show e-value column when eValueResult is absent', () => {
+    render(
+      <TreatmentEffectsTable
+        metricResults={METRIC_RESULTS}
+        showCuped={false}
+      />,
+    );
+
+    expect(screen.queryByTestId('evalue-header')).not.toBeInTheDocument();
+  });
+
+  it('renders e-value cell with formatted value', () => {
+    render(
+      <TreatmentEffectsTable
+        metricResults={METRIC_RESULTS}
+        showCuped={false}
+        eValueResult={E_VALUE_REJECTING}
+      />,
+    );
+
+    const cell = screen.getByTestId('evalue-cell');
+    expect(cell).toHaveTextContent('25.0');
+  });
+
+  it('highlights e-value cell in red when null is rejected', () => {
+    render(
+      <TreatmentEffectsTable
+        metricResults={METRIC_RESULTS}
+        showCuped={false}
+        eValueResult={E_VALUE_REJECTING}
+      />,
+    );
+
+    const cell = screen.getByTestId('evalue-cell');
+    const span = cell.querySelector('span');
+    expect(span?.className).toContain('text-red-700');
+  });
+
+  it('does not highlight e-value cell when null is not rejected', () => {
+    render(
+      <TreatmentEffectsTable
+        metricResults={METRIC_RESULTS}
+        showCuped={false}
+        eValueResult={E_VALUE_NOT_REJECTING}
+      />,
+    );
+
+    const cell = screen.getByTestId('evalue-cell');
+    const span = cell.querySelector('span');
+    expect(span?.className).not.toContain('text-red-700');
+  });
+});
+
+// --- FDR Decision Badge ---
+
+describe('FdrDecisionBadge', () => {
+  it('shows PASS when e-value rejects and FDR is under control', () => {
+    render(
+      <FdrDecisionBadge
+        eValueResult={E_VALUE_REJECTING}
+        fdrState={FDR_STATE_CONTROLLED}
+      />,
+    );
+
+    const badge = screen.getByTestId('fdr-decision-badge');
+    expect(badge).toHaveAttribute('data-decision', 'PASS');
+    expect(badge).toHaveTextContent('FDR Pass');
+  });
+
+  it('shows FAIL when e-value does not reject', () => {
+    render(
+      <FdrDecisionBadge
+        eValueResult={E_VALUE_NOT_REJECTING}
+        fdrState={FDR_STATE_CONTROLLED}
+      />,
+    );
+
+    const badge = screen.getByTestId('fdr-decision-badge');
+    expect(badge).toHaveAttribute('data-decision', 'FAIL');
+    expect(badge).toHaveTextContent('FDR Fail');
+  });
+
+  it('shows FAIL when e-value rejects but FDR is over budget', () => {
+    render(
+      <FdrDecisionBadge
+        eValueResult={E_VALUE_REJECTING}
+        fdrState={FDR_STATE_OVER_BUDGET}
+      />,
+    );
+
+    const badge = screen.getByTestId('fdr-decision-badge');
+    expect(badge).toHaveAttribute('data-decision', 'FAIL');
+  });
+
+  it('shows PENDING when no e-value result', () => {
+    render(<FdrDecisionBadge />);
+
+    const badge = screen.getByTestId('fdr-decision-badge');
+    expect(badge).toHaveAttribute('data-decision', 'PENDING');
+    expect(badge).toHaveTextContent('FDR Pending');
+  });
+
+  it('shows PASS without FDR state when e-value rejects', () => {
+    render(<FdrDecisionBadge eValueResult={E_VALUE_REJECTING} />);
+
+    const badge = screen.getByTestId('fdr-decision-badge');
+    expect(badge).toHaveAttribute('data-decision', 'PASS');
+  });
+});
+
+// --- Optimal Alpha Widget ---
+
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual('@/lib/api');
+  return {
+    ...actual,
+    getOptimalAlpha: vi.fn().mockResolvedValue({
+      optimalAlpha: 0.10,
+      expectedPortfolioFdr: 0.042,
+      computedAt: '2026-03-24T10:00:00Z',
+    }),
+  };
+});
+
+describe('OptimalAlphaWidget', () => {
+  it('renders recommended alpha value', async () => {
+    render(
+      <OptimalAlphaWidget
+        experimentId="11111111-1111-1111-1111-111111111111"
+        currentAlpha={0.05}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('optimal-alpha-widget')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('0.100')).toBeInTheDocument();
+    expect(screen.getByText('recommended')).toBeInTheDocument();
+  });
+
+  it('shows relaxation suggestion when optimal > current', async () => {
+    render(
+      <OptimalAlphaWidget
+        experimentId="11111111-1111-1111-1111-111111111111"
+        currentAlpha={0.05}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Relaxation suggested')).toBeInTheDocument();
+    });
+  });
+
+  it('displays current alpha for comparison', async () => {
+    render(
+      <OptimalAlphaWidget
+        experimentId="11111111-1111-1111-1111-111111111111"
+        currentAlpha={0.05}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('0.050')).toBeInTheDocument();
+    });
+  });
+
+  it('shows expected portfolio FDR', async () => {
+    render(
+      <OptimalAlphaWidget
+        experimentId="11111111-1111-1111-1111-111111111111"
+        currentAlpha={0.05}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('4.2%')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/app/experiments/[id]/results/page.tsx
+++ b/ui/src/app/experiments/[id]/results/page.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState, useCallback, Suspense } from 'react';
 import { useParams, useSearchParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
-import type { Experiment, AnalysisResult } from '@/lib/types';
-import { getExperiment, getAnalysisResult, getAdaptiveN, RpcError } from '@/lib/api';
+import type { Experiment, AnalysisResult, OnlineFdrState } from '@/lib/types';
+import { getExperiment, getAnalysisResult, getAdaptiveN, getOnlineFdrState, RpcError } from '@/lib/api';
 import type { AdaptiveNResult } from '@/lib/types';
 import { RetryableError } from '@/components/retryable-error';
 import { Breadcrumb } from '@/components/breadcrumb';
@@ -92,6 +92,14 @@ const FdrBudgetBar = dynamic(
   () => import('@/components/fdr-budget-bar').then(m => ({ default: m.FdrBudgetBar })),
   { ssr: false },
 );
+const FdrDecisionBadge = dynamic(
+  () => import('@/components/fdr-decision-badge').then(m => ({ default: m.FdrDecisionBadge })),
+  { ssr: false },
+);
+const OptimalAlphaWidget = dynamic(
+  () => import('@/components/optimal-alpha-widget').then(m => ({ default: m.OptimalAlphaWidget })),
+  { ssr: false },
+);
 const AvlmSequencePlot = dynamic(
   () => import('@/components/avlm-sequence-plot').then(m => ({ default: m.AvlmSequencePlot })),
   { ssr: false },
@@ -114,6 +122,7 @@ export default function ResultsPage() {
   const [showCuped, setShowCuped] = useState(false);
   const [showIpw, setShowIpw] = useState(false);
   const [adaptiveN, setAdaptiveN] = useState<AdaptiveNResult | null>(null);
+  const [fdrState, setFdrState] = useState<OnlineFdrState | null>(null);
   const searchParams = useSearchParams();
   const router = useRouter();
   const rawTab = searchParams.get('tab');
@@ -161,11 +170,15 @@ export default function ResultsPage() {
             throw err;
           }),
           getAdaptiveN(params.id).catch(() => null), // best-effort; 404 = not applicable
+          exp.onlineFdrConfig
+            ? getOnlineFdrState(params.id).catch(() => null)
+            : Promise.resolve(null),
         ]);
       })
-      .then(([analysis, adaptiveNResult]) => {
+      .then(([analysis, adaptiveNResult, fdrResult]) => {
         if (analysis) setAnalysisResult(analysis);
         setAdaptiveN(adaptiveNResult);
+        setFdrState(fdrResult);
       })
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
@@ -297,16 +310,26 @@ export default function ResultsPage() {
       {/* Summary */}
       <ResultsSummary analysisResult={analysisResult} experiment={experiment} />
 
-      {/* ADR-018: E-value gauge + online FDR budget (shown when data is present) */}
+      {/* ADR-018: E-value gauge + FDR decision badge + online FDR budget + optimal alpha (shown when data is present) */}
       {(analysisResult.eValueResult || experiment.onlineFdrConfig) && (
-        <div className="mb-6 flex flex-wrap gap-4">
-          {analysisResult.eValueResult && (
-            <EValueGauge eValueResult={analysisResult.eValueResult} />
-          )}
-          {experiment.onlineFdrConfig && (
-            <div className="flex-1 min-w-64">
-              <FdrBudgetBar experimentId={params.id} />
-            </div>
+        <div className="mb-6 space-y-4">
+          <div className="flex flex-wrap items-start gap-4">
+            {analysisResult.eValueResult && (
+              <EValueGauge eValueResult={analysisResult.eValueResult} />
+            )}
+            {analysisResult.eValueResult && (
+              <div className="flex items-center self-center">
+                <FdrDecisionBadge eValueResult={analysisResult.eValueResult} fdrState={fdrState} />
+              </div>
+            )}
+            {experiment.onlineFdrConfig && (
+              <div className="flex-1 min-w-64">
+                <FdrBudgetBar experimentId={params.id} />
+              </div>
+            )}
+          </div>
+          {experiment.onlineFdrConfig && analysisResult.eValueResult && (
+            <OptimalAlphaWidget experimentId={params.id} currentAlpha={analysisResult.eValueResult.alpha} />
           )}
         </div>
       )}
@@ -366,7 +389,7 @@ export default function ResultsPage() {
           {/* Treatment Effects Table */}
           <section className="mb-6">
             <h2 className="mb-3 text-lg font-semibold text-gray-900">Metric Results</h2>
-            <TreatmentEffectsTable metricResults={analysisResult.metricResults} showCuped={showCuped} showIpw={showIpw} />
+            <TreatmentEffectsTable metricResults={analysisResult.metricResults} showCuped={showCuped} showIpw={showIpw} eValueResult={analysisResult.eValueResult} />
           </section>
 
           {/* IPW Details Panel (when IPW data exists) */}

--- a/ui/src/components/fdr-decision-badge.tsx
+++ b/ui/src/components/fdr-decision-badge.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { memo } from 'react';
+import type { EValueResult, OnlineFdrState, FdrDecision } from '@/lib/types';
+
+interface FdrDecisionBadgeProps {
+  eValueResult?: EValueResult;
+  fdrState?: OnlineFdrState | null;
+}
+
+const DECISION_CONFIG: Record<FdrDecision, { label: string; bg: string; text: string; dot: string; title: string }> = {
+  PASS: {
+    label: 'FDR Pass',
+    bg: 'bg-green-100',
+    text: 'text-green-800',
+    dot: 'bg-green-500',
+    title: 'Null rejected and FDR is under control. Safe to act on this result.',
+  },
+  FAIL: {
+    label: 'FDR Fail',
+    bg: 'bg-red-100',
+    text: 'text-red-800',
+    dot: 'bg-red-500',
+    title: 'Insufficient evidence to reject the null after FDR correction.',
+  },
+  PENDING: {
+    label: 'FDR Pending',
+    bg: 'bg-gray-100',
+    text: 'text-gray-700',
+    dot: 'bg-gray-400',
+    title: 'Awaiting e-value computation or FDR evaluation.',
+  },
+};
+
+function deriveDecision(eValueResult?: EValueResult, fdrState?: OnlineFdrState | null): FdrDecision {
+  if (!eValueResult) return 'PENDING';
+
+  // If online FDR is available, use it: reject only if both the e-value rejects
+  // and the current FDR is below the target alpha (cross-experiment control).
+  if (fdrState) {
+    if (eValueResult.reject && fdrState.currentFdr <= eValueResult.alpha) return 'PASS';
+    if (!eValueResult.reject) return 'FAIL';
+    // e-value rejects but FDR is over budget — conservative: fail
+    return 'FAIL';
+  }
+
+  // No FDR state — use within-experiment e-value decision only.
+  if (eValueResult.reject) return 'PASS';
+  return 'FAIL';
+}
+
+function FdrDecisionBadgeInner({ eValueResult, fdrState }: FdrDecisionBadgeProps) {
+  const decision = deriveDecision(eValueResult, fdrState);
+  const cfg = DECISION_CONFIG[decision];
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cfg.bg} ${cfg.text}`}
+      title={cfg.title}
+      data-testid="fdr-decision-badge"
+      data-decision={decision}
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${cfg.dot}`} aria-hidden="true" />
+      {cfg.label}
+    </span>
+  );
+}
+
+export const FdrDecisionBadge = memo(FdrDecisionBadgeInner);

--- a/ui/src/components/optimal-alpha-widget.tsx
+++ b/ui/src/components/optimal-alpha-widget.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { memo, useEffect, useState } from 'react';
+import type { OptimalAlphaRecommendation } from '@/lib/types';
+import { getOptimalAlpha, RpcError } from '@/lib/api';
+
+interface OptimalAlphaWidgetProps {
+  experimentId: string;
+  currentAlpha: number;
+}
+
+/**
+ * Displays the portfolio-level optimal alpha recommendation (ADR-019).
+ *
+ * Compares the experiment's current alpha with the portfolio-recommended alpha.
+ * When the recommended alpha differs from the current setting, highlights the
+ * recommendation with an explanation.
+ */
+function OptimalAlphaWidgetInner({ experimentId, currentAlpha }: OptimalAlphaWidgetProps) {
+  const [rec, setRec] = useState<OptimalAlphaRecommendation | null>(null);
+
+  useEffect(() => {
+    getOptimalAlpha(experimentId)
+      .then(setRec)
+      .catch((err) => {
+        if (!(err instanceof RpcError && err.status === 404)) {
+          console.error('OptimalAlphaWidget:', err);
+        }
+      });
+  }, [experimentId]);
+
+  if (!rec) return null;
+
+  const isRelaxed = rec.optimalAlpha > currentAlpha;
+  const isStricter = rec.optimalAlpha < currentAlpha;
+  const isSame = !isRelaxed && !isStricter;
+
+  const borderColor = isRelaxed
+    ? 'border-blue-200 bg-blue-50'
+    : isStricter
+    ? 'border-amber-200 bg-amber-50'
+    : 'border-gray-200 bg-white';
+
+  return (
+    <div
+      className={`rounded-lg border px-4 py-3 ${borderColor}`}
+      data-testid="optimal-alpha-widget"
+    >
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-xs font-medium uppercase text-gray-500">
+          Optimal Alpha (ADR-019)
+        </span>
+        {!isSame && (
+          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+            isRelaxed ? 'bg-blue-100 text-blue-700' : 'bg-amber-100 text-amber-700'
+          }`}>
+            {isRelaxed ? 'Relaxation suggested' : 'Stricter threshold suggested'}
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-baseline gap-4">
+        <div>
+          <span className="text-2xl font-bold text-gray-900">
+            {rec.optimalAlpha.toFixed(3)}
+          </span>
+          <span className="ml-1 text-sm text-gray-500">recommended</span>
+        </div>
+        <div className="text-sm text-gray-500">
+          vs. current <span className="font-medium text-gray-700">{currentAlpha.toFixed(3)}</span>
+        </div>
+      </div>
+
+      <p className="mt-2 text-xs text-gray-500">
+        {isRelaxed
+          ? 'Portfolio analysis suggests a relaxed threshold may maximize total program value. Low-cost treatments benefit from running more experiments at higher alpha.'
+          : isStricter
+          ? 'Given the current FDR budget, a stricter threshold is recommended to maintain cross-experiment error control.'
+          : 'Current alpha aligns with the portfolio-level recommendation.'}
+      </p>
+
+      <dl className="mt-2 flex gap-4 text-xs text-gray-500">
+        <div>
+          <dt className="font-medium text-gray-400">Expected FDR</dt>
+          <dd>{(rec.expectedPortfolioFdr * 100).toFixed(1)}%</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export const OptimalAlphaWidget = memo(OptimalAlphaWidgetInner);

--- a/ui/src/components/treatment-effects-table.tsx
+++ b/ui/src/components/treatment-effects-table.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import { memo } from 'react';
-import type { MetricResult } from '@/lib/types';
-import { formatPValue, formatEffect } from '@/lib/utils';
+import type { MetricResult, EValueResult } from '@/lib/types';
+import { formatPValue, formatEffect, formatEValue } from '@/lib/utils';
 
 interface TreatmentEffectsTableProps {
   metricResults: MetricResult[];
   showCuped: boolean;
   showIpw?: boolean;
+  eValueResult?: EValueResult;
 }
 
-function TreatmentEffectsTableInner({ metricResults, showCuped, showIpw }: TreatmentEffectsTableProps) {
+function TreatmentEffectsTableInner({ metricResults, showCuped, showIpw, eValueResult }: TreatmentEffectsTableProps) {
+  const showEValue = !!eValueResult;
+
   return (
     <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
       <table className="min-w-full divide-y divide-gray-200">
@@ -22,6 +25,12 @@ function TreatmentEffectsTableInner({ metricResults, showCuped, showIpw }: Treat
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Effect</th>
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">95% CI</th>
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">p-value</th>
+            {showEValue && (
+              <>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500" data-testid="evalue-header">E-value</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Implied p</th>
+              </>
+            )}
             <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Significance</th>
           </tr>
         </thead>
@@ -64,6 +73,18 @@ function TreatmentEffectsTableInner({ metricResults, showCuped, showIpw }: Treat
                 <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
                   {formatPValue(pVal)}
                 </td>
+                {showEValue && (
+                  <>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600" data-testid="evalue-cell">
+                      <span className={eValueResult.reject ? 'font-medium text-red-700' : ''}>
+                        {formatEValue(eValueResult.eValue)}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
+                      {formatPValue(eValueResult.impliedLevel)}
+                    </td>
+                  </>
+                )}
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
                   {significant ? (
                     <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -10,7 +10,7 @@ import type {
   AuditLogEntry, AuditAction, ListAuditLogResponse,
   ProviderHealthResult,
   AvlmResult, AdaptiveNResult, FeedbackLoopResult,
-  OnlineFdrState,
+  OnlineFdrState, OptimalAlphaRecommendation,
   PortfolioAllocationResult, PortfolioMetricsResult,
   ParetoFrontierResult,
   MetaExperimentResult,
@@ -763,6 +763,12 @@ export async function getPortfolioAllocation(): Promise<PortfolioAllocationResul
 export async function getPortfolioMetrics(): Promise<PortfolioMetricsResult> {
   return callRpc<Record<string, never>, PortfolioMetricsResult>(
     ANALYSIS_URL, ANALYSIS_SVC, 'GetPortfolioMetrics', {},
+  );
+}
+
+export async function getOptimalAlpha(experimentId: string): Promise<OptimalAlphaRecommendation> {
+  return callRpc<{ experimentId: string }, OptimalAlphaRecommendation>(
+    ANALYSIS_URL, ANALYSIS_SVC, 'GetOptimalAlpha', { experimentId },
   );
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -730,6 +730,16 @@ export interface OnlineFdrState {
   computedAt: string;
 }
 
+/** FDR decision status for a single experiment within an online testing program. */
+export type FdrDecision = 'PASS' | 'FAIL' | 'PENDING';
+
+/** Portfolio-level optimal alpha recommendation (ADR-019). */
+export interface OptimalAlphaRecommendation {
+  optimalAlpha: number;
+  expectedPortfolioFdr: number;
+  computedAt: string;
+}
+
 // --- Feedback Loop Analysis ---
 
 export interface RetrainingEvent {

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -98,6 +98,13 @@ export function formatPValue(p: number): string {
   return p.toFixed(2);
 }
 
+export function formatEValue(e: number): string {
+  if (e >= 1000) return `${(e / 1000).toFixed(1)}k`;
+  if (e >= 100) return e.toFixed(0);
+  if (e >= 10) return e.toFixed(1);
+  return e.toFixed(2);
+}
+
 export function formatEffect(effect: number, isPercent = false): string {
   const prefix = effect > 0 ? '+' : '';
   if (isPercent) return `${prefix}${(effect * 100).toFixed(2)}%`;


### PR DESCRIPTION
## Summary

Implements Sprint 5.5 task 5.5.4 — E-value UI components for ADR-018 (e-value framework & online FDR control).

- **E-value column in treatment effects table**: Added `eValue` and `Implied p` columns alongside existing p-value column. E-value cells highlight red when the null is rejected. Columns only render when `eValueResult` is present on the analysis result.
- **FDR decision badge**: New `FdrDecisionBadge` component with three states — PASS (e-value rejects + FDR under control), FAIL (insufficient evidence or FDR over budget), PENDING (no e-value data yet). Derives decision client-side from `EValueResult` + `OnlineFdrState`.
- **Optimal alpha recommendation widget**: New `OptimalAlphaWidget` fetches portfolio-level recommended alpha (ADR-019) and compares against current experiment alpha. Shows relaxation/stricter suggestions with explanation text and expected portfolio FDR.
- **New types**: `FdrDecision`, `OptimalAlphaRecommendation` in `types.ts`
- **New API**: `getOptimalAlpha()` in `api.ts`, `formatEValue()` in `utils.ts`
- **Mock data**: Seed data + MSW handler for `GetOptimalAlpha` endpoint

### Files changed
| File | Change |
|------|--------|
| `src/components/treatment-effects-table.tsx` | Added optional `eValueResult` prop, e-value + implied p columns |
| `src/components/fdr-decision-badge.tsx` | **New** — FDR pass/fail/pending badge |
| `src/components/optimal-alpha-widget.tsx` | **New** — Portfolio alpha recommendation |
| `src/app/experiments/[id]/results/page.tsx` | Wired new components, fetch OnlineFdrState in parallel |
| `src/lib/types.ts` | `FdrDecision`, `OptimalAlphaRecommendation` |
| `src/lib/api.ts` | `getOptimalAlpha()` |
| `src/lib/utils.ts` | `formatEValue()` |
| `src/__mocks__/seed-data.ts` | Optimal alpha seed data |
| `src/__mocks__/handlers.ts` | `GetOptimalAlpha` handler |
| `src/__tests__/evalue-fdr.test.tsx` | **New** — 14 tests covering all components |

### Dependencies
- e-LOND OnlineFdrController (#305)
- MAD e-processes (5.5.3)

### Opportunities (not implemented)
- Per-metric e-values when backend supports metric-level e-value computation
- Historical e-value trend chart (e-process visualization over time)
- Interactive alpha slider allowing experimenters to explore different thresholds

Closes #315

## Test plan
- [x] `cd ui && npm test` — 647 tests pass, 0 failures
- [x] 14 new tests in `evalue-fdr.test.tsx` covering:
  - E-value column presence/absence in treatment effects table
  - E-value formatting and red highlight on rejection
  - FDR badge: PASS, FAIL, PENDING states
  - FDR badge: over-budget FDR state → FAIL
  - Optimal alpha widget: rendering, relaxation suggestion, FDR display
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
