### PR TITLE
🎨 Palette: Polish Metric Browser UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,6 +25,14 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 **Learning:** Providing technical identifiers in a `<code>` block with an adjacent `CopyButton` in a "Review" or "Summary" step significantly reduces the cognitive load for users who need to verify or cross-reference these IDs before final submission. Using `text-xs` for these inline code blocks maintains legibility without breaking the layout of dense description lists.
 **Action:** Always include copy-to-clipboard utilities for primary technical IDs in summary views. Use `flex items-center gap-2` to align the code block and the copy button.
 
+## 2026-05-20 - Keyboard Accessibility for Expandable Rows
+**Learning:** Making table rows clickable for expansion is a common UX pattern, but it's completely inaccessible to keyboard users unless explicitly handled. Adding `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler for 'Enter' and 'Space' keys is critical for a11y.
+**Action:** When making non-interactive elements (like table rows) interactive, always provide standard keyboard triggers and appropriate ARIA roles/attributes.
+
+## 2026-05-20 - Consistent Search UI Pattern
+**Learning:** Consistency in repetitive UI elements like search bars builds user trust and makes the interface feel predictable. Using a relative container with an absolute-positioned icon (with `pointer-events-none`) and `pl-9` padding on the input is the established pattern in this app.
+**Action:** Always wrap search inputs in a relative container with a magnifying glass SVG to maintain visual consistency with other filtered lists.
+
 ## 2026-04-12 - Expandable Audit Log for Technical IDs
 **Learning:** Even if an audit entry doesn't have "changed values", users still benefit from row expansion to access the Experiment ID and other metadata without leaving the page.
 **Action:** Design tables such that all rows are interactive/expandable if they contain hidden technical identifiers that are useful for developer workflows.

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -31,15 +31,38 @@ const ALL_METRIC_TYPES: MetricType[] = ['MEAN', 'PROPORTION', 'RATIO', 'COUNT', 
 function MetricRow({ metric }: { metric: MetricDefinition }) {
   const [expanded, setExpanded] = useState(false);
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setExpanded(!expanded);
+    }
+  };
+
   return (
     <>
       <tr
-        className="cursor-pointer hover:bg-gray-50"
+        className="cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
         onClick={() => setExpanded(!expanded)}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+        role="button"
+        aria-expanded={expanded}
+        aria-label={`Toggle details for ${metric.name}`}
         data-testid={`metric-row-${metric.metricId}`}
       >
         <td className="px-4 py-3">
-          <span className="font-medium text-gray-900">{metric.name}</span>
+          <div className="flex items-center gap-2">
+            <svg
+              className={`h-4 w-4 text-gray-400 transition-transform ${expanded ? 'rotate-90' : ''}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            <span className="font-medium text-gray-900">{metric.name}</span>
+          </div>
         </td>
         <td className="px-4 py-3">
           <div className="flex items-center gap-2">
@@ -234,15 +257,26 @@ function MetricBrowserContent() {
       </div>
 
       <div className="mb-4 flex flex-wrap items-center gap-3">
-        <input
-          type="text"
-          placeholder="Search by name, ID, or description..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-          data-testid="metric-search"
-          aria-label="Search metrics"
-        />
+        <div className="relative flex-1 min-w-[300px] max-w-md">
+          <svg
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search by name, ID, or description..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            data-testid="metric-search"
+            aria-label="Search metrics"
+          />
+        </div>
         <select
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value as MetricType | '')}


### PR DESCRIPTION
Implemented a micro-UX polish pass on the Metric Browser page. 

Key enhancements:
1. **Accessibility**: Metric rows are now fully navigable and interactive via keyboard (Enter/Space to toggle) with appropriate ARIA roles and states.
2. **Visual Affordance**: Added a rotating chevron icon to metric rows to clearly signal that they are expandable.
3. **Consistency**: Added a magnifying glass icon to the metric search bar to match the design pattern used elsewhere in the platform.

Verified via Playwright and passed lint/build checks.

---
*PR created automatically by Jules for task [284020336170344845](https://jules.google.com/task/284020336170344845) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
