### PR TITLE
feat(infra): Wire RDS + Redis + S3 + Secrets to VPC

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -44,16 +44,10 @@ func main() {
 		}
 		ctx.Export("cloudMapNamespaceId", sdOutputs.NamespaceId)
 
-		// ── 2. Secrets ──────────────────────────────────────────────────────
-		secretsOutputs, err := secrets.NewSecrets(ctx, cfg)
-		if err != nil {
-			return err
-		}
-		ctx.Export("databaseSecretArn", secretsOutputs.DatabaseSecretArn)
-		ctx.Export("kafkaSecretArn", secretsOutputs.KafkaSecretArn)
-
-		// ── 3. Storage (S3 buckets) ─────────────────────────────────────────
-		storageOutputs, err := storage.NewStorage(ctx, env)
+		// ── 2. Storage (S3 buckets) ─────────────────────────────────────────
+		storageOutputs, err := storage.NewStorage(ctx, env, &storage.StorageInputs{
+			S3VpcEndpointId: vpcOutputs.S3VpcEndpointId,
+		})
 		if err != nil {
 			return err
 		}
@@ -61,7 +55,7 @@ func main() {
 		ctx.Export("mlflowBucketName", storageOutputs.MlflowBucketName)
 		ctx.Export("logsBucketName", storageOutputs.LogsBucketName)
 
-		// ── 4. Cache (ElastiCache Redis) ────────────────────────────────────
+		// ── 3. Cache (ElastiCache Redis) ────────────────────────────────────
 		redisOutputs, err := cache.NewRedis(ctx, "kaizen-redis", &cache.RedisConfig{
 			NodeType:         cfg.RedisNodeType,
 			NumCacheClusters: 2,
@@ -74,7 +68,7 @@ func main() {
 		}
 		ctx.Export("redisEndpoint", redisOutputs.RedisEndpoint)
 
-		// ── 5. Database (RDS PostgreSQL) ────────────────────────────────────
+		// ── 4. Database (RDS PostgreSQL) ────────────────────────────────────
 		dbOutputs, err := database.NewRds(ctx, cfg, &database.RdsInputs{
 			SubnetIds:           vpcOutputs.PrivateSubnetIds,
 			VpcSecurityGroupIds: pulumi.StringArray{sgResult.Groups["rds"].ToStringOutput()},
@@ -84,7 +78,7 @@ func main() {
 		}
 		ctx.Export("rdsEndpoint", dbOutputs.RdsEndpoint)
 
-		// ── 6. Streaming (MSK Kafka) ────────────────────────────────────────
+		// ── 5. Streaming (MSK Kafka) ────────────────────────────────────────
 		mskOutputs, err := streaming.NewMskCluster(ctx, "kaizen", &streaming.MskInputs{
 			SubnetIds:        vpcOutputs.PrivateSubnetIds,
 			SecurityGroupIds: pulumi.StringArray{sgResult.Groups["msk"].ToStringOutput()},
@@ -101,6 +95,19 @@ func main() {
 			return err
 		}
 		ctx.Export("mskBootstrapBrokers", mskOutputs.MskBootstrapBrokers)
+
+		// ── 6. Secrets (wired to actual data store endpoints) ───────────────
+		secretsOutputs, err := secrets.NewSecrets(ctx, cfg, &secrets.SecretsInputs{
+			RdsEndpoint:         dbOutputs.RdsEndpoint,
+			MskBootstrapBrokers: mskOutputs.MskBootstrapBrokers,
+			RedisEndpoint:       redisOutputs.RedisEndpoint,
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("databaseSecretArn", secretsOutputs.DatabaseSecretArn)
+		ctx.Export("kafkaSecretArn", secretsOutputs.KafkaSecretArn)
+		ctx.Export("redisSecretArn", secretsOutputs.RedisSecretArn)
 
 		// ── 7. Kafka Topics ─────────────────────────────────────────────────
 		_, err = streaming.NewTopics(ctx, &streaming.TopicsArgs{
@@ -169,11 +176,6 @@ func main() {
 		if url, ok := ecrOutputs.RepositoryURLs["assignment"]; ok {
 			ctx.Export("ecrAssignmentUrl", url)
 		}
-
-		// Suppress unused variable warnings.
-		_ = albOutputs
-		_ = redisOutputs
-		_ = secretsOutputs
 
 		return nil
 	})

--- a/infra/pkg/cache/redis.go
+++ b/infra/pkg/cache/redis.go
@@ -2,7 +2,7 @@
 package cache
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/elasticache"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/elasticache"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/infra/pkg/network/service_discovery.go
+++ b/infra/pkg/network/service_discovery.go
@@ -1,7 +1,7 @@
 package network
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/servicediscovery"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/servicediscovery"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/infra/pkg/network/vpc.go
+++ b/infra/pkg/network/vpc.go
@@ -17,6 +17,7 @@ type VpcOutputs struct {
 	VpcId            pulumi.IDOutput
 	PublicSubnetIds  pulumi.StringArrayOutput
 	PrivateSubnetIds pulumi.StringArrayOutput
+	S3VpcEndpointId  pulumi.IDOutput
 }
 
 // NewVpc creates the core networking foundation: VPC, subnets across 3 AZs,
@@ -36,6 +37,13 @@ func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
 	if natCount == 0 {
 		natCount = 2
 	}
+
+	// Discover the current region (needed for VPC endpoint service names).
+	currentRegion, err := aws.GetRegion(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get region: %w", err)
+	}
+	region := currentRegion.Name
 
 	// Discover AZs in the current region.
 	azs, err := aws.GetAvailabilityZones(ctx, &aws.GetAvailabilityZonesArgs{
@@ -177,6 +185,7 @@ func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
 	}
 
 	// ── Private route tables → NAT (round-robin across NAT GWs) ────────
+	privateRouteTableIds := pulumi.StringArray{}
 	for i, subnet := range privateSubnets {
 		natIdx := i % natCount
 		rtName := fmt.Sprintf("kaizen-private-rt-%d", i)
@@ -190,6 +199,8 @@ func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
 		if err != nil {
 			return nil, fmt.Errorf("create private route table %d: %w", i, err)
 		}
+
+		privateRouteTableIds = append(privateRouteTableIds, privateRT.ID().ToStringOutput())
 
 		_, err = ec2.NewRoute(ctx, fmt.Sprintf("kaizen-private-default-%d", i), &ec2.RouteArgs{
 			RouteTableId:         privateRT.ID(),
@@ -209,16 +220,34 @@ func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
 		}
 	}
 
+	// ── S3 Gateway VPC Endpoint ─────────────────────────────────────────
+	// Gateway endpoint keeps S3 traffic on the AWS backbone (free, no ENIs).
+	// Associated with private route tables so ECS/M4b tasks access S3 without NAT.
+	s3Endpoint, err := ec2.NewVpcEndpoint(ctx, "kaizen-s3-endpoint", &ec2.VpcEndpointArgs{
+		VpcId:          vpc.ID(),
+		ServiceName:    pulumi.String(fmt.Sprintf("com.amazonaws.%s.s3", region)),
+		VpcEndpointType: pulumi.String("Gateway"),
+		RouteTableIds:  privateRouteTableIds,
+		Tags: kconfig.MergeTags(tags, pulumi.StringMap{
+			"Name": pulumi.String("kaizen-s3-endpoint"),
+		}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create S3 VPC endpoint: %w", err)
+	}
+
 	// ── Pulumi stack exports ────────────────────────────────────────────
 	pubIds := publicSubnetIds.ToStringArrayOutput()
 	privIds := privateSubnetIds.ToStringArrayOutput()
 	ctx.Export("vpcId", vpc.ID())
 	ctx.Export("publicSubnetIds", pubIds)
 	ctx.Export("privateSubnetIds", privIds)
+	ctx.Export("s3VpcEndpointId", s3Endpoint.ID())
 
 	return &VpcOutputs{
 		VpcId:            vpc.ID(),
 		PublicSubnetIds:  pubIds,
 		PrivateSubnetIds: privIds,
+		S3VpcEndpointId:  s3Endpoint.ID(),
 	}, nil
 }

--- a/infra/pkg/secrets/secrets.go
+++ b/infra/pkg/secrets/secrets.go
@@ -6,8 +6,9 @@ package secrets
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/kennethsylvain/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/config"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/secretsmanager"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -56,43 +57,106 @@ type AuthSecret struct {
 	Issuer       string `json:"issuer"`
 }
 
+// SecretsInputs holds actual resource outputs wired from data store modules.
+// These replace the placeholder values from Sprint I.0.
+type SecretsInputs struct {
+	// RDS endpoint (host:port format from the RDS instance).
+	RdsEndpoint pulumi.StringOutput
+	// MSK bootstrap broker connection string.
+	MskBootstrapBrokers pulumi.StringOutput
+	// Redis primary endpoint address.
+	RedisEndpoint pulumi.StringOutput
+}
+
 // NewSecrets creates all four Secrets Manager secrets with environment-
-// appropriate recovery windows.
-func NewSecrets(ctx *pulumi.Context, cfg *config.Config) (*SecretsOutputs, error) {
+// appropriate recovery windows. Resource endpoints from SecretsInputs
+// replace the Sprint I.0 placeholders.
+func NewSecrets(ctx *pulumi.Context, cfg *config.Config, inputs *SecretsInputs) (*SecretsOutputs, error) {
 	// recovery_window_in_days: 7 for prod (safety), 0 for dev/staging (instant cleanup).
 	recoveryDays := 0
 	if cfg.IsProd() {
 		recoveryDays = 7
 	}
 
-	dbSecret, err := createSecret(ctx, cfg, "database", recoveryDays, DatabaseSecret{
-		Engine:   "postgres",
-		Host:     "placeholder-rds-endpoint",
-		Port:     5432,
-		Username: "kaizen",
-		Password: "CHANGE_ME",
-		Dbname:   "kaizen",
-	})
+	dbSecret, err := createSecretContainer(ctx, cfg, "database", recoveryDays)
 	if err != nil {
 		return nil, err
 	}
 
-	kafkaSecret, err := createSecret(ctx, cfg, "kafka", recoveryDays, KafkaSecret{
-		SaslUsername:    "kaizen-msk-user",
-		SaslPassword:   "CHANGE_ME",
-		SaslMechanism:  "SCRAM-SHA-512",
-		BootstrapBrokers: "placeholder-msk-brokers",
-	})
+	// Database secret version: wire actual RDS endpoint.
+	dbSecretValue := inputs.RdsEndpoint.ApplyT(func(endpoint string) (string, error) {
+		v := DatabaseSecret{
+			Engine:   "postgres",
+			Host:     endpoint,
+			Port:     5432,
+			Username: "kaizen_admin",
+			Password: "CHANGE_ME",
+			Dbname:   "kaizen",
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("marshal database secret: %w", err)
+		}
+		return string(b), nil
+	}).(pulumi.StringOutput)
+
+	if _, err := secretsmanager.NewSecretVersion(ctx, cfg.ResourceName("secret-database")+"-version", &secretsmanager.SecretVersionArgs{
+		SecretId:     dbSecret.ID(),
+		SecretString: dbSecretValue,
+	}); err != nil {
+		return nil, err
+	}
+
+	kafkaSecret, err := createSecretContainer(ctx, cfg, "kafka", recoveryDays)
 	if err != nil {
 		return nil, err
 	}
 
-	redisSecret, err := createSecret(ctx, cfg, "redis", recoveryDays, RedisSecret{
-		AuthToken: "CHANGE_ME",
-		Endpoint:  "placeholder-redis-endpoint",
-		Port:      6379,
-	})
+	// Kafka secret version: wire actual MSK bootstrap brokers.
+	kafkaSecretValue := inputs.MskBootstrapBrokers.ApplyT(func(brokers string) (string, error) {
+		v := KafkaSecret{
+			SaslUsername:     "kaizen-msk-user",
+			SaslPassword:     "CHANGE_ME",
+			SaslMechanism:    "SCRAM-SHA-512",
+			BootstrapBrokers: brokers,
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("marshal kafka secret: %w", err)
+		}
+		return string(b), nil
+	}).(pulumi.StringOutput)
+
+	if _, err := secretsmanager.NewSecretVersion(ctx, cfg.ResourceName("secret-kafka")+"-version", &secretsmanager.SecretVersionArgs{
+		SecretId:     kafkaSecret.ID(),
+		SecretString: kafkaSecretValue,
+	}); err != nil {
+		return nil, err
+	}
+
+	redisSecret, err := createSecretContainer(ctx, cfg, "redis", recoveryDays)
 	if err != nil {
+		return nil, err
+	}
+
+	// Redis secret version: wire actual ElastiCache endpoint.
+	redisSecretValue := inputs.RedisEndpoint.ApplyT(func(endpoint string) (string, error) {
+		v := RedisSecret{
+			AuthToken: "CHANGE_ME",
+			Endpoint:  endpoint,
+			Port:      6379,
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("marshal redis secret: %w", err)
+		}
+		return string(b), nil
+	}).(pulumi.StringOutput)
+
+	if _, err := secretsmanager.NewSecretVersion(ctx, cfg.ResourceName("secret-redis")+"-version", &secretsmanager.SecretVersionArgs{
+		SecretId:     redisSecret.ID(),
+		SecretString: redisSecretValue,
+	}); err != nil {
 		return nil, err
 	}
 
@@ -114,10 +178,35 @@ func NewSecrets(ctx *pulumi.Context, cfg *config.Config) (*SecretsOutputs, error
 	}, nil
 }
 
+// createSecretContainer provisions a Secrets Manager secret without an initial
+// version. The caller is responsible for creating a SecretVersion with resolved
+// resource outputs (used for database, kafka, redis secrets).
+func createSecretContainer(
+	ctx *pulumi.Context,
+	cfg *config.Config,
+	name string,
+	recoveryDays int,
+) (*secretsmanager.Secret, error) {
+	secretPath := cfg.SecretPath(name)
+	resourceName := cfg.ResourceName("secret-" + name)
+
+	return secretsmanager.NewSecret(ctx, resourceName, &secretsmanager.SecretArgs{
+		Name:                        pulumi.String(secretPath),
+		Description:                 pulumi.Sprintf("Kaizen %s credentials (%s)", name, cfg.Env),
+		RecoveryWindowInDays:        pulumi.Int(recoveryDays),
+		ForceOverwriteReplicaSecret: pulumi.Bool(false),
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String(cfg.Project),
+			"Environment": pulumi.String(string(cfg.Env)),
+			"ManagedBy":   pulumi.String("pulumi"),
+			"Component":   pulumi.String(name),
+		},
+	})
+}
+
 // createSecret provisions a single Secrets Manager secret with an initial
-// placeholder version. The secret value is JSON-encoded from the provided
-// struct. In Sprint I.1, the wiring task (I.1.4) replaces placeholders
-// with actual resource outputs (RDS endpoint, MSK brokers, etc.).
+// version from a static value (used for auth secret which doesn't reference
+// infrastructure outputs).
 func createSecret(
 	ctx *pulumi.Context,
 	cfg *config.Config,

--- a/infra/pkg/storage/s3.go
+++ b/infra/pkg/storage/s3.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
-	"github.com/wunderkennd/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/config"
 )
 
 // StorageOutputs is the cross-agent contract for S3 resources.
@@ -23,8 +23,15 @@ type StorageOutputs struct {
 	LogsBucketArn    pulumi.StringOutput
 }
 
+// StorageInputs contains VPC-level resources injected by the caller.
+type StorageInputs struct {
+	// S3VpcEndpointId is the Gateway VPC endpoint ID used to restrict
+	// bucket access to VPC-internal traffic only.
+	S3VpcEndpointId pulumi.IDOutput
+}
+
 // NewStorage provisions the three S3 buckets and returns their outputs.
-func NewStorage(ctx *pulumi.Context, env string) (*StorageOutputs, error) {
+func NewStorage(ctx *pulumi.Context, env string, inputs *StorageInputs) (*StorageOutputs, error) {
 	tags := config.DefaultTags(env)
 
 	data, err := newDataBucket(ctx, env, tags)
@@ -40,6 +47,18 @@ func NewStorage(ctx *pulumi.Context, env string) (*StorageOutputs, error) {
 	logs, err := newLogsBucket(ctx, env, tags)
 	if err != nil {
 		return nil, fmt.Errorf("logs bucket: %w", err)
+	}
+
+	// VPC endpoint policies for data and mlflow buckets restrict access to
+	// traffic originating from the VPC gateway endpoint. The logs bucket is
+	// excluded — ALB writes logs via the AWS ELB service account, not the VPC.
+	if inputs != nil {
+		if err := applyVpcEndpointPolicy(ctx, "data", data, inputs.S3VpcEndpointId); err != nil {
+			return nil, fmt.Errorf("data bucket vpc policy: %w", err)
+		}
+		if err := applyVpcEndpointPolicy(ctx, "mlflow", mlflow, inputs.S3VpcEndpointId); err != nil {
+			return nil, fmt.Errorf("mlflow bucket vpc policy: %w", err)
+		}
 	}
 
 	return &StorageOutputs{
@@ -281,6 +300,37 @@ func newLogsBucket(ctx *pulumi.Context, env string, tags pulumi.StringMap) (*s3.
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+// applyVpcEndpointPolicy attaches a bucket policy that denies access unless
+// the request originates from the specified S3 Gateway VPC endpoint. This
+// ensures data/mlflow bucket traffic stays within the VPC.
+func applyVpcEndpointPolicy(ctx *pulumi.Context, prefix string, bucket *s3.BucketV2, vpceId pulumi.IDOutput) error {
+	policyJSON := pulumi.All(bucket.Arn, vpceId).ApplyT(func(args []interface{}) string {
+		bucketArn := args[0].(string)
+		endpointId := args[1].(string)
+		return fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "VPCEndpointOnly",
+    "Effect": "Deny",
+    "Principal": "*",
+    "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+    "Resource": ["%s", "%s/*"],
+    "Condition": {
+      "StringNotEquals": {
+        "aws:sourceVpce": "%s"
+      }
+    }
+  }]
+}`, bucketArn, bucketArn, endpointId)
+	}).(pulumi.StringOutput)
+
+	_, err := s3.NewBucketPolicy(ctx, prefix+"-bucket-vpce-policy", &s3.BucketPolicyArgs{
+		Bucket: bucket.ID(),
+		Policy: policyJSON,
+	}, pulumi.Parent(bucket))
+	return err
+}
 
 // applyBucketDefaults configures ownership controls and public access block
 // on every bucket. These are security baselines — all buckets are private.

--- a/infra/pkg/streaming/msk.go
+++ b/infra/pkg/streaming/msk.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/msk"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
-	"github.com/wunderkennd/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/config"
 )
 
 // MskInputs are the parameters required to create the MSK cluster.


### PR DESCRIPTION
## Summary

Sprint I.1.2: Wire all data store modules to consume VPC outputs from Infra-1 (Sprint I.0).

- **S3 Gateway VPC Endpoint**: Added to VPC module on private route tables — keeps data plane S3 traffic on the AWS backbone without traversing NAT gateways (free, no ENIs)
- **S3 Bucket Policies**: Data and MLflow buckets now have `aws:sourceVpce` deny policies restricting access to VPC-internal traffic only. Logs bucket excluded (ALB writes via ELB service account)
- **Secrets → Real Endpoints**: Replaced placeholder values (`placeholder-rds-endpoint`, etc.) with actual `pulumi.StringOutput` values from RDS, MSK, and Redis modules using `ApplyT()` for deploy-time resolution
- **Orchestration Reorder**: Moved secrets creation to after all data stores in `main.go` so resource outputs are available for wiring
- **Import Path Fixes**: Fixed pre-existing `v7→v6` SDK version mismatches in cache and service_discovery, and corrected wrong module paths in storage and streaming

### Files Changed (7)

| File | Change |
|------|--------|
| `infra/pkg/network/vpc.go` | S3 Gateway VPC endpoint + region lookup + export endpoint ID |
| `infra/pkg/storage/s3.go` | `StorageInputs` struct, `applyVpcEndpointPolicy()` helper, import fix |
| `infra/pkg/secrets/secrets.go` | `SecretsInputs` struct, `createSecretContainer()`, `ApplyT` wiring, import fix |
| `infra/main.go` | Reorder: storage→cache→RDS→MSK→secrets; pass VPC endpoint + resource outputs |
| `infra/pkg/cache/redis.go` | Fix import `v7→v6` |
| `infra/pkg/network/service_discovery.go` | Fix import `v7→v6` |
| `infra/pkg/streaming/msk.go` | Fix import path |

### Deliverables Checklist

- [x] RDS subnet group → private subnets, SG → rds-sg, Multi-AZ, automated backups
- [x] Redis subnet group → private subnets, SG → redis-sg
- [x] S3 bucket policies (VPC endpoint access)
- [x] Secrets values referencing RDS endpoint, MSK brokers, Redis endpoint

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [ ] `pulumi preview` on dev stack (requires AWS credentials)
- [ ] Verify S3 VPC endpoint appears in route tables
- [ ] Verify secret versions contain actual endpoints after deploy

### Opportunities (not implemented)

- DynamoDB Gateway endpoint could be added alongside S3 for future DDB usage
- Secret rotation lambda could be wired to the database secret
- KMS CMK for S3 buckets (currently using SSE-S3/AES256)

Closes #353
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
