### PR TITLE
feat(infra): wire MSK to VPC + provision topics (I.1.3)

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -12,3 +12,5 @@ config:
   kaizen-experimentation:wafEnabled: "false"
   kaizen-experimentation:fargateMinTasks: "1"
   kaizen-experimentation:cloudwatchRetentionDays: "7"
+  kafka:saslUsername: kaizen-msk-user
+  kafka:saslPassword: CHANGE_ME_VIA_PULUMI_CONFIG_SET_SECRET

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -12,3 +12,5 @@ config:
   kaizen-experimentation:wafEnabled: "true"
   kaizen-experimentation:fargateMinTasks: "2"
   kaizen-experimentation:cloudwatchRetentionDays: "30"
+  kafka:saslUsername: kaizen-msk-user
+  kafka:saslPassword: CHANGE_ME_VIA_PULUMI_CONFIG_SET_SECRET

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -12,3 +12,5 @@ config:
   kaizen-experimentation:wafEnabled: "true"
   kaizen-experimentation:fargateMinTasks: "1"
   kaizen-experimentation:cloudwatchRetentionDays: "14"
+  kafka:saslUsername: kaizen-msk-user
+  kafka:saslPassword: CHANGE_ME_VIA_PULUMI_CONFIG_SET_SECRET

--- a/infra/main.go
+++ b/infra/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	pulumiConfig "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 
 	"github.com/kaizen-experimentation/infra/pkg/cache"
 	"github.com/kaizen-experimentation/infra/pkg/cicd"
