### PR TITLE
feat(streaming): Kafka topic provisioning module

### DIFF
--- a/infra/pkg/streaming/topics.go
+++ b/infra/pkg/streaming/topics.go
@@ -1,0 +1,127 @@
+// Package streaming provides Pulumi modules for Kafka topic provisioning
+// on Amazon MSK. Topics match the canonical definitions in kafka/topic_configs.sh.
+package streaming
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pulumi/pulumi-kafka/sdk/v3/go/kafka"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// topicSpec defines the per-topic configuration derived from kafka/topic_configs.sh.
+type topicSpec struct {
+	Name            string
+	Partitions      int
+	RetentionMs     int64 // retention.ms in milliseconds
+	SegmentBytes    int   // segment.bytes
+	MaxMessageBytes int   // max.message.bytes
+}
+
+// Common settings applied to every topic (task requirement + topic_configs.sh).
+const (
+	replicationFactor = 3
+	minInsyncReplicas = 2
+	cleanupPolicy     = "delete"
+	compressionType   = "lz4"
+)
+
+// Retention constants in milliseconds.
+const (
+	retention30d  int64 = 2_592_000_000  // 30 days
+	retention90d  int64 = 7_776_000_000  // 90 days
+	retention180d int64 = 15_552_000_000 // 180 days
+)
+
+// Segment size constants in bytes.
+const (
+	segment1GB   = 1_073_741_824 // 1 GB
+	segment512MB = 536_870_912   // 512 MB
+	segment256MB = 268_435_456   // 256 MB
+)
+
+// maxMessageBytes is 1 MB, consistent across all topics.
+const maxMessageBytes = 1_048_576
+
+// topics defines the 8 experimentation platform Kafka topics.
+// Each entry matches kafka/topic_configs.sh exactly.
+var topics = []topicSpec{
+	// High-volume event topics (M2 → M3/M4a)
+	{Name: "exposures", Partitions: 64, RetentionMs: retention90d, SegmentBytes: segment1GB, MaxMessageBytes: maxMessageBytes},
+	{Name: "metric_events", Partitions: 128, RetentionMs: retention90d, SegmentBytes: segment1GB, MaxMessageBytes: maxMessageBytes},
+	{Name: "reward_events", Partitions: 32, RetentionMs: retention180d, SegmentBytes: segment512MB, MaxMessageBytes: maxMessageBytes},
+	{Name: "qoe_events", Partitions: 64, RetentionMs: retention90d, SegmentBytes: segment1GB, MaxMessageBytes: maxMessageBytes},
+
+	// Alert topics (low-volume, low-latency)
+	{Name: "guardrail_alerts", Partitions: 8, RetentionMs: retention30d, SegmentBytes: segment256MB, MaxMessageBytes: maxMessageBytes},
+	{Name: "sequential_boundary_alerts", Partitions: 8, RetentionMs: retention30d, SegmentBytes: segment256MB, MaxMessageBytes: maxMessageBytes},
+
+	// Operational topics
+	{Name: "model_retraining_events", Partitions: 8, RetentionMs: retention180d, SegmentBytes: segment256MB, MaxMessageBytes: maxMessageBytes},
+	{Name: "surrogate_recalibration_requests", Partitions: 4, RetentionMs: retention30d, SegmentBytes: segment256MB, MaxMessageBytes: maxMessageBytes},
+}
+
+// TopicsArgs holds the inputs for Kafka topic provisioning.
+type TopicsArgs struct {
+	// BootstrapBrokers is the comma-separated MSK bootstrap broker string.
+	// Wired from MskOutputs.BootstrapBrokers in Sprint I.1.
+	BootstrapBrokers pulumi.StringInput
+}
+
+// TopicsOutputs holds references to all created Kafka topic resources.
+type TopicsOutputs struct {
+	// Topics maps topic name to its Pulumi resource for downstream references.
+	Topics map[string]*kafka.Topic
+}
+
+// NewTopics provisions the 8 experimentation platform Kafka topics against
+// the MSK cluster identified by the bootstrap brokers in args.
+//
+// Each topic's partition count, retention, segment size, and message size
+// exactly match kafka/topic_configs.sh. All topics share replication factor 3,
+// min.insync.replicas 2, cleanup.policy delete, and compression.type lz4.
+//
+// The Kafka provider is created internally so that topic resources depend on
+// the MSK cluster being available. In Sprint I.0 this module is code-only;
+// it will be wired to MSK outputs in Sprint I.1.
+func NewTopics(ctx *pulumi.Context, args *TopicsArgs) (*TopicsOutputs, error) {
+	// Create a Kafka provider that targets the MSK cluster.
+	// MSK bootstrap brokers come as "b-1:9098,b-2:9098,b-3:9098".
+	provider, err := kafka.NewProvider(ctx, "kaizen-kafka", &kafka.ProviderArgs{
+		BootstrapServers: args.BootstrapBrokers.ToStringOutput().ApplyT(func(brokers string) []string {
+			return strings.Split(brokers, ",")
+		}).(pulumi.StringArrayOutput),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating Kafka provider: %w", err)
+	}
+
+	outputs := &TopicsOutputs{
+		Topics: make(map[string]*kafka.Topic, len(topics)),
+	}
+
+	for _, spec := range topics {
+		topic, err := kafka.NewTopic(ctx, spec.Name, &kafka.TopicArgs{
+			Name:              pulumi.String(spec.Name),
+			Partitions:        pulumi.Int(spec.Partitions),
+			ReplicationFactor: pulumi.Int(replicationFactor),
+			Config: pulumi.StringMap{
+				"retention.ms":        pulumi.String(strconv.FormatInt(spec.RetentionMs, 10)),
+				"cleanup.policy":      pulumi.String(cleanupPolicy),
+				"compression.type":    pulumi.String(compressionType),
+				"segment.bytes":       pulumi.String(strconv.Itoa(spec.SegmentBytes)),
+				"max.message.bytes":   pulumi.String(strconv.Itoa(spec.MaxMessageBytes)),
+				"min.insync.replicas": pulumi.String(strconv.Itoa(minInsyncReplicas)),
+			},
+		}, pulumi.Provider(provider))
+		if err != nil {
+			return nil, fmt.Errorf("creating topic %q: %w", spec.Name, err)
+		}
+
+		outputs.Topics[spec.Name] = topic
+	}
+
+	return outputs, nil
+}


### PR DESCRIPTION
## Summary

- Implements `infra/pkg/streaming/topics.go` — Pulumi Kafka provider module provisioning all 8 experimentation platform Kafka topics
- Every topic config (partitions, retention, segment size, max message bytes) verified against `kafka/topic_configs.sh` line-by-line
- Common settings: replication factor 3, min.insync.replicas 2, cleanup.policy delete, compression.type lz4

### Topic Matrix

| Topic | Partitions | Retention | Segment |
|-------|-----------|-----------|---------|
| `exposures` | 64 | 90d | 1 GB |
| `metric_events` | 128 | 90d | 1 GB |
| `reward_events` | 32 | 180d | 512 MB |
| `qoe_events` | 64 | 90d | 1 GB |
| `guardrail_alerts` | 8 | 30d | 256 MB |
| `sequential_boundary_alerts` | 8 | 30d | 256 MB |
| `model_retraining_events` | 8 | 180d | 256 MB |
| `surrogate_recalibration_requests` | 4 | 30d | 256 MB |

### Design Notes

- `NewTopics()` accepts `TopicsArgs{BootstrapBrokers}` — wired to `MskOutputs.BootstrapBrokers` in Sprint I.1
- Creates an internal `kafka.Provider` targeting MSK, all topics created with `pulumi.Provider(provider)` dependency
- No `go.mod` — Infra-2 creates the project scaffold in I.0.1; this module integrates after that merges
- `experiment_lifecycle` topic (in `topic_configs.sh`) is out of scope for this task — it may be provisioned separately by M5's agent

### Opportunities (not implemented)

- `experiment_lifecycle` topic could be added here or in a separate M5-owned module
- Topic ACLs for consumer groups listed in `topic_configs.sh` comments (e.g., `bandit-policy-service`)
- Schema Registry subject compatibility mode configuration per topic

Closes #347

## Test plan

- [ ] Verify `go build ./...` compiles after Infra-2 merges I.0.1 (project scaffold with go.mod)
- [ ] Cross-reference each topic's config values against `kafka/topic_configs.sh`
- [ ] Pulumi preview with mock MSK bootstrap brokers in Sprint I.1
- [ ] Integration test in Sprint I.2 (I.2.4: topic health check post-deploy)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
