### PR TITLE
feat(M3): MLRATE K-fold cross-fitting pipeline (ADR-015 Phase 2)

### DIFF
--- a/services/metrics/internal/config/loader.go
+++ b/services/metrics/internal/config/loader.go
@@ -38,6 +38,9 @@ type ExperimentConfig struct {
 	CreditAssignment             string            `json:"credit_assignment,omitempty"`       // "binary_win", "proportional", or "weighted"
 	EngagementEventType          string            `json:"engagement_event_type,omitempty"`   // event_type to join for engagement
 	SessionLevel                 bool              `json:"session_level,omitempty"`           // whether metrics are session-level
+	// MLRATE cross-fitting fields (ADR-015 Phase 2)
+	MLRATEEnabled                bool              `json:"mlrate_enabled,omitempty"`          // enable MLRATE cross-fitting for AVLM covariates
+	MLRATEFolds                  int               `json:"mlrate_folds,omitempty"`            // K-fold count (default 5)
 }
 
 type SurrogateModelConfig struct {
@@ -67,6 +70,10 @@ type MetricConfig struct {
 	IsQoEMetric          bool   `json:"is_qoe_metric,omitempty"`
 	QoEField             string `json:"qoe_field,omitempty"`
 	CustomSQL            string `json:"custom_sql,omitempty"`
+	// MLRATE cross-fitting fields (ADR-015 Phase 2)
+	MLRATEFeatureEventTypes []string `json:"mlrate_feature_event_types,omitempty"` // pre-experiment event types as LightGBM features
+	MLRATEModelURI          string   `json:"mlrate_model_uri,omitempty"`           // MLflow model URI prefix (fold models at {uri}/fold_{k})
+	MLRATELookbackDays      int      `json:"mlrate_lookback_days,omitempty"`       // days of pre-experiment data for features (default 14)
 }
 
 type seedFile struct {
@@ -173,6 +180,22 @@ func (e *ExperimentConfig) ControlVariantID() string {
 		}
 	}
 	return ""
+}
+
+// MLRATEFoldsOrDefault returns the configured fold count, or 5 if unset.
+func (e *ExperimentConfig) MLRATEFoldsOrDefault() int {
+	if e.MLRATEFolds > 0 {
+		return e.MLRATEFolds
+	}
+	return 5
+}
+
+// MLRATELookbackDaysOrDefault returns the configured lookback, or 14 if unset.
+func (m *MetricConfig) MLRATELookbackDaysOrDefault() int {
+	if m.MLRATELookbackDays > 0 {
+		return m.MLRATELookbackDays
+	}
+	return 14
 }
 
 func (c *ConfigStore) GetSurrogateModel(id string) (*SurrogateModelConfig, error) {

--- a/services/metrics/internal/config/loader_test.go
+++ b/services/metrics/internal/config/loader_test.go
@@ -110,7 +110,7 @@ func TestLoadFromFile(t *testing.T) {
 
 	t.Run("running experiments", func(t *testing.T) {
 		ids := cs.RunningExperimentIDs()
-		assert.Len(t, ids, 6)
+		assert.Len(t, ids, 7)
 	})
 
 	t.Run("not found", func(t *testing.T) {

--- a/services/metrics/internal/config/testdata/seed_config.json
+++ b/services/metrics/internal/config/testdata/seed_config.json
@@ -143,6 +143,31 @@
       ]
     },
     {
+      "experiment_id": "e0000000-0000-0000-0000-000000000008",
+      "name": "mlrate_crossfit_test",
+      "type": "AB",
+      "state": "RUNNING",
+      "started_at": "2024-02-01",
+      "primary_metric_id": "watch_time_minutes_mlrate",
+      "secondary_metric_ids": [],
+      "mlrate_enabled": true,
+      "mlrate_folds": 3,
+      "variants": [
+        {
+          "variant_id": "f0000000-0000-0000-0000-000000000015",
+          "name": "control",
+          "traffic_fraction": 0.5,
+          "is_control": true
+        },
+        {
+          "variant_id": "f0000000-0000-0000-0000-000000000016",
+          "name": "treatment",
+          "traffic_fraction": 0.5,
+          "is_control": false
+        }
+      ]
+    },
+    {
       "experiment_id": "e0000000-0000-0000-0000-000000000004",
       "name": "playback_qoe_test",
       "type": "AB",
@@ -245,6 +270,15 @@
       "name": "Power Users Watch Time",
       "type": "CUSTOM",
       "custom_sql": "SELECT user_id, AVG(value) AS metric_value FROM delta.metric_events WHERE event_type = 'heartbeat' GROUP BY user_id HAVING COUNT(*) >= 10"
+    },
+    {
+      "metric_id": "watch_time_minutes_mlrate",
+      "name": "Watch Time (MLRATE)",
+      "type": "MEAN",
+      "source_event_type": "heartbeat",
+      "mlrate_feature_event_types": ["heartbeat", "stream_start"],
+      "mlrate_model_uri": "models:/mlrate-watch-time",
+      "mlrate_lookback_days": 14
     },
     {
       "metric_id": "ttff_mean",

--- a/services/metrics/internal/jobs/latency_sla_test.go
+++ b/services/metrics/internal/jobs/latency_sla_test.go
@@ -224,9 +224,10 @@ func TestSLA_DailyPipeline_QueryBudget(t *testing.T) {
 
 	total := runDailyPipeline(t, cfg, executor, qlWriter)
 
-	// Exact regression check: 35 standard + 6 content_consumption + 1 interleaving = 42.
-	assert.Equal(t, 42, total,
-		"Daily pipeline query count regression: expected exactly 42 SQL queries")
+	// Exact regression check: 35 standard + 6 content_consumption + 1 interleaving
+	// + 1 mlrate_metric + 4 mlrate (1 feat + 3 crossfit) + 1 mlrate_treatment_effect + 1 mlrate_cc = 49.
+	assert.Equal(t, 49, total,
+		"Daily pipeline query count regression: expected exactly 49 SQL queries")
 
 	// SLA budget check.
 	assert.Less(t, total, MaxDailyQueries,

--- a/services/metrics/internal/jobs/mlrate.go
+++ b/services/metrics/internal/jobs/mlrate.go
@@ -1,0 +1,167 @@
+// Package jobs provides metric computation job orchestrators.
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	m3metrics "github.com/org/experimentation-platform/services/metrics/internal/metrics"
+	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
+	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+)
+
+// MLRATEResult summarizes the outcome of a cross-fitting run.
+type MLRATEResult struct {
+	ExperimentID string
+	MetricID     string
+	Folds        int
+	UsersScored  int64
+	CompletedAt  time.Time
+}
+
+// MLRATEJob orchestrates LightGBM K-fold cross-fitted prediction generation
+// for AVLM Phase 2 covariate consumption (ADR-015 Phase 2).
+//
+// Pipeline:
+//  1. Prepare per-user features from pre-experiment data with fold assignment
+//     → writes to delta.mlrate_features
+//  2. For each fold k=1..K, generate out-of-fold predictions using the
+//     MLflow-registered model trained on all folds except k
+//     → writes to delta.metric_summaries (as mlrate_covariate column)
+type MLRATEJob struct {
+	renderer *spark.SQLRenderer
+	executor spark.SQLExecutor
+	queryLog querylog.Writer
+}
+
+// NewMLRATEJob creates a new MLRATE cross-fitting job.
+func NewMLRATEJob(
+	renderer *spark.SQLRenderer,
+	executor spark.SQLExecutor,
+	ql querylog.Writer,
+) *MLRATEJob {
+	return &MLRATEJob{
+		renderer: renderer,
+		executor: executor,
+		queryLog: ql,
+	}
+}
+
+// Run executes the K-fold cross-fitting pipeline for a single metric.
+func (j *MLRATEJob) Run(
+	ctx context.Context,
+	exp *config.ExperimentConfig,
+	metric *config.MetricConfig,
+	computationDate string,
+) (*MLRATEResult, error) {
+	folds := exp.MLRATEFoldsOrDefault()
+	lookbackDays := metric.MLRATELookbackDaysOrDefault()
+
+	if len(metric.MLRATEFeatureEventTypes) == 0 {
+		return nil, fmt.Errorf("mlrate: metric %q has no mlrate_feature_event_types configured", metric.MetricID)
+	}
+	if metric.MLRATEModelURI == "" {
+		return nil, fmt.Errorf("mlrate: metric %q has no mlrate_model_uri configured", metric.MetricID)
+	}
+	if exp.StartedAt == "" {
+		return nil, fmt.Errorf("mlrate: experiment %q has no started_at date", exp.ExperimentID)
+	}
+
+	// Step 1: Prepare features with fold assignment.
+	featParams := spark.TemplateParams{
+		ExperimentID:            exp.ExperimentID,
+		ComputationDate:         computationDate,
+		ExperimentStartDate:     exp.StartedAt,
+		MLRATEFolds:             folds,
+		MLRATEFeatureEventTypes: metric.MLRATEFeatureEventTypes,
+		MLRATELookbackDays:      lookbackDays,
+	}
+
+	featSQL, err := j.renderer.RenderMLRATEFeatures(featParams)
+	if err != nil {
+		return nil, fmt.Errorf("mlrate: render features for %s: %w", metric.MetricID, err)
+	}
+
+	featResult, err := j.executor.ExecuteAndWrite(ctx, featSQL, "delta.mlrate_features")
+	if err != nil {
+		return nil, fmt.Errorf("mlrate: execute features for %s: %w", metric.MetricID, err)
+	}
+	m3metrics.SparkQueryDuration.WithLabelValues("mlrate_features").Observe(featResult.Duration.Seconds())
+	m3metrics.SparkQueryRows.WithLabelValues("mlrate_features").Observe(float64(featResult.RowCount))
+
+	if err := j.queryLog.Log(ctx, querylog.Entry{
+		ExperimentID: exp.ExperimentID,
+		MetricID:     metric.MetricID,
+		SQLText:      featSQL,
+		RowCount:     featResult.RowCount,
+		DurationMs:   featResult.Duration.Milliseconds(),
+		JobType:      "mlrate_features",
+	}); err != nil {
+		return nil, fmt.Errorf("mlrate: log features query for %s: %w", metric.MetricID, err)
+	}
+
+	slog.Info("computed MLRATE features",
+		"experiment_id", exp.ExperimentID,
+		"metric_id", metric.MetricID,
+		"folds", folds,
+		"lookback_days", lookbackDays,
+		"rows", featResult.RowCount,
+	)
+
+	// Step 2: For each fold, generate cross-fitted predictions.
+	var totalPredictionRows int64
+	for foldID := 1; foldID <= folds; foldID++ {
+		predParams := spark.TemplateParams{
+			ExperimentID:            exp.ExperimentID,
+			MetricID:                metric.MetricID,
+			ComputationDate:         computationDate,
+			MLRATEFolds:             folds,
+			MLRATEFeatureEventTypes: metric.MLRATEFeatureEventTypes,
+			MLRATEModelURI:          metric.MLRATEModelURI,
+			MLRATEFoldID:            foldID,
+		}
+
+		predSQL, err := j.renderer.RenderMLRATECrossFitPredict(predParams)
+		if err != nil {
+			return nil, fmt.Errorf("mlrate: render prediction fold %d for %s: %w", foldID, metric.MetricID, err)
+		}
+
+		predResult, err := j.executor.ExecuteAndWrite(ctx, predSQL, "delta.metric_summaries")
+		if err != nil {
+			return nil, fmt.Errorf("mlrate: execute prediction fold %d for %s: %w", foldID, metric.MetricID, err)
+		}
+		m3metrics.SparkQueryDuration.WithLabelValues("mlrate_crossfit").Observe(predResult.Duration.Seconds())
+		m3metrics.SparkQueryRows.WithLabelValues("mlrate_crossfit").Observe(float64(predResult.RowCount))
+
+		if err := j.queryLog.Log(ctx, querylog.Entry{
+			ExperimentID: exp.ExperimentID,
+			MetricID:     metric.MetricID,
+			SQLText:      predSQL,
+			RowCount:     predResult.RowCount,
+			DurationMs:   predResult.Duration.Milliseconds(),
+			JobType:      "mlrate_crossfit",
+		}); err != nil {
+			return nil, fmt.Errorf("mlrate: log prediction fold %d query for %s: %w", foldID, metric.MetricID, err)
+		}
+
+		totalPredictionRows += predResult.RowCount
+
+		slog.Info("computed MLRATE cross-fit prediction",
+			"experiment_id", exp.ExperimentID,
+			"metric_id", metric.MetricID,
+			"fold", foldID,
+			"rows", predResult.RowCount,
+		)
+	}
+
+	return &MLRATEResult{
+		ExperimentID: exp.ExperimentID,
+		MetricID:     metric.MetricID,
+		Folds:        folds,
+		UsersScored:  totalPredictionRows,
+		CompletedAt:  time.Now(),
+	}, nil
+}

--- a/services/metrics/internal/jobs/mlrate_test.go
+++ b/services/metrics/internal/jobs/mlrate_test.go
@@ -1,0 +1,197 @@
+package jobs
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
+	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+)
+
+func setupMLRATEJob(t *testing.T) (*MLRATEJob, *spark.MockExecutor, *querylog.MemWriter) {
+	t.Helper()
+	renderer, err := spark.NewSQLRenderer()
+	require.NoError(t, err)
+	executor := spark.NewMockExecutor(1000)
+	qlWriter := querylog.NewMemWriter()
+	job := NewMLRATEJob(renderer, executor, qlWriter)
+	return job, executor, qlWriter
+}
+
+func mlrateTestExperiment() *config.ExperimentConfig {
+	return &config.ExperimentConfig{
+		ExperimentID: "e0000000-0000-0000-0000-000000000008",
+		Name:         "mlrate_crossfit_test",
+		Type:         "AB",
+		State:        "RUNNING",
+		StartedAt:    "2024-02-01",
+		MLRATEEnabled: true,
+		MLRATEFolds:   3,
+		Variants: []config.VariantConfig{
+			{VariantID: "f0000000-0000-0000-0000-000000000015", Name: "control", TrafficFraction: 0.5, IsControl: true},
+			{VariantID: "f0000000-0000-0000-0000-000000000016", Name: "treatment", TrafficFraction: 0.5, IsControl: false},
+		},
+	}
+}
+
+func mlrateTestMetric() *config.MetricConfig {
+	return &config.MetricConfig{
+		MetricID:                "watch_time_minutes_mlrate",
+		Name:                    "Watch Time (MLRATE)",
+		Type:                    "MEAN",
+		SourceEventType:         "heartbeat",
+		MLRATEFeatureEventTypes: []string{"heartbeat", "stream_start"},
+		MLRATEModelURI:          "models:/mlrate-watch-time",
+		MLRATELookbackDays:      14,
+	}
+}
+
+func TestMLRATEJob_Run(t *testing.T) {
+	job, executor, qlWriter := setupMLRATEJob(t)
+	ctx := context.Background()
+	exp := mlrateTestExperiment()
+	metric := mlrateTestMetric()
+
+	result, err := job.Run(ctx, exp, metric, "2024-02-15")
+	require.NoError(t, err)
+
+	assert.Equal(t, exp.ExperimentID, result.ExperimentID)
+	assert.Equal(t, metric.MetricID, result.MetricID)
+	assert.Equal(t, 3, result.Folds)
+	assert.False(t, result.CompletedAt.IsZero())
+
+	// 1 feature prep + 3 fold predictions = 4 calls
+	calls := executor.GetCalls()
+	assert.Len(t, calls, 4)
+
+	// First call: feature preparation → delta.mlrate_features
+	assert.Equal(t, "delta.mlrate_features", calls[0].TargetTable)
+	assert.Contains(t, calls[0].SQL, "delta.exposures")
+	assert.Contains(t, calls[0].SQL, "delta.metric_events")
+	assert.Contains(t, calls[0].SQL, "'heartbeat', 'stream_start'")
+	assert.Contains(t, calls[0].SQL, "fold_id")
+	assert.Contains(t, calls[0].SQL, "% 3 + 1")
+
+	// Next 3 calls: fold predictions → delta.metric_summaries
+	for i := 1; i <= 3; i++ {
+		assert.Equal(t, "delta.metric_summaries", calls[i].TargetTable)
+		assert.Contains(t, calls[i].SQL, "delta.mlrate_features")
+		assert.Contains(t, calls[i].SQL, "ai_predict")
+		assert.Contains(t, calls[i].SQL, "mlrate_covariate")
+		assert.Contains(t, calls[i].SQL, "models:/mlrate-watch-time/fold_"+string(rune('0'+i)))
+	}
+
+	// Verify query log: 1 mlrate_features + 3 mlrate_crossfit = 4 entries
+	entries := qlWriter.AllEntries()
+	assert.Len(t, entries, 4)
+
+	featCount := 0
+	crossfitCount := 0
+	for _, e := range entries {
+		assert.Equal(t, exp.ExperimentID, e.ExperimentID)
+		assert.Equal(t, metric.MetricID, e.MetricID)
+		switch e.JobType {
+		case "mlrate_features":
+			featCount++
+		case "mlrate_crossfit":
+			crossfitCount++
+		}
+	}
+	assert.Equal(t, 1, featCount)
+	assert.Equal(t, 3, crossfitCount)
+}
+
+func TestMLRATEJob_Run_DefaultFolds(t *testing.T) {
+	job, executor, _ := setupMLRATEJob(t)
+	ctx := context.Background()
+	exp := mlrateTestExperiment()
+	exp.MLRATEFolds = 0 // should default to 5
+	metric := mlrateTestMetric()
+
+	result, err := job.Run(ctx, exp, metric, "2024-02-15")
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, result.Folds)
+	// 1 feature prep + 5 fold predictions = 6 calls
+	calls := executor.GetCalls()
+	assert.Len(t, calls, 6)
+}
+
+func TestMLRATEJob_Run_DefaultLookbackDays(t *testing.T) {
+	job, executor, _ := setupMLRATEJob(t)
+	ctx := context.Background()
+	exp := mlrateTestExperiment()
+	metric := mlrateTestMetric()
+	metric.MLRATELookbackDays = 0 // should default to 14
+
+	result, err := job.Run(ctx, exp, metric, "2024-02-15")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Feature prep query should use default lookback of 14
+	calls := executor.GetCalls()
+	assert.Contains(t, calls[0].SQL, "14")
+}
+
+func TestMLRATEJob_Run_MissingFeatureEventTypes(t *testing.T) {
+	job, _, _ := setupMLRATEJob(t)
+	ctx := context.Background()
+	exp := mlrateTestExperiment()
+	metric := mlrateTestMetric()
+	metric.MLRATEFeatureEventTypes = nil
+
+	_, err := job.Run(ctx, exp, metric, "2024-02-15")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no mlrate_feature_event_types")
+}
+
+func TestMLRATEJob_Run_MissingModelURI(t *testing.T) {
+	job, _, _ := setupMLRATEJob(t)
+	ctx := context.Background()
+	exp := mlrateTestExperiment()
+	metric := mlrateTestMetric()
+	metric.MLRATEModelURI = ""
+
+	_, err := job.Run(ctx, exp, metric, "2024-02-15")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no mlrate_model_uri")
+}
+
+func TestMLRATEJob_Run_MissingStartDate(t *testing.T) {
+	job, _, _ := setupMLRATEJob(t)
+	ctx := context.Background()
+	exp := mlrateTestExperiment()
+	exp.StartedAt = ""
+	metric := mlrateTestMetric()
+
+	_, err := job.Run(ctx, exp, metric, "2024-02-15")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no started_at date")
+}
+
+func TestMLRATEJob_Run_FoldPredictionsSQLContent(t *testing.T) {
+	job, executor, _ := setupMLRATEJob(t)
+	ctx := context.Background()
+	exp := mlrateTestExperiment()
+	metric := mlrateTestMetric()
+
+	_, err := job.Run(ctx, exp, metric, "2024-02-15")
+	require.NoError(t, err)
+
+	calls := executor.GetCalls()
+	// Verify each fold prediction targets the correct fold model
+	for i := 1; i <= 3; i++ {
+		predSQL := calls[i].SQL
+		expectedFoldRef := "fold_" + string(rune('0'+i))
+		assert.True(t, strings.Contains(predSQL, expectedFoldRef),
+			"Fold %d prediction should reference fold_%d model", i, i)
+		assert.Contains(t, predSQL, "NAMED_STRUCT")
+		assert.Contains(t, predSQL, "'heartbeat'")
+		assert.Contains(t, predSQL, "'stream_start'")
+	}
+}

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -198,6 +198,23 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 			)
 		}
 
