### PR TITLE
🎨 Palette: Improve accessibility of expandable audit log rows

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-04-12 - Expandable Audit Log for Technical IDs
 **Learning:** Even if an audit entry doesn't have "changed values", users still benefit from row expansion to access the Experiment ID and other metadata without leaving the page.
 **Action:** Design tables such that all rows are interactive/expandable if they contain hidden technical identifiers that are useful for developer workflows.
+
+## 2026-04-15 - Keyboard Accessibility for Expandable Rows
+**Learning:** Interactive table rows that toggle visibility of details must be explicitly marked as buttons and support keyboard navigation. Without `role="button"` and `onKeyDown` handlers for Enter/Space, these features remain "mouse-only" and inaccessible to screen reader or keyboard-only users.
+**Action:** Always add `role="button"`, `tabIndex={0}`, `aria-expanded`, and keyboard handlers to custom interactive containers that lack native button semantics. Use `focus-within` with a ring to provide clear focus indicators.

--- a/ui/src/__tests__/audit-log-a11y.test.tsx
+++ b/ui/src/__tests__/audit-log-a11y.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import AuditLogPage from '@/app/audit/page';
+import { ToastProvider } from '@/lib/toast-context';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock next/link to render an anchor tag
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+async function renderAndWait() {
+  render(
+    <ToastProvider>
+      <AuditLogPage />
+    </ToastProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: 'Audit Log' })).toBeInTheDocument();
+  });
+}
+
+describe('Audit Log Accessibility', () => {
+  it('toggles row expansion with Enter key', async () => {
+    const user = userEvent.setup();
+    await renderAndWait();
+
+    const row = screen.getByTestId('audit-row-audit-001');
+    expect(row).toHaveAttribute('role', 'button');
+    expect(row).toHaveAttribute('tabIndex', '0');
+    expect(row).toHaveAttribute('aria-expanded', 'false');
+
+    // Focus row and press Enter
+    await row.focus();
+    await user.keyboard('{Enter}');
+
+    expect(row).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('audit-detail-audit-001')).toBeInTheDocument();
+
+    // Press Enter again to collapse
+    await user.keyboard('{Enter}');
+    expect(row).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('audit-detail-audit-001')).not.toBeInTheDocument();
+  });
+
+  it('toggles row expansion with Space key', async () => {
+    const user = userEvent.setup();
+    await renderAndWait();
+
+    const row = screen.getByTestId('audit-row-audit-002');
+
+    // Focus row and press Space
+    await row.focus();
+    await user.keyboard(' ');
+
+    expect(row).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('audit-detail-audit-002')).toBeInTheDocument();
+
+    // Press Space again to collapse
+    await user.keyboard(' ');
+    expect(row).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('audit-detail-audit-002')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/audit-log-table.tsx
+++ b/ui/src/components/audit-log-table.tsx
@@ -58,8 +58,17 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
             return (
               <tr
                 key={entry.entryId}
-                className="cursor-pointer hover:bg-gray-50"
+                className="cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
                 onClick={() => toggleExpand(entry.entryId)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleExpand(entry.entryId);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+                aria-expanded={isExpanded}
                 data-testid={`audit-row-${entry.entryId}`}
               >
                 <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap align-top">


### PR DESCRIPTION
I have improved the accessibility of the expandable rows in the Audit Log table. Previously, these rows were only interactive via mouse clicks, making them inaccessible to keyboard and screen reader users.

Key changes:
- Added `role="button"` and `tabIndex={0}` to the `<tr>` elements in `AuditLogTable`.
- Implemented `onKeyDown` handlers to allow expanding/collapsing rows using the 'Enter' and 'Space' keys.
- Added `aria-expanded` state to communicate the visibility of details to assistive technologies.
- Enhanced the visual focus state using `focus-within:ring-indigo-500`, ensuring the entire row is highlighted when focused.
- Added a new test suite `ui/src/__tests__/audit-log-a11y.test.tsx` to verify these accessibility features.
- Updated Palette's journal with learnings regarding keyboard accessibility for custom interactive components.

These changes ensure that all users, regardless of how they navigate the web, can access the detailed technical information contained within the audit log.

---
*PR created automatically by Jules for task [10602137224168873021](https://jules.google.com/task/10602137224168873021) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