@@ -88,6 +89,7 @@ func main() {
 		mskOutputs, err := streaming.NewMskCluster(ctx, "kaizen", &streaming.MskInputs{
 			SubnetIds:        vpcOutputs.PrivateSubnetIds,
 			SecurityGroupIds: pulumi.StringArray{sgResult.Groups["msk"].ToStringOutput()},
+			KafkaSecretArn:   secretsOutputs.KafkaSecretArn,
 			Config: config.MskConfig{
 				KafkaVersion:  "3.5.1",
 				BrokerCount:   cfg.MskBrokerCount,
@@ -103,8 +105,12 @@ func main() {
 		ctx.Export("mskBootstrapBrokers", mskOutputs.MskBootstrapBrokers)
 
 		// ── 7. Kafka Topics ─────────────────────────────────────────────────
+		kafkaCfg := pulumiConfig.New(ctx, "kafka")
 		_, err = streaming.NewTopics(ctx, &streaming.TopicsArgs{
 			BootstrapBrokers: mskOutputs.MskBootstrapBrokers,
+			SaslUsername:     kafkaCfg.RequireSecretOutput("saslUsername"),
+			SaslPassword:     kafkaCfg.RequireSecretOutput("saslPassword"),
+			KafkaVersion:     "3.5.1",
 		})
 		if err != nil {
 			return err

--- a/infra/pkg/network/security_groups.go
+++ b/infra/pkg/network/security_groups.go
@@ -211,6 +211,19 @@ func NewSecurityGroups(ctx *pulumi.Context, prefix string, args *SecurityGroupsA
 		return nil, fmt.Errorf("ecs-out-msk-tls: %w", err)
 	}
 
+	// ECS egress: to MSK (SASL_SSL Kafka — port 9096).
+	if _, err = ec2.NewSecurityGroupRule(ctx, fmt.Sprintf("%s-ecs-out-msk-sasl", prefix), &ec2.SecurityGroupRuleArgs{
+		Type:                     pulumi.String("egress"),
+		SecurityGroupId:          ecsSg.ID().ToStringOutput(),
+		Protocol:                 pulumi.String("tcp"),
+		FromPort:                 pulumi.Int(9096),
+		ToPort:                   pulumi.Int(9096),
+		SourceSecurityGroupId:    mskSg.ID().ToStringOutput(),
+		Description:              pulumi.String("Kafka SASL_SSL to MSK"),
+	}); err != nil {
+		return nil, fmt.Errorf("ecs-out-msk-sasl: %w", err)
+	}
+
 	// ECS egress: to Redis (ElastiCache).
 	if _, err = ec2.NewSecurityGroupRule(ctx, fmt.Sprintf("%s-ecs-out-redis", prefix), &ec2.SecurityGroupRuleArgs{
 		Type:                     pulumi.String("egress"),
@@ -304,6 +317,19 @@ func NewSecurityGroups(ctx *pulumi.Context, prefix string, args *SecurityGroupsA
 		return nil, fmt.Errorf("msk-in-ecs-tls: %w", err)
 	}
 
+	// MSK ingress: Kafka SASL_SSL from ECS (port 9096).
+	if _, err = ec2.NewSecurityGroupRule(ctx, fmt.Sprintf("%s-msk-in-ecs-sasl", prefix), &ec2.SecurityGroupRuleArgs{
+		Type:                     pulumi.String("ingress"),
+		SecurityGroupId:          mskSg.ID().ToStringOutput(),
+		Protocol:                 pulumi.String("tcp"),
+		FromPort:                 pulumi.Int(9096),
+		ToPort:                   pulumi.Int(9096),
+		SourceSecurityGroupId:    ecsSg.ID().ToStringOutput(),
+		Description:              pulumi.String("Kafka SASL_SSL from ECS services"),
+	}); err != nil {
+		return nil, fmt.Errorf("msk-in-ecs-sasl: %w", err)
+	}
+
 	// MSK ingress: Kafka plaintext from M4b.
 	if _, err = ec2.NewSecurityGroupRule(ctx, fmt.Sprintf("%s-msk-in-m4b-plain", prefix), &ec2.SecurityGroupRuleArgs{
 		Type:                     pulumi.String("ingress"),
@@ -328,6 +354,19 @@ func NewSecurityGroups(ctx *pulumi.Context, prefix string, args *SecurityGroupsA
 		Description:              pulumi.String("Kafka TLS from M4b Policy service"),
 	}); err != nil {
 		return nil, fmt.Errorf("msk-in-m4b-tls: %w", err)
+	}
+
+	// MSK ingress: Kafka SASL_SSL from M4b (port 9096).
+	if _, err = ec2.NewSecurityGroupRule(ctx, fmt.Sprintf("%s-msk-in-m4b-sasl", prefix), &ec2.SecurityGroupRuleArgs{
+		Type:                     pulumi.String("ingress"),
+		SecurityGroupId:          mskSg.ID().ToStringOutput(),
+		Protocol:                 pulumi.String("tcp"),
+		FromPort:                 pulumi.Int(9096),
+		ToPort:                   pulumi.Int(9096),
+		SourceSecurityGroupId:    m4bSg.ID().ToStringOutput(),
+		Description:              pulumi.String("Kafka SASL_SSL from M4b Policy service"),
+	}); err != nil {
+		return nil, fmt.Errorf("msk-in-m4b-sasl: %w", err)
 	}
 
 	// Redis ingress: from ECS.
@@ -434,6 +473,19 @@ func NewSecurityGroups(ctx *pulumi.Context, prefix string, args *SecurityGroupsA
 		Description:              pulumi.String("Kafka TLS to MSK"),
 	}); err != nil {
 		return nil, fmt.Errorf("m4b-out-msk-tls: %w", err)
+	}
+
+	// M4b egress: to MSK (SASL_SSL — port 9096).
+	if _, err = ec2.NewSecurityGroupRule(ctx, fmt.Sprintf("%s-m4b-out-msk-sasl", prefix), &ec2.SecurityGroupRuleArgs{
+		Type:                     pulumi.String("egress"),
+		SecurityGroupId:          m4bSg.ID().ToStringOutput(),
+		Protocol:                 pulumi.String("tcp"),
+		FromPort:                 pulumi.Int(9096),
+		ToPort:                   pulumi.Int(9096),
+		SourceSecurityGroupId:    mskSg.ID().ToStringOutput(),
+		Description:              pulumi.String("Kafka SASL_SSL to MSK"),
+	}); err != nil {
+		return nil, fmt.Errorf("m4b-out-msk-sasl: %w", err)
 	}
 
 	// M4b egress: to Redis.

--- a/infra/pkg/streaming/msk.go
+++ b/infra/pkg/streaming/msk.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/msk"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
-	"github.com/wunderkennd/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/config"
 )
 
 // MskInputs are the parameters required to create the MSK cluster.
@@ -22,6 +22,9 @@ type MskInputs struct {
 	SubnetIds pulumi.StringArrayInput
 	// SecurityGroupIds to attach to the MSK brokers.
 	SecurityGroupIds pulumi.StringArrayInput
+	// KafkaSecretArn is the Secrets Manager secret ARN containing SASL/SCRAM
+	// credentials. Wired in Sprint I.1 to enable SCRAM authentication.
+	KafkaSecretArn pulumi.StringInput
 	// Config holds environment-specific sizing and monitoring settings.
 	Config config.MskConfig
 	// Tags applied to all resources created by this module.
@@ -124,6 +127,19 @@ func NewMskCluster(ctx *pulumi.Context, name string, inputs *MskInputs, opts ...
 	}, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating MSK cluster: %w", err)
+	}
+
+	// --- SCRAM secret association ---
+	// Links the Secrets Manager SASL/SCRAM credential to the MSK cluster,
+	// enabling clients to authenticate via SASL/SCRAM-SHA-512 on port 9096.
+	if inputs.KafkaSecretArn != nil {
+		_, err = msk.NewSingleScramSecretAssociation(ctx, fmt.Sprintf("%s-scram-assoc", name), &msk.SingleScramSecretAssociationArgs{
+			ClusterArn: cluster.Arn,
+			SecretArn:  inputs.KafkaSecretArn,
+		}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("creating SCRAM secret association: %w", err)
+		}
 	}
 
 	return &config.StreamingOutputs{

--- a/infra/pkg/streaming/msk_test.go
+++ b/infra/pkg/streaming/msk_test.go
@@ -1,0 +1,66 @@
+package streaming
+
+import (
+	"testing"
+
+	"github.com/kaizen-experimentation/infra/pkg/config"
+)
+
+func TestEnhancedMonitoring(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.MskConfig
+		want string
+	}{
+		{
+			name: "prod always gets PER_TOPIC_PER_BROKER",
+			cfg:  config.MskConfig{Environment: "prod"},
+			want: "PER_TOPIC_PER_BROKER",
+		},
+		{
+			name: "staging with explicit override",
+			cfg:  config.MskConfig{Environment: "staging", EnhancedMonitoring: "PER_TOPIC_PER_PARTITION"},
+			want: "PER_TOPIC_PER_PARTITION",
+		},
+		{
+			name: "dev defaults to PER_BROKER",
+			cfg:  config.MskConfig{Environment: "dev"},
+			want: "PER_BROKER",
+		},
+		{
+			name: "prod ignores override",
+			cfg:  config.MskConfig{Environment: "prod", EnhancedMonitoring: "PER_BROKER"},
+			want: "PER_TOPIC_PER_BROKER",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enhancedMonitoring(tt.cfg)
+			if got != tt.want {
+				t.Errorf("enhancedMonitoring() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLogRetentionDays(t *testing.T) {
+	tests := []struct {
+		env  string
+		want int
+	}{
+		{"prod", 30},
+		{"staging", 14},
+		{"dev", 7},
+		{"", 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			got := logRetentionDays(tt.env)
+			if got != tt.want {
+				t.Errorf("logRetentionDays(%q) = %d, want %d", tt.env, got, tt.want)
+			}
+		})
+	}
+}

--- a/infra/pkg/streaming/topics.go
+++ b/infra/pkg/streaming/topics.go
@@ -65,9 +65,14 @@ var topics = []topicSpec{
 
 // TopicsArgs holds the inputs for Kafka topic provisioning.
 type TopicsArgs struct {
-	// BootstrapBrokers is the comma-separated MSK bootstrap broker string.
-	// Wired from MskOutputs.BootstrapBrokers in Sprint I.1.
+	// BootstrapBrokers is the comma-separated MSK SASL_SSL bootstrap broker string.
 	BootstrapBrokers pulumi.StringInput
+	// SaslUsername for SCRAM-SHA-512 authentication against MSK.
+	SaslUsername pulumi.StringInput
+	// SaslPassword for SCRAM-SHA-512 authentication against MSK.
+	SaslPassword pulumi.StringInput
+	// KafkaVersion matches the MSK cluster's Kafka version (e.g. "3.5.1").
+	KafkaVersion string
 }
 
 // TopicsOutputs holds references to all created Kafka topic resources.
@@ -87,12 +92,17 @@ type TopicsOutputs struct {
 // the MSK cluster being available. In Sprint I.0 this module is code-only;
 // it will be wired to MSK outputs in Sprint I.1.
 func NewTopics(ctx *pulumi.Context, args *TopicsArgs) (*TopicsOutputs, error) {
-	// Create a Kafka provider that targets the MSK cluster.
-	// MSK bootstrap brokers come as "b-1:9098,b-2:9098,b-3:9098".
+	// Create a Kafka provider that targets the MSK cluster via SASL_SSL.
+	// MSK SASL/SCRAM bootstrap brokers come as "b-1:9096,b-2:9096,b-3:9096".
 	provider, err := kafka.NewProvider(ctx, "kaizen-kafka", &kafka.ProviderArgs{
 		BootstrapServers: args.BootstrapBrokers.ToStringOutput().ApplyT(func(brokers string) []string {
 			return strings.Split(brokers, ",")
 		}).(pulumi.StringArrayOutput),
+		TlsEnabled:    pulumi.BoolPtr(true),
+		SaslMechanism: pulumi.StringPtr("scram-sha512"),
+		SaslUsername:   args.SaslUsername,
+		SaslPassword:   args.SaslPassword,
+		KafkaVersion:   pulumi.StringPtr(args.KafkaVersion),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating Kafka provider: %w", err)

--- a/infra/pkg/streaming/topics_test.go
+++ b/infra/pkg/streaming/topics_test.go
@@ -1,0 +1,108 @@
+package streaming
+
+import (
+	"testing"
+)
+
+func TestTopicSpecsCount(t *testing.T) {
+	if len(topics) != 8 {
+		t.Fatalf("expected 8 topics, got %d", len(topics))
+	}
+}
+
+func TestTopicNames(t *testing.T) {
+	expected := map[string]bool{
+		"exposures":                         true,
+		"metric_events":                     true,
+		"reward_events":                     true,
+		"qoe_events":                        true,
+		"guardrail_alerts":                  true,
+		"sequential_boundary_alerts":        true,
+		"model_retraining_events":           true,
+		"surrogate_recalibration_requests":  true,
+	}
+
+	for _, spec := range topics {
+		if !expected[spec.Name] {
+			t.Errorf("unexpected topic: %q", spec.Name)
+		}
+		delete(expected, spec.Name)
+	}
+
+	for name := range expected {
+		t.Errorf("missing topic: %q", name)
+	}
+}
+
+func TestTopicPartitions(t *testing.T) {
+	expectedPartitions := map[string]int{
+		"exposures":                         64,
+		"metric_events":                     128,
+		"reward_events":                     32,
+		"qoe_events":                        64,
+		"guardrail_alerts":                  8,
+		"sequential_boundary_alerts":        8,
+		"model_retraining_events":           8,
+		"surrogate_recalibration_requests":  4,
+	}
+
+	for _, spec := range topics {
+		want, ok := expectedPartitions[spec.Name]
+		if !ok {
+			continue
+		}
+		if spec.Partitions != want {
+			t.Errorf("topic %q: partitions = %d, want %d", spec.Name, spec.Partitions, want)
+		}
+	}
+}
+
+func TestTopicRetention(t *testing.T) {
+	for _, spec := range topics {
+		if spec.RetentionMs <= 0 {
+			t.Errorf("topic %q: retention must be positive, got %d", spec.Name, spec.RetentionMs)
+		}
+	}
+
+	// High-volume topics: 90d retention
+	for _, name := range []string{"exposures", "metric_events", "qoe_events"} {
+		for _, spec := range topics {
+			if spec.Name == name && spec.RetentionMs != retention90d {
+				t.Errorf("topic %q: retention = %d, want %d (90d)", name, spec.RetentionMs, retention90d)
+			}
+		}
+	}
+
+	// Long-retention topics: 180d
+	for _, name := range []string{"reward_events", "model_retraining_events"} {
+		for _, spec := range topics {
+			if spec.Name == name && spec.RetentionMs != retention180d {
+				t.Errorf("topic %q: retention = %d, want %d (180d)", name, spec.RetentionMs, retention180d)
+			}
+		}
+	}
+
+	// Short-retention alert topics: 30d
+	for _, name := range []string{"guardrail_alerts", "sequential_boundary_alerts", "surrogate_recalibration_requests"} {
+		for _, spec := range topics {
+			if spec.Name == name && spec.RetentionMs != retention30d {
+				t.Errorf("topic %q: retention = %d, want %d (30d)", name, spec.RetentionMs, retention30d)
+			}
+		}
+	}
+}
+
+func TestReplicationAndCompressionConstants(t *testing.T) {
+	if replicationFactor != 3 {
+		t.Errorf("replicationFactor = %d, want 3", replicationFactor)
+	}
+	if minInsyncReplicas != 2 {
+		t.Errorf("minInsyncReplicas = %d, want 2", minInsyncReplicas)
+	}
+	if cleanupPolicy != "delete" {
+		t.Errorf("cleanupPolicy = %q, want %q", cleanupPolicy, "delete")
+	}
+	if compressionType != "lz4" {
+		t.Errorf("compressionType = %q, want %q", compressionType, "lz4")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #354

Completes Sprint I.1.3: Wire MSK cluster to VPC and provision all 8 Kafka topics with SASL/SCRAM authentication.

### What was wired

The Sprint I.0 modules created all building blocks (MSK cluster, topics definitions, SGs, secrets) as standalone code. This PR connects them:

- **SG port 9096 rules** — Added 4 new security group rules for SASL_SSL (port 9096) traffic between ECS↔MSK and M4b↔MSK. The I.0 SGs only had plaintext (9092) and mTLS (9094) — but `BootstrapBrokersSaslScram` uses port 9096.
- **SCRAM secret association** — `msk.NewSingleScramSecretAssociation` links the Secrets Manager SASL credential to the MSK cluster. Without this, SCRAM auth is enabled on the broker config but no credentials exist.
- **Kafka provider auth** — Configured the Pulumi Kafka provider with `TlsEnabled=true`, `SaslMechanism=scram-sha512`, and credentials from Pulumi config secrets. This lets the provider authenticate to create topics.
- **Cross-module wiring in main.go** — `KafkaSecretArn` flows from secrets→MSK, SASL creds from Pulumi config→topics.
- **Import path fix** — Fixed `msk.go` import from `github.com/wunderkennd/...` to canonical `github.com/kaizen-experimentation/...` per go.mod.

### Files changed

| File | Change |
|------|--------|
| `infra/pkg/network/security_groups.go` | +4 SG rules for port 9096 (SASL_SSL) |
| `infra/pkg/streaming/msk.go` | +`KafkaSecretArn` input, +SCRAM association, fix import |
| `infra/pkg/streaming/topics.go` | +SASL/TLS config on Kafka provider |
| `infra/main.go` | Wire secret ARN to MSK, wire SASL creds to topics |
| `infra/Pulumi.{dev,staging,prod}.yaml` | +`kafka:saslUsername/Password` config keys |
| `infra/pkg/streaming/msk_test.go` | Tests for monitoring/retention helpers |
| `infra/pkg/streaming/topics_test.go` | Tests for 8 topic specs (names, partitions, retention) |

### Depends on

- I.0.2 (VPC) ✅ merged in #386
- I.0.3 (SGs) ✅ merged in #386
- I.0.9-I.0.10 (MSK + topics modules) ✅ merged in #386

### Pre-deploy action required

Before first `pulumi up`, set real SASL credentials as Pulumi secrets:
```bash
pulumi config set kafka:saslPassword --secret --stack <stack>
```

### Opportunities (not implemented)

- The SM secret version still has placeholder `CHANGE_ME` values — a follow-up task (I.1.4) should populate them with actual resource outputs
- Pre-existing build issues: `redis.go` and `service_discovery.go` import `pulumi-aws/sdk/v7` but go.mod has v6; `secrets.go` and `s3.go` have wrong module paths

## Test plan

- [x] `go build ./pkg/streaming/ ./pkg/config/` — compiles cleanly
- [x] `go test ./pkg/streaming/ -v` — 7/7 tests pass (topic specs + MSK helpers)
- [ ] `pulumi preview --stack dev` — verify resource plan shows SCRAM association + 8 topics
- [ ] Verify no credentials in git: `git diff --staged | grep -i secret`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
