### PR TITLE
feat(infra): ALB target groups + listener rules (I.1.8)

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -160,6 +160,21 @@ func main() {
 		ctx.Export("albDnsName", albOutputs.AlbDnsName)
 		ctx.Export("albArn", albOutputs.AlbArn)
 
+		// ── 10a. ALB Target Groups + Listener Rules ────────────────────────
+		tgOutputs, err := loadbalancer.NewTargetGroups(ctx, &loadbalancer.TargetGroupInputs{
+			VpcId:            vpcOutputs.VpcId,
+			HttpsListenerArn: albOutputs.HttpsListenerArn,
+			Domain:           cfg.Domain,
+			Environment:      env,
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("m1AssignmentTgArn", tgOutputs.M1AssignmentTgArn)
+		ctx.Export("m5ManagementTgArn", tgOutputs.M5ManagementTgArn)
+		ctx.Export("m6UITgArn", tgOutputs.M6UITgArn)
+		ctx.Export("m7FlagsTgArn", tgOutputs.M7FlagsTgArn)
+
 		// ── 11. ECR Repositories ────────────────────────────────────────────
 		ecrOutputs, err := cicd.NewECRRepositories(ctx, env)
 		if err != nil {
@@ -171,7 +186,6 @@ func main() {
 		}
 
 		// Suppress unused variable warnings.
-		_ = albOutputs
 		_ = redisOutputs
 		_ = secretsOutputs
 

--- a/infra/pkg/loadbalancer/alb.go
+++ b/infra/pkg/loadbalancer/alb.go
@@ -1,7 +1,7 @@
 // Package loadbalancer provisions the internet-facing Application Load Balancer
 // for the Kaizen experimentation platform.
 //
-// Sprint I.0: ALB + listeners (code only). Target groups wired in I.1.18.
+// Sprint I.0: ALB + listeners. Target groups + listener rules in target_groups.go (I.1.8).
 package loadbalancer
 
 import (

--- a/infra/pkg/loadbalancer/target_groups.go
+++ b/infra/pkg/loadbalancer/target_groups.go
@@ -1,0 +1,251 @@
+// Package loadbalancer — target_groups.go provisions ALB target groups
+// and path-based / host-based listener rules for public-facing services.
+//
+// Sprint I.1 task I.1.8 — depends on I.0.13 (ALB) and I.1.5 (ECS services).
+//
+// Routing topology:
+//
+//	assign.kaizen.{domain}  →  M1 Assignment   (gRPC, port 50051)
+//	/api/*                  →  M5 Management   (HTTP/2, port 50055)
+//	/flags/*                →  M7 Flags        (gRPC, port 50057)
+//	/* (default)            →  M6 UI           (HTTP, port 3000)
+package loadbalancer
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/lb"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// TargetGroupInputs are the cross-module dependencies for target groups.
+type TargetGroupInputs struct {
+	// VpcId is required by ALB target groups for IP-mode registration.
+	VpcId pulumi.StringInput
+	// HttpsListenerArn from ALBOutputs — listener rules attach here.
+	HttpsListenerArn pulumi.StringOutput
+	// Domain is the base domain (e.g., "example.com"). M1 uses
+	// assign.kaizen.{domain} for host-based routing.
+	Domain string
+	// Environment name used for resource naming and tagging.
+	Environment string
+}
+
+// TargetGroupOutputs are exported for ECS service registration and monitoring.
+type TargetGroupOutputs struct {
+	// M1AssignmentTgArn — ECS service registers tasks here.
+	M1AssignmentTgArn pulumi.StringOutput
+	// M5ManagementTgArn — ECS service registers tasks here.
+	M5ManagementTgArn pulumi.StringOutput
+	// M6UITgArn — ECS service registers tasks here.
+	M6UITgArn pulumi.StringOutput
+	// M7FlagsTgArn — ECS service registers tasks here.
+	M7FlagsTgArn pulumi.StringOutput
+}
+
+// targetGroupSpec defines a service target group configuration.
+type targetGroupSpec struct {
+	name            string
+	port            int
+	protocolVersion string // "gRPC", "HTTP2", or "HTTP1"
+	healthCheckPath string
+	healthCheckMatcher string // gRPC codes for gRPC TGs, HTTP codes otherwise
+}
+
+// NewTargetGroups creates the 4 ALB target groups and listener rules
+// for public-facing Kaizen services.
+func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGroupOutputs, error) {
+	prefix := fmt.Sprintf("kaizen-%s", inputs.Environment)
+	tags := pulumi.StringMap{
+		"Project":     pulumi.String("kaizen-experimentation"),
+		"Environment": pulumi.String(inputs.Environment),
+		"ManagedBy":   pulumi.String("pulumi"),
+		"Module":      pulumi.String("loadbalancer"),
+	}
+
+	specs := []targetGroupSpec{
+		{
+			name:               "m1-assignment",
+			port:               50051,
+			protocolVersion:    "gRPC",
+			healthCheckPath:    "/grpc.health.v1.Health/Check",
+			healthCheckMatcher: "0",  // gRPC OK
+		},
+		{
+			name:               "m5-management",
+			port:               50055,
+			protocolVersion:    "HTTP2",
+			healthCheckPath:    "/healthz",
+			healthCheckMatcher: "200",
+		},
+		{
+			name:            "m6-ui",
+			port:            3000,
+			protocolVersion: "HTTP1",
+			healthCheckPath: "/",
+			healthCheckMatcher: "200",
+		},
+		{
+			name:               "m7-flags",
+			port:               50057,
+			protocolVersion:    "gRPC",
+			healthCheckPath:    "/grpc.health.v1.Health/Check",
+			healthCheckMatcher: "0",
+		},
+	}
+
+	tgArns := make(map[string]pulumi.StringOutput, len(specs))
+
+	for _, spec := range specs {
+		tg, err := newTargetGroup(ctx, prefix, spec, inputs.VpcId, tags)
+		if err != nil {
+			return nil, err
+		}
+		tgArns[spec.name] = tg.Arn
+	}
+
+	// --- Listener Rules ---
+	// Priority ordering: lower number = evaluated first.
+	//   10: host = assign.kaizen.{domain} → M1
+	//   20: path = /api/*                 → M5
+	//   30: path = /flags/*               → M7
+	//  100: path = /* (catch-all)         → M6
+
+	assignHost := fmt.Sprintf("assign.kaizen.%s", inputs.Domain)
+
+	rules := []struct {
+		name     string
+		priority int
+		target   string
+		conditions func() lb.ListenerRuleConditionArray
+	}{
+		{
+			name:     "m1-host",
+			priority: 10,
+			target:   "m1-assignment",
+			conditions: func() lb.ListenerRuleConditionArray {
+				return lb.ListenerRuleConditionArray{
+					&lb.ListenerRuleConditionArgs{
+						HostHeader: &lb.ListenerRuleConditionHostHeaderArgs{
+							Values: pulumi.StringArray{pulumi.String(assignHost)},
+						},
+					},
+				}
+			},
+		},
+		{
+			name:     "m5-api",
+			priority: 20,
+			target:   "m5-management",
+			conditions: func() lb.ListenerRuleConditionArray {
+				return lb.ListenerRuleConditionArray{
+					&lb.ListenerRuleConditionArgs{
+						PathPattern: &lb.ListenerRuleConditionPathPatternArgs{
+							Values: pulumi.StringArray{pulumi.String("/api/*")},
+						},
+					},
+				}
+			},
+		},
+		{
+			name:     "m7-flags",
+			priority: 30,
+			target:   "m7-flags",
+			conditions: func() lb.ListenerRuleConditionArray {
+				return lb.ListenerRuleConditionArray{
+					&lb.ListenerRuleConditionArgs{
+						PathPattern: &lb.ListenerRuleConditionPathPatternArgs{
+							Values: pulumi.StringArray{pulumi.String("/flags/*")},
+						},
+					},
+				}
+			},
+		},
+		{
+			name:     "m6-default",
+			priority: 100,
+			target:   "m6-ui",
+			conditions: func() lb.ListenerRuleConditionArray {
+				return lb.ListenerRuleConditionArray{
+					&lb.ListenerRuleConditionArgs{
+						PathPattern: &lb.ListenerRuleConditionPathPatternArgs{
+							Values: pulumi.StringArray{pulumi.String("/*")},
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for _, rule := range rules {
+		_, err := lb.NewListenerRule(ctx, fmt.Sprintf("%s-rule-%s", prefix, rule.name), &lb.ListenerRuleArgs{
+			ListenerArn: inputs.HttpsListenerArn,
+			Priority:    pulumi.Int(rule.priority),
+			Actions: lb.ListenerRuleActionArray{
+				&lb.ListenerRuleActionArgs{
+					Type:           pulumi.String("forward"),
+					TargetGroupArn: tgArns[rule.target],
+				},
+			},
+			Conditions: rule.conditions(),
+			Tags:       tags,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating listener rule %q: %w", rule.name, err)
+		}
+	}
+
+	return &TargetGroupOutputs{
+		M1AssignmentTgArn: tgArns["m1-assignment"],
+		M5ManagementTgArn: tgArns["m5-management"],
+		M6UITgArn:         tgArns["m6-ui"],
+		M7FlagsTgArn:      tgArns["m7-flags"],
+	}, nil
+}
+
+// newTargetGroup creates a single ALB target group with health check
+// configuration appropriate for its protocol version (gRPC, HTTP/2, or HTTP/1).
+func newTargetGroup(
+	ctx *pulumi.Context,
+	prefix string,
+	spec targetGroupSpec,
+	vpcId pulumi.StringInput,
+	tags pulumi.StringMap,
+) (*lb.TargetGroup, error) {
+	// ALB target groups for ECS Fargate use IP target type.
+	// Protocol is always "HTTP" — ProtocolVersion distinguishes gRPC/HTTP2/HTTP1.
+	// Health checks also use HTTP; the Matcher field differentiates gRPC codes
+	// (e.g., "0" for OK) from HTTP status codes (e.g., "200").
+	tg, err := lb.NewTargetGroup(ctx, fmt.Sprintf("%s-tg-%s", prefix, spec.name), &lb.TargetGroupArgs{
+		Name:            pulumi.Sprintf("%s-%s", prefix, spec.name),
+		Port:            pulumi.Int(spec.port),
+		Protocol:        pulumi.String("HTTP"),
+		ProtocolVersion: pulumi.String(spec.protocolVersion),
+		VpcId:           vpcId.ToStringOutput(),
+		TargetType:      pulumi.String("ip"),
+
+		// Deregistration delay: 30s gives in-flight requests time to drain
+		// without holding up deployments. Default 300s is too long for
+		// rolling ECS deployments.
+		DeregistrationDelay: pulumi.Int(30),
+
+		HealthCheck: &lb.TargetGroupHealthCheckArgs{
+			Enabled:            pulumi.Bool(true),
+			Protocol:           pulumi.String("HTTP"),
+			Path:               pulumi.String(spec.healthCheckPath),
+			Port:               pulumi.String("traffic-port"),
+			Interval:           pulumi.Int(15),
+			Timeout:            pulumi.Int(5),
+			HealthyThreshold:   pulumi.Int(2),
+			UnhealthyThreshold: pulumi.Int(3),
+			Matcher:            pulumi.String(spec.healthCheckMatcher),
+		},
+
+		Tags: tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating target group %q: %w", spec.name, err)
+	}
+
+	return tg, nil
+}

--- a/infra/pkg/loadbalancer/target_groups_test.go
+++ b/infra/pkg/loadbalancer/target_groups_test.go
@@ -1,0 +1,139 @@
+package loadbalancer
+
+import "testing"
+
+func TestTargetGroupSpecs(t *testing.T) {
+	// Verify the 4 target groups have the correct port, protocol, and health
+	// check configuration as specified in task I.1.8.
+	specs := []targetGroupSpec{
+		{
+			name:               "m1-assignment",
+			port:               50051,
+			protocolVersion:    "gRPC",
+			healthCheckPath:    "/grpc.health.v1.Health/Check",
+			healthCheckMatcher: "0",
+		},
+		{
+			name:               "m5-management",
+			port:               50055,
+			protocolVersion:    "HTTP2",
+			healthCheckPath:    "/healthz",
+			healthCheckMatcher: "200",
+		},
+		{
+			name:               "m6-ui",
+			port:               3000,
+			protocolVersion:    "HTTP1",
+			healthCheckPath:    "/",
+			healthCheckMatcher: "200",
+		},
+		{
+			name:               "m7-flags",
+			port:               50057,
+			protocolVersion:    "gRPC",
+			healthCheckPath:    "/grpc.health.v1.Health/Check",
+			healthCheckMatcher: "0",
+		},
+	}
+
+	if len(specs) != 4 {
+		t.Fatalf("expected 4 target group specs, got %d", len(specs))
+	}
+
+	// Verify gRPC services use gRPC protocol version and health check.
+	grpcServices := map[string]int{
+		"m1-assignment": 50051,
+		"m7-flags":      50057,
+	}
+	for _, s := range specs {
+		if expected, ok := grpcServices[s.name]; ok {
+			if s.protocolVersion != "gRPC" {
+				t.Errorf("%s: protocol version = %q, want gRPC", s.name, s.protocolVersion)
+			}
+			if s.port != expected {
+				t.Errorf("%s: port = %d, want %d", s.name, s.port, expected)
+			}
+			if s.healthCheckMatcher != "0" {
+				t.Errorf("%s: health check matcher = %q, want gRPC OK (0)", s.name, s.healthCheckMatcher)
+			}
+		}
+	}
+
+	// Verify M5 Management uses HTTP/2.
+	for _, s := range specs {
+		if s.name == "m5-management" {
+			if s.protocolVersion != "HTTP2" {
+				t.Errorf("m5-management: protocol = %q, want HTTP2", s.protocolVersion)
+			}
+			if s.healthCheckPath != "/healthz" {
+				t.Errorf("m5-management: health path = %q, want /healthz", s.healthCheckPath)
+			}
+		}
+	}
+
+	// Verify M6 UI uses HTTP/1.
+	for _, s := range specs {
+		if s.name == "m6-ui" {
+			if s.protocolVersion != "HTTP1" {
+				t.Errorf("m6-ui: protocol = %q, want HTTP1", s.protocolVersion)
+			}
+			if s.port != 3000 {
+				t.Errorf("m6-ui: port = %d, want 3000", s.port)
+			}
+		}
+	}
+}
+
+func TestListenerRulePriorities(t *testing.T) {
+	// Verify listener rule priority ordering:
+	//   10: M1 (host-based, assign.kaizen.{domain})
+	//   20: M5 (/api/*)
+	//   30: M7 (/flags/*)
+	//  100: M6 (catch-all /*)
+	type rule struct {
+		name     string
+		priority int
+		pattern  string
+	}
+
+	rules := []rule{
+		{name: "m1-host", priority: 10, pattern: "assign.kaizen.{domain}"},
+		{name: "m5-api", priority: 20, pattern: "/api/*"},
+		{name: "m7-flags", priority: 30, pattern: "/flags/*"},
+		{name: "m6-default", priority: 100, pattern: "/*"},
+	}
+
+	// Priorities must be unique and in ascending order.
+	seen := make(map[int]string)
+	prevPriority := 0
+	for _, r := range rules {
+		if prev, exists := seen[r.priority]; exists {
+			t.Errorf("duplicate priority %d: %s and %s", r.priority, prev, r.name)
+		}
+		seen[r.priority] = r.name
+
+		if r.priority <= prevPriority {
+			t.Errorf("rule %s (priority %d) must be > previous (%d)", r.name, r.priority, prevPriority)
+		}
+		prevPriority = r.priority
+	}
+
+	// M6 must be the last (highest priority number = catch-all).
+	last := rules[len(rules)-1]
+	if last.name != "m6-default" {
+		t.Errorf("last rule should be m6-default, got %s", last.name)
+	}
+	if last.pattern != "/*" {
+		t.Errorf("catch-all pattern should be /*, got %s", last.pattern)
+	}
+}
+
+func TestAssignHostname(t *testing.T) {
+	// M1 must be on separate hostname: assign.kaizen.{domain}
+	domain := "example.com"
+	expected := "assign.kaizen.example.com"
+	got := "assign.kaizen." + domain
+	if got != expected {
+		t.Errorf("assign hostname = %q, want %q", got, expected)
+	}
+}


### PR DESCRIPTION
## Summary

- Creates 4 ALB target groups for public-facing services (M1 Assignment, M5 Management, M6 UI, M7 Flags)
- Adds path-based and host-based listener rules on the HTTPS listener
- Exports target group ARNs for downstream ECS service registration

## Target Groups

| Service | Protocol | Port | Health Check | Routing |
|---------|----------|------|-------------|---------|
| M1 Assignment | gRPC | 50051 | `/grpc.health.v1.Health/Check` (code 0) | Host: `assign.kaizen.{domain}` |
| M5 Management | HTTP/2 | 50055 | `/healthz` (200) | Path: `/api/*` |
| M6 UI | HTTP/1 | 3000 | `/` (200) | Catch-all: `/*` |
| M7 Flags | gRPC | 50057 | `/grpc.health.v1.Health/Check` (code 0) | Path: `/flags/*` |

## Listener Rule Priorities

| Priority | Condition | Target |
|----------|-----------|--------|
| 10 | Host = `assign.kaizen.{domain}` | M1 Assignment |
| 20 | Path = `/api/*` | M5 Management |
| 30 | Path = `/flags/*` | M7 Flags |
| 100 | Path = `/*` (catch-all) | M6 UI |

## Design Decisions

- **IP target type**: Required for ECS Fargate tasks (awsvpc networking)
- **30s deregistration delay**: Allows in-flight requests to drain without blocking ECS rolling deployments (default 300s is too slow)
- **M1 on separate hostname**: gRPC services benefit from dedicated host-based routing since gRPC method paths (`/{package}.{Service}/{Method}`) don't map cleanly to path prefixes
- **HTTPS listener default action unchanged**: The existing 503 fixed-response from I.0.13 remains as a safety net; the catch-all `/*` rule at priority 100 handles all normal traffic

## Potential Concern (for follow-up)

The M7 Flags service uses gRPC, and standard gRPC method paths follow `/{package}.{Service}/{Method}` format (e.g., `/experimentation.flags.v1.FlagsService/GetFlag`). The `/flags/*` path pattern won't match these unless the service exposes an HTTP gateway or the gRPC package path is designed to match. If M7 needs the same host-based routing as M1, a follow-up task should add `flags.kaizen.{domain}` DNS + listener rule. This matches the task spec as written.

## Depends On
- I.0.13 (ALB) — uses `HttpsListenerArn` from existing ALB module
- I.1.5 (ECS services) — target group ARNs consumed by ECS service definitions

## Test Plan
- [x] `go build ./pkg/loadbalancer/` — compiles clean
- [x] `go vet ./pkg/loadbalancer/` — no issues
- [x] `go test ./pkg/loadbalancer/ -v` — 3 tests pass (specs, priorities, hostname)
- [ ] `pulumi preview` in dev stack (requires AWS credentials)
- [ ] Verify traffic routing after ECS services register with target groups

Closes #359
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
