### PR TITLE
feat(infra): I.1.4 Schema Registry ECS Fargate service

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	pulumiConfig "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 
 	"github.com/kaizen-experimentation/infra/pkg/cache"
 	"github.com/kaizen-experimentation/infra/pkg/cicd"
@@ -20,6 +21,9 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		cfg := config.LoadConfig(ctx)
 		env := cfg.Environment
+
+		awsCfg := pulumiConfig.New(ctx, "aws")
+		awsRegion := awsCfg.Require("region")
 
 		ctx.Export("environment", pulumi.String(env))
 
@@ -122,6 +126,23 @@ func main() {
 		}
 		ctx.Export("ecsClusterId", clusterOutputs.ClusterId)
 		ctx.Export("ecsClusterArn", clusterOutputs.ClusterArn)
+
+		// ── 8b. Schema Registry (Fargate on ECS) ───────────────────────────
+		srOutputs, err := streaming.NewSchemaRegistry(ctx, &streaming.SchemaRegistryArgs{
+			Environment:      env,
+			Region:           awsRegion,
+			ClusterArn:       clusterOutputs.ClusterArn,
+			PrivateSubnetIds: vpcOutputs.PrivateSubnetIds,
+			SecurityGroupId:  sgResult.Groups["ecs"],
+			NamespaceId:      sdOutputs.NamespaceId,
+			BootstrapBrokers: mskOutputs.MskBootstrapBrokers,
+			KafkaSecretArn:   secretsOutputs.KafkaSecretArn,
+			Tags:             config.DefaultTags(env),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("schemaRegistryUrl", srOutputs.SchemaRegistryUrl)
 
 		// ── 9. DNS (Route 53 + ACM) ─────────────────────────────────────────
 		// DNS must be created before ALB so the certificate ARN is available.

--- a/infra/pkg/streaming/schema_registry.go
+++ b/infra/pkg/streaming/schema_registry.go
@@ -1,0 +1,262 @@
+package streaming
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudwatch"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/servicediscovery"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// SchemaRegistryArgs configures the Confluent Schema Registry ECS Fargate service.
+type SchemaRegistryArgs struct {
+	// Environment name: "dev", "staging", or "prod".
+	Environment string
+	// Region is the AWS region for CloudWatch log configuration.
+	Region string
+	// ClusterArn is the ECS cluster to deploy into.
+	ClusterArn pulumi.StringOutput
+	// PrivateSubnetIds for Fargate task placement.
+	PrivateSubnetIds pulumi.StringArrayOutput
+	// SecurityGroupId is the ECS security group.
+	SecurityGroupId pulumi.IDOutput
+	// NamespaceId is the Cloud Map private DNS namespace ID (kaizen.local).
+	NamespaceId pulumi.IDOutput
+	// BootstrapBrokers is the MSK SASL/SCRAM bootstrap broker connection string.
+	BootstrapBrokers pulumi.StringOutput
+	// KafkaSecretArn is the Secrets Manager ARN containing Kafka SASL credentials.
+	KafkaSecretArn pulumi.StringOutput
+	// Tags applied to all resources.
+	Tags pulumi.StringMap
+}
+
+// SchemaRegistryOutputs holds the outputs from the Schema Registry ECS service.
+type SchemaRegistryOutputs struct {
+	// ServiceArn is the ECS service ARN.
+	ServiceArn pulumi.StringOutput
+	// SchemaRegistryUrl is the internal URL for schema-registry.kaizen.local:8081.
+	SchemaRegistryUrl pulumi.StringOutput
+}
+
+// ecsAssumeRolePolicy allows the ECS tasks service to assume IAM roles.
+const ecsAssumeRolePolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}`
+
+// NewSchemaRegistry deploys Confluent Schema Registry on ECS Fargate,
+// wired to MSK via SASL/SCRAM and registered in Cloud Map as
+// schema-registry.kaizen.local:8081.
+//
+// Task: I.1.4 — 0.25 vCPU / 512 MB, HTTP health check on /subjects,
+// Protobuf compatibility mode BACKWARD.
+func NewSchemaRegistry(ctx *pulumi.Context, args *SchemaRegistryArgs) (*SchemaRegistryOutputs, error) {
+	prefix := fmt.Sprintf("kaizen-%s", args.Environment)
+
+	// --- IAM Execution Role (ECR pull + CloudWatch Logs + Secrets Manager) ---
+
+	execRole, err := iam.NewRole(ctx, "sr-exec-role", &iam.RoleArgs{
+		Name:             pulumi.Sprintf("%s-sr-exec-role", prefix),
+		AssumeRolePolicy: pulumi.String(ecsAssumeRolePolicy),
+		Tags:             args.Tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating SR execution role: %w", err)
+	}
+
+	_, err = iam.NewRolePolicyAttachment(ctx, "sr-exec-ecs-policy", &iam.RolePolicyAttachmentArgs{
+		Role:      execRole.Name,
+		PolicyArn: pulumi.String("arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attaching SR execution policy: %w", err)
+	}
+
+	// Inline policy: read Kafka SASL credentials from Secrets Manager.
+	secretsPolicy := args.KafkaSecretArn.ApplyT(func(arn string) (string, error) {
+		policy := map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
+				{
+					"Effect":   "Allow",
+					"Action":   []string{"secretsmanager:GetSecretValue"},
+					"Resource": arn,
+				},
+			},
+		}
+		b, err := json.Marshal(policy)
+		return string(b), err
+	}).(pulumi.StringOutput)
+
+	_, err = iam.NewRolePolicy(ctx, "sr-exec-secrets-policy", &iam.RolePolicyArgs{
+		Role:   execRole.Name,
+		Policy: secretsPolicy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating SR secrets policy: %w", err)
+	}
+
+	// --- IAM Task Role (running container identity) ---
+
+	taskRole, err := iam.NewRole(ctx, "sr-task-role", &iam.RoleArgs{
+		Name:             pulumi.Sprintf("%s-sr-task-role", prefix),
+		AssumeRolePolicy: pulumi.String(ecsAssumeRolePolicy),
+		Tags:             args.Tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating SR task role: %w", err)
+	}
+
+	// --- CloudWatch Log Group ---
+
+	logGroup, err := cloudwatch.NewLogGroup(ctx, "sr-logs", &cloudwatch.LogGroupArgs{
+		Name:            pulumi.Sprintf("/ecs/%s/schema-registry", prefix),
+		RetentionInDays: pulumi.Int(logRetentionDays(args.Environment)),
+		Tags:            args.Tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating SR log group: %w", err)
+	}
+
+	// --- ECS Task Definition ---
+	// 0.25 vCPU / 512 MB Fargate, Confluent Schema Registry 7.5.3,
+	// Protobuf compatibility = BACKWARD, health check on :8081/subjects.
+
+	containerDef := pulumi.All(args.BootstrapBrokers, logGroup.Name, args.KafkaSecretArn).ApplyT(
+		func(vals []interface{}) (string, error) {
+			brokers := vals[0].(string)
+			logGroupName := vals[1].(string)
+			kafkaSecretArn := vals[2].(string)
+
+			containers := []map[string]interface{}{
+				{
+					"name":      "schema-registry",
+					"image":     "confluentinc/cp-schema-registry:7.5.3",
+					"cpu":       256,
+					"memory":    512,
+					"essential": true,
+					"portMappings": []map[string]interface{}{
+						{
+							"containerPort": 8081,
+							"protocol":      "tcp",
+						},
+					},
+					"environment": []map[string]string{
+						{"name": "SCHEMA_REGISTRY_HOST_NAME", "value": "0.0.0.0"},
+						{"name": "SCHEMA_REGISTRY_LISTENERS", "value": "http://0.0.0.0:8081"},
+						{"name": "SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "value": brokers},
+						{"name": "SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL", "value": "SASL_SSL"},
+						{"name": "SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM", "value": "SCRAM-SHA-512"},
+						{"name": "SCHEMA_REGISTRY_SCHEMA_COMPATIBILITY_LEVEL", "value": "BACKWARD"},
+						{"name": "SCHEMA_REGISTRY_KAFKASTORE_TOPIC", "value": "_schemas"},
+						{"name": "SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR", "value": "3"},
+					},
+					"secrets": []map[string]string{
+						{
+							"name":      "SCHEMA_REGISTRY_KAFKASTORE_SASL_JAAS_CONFIG",
+							"valueFrom": kafkaSecretArn + ":sasl_jaas_config::",
+						},
+					},
+					"healthCheck": map[string]interface{}{
+						"command":     []string{"CMD-SHELL", "curl -f http://localhost:8081/subjects || exit 1"},
+						"interval":    30,
+						"timeout":     5,
+						"retries":     3,
+						"startPeriod": 60,
+					},
+					"logConfiguration": map[string]interface{}{
+						"logDriver": "awslogs",
+						"options": map[string]string{
+							"awslogs-group":         logGroupName,
+							"awslogs-region":        args.Region,
+							"awslogs-stream-prefix": "schema-registry",
+						},
+					},
+				},
+			}
+			b, err := json.Marshal(containers)
+			return string(b), err
+		},
+	).(pulumi.StringOutput)
+
+	taskDef, err := ecs.NewTaskDefinition(ctx, "sr-task-def", &ecs.TaskDefinitionArgs{
+		Family:                  pulumi.Sprintf("%s-schema-registry", prefix),
+		NetworkMode:             pulumi.String("awsvpc"),
+		RequiresCompatibilities: pulumi.StringArray{pulumi.String("FARGATE")},
+		Cpu:                     pulumi.String("256"),
+		Memory:                  pulumi.String("512"),
+		ExecutionRoleArn:        execRole.Arn,
+		TaskRoleArn:             taskRole.Arn,
+		ContainerDefinitions:    containerDef,
+		Tags:                    args.Tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating SR task definition: %w", err)
+	}
+
+	// --- Cloud Map Service Discovery ---
+	// Registers as schema-registry.kaizen.local, A record with 10s TTL.
+
+	cmService, err := servicediscovery.NewService(ctx, "sr-discovery", &servicediscovery.ServiceArgs{
+		Name:        pulumi.String("schema-registry"),
+		NamespaceId: args.NamespaceId.ToStringOutput(),
+		DnsConfig: &servicediscovery.ServiceDnsConfigArgs{
+			DnsRecords: servicediscovery.ServiceDnsConfigDnsRecordArray{
+				&servicediscovery.ServiceDnsConfigDnsRecordArgs{
+					Type: pulumi.String("A"),
+					Ttl:  pulumi.Int(10),
+				},
+			},
+			RoutingPolicy: pulumi.String("MULTIVALUE"),
+		},
+		HealthCheckCustomConfig: &servicediscovery.ServiceHealthCheckCustomConfigArgs{
+			FailureThreshold: pulumi.Int(1),
+		},
+		Tags: args.Tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating SR Cloud Map service: %w", err)
+	}
+
+	// --- ECS Service ---
+
+	svc, err := ecs.NewService(ctx, "sr-service", &ecs.ServiceArgs{
+		Name:           pulumi.Sprintf("%s-schema-registry", prefix),
+		Cluster:        args.ClusterArn,
+		TaskDefinition: taskDef.Arn,
+		DesiredCount:   pulumi.Int(1),
+		LaunchType:     pulumi.String("FARGATE"),
+
+		NetworkConfiguration: &ecs.ServiceNetworkConfigurationArgs{
+			Subnets:        args.PrivateSubnetIds,
+			SecurityGroups: pulumi.StringArray{args.SecurityGroupId.ToStringOutput()},
+			AssignPublicIp: pulumi.Bool(false),
+		},
+
+		ServiceRegistries: &ecs.ServiceServiceRegistriesArgs{
+			RegistryArn:   cmService.Arn,
+			ContainerName: pulumi.String("schema-registry"),
+			ContainerPort: pulumi.Int(8081),
+		},
+
+		Tags: args.Tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating SR ECS service: %w", err)
+	}
+
+	// Suppress unused warning for task role (will gain policies in future sprints).
+	_ = taskRole
+
+	return &SchemaRegistryOutputs{
+		ServiceArn:        svc.ID().ToStringOutput(),
+		SchemaRegistryUrl: pulumi.Sprintf("http://schema-registry.kaizen.local:8081"),
+	}, nil
+}


### PR DESCRIPTION
## Summary
- Deploy Confluent Schema Registry (`confluentinc/cp-schema-registry:7.5.3`) on ECS Fargate
- Fargate task definition: **0.25 vCPU / 512 MB**, matching task spec exactly
- Health check: `HTTP GET :8081/subjects` with 30s interval, 60s start period, 3 retries
- Cloud Map service discovery: `schema-registry.kaizen.local:8081` (A record, 10s TTL, MULTIVALUE routing)
- Protobuf compatibility mode: **BACKWARD**
- MSK wiring: SASL_SSL + SCRAM-SHA-512, JAAS config injected from Secrets Manager (`kafkaSecretArn`)
- IAM: separate execution role (ECR pull + CloudWatch Logs + Secrets Manager read) and task role
- CloudWatch log group with environment-based retention (7d dev, 14d staging, 30d prod)
- Wired into `main.go` as section 8b, after ECS cluster creation

## Architecture Notes
- Placed in `infra/pkg/streaming/` package alongside MSK and Kafka Topics — Schema Registry is part of the streaming/Kafka infrastructure
- Reuses existing `logRetentionDays()` helper from `msk.go` for consistent log retention
- Runs in `ecs-sg` security group which already permits MSK egress (9092/9094) and self-referencing traffic (for other ECS services to reach port 8081)
- No new security group rules needed — existing ECS SG covers all required flows

## Pre-existing Build Notes
The workspace has pre-existing build issues from other agent branches (v6/v7 SDK version mismatch in `service_discovery.go`/`redis.go`, module path inconsistencies in `msk.go`/`secrets.go`). This PR's new code uses only v6 SDK consistently and does not introduce additional build errors.

## Opportunities (not implemented)
- Add ECS Service Connect for mesh-style service-to-service communication
- Add autoscaling policy for Schema Registry (currently fixed at 1 task)
- Add circuit breaker deployment configuration for safer rollouts
- Add Schema Registry HA (2+ tasks) for prod environments

## Test plan
- [ ] `pulumi preview` shows Schema Registry resources (task def, service, Cloud Map, IAM roles, log group)
- [ ] Container definition JSON includes all 8 env vars + 1 secret + health check
- [ ] Cloud Map service registers under `kaizen.local` namespace
- [ ] ECS service uses Fargate launch type with `awsvpc` networking
- [ ] No new security group rules required (verify ECS SG self-referencing covers port 8081)

Closes #355
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
