### PR TITLE
🎨 Palette: Add CopyButton to Metric identifiers in Metric Browser

### DIFF
--- a/ui/src/__tests__/metric-browser.test.tsx
+++ b/ui/src/__tests__/metric-browser.test.tsx
@@ -2,8 +2,9 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/__mocks__/server';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import MetricBrowserPage from '@/app/metrics/page';
+import { ToastProvider } from '@/lib/toast-context';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
 
@@ -23,7 +24,11 @@ vi.mock('next/link', () => ({
 }));
 
 async function renderAndWait() {
-  render(<MetricBrowserPage />);
+  render(
+    <ToastProvider>
+      <MetricBrowserPage />
+    </ToastProvider>
+  );
   await waitFor(() => {
     expect(screen.getByText('Stream Start Rate')).toBeInTheDocument();
   });
@@ -51,7 +56,11 @@ describe('Metric Browser Page', () => {
   });
 
   it('shows loading spinner initially', () => {
-    render(<MetricBrowserPage />);
+    render(
+      <ToastProvider>
+        <MetricBrowserPage />
+      </ToastProvider>
+    );
     expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
 
@@ -62,7 +71,11 @@ describe('Metric Browser Page', () => {
       }),
     );
 
-    render(<MetricBrowserPage />);
+    render(
+      <ToastProvider>
+        <MetricBrowserPage />
+      </ToastProvider>
+    );
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
     });
@@ -84,7 +97,11 @@ describe('Metric Browser Page', () => {
       }),
     );
 
-    render(<MetricBrowserPage />);
+    render(
+      <ToastProvider>
+        <MetricBrowserPage />
+      </ToastProvider>
+    );
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
     });

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import type { MetricDefinition, MetricType } from '@/lib/types';
 import { listMetricDefinitions } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
+import { CopyButton } from '@/components/copy-button';
 
 const SqlHighlighter = dynamic(
   () => import('@/components/sql-highlighter').then((m) => ({ default: m.SqlHighlighter })),
@@ -41,7 +42,15 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
           <span className="font-medium text-gray-900">{metric.name}</span>
         </td>
         <td className="px-4 py-3">
-          <code className="text-xs text-gray-500">{metric.metricId}</code>
+          <div className="flex items-center gap-2">
+            <code className="text-xs text-gray-500">{metric.metricId}</code>
+            <CopyButton
+              value={metric.metricId}
+              label="Copy metric ID"
+              successMessage="Metric ID copied"
+              className="h-4 w-4"
+            />
+          </div>
         </td>
         <td className="px-4 py-3">
           <span
@@ -120,13 +129,29 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
               {metric.cupedCovariateMetricId && (
                 <div>
                   <dt className="font-medium text-gray-500">CUPED Covariate</dt>
-                  <dd className="text-gray-900"><code className="text-xs">{metric.cupedCovariateMetricId}</code></dd>
+                  <dd className="mt-1 flex items-center gap-2 text-gray-900">
+                    <code className="text-xs">{metric.cupedCovariateMetricId}</code>
+                    <CopyButton
+                      value={metric.cupedCovariateMetricId}
+                      label="Copy CUPED covariate ID"
+                      successMessage="CUPED covariate ID copied"
+                      className="h-4 w-4"
+                    />
+                  </dd>
                 </div>
               )}
               {metric.surrogateTargetMetricId && (
                 <div>
                   <dt className="font-medium text-gray-500">Surrogate Target</dt>
-                  <dd className="text-gray-900"><code className="text-xs">{metric.surrogateTargetMetricId}</code></dd>
+                  <dd className="mt-1 flex items-center gap-2 text-gray-900">
+                    <code className="text-xs">{metric.surrogateTargetMetricId}</code>
+                    <CopyButton
+                      value={metric.surrogateTargetMetricId}
+                      label="Copy surrogate target ID"
+                      successMessage="Surrogate target ID copied"
+                      className="h-4 w-4"
+                    />
+                  </dd>
                 </div>
               )}
             </dl>


### PR DESCRIPTION
Added copy-to-clipboard functionality for metric identifiers in the Metric Browser. This includes:
- Main Metric ID in the table row.
- CUPED Covariate ID in the expanded details.
- Surrogate Target ID in the expanded details.

Verified with:
- `pnpm lint` and `pnpm type-check`
- `pnpm test src/__tests__/metric-browser.test.tsx` (all 10 passed)
- Playwright visual verification script (screenshots and video recorded)
- Manual code review (rating: #Correct#)

---
*PR created automatically by Jules for task [8153490747878527954](https://jules.google.com/task/8153490747878527954) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