+		// MLRATE cross-fitting: if experiment has MLRATE enabled and metric has
+		// feature config, generate K-fold cross-fitted predictions as AVLM covariates.
+		if exp.MLRATEEnabled && len(m.MLRATEFeatureEventTypes) > 0 && m.MLRATEModelURI != "" && exp.StartedAt != "" {
+			mlrateJob := NewMLRATEJob(j.renderer, j.executor, j.queryLog)
+			mlrateResult, err := mlrateJob.Run(ctx, exp, &m, computationDate)
+			if err != nil {
+				return nil, fmt.Errorf("jobs: MLRATE cross-fit for %s: %w", m.MetricID, err)
+			}
+
+			slog.Info("computed MLRATE cross-fitted predictions",
+				"experiment_id", experimentID,
+				"metric_id", m.MetricID,
+				"folds", mlrateResult.Folds,
+				"users_scored", mlrateResult.UsersScored,
+			)
+		}
+
 		// Session-level aggregation: if enabled, also compute per-session metrics.
 		if exp.SessionLevel && !m.IsQoEMetric {
 			slParams := params

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -353,6 +353,57 @@ func TestStandardJob_Run_CustomMetricType(t *testing.T) {
 	assert.Contains(t, customLogEntry.SQLText, "custom_result")
 }
 
+func TestStandardJob_Run_MLRATECrossFitting(t *testing.T) {
+	job, executor, qlWriter := setupTestJob(t)
+	ctx := context.Background()
+
+	// mlrate_crossfit_test (e...0008): mlrate_enabled=true, mlrate_folds=3
+	// watch_time_minutes_mlrate: MEAN + MLRATE with 2 features (heartbeat, stream_start)
+	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000008")
+	require.NoError(t, err)
+
+	assert.Equal(t, "e0000000-0000-0000-0000-000000000008", result.ExperimentID)
+	assert.Equal(t, 1, result.MetricsComputed)
+
+	calls := executor.GetCalls()
+	// 1 daily metric + 1 MLRATE features + 3 MLRATE crossfit + 1 daily treatment effect = 6
+	assert.Len(t, calls, 6)
+
+	// First call: daily metric (MEAN) → delta.metric_summaries
+	assert.Equal(t, "delta.metric_summaries", calls[0].TargetTable)
+	assert.Contains(t, calls[0].SQL, "AVG(metric_data.value)")
+
+	// Second call: MLRATE feature prep → delta.mlrate_features
+	assert.Equal(t, "delta.mlrate_features", calls[1].TargetTable)
+	assert.Contains(t, calls[1].SQL, "fold_id")
+	assert.Contains(t, calls[1].SQL, "'heartbeat', 'stream_start'")
+
+	// Calls 3-5: MLRATE fold predictions → delta.metric_summaries
+	for i := 2; i <= 4; i++ {
+		assert.Equal(t, "delta.metric_summaries", calls[i].TargetTable)
+		assert.Contains(t, calls[i].SQL, "ai_predict")
+		assert.Contains(t, calls[i].SQL, "mlrate_covariate")
+	}
+
+	// Last call: daily treatment effect → delta.daily_treatment_effects
+	assert.Equal(t, "delta.daily_treatment_effects", calls[5].TargetTable)
+
+	// Verify query log
+	entries := qlWriter.AllEntries()
+	mlrateFeatCount := 0
+	mlrateCrossfitCount := 0
+	for _, e := range entries {
+		switch e.JobType {
+		case "mlrate_features":
+			mlrateFeatCount++
+		case "mlrate_crossfit":
+			mlrateCrossfitCount++
+		}
+	}
+	assert.Equal(t, 1, mlrateFeatCount)
+	assert.Equal(t, 3, mlrateCrossfitCount)
+}
+
 func TestStandardJob_Run_AllExperimentsWithExposureJoin(t *testing.T) {
 	job, executor, _ := setupTestJob(t)
 	ctx := context.Background()

--- a/services/metrics/internal/m3m5_wire_format_contract_test.go
+++ b/services/metrics/internal/m3m5_wire_format_contract_test.go
@@ -161,6 +161,8 @@ func TestM3M5_ExperimentConfig_FieldCompleteness(t *testing.T) {
 		"credit_assignment":               "interleavingConfig.creditAssignment",
 		"engagement_event_type":           "interleavingConfig.engagementEventType",
 		"session_level":                   "sessionConfig.sessionLevel",
+		"mlrate_enabled":                  "mlrateConfig.enabled",
+		"mlrate_folds":                    "mlrateConfig.folds",
 	}
 
 	// Extract JSON tags from M3's ExperimentConfig struct.
@@ -193,8 +195,11 @@ func TestM3M5_MetricConfig_FieldCompleteness(t *testing.T) {
 		"percentile":              "percentile",
 		"lower_is_better":         "lowerIsBetter",
 		"is_qoe_metric":           "isQoeMetric",
-		"qoe_field":               "", // M3-only; not in M5 proto (derived from source_event_type)
-		"custom_sql":              "customSql",
+		"qoe_field":                  "", // M3-only; not in M5 proto (derived from source_event_type)
+		"custom_sql":                 "customSql",
+		"mlrate_feature_event_types": "mlrateConfig.featureEventTypes",
+		"mlrate_model_uri":           "mlrateConfig.modelUri",
+		"mlrate_lookback_days":       "mlrateConfig.lookbackDays",
 	}
 
 	m3Tags := extractJSONTags(reflect.TypeOf(config.MetricConfig{}))

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -47,6 +47,12 @@ type TemplateParams struct {
 	LongtailThreshold float64 // PERCENT_RANK threshold for longtail classification (e.g. 0.80)
 	ProviderField     string  // provider column name in content_catalog (default "provider_id")
 	GenreField        string  // genre column name in content_catalog (default "genre")
+	// MLRATE cross-fitting fields (ADR-015 Phase 2)
+	MLRATEFolds             int      // K-fold count for cross-fitting
+	MLRATEFeatureEventTypes []string // pre-experiment event types used as LightGBM features
+	MLRATELookbackDays      int      // days of pre-experiment data for feature computation
+	MLRATEModelURI          string   // MLflow model URI prefix; fold models at {uri}/fold_{k}
+	MLRATEFoldID            int      // current fold ID for per-fold prediction (1-indexed)
 }
 
 type SQLRenderer struct {
@@ -101,6 +107,18 @@ func (r *SQLRenderer) RenderUserGenreEntropy(p TemplateParams) (string, error)  
 func (r *SQLRenderer) RenderUserDiscoveryRate(p TemplateParams) (string, error)     { return r.Render("user_discovery_rate.sql.tmpl", p) }
 func (r *SQLRenderer) RenderUserProviderDiversity(p TemplateParams) (string, error) { return r.Render("user_provider_diversity.sql.tmpl", p) }
 func (r *SQLRenderer) RenderIntraListDistance(p TemplateParams) (string, error)     { return r.Render("intra_list_distance.sql.tmpl", p) }
+
+// MLRATE cross-fitting (ADR-015 Phase 2).
+// Step 1: Feature preparation with fold assignment — results go to delta.mlrate_features.
+func (r *SQLRenderer) RenderMLRATEFeatures(p TemplateParams) (string, error) {
+	return r.Render("mlrate_features.sql.tmpl", p)
+}
+
+// Step 2: Per-fold cross-fitted prediction — results go to delta.metric_summaries.
+// Called K times (once per fold), each time with a different MLRATEFoldID.
+func (r *SQLRenderer) RenderMLRATECrossFitPredict(p TemplateParams) (string, error) {
+	return r.Render("mlrate_crossfit_predict.sql.tmpl", p)
+}
 
 // Feedback loop contamination (ADR-021).
 // Results go to delta.feedback_loop_contamination; consumed by M4a FeedbackLoopDetector.

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -357,6 +357,81 @@ func TestRenderQoEEngagementCorrelation_ContainsKeyFields(t *testing.T) {
 	assert.Contains(t, sql, "STDDEV_SAMP")
 }
 
+// ADR-015 Phase 2: MLRATE cross-fitting templates.
+
+func TestRenderMLRATEFeatures(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+	p := testParams
+	p.ExperimentStartDate = "2024-01-08"
+	p.MLRATEFolds = 5
+	p.MLRATEFeatureEventTypes = []string{"heartbeat", "stream_start"}
+	p.MLRATELookbackDays = 14
+	sql, err := r.RenderMLRATEFeatures(p)
+	require.NoError(t, err)
+	assert.Equal(t, readGolden(t, "mlrate_features_expected.sql"), sql)
+}
+
+func TestRenderMLRATEFeatures_ContainsKeyFields(t *testing.T) {
+	r, _ := NewSQLRenderer()
+	p := TemplateParams{
+		ExperimentID:            "test-exp-mlrate",
+		ComputationDate:         "2024-06-01",
+		ExperimentStartDate:     "2024-05-15",
+		MLRATEFolds:             3,
+		MLRATEFeatureEventTypes: []string{"heartbeat", "stream_start", "click"},
+		MLRATELookbackDays:      7,
+	}
+	sql, err := r.RenderMLRATEFeatures(p)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "delta.exposures")
+	assert.Contains(t, sql, "delta.metric_events")
+	assert.Contains(t, sql, "'heartbeat', 'stream_start', 'click'")
+	assert.Contains(t, sql, "DATE_SUB")
+	assert.Contains(t, sql, "2024-05-15")
+	assert.Contains(t, sql, "% 3 + 1")
+	assert.Contains(t, sql, "fold_id")
+	assert.Contains(t, sql, "feature_heartbeat")
+	assert.Contains(t, sql, "feature_stream_start")
+	assert.Contains(t, sql, "feature_click")
+}
+
+func TestRenderMLRATECrossFitPredict(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+	p := testParams
+	p.MetricID = "watch_time_minutes"
+	p.MLRATEFolds = 5
+	p.MLRATEFeatureEventTypes = []string{"heartbeat", "stream_start"}
+	p.MLRATEModelURI = "models:/mlrate-watch-time"
+	p.MLRATEFoldID = 2
+	sql, err := r.RenderMLRATECrossFitPredict(p)
+	require.NoError(t, err)
+	assert.Equal(t, readGolden(t, "mlrate_crossfit_predict_expected.sql"), sql)
+}
+
+func TestRenderMLRATECrossFitPredict_ContainsKeyFields(t *testing.T) {
+	r, _ := NewSQLRenderer()
+	p := TemplateParams{
+		ExperimentID:            "test-exp-mlrate",
+		MetricID:                "ctr_recommendation",
+		ComputationDate:         "2024-06-01",
+		MLRATEFolds:             5,
+		MLRATEFeatureEventTypes: []string{"impression", "click"},
+		MLRATEModelURI:          "models:/mlrate-ctr",
+		MLRATEFoldID:            3,
+	}
+	sql, err := r.RenderMLRATECrossFitPredict(p)
+	require.NoError(t, err)
+	assert.Contains(t, sql, "delta.mlrate_features")
+	assert.Contains(t, sql, "ai_predict")
+	assert.Contains(t, sql, "models:/mlrate-ctr/fold_3")
+	assert.Contains(t, sql, "NAMED_STRUCT")
+	assert.Contains(t, sql, "mlrate_covariate")
+	assert.Contains(t, sql, "fold_id = 3")
+	assert.Contains(t, sql, "'ctr_recommendation' AS metric_id")
+}
+
 // ADR-021: Feedback loop contamination template.
 
 func TestRenderFeedbackLoopContamination(t *testing.T) {

--- a/services/metrics/internal/spark/templates/mlrate_crossfit_predict.sql.tmpl
+++ b/services/metrics/internal/spark/templates/mlrate_crossfit_predict.sql.tmpl
@@ -1,0 +1,20 @@
+WITH fold_data AS (
+    SELECT user_id, variant_id,
+        {{range $i, $et := .MLRATEFeatureEventTypes}}feature_{{$et}},
+        {{end}}fold_id
+    FROM delta.mlrate_features
+    WHERE experiment_id = '{{.ExperimentID}}'
+      AND computation_date = CAST('{{.ComputationDate}}' AS DATE)
+      AND fold_id = {{.MLRATEFoldID}}
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    fd.user_id,
+    fd.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    ai_predict(
+        '{{.MLRATEModelURI}}/fold_{{.MLRATEFoldID}}',
+        NAMED_STRUCT({{range $i, $et := .MLRATEFeatureEventTypes}}{{if $i}}, {{end}}'{{$et}}', fd.feature_{{$et}}{{end}})
+    ) AS mlrate_covariate,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM fold_data fd

--- a/services/metrics/internal/spark/templates/mlrate_features.sql.tmpl
+++ b/services/metrics/internal/spark/templates/mlrate_features.sql.tmpl
@@ -1,0 +1,31 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+),
+pre_experiment_events AS (
+    SELECT me.user_id, me.event_type, AVG(me.value) AS avg_value
+    FROM delta.metric_events me
+    WHERE me.event_type IN ({{range $i, $et := .MLRATEFeatureEventTypes}}{{if $i}}, {{end}}'{{$et}}'{{end}})
+      AND me.event_date >= DATE_SUB(CAST('{{.ExperimentStartDate}}' AS DATE), {{.MLRATELookbackDays}})
+      AND me.event_date < CAST('{{.ExperimentStartDate}}' AS DATE)
+    GROUP BY me.user_id, me.event_type
+),
+user_features AS (
+    SELECT
+        eu.user_id,
+        eu.variant_id,
+        {{range $i, $et := .MLRATEFeatureEventTypes}}COALESCE(MAX(CASE WHEN pee.event_type = '{{$et}}' THEN pee.avg_value END), 0.0) AS feature_{{$et}},
+        {{end}}CAST(ABS(HASH(eu.user_id)) % {{.MLRATEFolds}} + 1 AS INT) AS fold_id
+    FROM exposed_users eu
+    LEFT JOIN pre_experiment_events pee ON eu.user_id = pee.user_id
+    GROUP BY eu.user_id, eu.variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    uf.user_id,
+    uf.variant_id,
+    {{range $i, $et := .MLRATEFeatureEventTypes}}uf.feature_{{$et}},
+    {{end}}uf.fold_id,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date
+FROM user_features uf

--- a/services/metrics/testdata/golden/mlrate_crossfit_predict_expected.sql
+++ b/services/metrics/testdata/golden/mlrate_crossfit_predict_expected.sql
@@ -1,0 +1,21 @@
+WITH fold_data AS (
+    SELECT user_id, variant_id,
+        feature_heartbeat,
+        feature_stream_start,
+        fold_id
+    FROM delta.mlrate_features
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND fold_id = 2
+)
+SELECT
+    'exp-001' AS experiment_id,
+    fd.user_id,
+    fd.variant_id,
+    'watch_time_minutes' AS metric_id,
+    ai_predict(
+        'models:/mlrate-watch-time/fold_2',
+        NAMED_STRUCT('heartbeat', fd.feature_heartbeat, 'stream_start', fd.feature_stream_start)
+    ) AS mlrate_covariate,
+    CAST('2024-01-15' AS DATE) AS computation_date
+FROM fold_data fd

--- a/services/metrics/testdata/golden/mlrate_features_expected.sql
+++ b/services/metrics/testdata/golden/mlrate_features_expected.sql
@@ -1,0 +1,33 @@
+WITH exposed_users AS (
+    SELECT DISTINCT user_id, variant_id
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+),
+pre_experiment_events AS (
+    SELECT me.user_id, me.event_type, AVG(me.value) AS avg_value
+    FROM delta.metric_events me
+    WHERE me.event_type IN ('heartbeat', 'stream_start')
+      AND me.event_date >= DATE_SUB(CAST('2024-01-08' AS DATE), 14)
+      AND me.event_date < CAST('2024-01-08' AS DATE)
+    GROUP BY me.user_id, me.event_type
+),
+user_features AS (
+    SELECT
+        eu.user_id,
+        eu.variant_id,
+        COALESCE(MAX(CASE WHEN pee.event_type = 'heartbeat' THEN pee.avg_value END), 0.0) AS feature_heartbeat,
+        COALESCE(MAX(CASE WHEN pee.event_type = 'stream_start' THEN pee.avg_value END), 0.0) AS feature_stream_start,
+        CAST(ABS(HASH(eu.user_id)) % 5 + 1 AS INT) AS fold_id
+    FROM exposed_users eu
+    LEFT JOIN pre_experiment_events pee ON eu.user_id = pee.user_id
+    GROUP BY eu.user_id, eu.variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    uf.user_id,
+    uf.variant_id,
+    uf.feature_heartbeat,
+    uf.feature_stream_start,
+    uf.fold_id,
+    CAST('2024-01-15' AS DATE) AS computation_date
+FROM user_features uf


### PR DESCRIPTION
## Summary
- Implement LightGBM K-fold cross-fitted prediction pipeline in M3 for AVLM Phase 2 covariate generation
- Two-phase SQL pipeline: feature prep with deterministic fold assignment → per-fold `ai_predict()` predictions
- Cross-fitted predictions stored in `delta.metric_summaries` as `mlrate_covariate` column for M4a consumption
- Integrated into `StandardJob.Run()` — triggers when experiment has `mlrate_enabled` and metric has MLRATE config

## New Files
| File | Purpose |
|------|---------|
| `jobs/mlrate.go` | `MLRATEJob` orchestrator: 1 feature prep + K prediction queries |
| `spark/templates/mlrate_features.sql.tmpl` | Pre-experiment feature aggregation + `HASH(user_id) % K` fold assignment |
| `spark/templates/mlrate_crossfit_predict.sql.tmpl` | Per-fold prediction via `ai_predict()` with MLflow models |

## Config Extensions
- `ExperimentConfig`: `mlrate_enabled`, `mlrate_folds` (default 5)
- `MetricConfig`: `mlrate_feature_event_types`, `mlrate_model_uri`, `mlrate_lookback_days` (default 14)

## Design Decisions
- **Deterministic fold assignment**: `HASH(user_id) % K` ensures reproducibility across reruns
- **Two-phase pipeline**: Feature prep runs once → stored in `delta.mlrate_features`; predictions run K times → stored in `delta.metric_summaries`. Avoids recomputing features K times.
- **Fail-fast validation**: Missing config fields (feature event types, model URI, start date) produce clear errors

## Future Opportunities (not in scope)
- Proto schema update for `MLRATEConfig` message in `metric.proto` (M5 wire format mapping added as placeholder)
- M4a `avlm.rs` integration to consume `mlrate_covariate` as the `x` parameter
- Model training pipeline (Databricks job / MLflow integration for fold model registration)

## Test Plan
- [x] `TestMLRATEJob_Run` — full 3-fold pipeline (1 feature + 3 crossfit = 4 queries)
- [x] `TestMLRATEJob_Run_DefaultFolds` — defaults to 5 folds when unset
- [x] `TestMLRATEJob_Run_DefaultLookbackDays` — defaults to 14 days when unset
- [x] `TestMLRATEJob_Run_MissingFeatureEventTypes` — error on missing config
- [x] `TestMLRATEJob_Run_MissingModelURI` — error on missing config
- [x] `TestMLRATEJob_Run_MissingStartDate` — error on missing config
- [x] `TestMLRATEJob_Run_FoldPredictionsSQLContent` — verifies per-fold SQL references correct model
- [x] `TestStandardJob_Run_MLRATECrossFitting` — end-to-end integration via StandardJob
- [x] `TestRenderMLRATEFeatures` — golden file validation
- [x] `TestRenderMLRATECrossFitPredict` — golden file validation
- [x] All existing M3 tests pass (42 → 49 query budget updated for new experiment)

Closes #313
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
