### PR TITLE
feat(infra): VPC endpoints + IAM roles (I.1.1)

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -44,6 +44,18 @@ func main() {
 		}
 		ctx.Export("cloudMapNamespaceId", sdOutputs.NamespaceId)
 
+		// ── 1b. VPC Endpoints ───────────────────────────────────────────────
+		vpceOutputs, err := network.NewVpcEndpoints(ctx, &network.VpcEndpointArgs{
+			VpcId:                vpcOutputs.VpcId,
+			PrivateSubnetIds:     vpcOutputs.PrivateSubnetIds,
+			PrivateRouteTableIds: vpcOutputs.PrivateRouteTableIds,
+			EcsSecurityGroupId:   sgResult.Groups["ecs"],
+			M4bSecurityGroupId:   sgResult.Groups["m4b"],
+		})
+		if err != nil {
+			return err
+		}
+
 		// ── 2. Secrets ──────────────────────────────────────────────────────
 		secretsOutputs, err := secrets.NewSecrets(ctx, cfg)
 		if err != nil {
@@ -60,6 +72,16 @@ func main() {
 		ctx.Export("dataBucketName", storageOutputs.DataBucketName)
 		ctx.Export("mlflowBucketName", storageOutputs.MlflowBucketName)
 		ctx.Export("logsBucketName", storageOutputs.LogsBucketName)
+
+		// ── 3b. IAM Roles (ECS task, execution, CI deploy) ─────────────────
+		iamOutputs, err := network.NewIAMRoles(ctx, &network.IAMArgs{
+			Environment:     env,
+			DataBucketArn:   storageOutputs.DataBucketArn,
+			MlflowBucketArn: storageOutputs.MlflowBucketArn,
+		})
+		if err != nil {
+			return err
+		}
 
 		// ── 4. Cache (ElastiCache Redis) ────────────────────────────────────
 		redisOutputs, err := cache.NewRedis(ctx, "kaizen-redis", &cache.RedisConfig{
@@ -174,6 +196,8 @@ func main() {
 		_ = albOutputs
 		_ = redisOutputs
 		_ = secretsOutputs
+		_ = vpceOutputs
+		_ = iamOutputs
 
 		return nil
 	})

--- a/infra/pkg/network/iam.go
+++ b/infra/pkg/network/iam.go
@@ -1,0 +1,404 @@
+// Package network provisions IAM roles for ECS tasks and CI/CD deployment.
+//
+// Three roles are created:
+//   - ECS task role: runtime permissions for running containers
+//   - ECS task execution role: agent permissions for ECS infrastructure
+//   - CI deploy role: GitHub Actions OIDC-based deployment
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// IAMArgs holds the inputs for creating IAM roles.
+type IAMArgs struct {
+	// Environment name: "dev", "staging", or "prod".
+	Environment string
+	// DataBucketArn is the ARN of the Delta Lake S3 bucket.
+	DataBucketArn pulumi.StringOutput
+	// MlflowBucketArn is the ARN of the MLflow artifact S3 bucket.
+	MlflowBucketArn pulumi.StringOutput
+}
+
+// IAMOutputs holds the IAM role ARNs consumed by downstream modules (compute, CI).
+type IAMOutputs struct {
+	TaskRoleArn     pulumi.StringOutput
+	ExecRoleArn     pulumi.StringOutput
+	CIDeployRoleArn pulumi.StringOutput
+}
+
+const ecsTrustPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}`
+
+// NewIAMRoles creates three IAM roles for ECS task runtime, ECS agent
+// infrastructure, and GitHub Actions CI/CD deployment.
+func NewIAMRoles(ctx *pulumi.Context, args *IAMArgs) (*IAMOutputs, error) {
+	prefix := fmt.Sprintf("kaizen-%s", args.Environment)
+
+	identity, err := aws.GetCallerIdentity(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get caller identity: %w", err)
+	}
+
+	region, err := aws.GetRegion(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get region: %w", err)
+	}
+
+	// ── ECS Task Role ───────────────────────────────────────────────────
+	taskRole, err := newEcsTaskRole(ctx, prefix, args, identity, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// ── ECS Task Execution Role ─────────────────────────────────────────
+	execRole, err := newEcsExecRole(ctx, prefix, args, identity, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// ── CI Deploy Role ──────────────────────────────────────────────────
+	ciRole, err := newCIDeployRole(ctx, prefix, identity, taskRole, execRole)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.Export("ecsTaskRoleArn", taskRole.Arn)
+	ctx.Export("ecsExecRoleArn", execRole.Arn)
+	ctx.Export("ciDeployRoleArn", ciRole.Arn)
+
+	return &IAMOutputs{
+		TaskRoleArn:     taskRole.Arn,
+		ExecRoleArn:     execRole.Arn,
+		CIDeployRoleArn: ciRole.Arn,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// ECS Task Role — runtime permissions for running containers
+// ---------------------------------------------------------------------------
+
+// newEcsTaskRole creates the role assumed by running ECS task containers.
+// Grants access to Secrets Manager (read secrets), S3 (data + mlflow buckets),
+// and X-Ray (distributed tracing).
+func newEcsTaskRole(
+	ctx *pulumi.Context,
+	prefix string,
+	args *IAMArgs,
+	identity *aws.GetCallerIdentityResult,
+	region *aws.GetRegionResult,
+) (*iam.Role, error) {
+	role, err := iam.NewRole(ctx, "ecs-task-role", &iam.RoleArgs{
+		Name:             pulumi.Sprintf("%s-ecs-task-role", prefix),
+		AssumeRolePolicy: pulumi.String(ecsTrustPolicy),
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("kaizen"),
+			"Environment": pulumi.String(args.Environment),
+			"ManagedBy":   pulumi.String("pulumi"),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ecs-task-role: %w", err)
+	}
+
+	// X-Ray distributed tracing (managed policy).
+	if _, err = iam.NewRolePolicyAttachment(ctx, "task-xray-policy", &iam.RolePolicyAttachmentArgs{
+		Role:      role.Name,
+		PolicyArn: pulumi.String("arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"),
+	}); err != nil {
+		return nil, fmt.Errorf("task-xray-policy: %w", err)
+	}
+
+	// Secrets Manager — scoped to kaizen/{env}/* path.
+	secretsArn := fmt.Sprintf(
+		"arn:aws:secretsmanager:%s:%s:secret:kaizen/%s/*",
+		region.Name, identity.AccountId, args.Environment,
+	)
+	if _, err = iam.NewRolePolicy(ctx, "task-secrets-policy", &iam.RolePolicyArgs{
+		Role: role.Name,
+		Policy: staticPolicyJSON([]policyStatement{{
+			Effect:    "Allow",
+			Actions:   []string{"secretsmanager:GetSecretValue"},
+			Resources: []string{secretsArn},
+		}}),
+	}); err != nil {
+		return nil, fmt.Errorf("task-secrets-policy: %w", err)
+	}
+
+	// S3 — read/write to data and mlflow buckets (dynamic ARNs).
+	s3Policy := pulumi.All(args.DataBucketArn, args.MlflowBucketArn).ApplyT(
+		func(arns []interface{}) (string, error) {
+			dataArn := arns[0].(string)
+			mlflowArn := arns[1].(string)
+			return marshalPolicy([]policyStatement{
+				{
+					Effect:  "Allow",
+					Actions: []string{"s3:GetObject", "s3:PutObject", "s3:DeleteObject"},
+					Resources: []string{
+						dataArn + "/*",
+						mlflowArn + "/*",
+					},
+				},
+				{
+					Effect:    "Allow",
+					Actions:   []string{"s3:ListBucket", "s3:GetBucketLocation"},
+					Resources: []string{dataArn, mlflowArn},
+				},
+			})
+		},
+	).(pulumi.StringOutput)
+
+	if _, err = iam.NewRolePolicy(ctx, "task-s3-policy", &iam.RolePolicyArgs{
+		Role:   role.Name,
+		Policy: s3Policy,
+	}); err != nil {
+		return nil, fmt.Errorf("task-s3-policy: %w", err)
+	}
+
+	return role, nil
+}
+
+// ---------------------------------------------------------------------------
+// ECS Task Execution Role — ECS agent infrastructure permissions
+// ---------------------------------------------------------------------------
+
+// newEcsExecRole creates the execution role used by the ECS agent to pull
+// images from ECR, write CloudWatch Logs, and inject secrets into containers.
+func newEcsExecRole(
+	ctx *pulumi.Context,
+	prefix string,
+	args *IAMArgs,
+	identity *aws.GetCallerIdentityResult,
+	region *aws.GetRegionResult,
+) (*iam.Role, error) {
+	role, err := iam.NewRole(ctx, "ecs-exec-role", &iam.RoleArgs{
+		Name:             pulumi.Sprintf("%s-ecs-exec-role", prefix),
+		AssumeRolePolicy: pulumi.String(ecsTrustPolicy),
+		Tags: pulumi.StringMap{
+			"Project":     pulumi.String("kaizen"),
+			"Environment": pulumi.String(args.Environment),
+			"ManagedBy":   pulumi.String("pulumi"),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ecs-exec-role: %w", err)
+	}
+
+	// Standard ECS execution role policy — ECR pull + CloudWatch Logs write.
+	if _, err = iam.NewRolePolicyAttachment(ctx, "exec-ecs-policy", &iam.RolePolicyAttachmentArgs{
+		Role:      role.Name,
+		PolicyArn: pulumi.String("arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"),
+	}); err != nil {
+		return nil, fmt.Errorf("exec-ecs-policy: %w", err)
+	}
+
+	// Secrets Manager — for injecting secrets as container environment variables.
+	// The managed policy above covers ECR/CW Logs but not Secrets Manager.
+	secretsArn := fmt.Sprintf(
+		"arn:aws:secretsmanager:%s:%s:secret:kaizen/%s/*",
+		region.Name, identity.AccountId, args.Environment,
+	)
+	if _, err = iam.NewRolePolicy(ctx, "exec-secrets-policy", &iam.RolePolicyArgs{
+		Role: role.Name,
+		Policy: staticPolicyJSON([]policyStatement{{
+			Effect:    "Allow",
+			Actions:   []string{"secretsmanager:GetSecretValue"},
+			Resources: []string{secretsArn},
+		}}),
+	}); err != nil {
+		return nil, fmt.Errorf("exec-secrets-policy: %w", err)
+	}
+
+	return role, nil
+}
+
+// ---------------------------------------------------------------------------
+// CI Deploy Role — GitHub Actions OIDC-based deployment
+// ---------------------------------------------------------------------------
+
+// newCIDeployRole creates a role for GitHub Actions CI/CD deployments.
+// Trusts the GitHub Actions OIDC provider scoped to kaizen-experimentation repos.
+func newCIDeployRole(
+	ctx *pulumi.Context,
+	prefix string,
+	identity *aws.GetCallerIdentityResult,
+	taskRole *iam.Role,
+	execRole *iam.Role,
+) (*iam.Role, error) {
+	// GitHub Actions OIDC provider — AWS validates the certificate chain
+	// for well-known providers; the thumbprint is required by the API but
+	// functionally a placeholder.
+	oidcProvider, err := iam.NewOpenIdConnectProvider(ctx, "github-oidc", &iam.OpenIdConnectProviderArgs{
+		Url:             pulumi.String("https://token.actions.githubusercontent.com"),
+		ClientIdLists:   pulumi.StringArray{pulumi.String("sts.amazonaws.com")},
+		ThumbprintLists: pulumi.StringArray{pulumi.String("6938fd4d98bab03faadb97b34396831e3780aea1")},
+		Tags: pulumi.StringMap{
+			"Project":   pulumi.String("kaizen"),
+			"ManagedBy": pulumi.String("pulumi"),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("github-oidc: %w", err)
+	}
+
+	// Trust policy: allow GitHub Actions from kaizen-experimentation repos.
+	trustPolicy := oidcProvider.Arn.ApplyT(func(arn string) (string, error) {
+		doc := map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
+				{
+					"Effect":    "Allow",
+					"Principal": map[string]string{"Federated": arn},
+					"Action":    "sts:AssumeRoleWithWebIdentity",
+					"Condition": map[string]interface{}{
+						"StringEquals": map[string]string{
+							"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+						},
+						"StringLike": map[string]string{
+							"token.actions.githubusercontent.com:sub": "repo:*kaizen-experimentation*:*",
+						},
+					},
+				},
+			},
+		}
+		b, err := json.Marshal(doc)
+		return string(b), err
+	}).(pulumi.StringOutput)
+
+	role, err := iam.NewRole(ctx, "ci-deploy-role", &iam.RoleArgs{
+		Name:             pulumi.Sprintf("%s-ci-deploy-role", prefix),
+		AssumeRolePolicy: trustPolicy,
+		Tags: pulumi.StringMap{
+			"Project":   pulumi.String("kaizen"),
+			"ManagedBy": pulumi.String("pulumi"),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ci-deploy-role: %w", err)
+	}
+
+	// ECS deployment permissions.
+	if _, err = iam.NewRolePolicy(ctx, "ci-ecs-policy", &iam.RolePolicyArgs{
+		Role: role.Name,
+		Policy: staticPolicyJSON([]policyStatement{{
+			Effect: "Allow",
+			Actions: []string{
+				"ecs:UpdateService",
+				"ecs:DescribeServices",
+				"ecs:ListServices",
+				"ecs:DescribeClusters",
+				"ecs:DescribeTaskDefinition",
+				"ecs:RegisterTaskDefinition",
+				"ecs:DeregisterTaskDefinition",
+				"ecs:ListTasks",
+				"ecs:DescribeTasks",
+				"ecs:TagResource",
+			},
+			Resources: []string{"*"},
+		}}),
+	}); err != nil {
+		return nil, fmt.Errorf("ci-ecs-policy: %w", err)
+	}
+
+	// ECR push permissions — scoped to kaizen-* repositories.
+	ecrRepoArn := fmt.Sprintf("arn:aws:ecr:*:%s:repository/kaizen-*", identity.AccountId)
+	if _, err = iam.NewRolePolicy(ctx, "ci-ecr-policy", &iam.RolePolicyArgs{
+		Role: role.Name,
+		Policy: staticPolicyJSON([]policyStatement{
+			{
+				Effect:    "Allow",
+				Actions:   []string{"ecr:GetAuthorizationToken"},
+				Resources: []string{"*"},
+			},
+			{
+				Effect: "Allow",
+				Actions: []string{
+					"ecr:BatchCheckLayerAvailability",
+					"ecr:CompleteLayerUpload",
+					"ecr:UploadLayerPart",
+					"ecr:InitiateLayerUpload",
+					"ecr:PutImage",
+					"ecr:BatchGetImage",
+					"ecr:GetDownloadUrlForLayer",
+				},
+				Resources: []string{ecrRepoArn},
+			},
+		}),
+	}); err != nil {
+		return nil, fmt.Errorf("ci-ecr-policy: %w", err)
+	}
+
+	// PassRole — allow CI to pass task and execution roles to ECS.
+	passRolePolicy := pulumi.All(taskRole.Arn, execRole.Arn).ApplyT(
+		func(arns []interface{}) (string, error) {
+			return marshalPolicy([]policyStatement{{
+				Effect:    "Allow",
+				Actions:   []string{"iam:PassRole"},
+				Resources: []string{arns[0].(string), arns[1].(string)},
+			}})
+		},
+	).(pulumi.StringOutput)
+
+	if _, err = iam.NewRolePolicy(ctx, "ci-passrole-policy", &iam.RolePolicyArgs{
+		Role:   role.Name,
+		Policy: passRolePolicy,
+	}); err != nil {
+		return nil, fmt.Errorf("ci-passrole-policy: %w", err)
+	}
+
+	// CloudWatch Logs — create log groups for new service deployments.
+	if _, err = iam.NewRolePolicy(ctx, "ci-logs-policy", &iam.RolePolicyArgs{
+		Role: role.Name,
+		Policy: staticPolicyJSON([]policyStatement{{
+			Effect:    "Allow",
+			Actions:   []string{"logs:CreateLogGroup", "logs:TagResource"},
+			Resources: []string{"*"},
+		}}),
+	}); err != nil {
+		return nil, fmt.Errorf("ci-logs-policy: %w", err)
+	}
+
+	return role, nil
+}
+
+// ---------------------------------------------------------------------------
+// Policy helpers
+// ---------------------------------------------------------------------------
+
+type policyDocument struct {
+	Version   string            `json:"Version"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+type policyStatement struct {
+	Effect    string   `json:"Effect"`
+	Actions   []string `json:"Action"`
+	Resources []string `json:"Resource"`
+}
+
+// staticPolicyJSON serializes statements into a JSON IAM policy string.
+// Safe for structs with only string/slice fields (json.Marshal cannot fail).
+func staticPolicyJSON(stmts []policyStatement) pulumi.StringInput {
+	doc := policyDocument{Version: "2012-10-17", Statement: stmts}
+	b, _ := json.Marshal(doc) //nolint:errcheck // struct with basic types only
+	return pulumi.String(string(b))
+}
+
+// marshalPolicy serializes statements into a JSON IAM policy string with error
+// propagation, for use in ApplyT callbacks.
+func marshalPolicy(stmts []policyStatement) (string, error) {
+	doc := policyDocument{Version: "2012-10-17", Statement: stmts}
+	b, err := json.Marshal(doc)
+	return string(b), err
+}

--- a/infra/pkg/network/vpc.go
+++ b/infra/pkg/network/vpc.go
@@ -14,9 +14,10 @@ import (
 
 // VpcOutputs exposes the VPC resources that downstream modules consume.
 type VpcOutputs struct {
-	VpcId            pulumi.IDOutput
-	PublicSubnetIds  pulumi.StringArrayOutput
-	PrivateSubnetIds pulumi.StringArrayOutput
+	VpcId                pulumi.IDOutput
+	PublicSubnetIds      pulumi.StringArrayOutput
+	PrivateSubnetIds     pulumi.StringArrayOutput
+	PrivateRouteTableIds pulumi.StringArrayOutput
 }
 
 // NewVpc creates the core networking foundation: VPC, subnets across 3 AZs,
@@ -177,6 +178,7 @@ func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
 	}
 
 	// ── Private route tables → NAT (round-robin across NAT GWs) ────────
+	privateRTIds := pulumi.StringArray{}
 	for i, subnet := range privateSubnets {
 		natIdx := i % natCount
 		rtName := fmt.Sprintf("kaizen-private-rt-%d", i)
@@ -190,6 +192,8 @@ func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
 		if err != nil {
 			return nil, fmt.Errorf("create private route table %d: %w", i, err)
 		}
+
+		privateRTIds = append(privateRTIds, privateRT.ID().ToStringOutput())
 
 		_, err = ec2.NewRoute(ctx, fmt.Sprintf("kaizen-private-default-%d", i), &ec2.RouteArgs{
 			RouteTableId:         privateRT.ID(),
@@ -216,9 +220,13 @@ func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
 	ctx.Export("publicSubnetIds", pubIds)
 	ctx.Export("privateSubnetIds", privIds)
 
+	privRTIds := privateRTIds.ToStringArrayOutput()
+	ctx.Export("privateRouteTableIds", privRTIds)
+
 	return &VpcOutputs{
-		VpcId:            vpc.ID(),
-		PublicSubnetIds:  pubIds,
-		PrivateSubnetIds: privIds,
+		VpcId:                vpc.ID(),
+		PublicSubnetIds:      pubIds,
+		PrivateSubnetIds:     privIds,
+		PrivateRouteTableIds: privRTIds,
 	}, nil
 }

--- a/infra/pkg/network/vpc_endpoints.go
+++ b/infra/pkg/network/vpc_endpoints.go
@@ -1,0 +1,163 @@
+// Package network provisions VPC endpoints for private AWS service access,
+// eliminating NAT gateway data processing charges for high-volume services.
+package network
+
+import (
+	"fmt"
+
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// VpcEndpointArgs holds the inputs for creating VPC endpoints.
+type VpcEndpointArgs struct {
+	VpcId                pulumi.IDOutput
+	PrivateSubnetIds     pulumi.StringArrayOutput
+	PrivateRouteTableIds pulumi.StringArrayOutput
+	EcsSecurityGroupId   pulumi.IDOutput
+	M4bSecurityGroupId   pulumi.IDOutput
+}
+
+// VpcEndpointOutputs holds the VPC endpoint resources for downstream modules.
+type VpcEndpointOutputs struct {
+	EndpointSecurityGroupId pulumi.IDOutput
+	S3EndpointId            pulumi.IDOutput
+}
+
+// NewVpcEndpoints creates VPC endpoints for private AWS service access.
+//
+// Endpoints created:
+//   - S3 (Gateway): routes S3 traffic through route tables, not NAT
+//   - ECR DKR + API (Interface): private Docker image pulls
+//   - CloudWatch Logs (Interface): private log delivery
+//   - Secrets Manager (Interface): private secret retrieval
+//
+// Also adds HTTPS egress rules to ECS and M4b security groups so compute
+// resources can reach the interface endpoint ENIs on port 443.
+func NewVpcEndpoints(ctx *pulumi.Context, args *VpcEndpointArgs) (*VpcEndpointOutputs, error) {
+	tags := kconfig.CommonTags(ctx)
+
+	region, err := aws.GetRegion(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get region: %w", err)
+	}
+
+	// ── Endpoint Security Group ─────────────────────────────────────────
+	// Interface endpoints receive HTTPS traffic from ECS and M4b compute.
+	endpointSg, err := ec2.NewSecurityGroup(ctx, "kaizen-vpce-sg", &ec2.SecurityGroupArgs{
+		VpcId:               args.VpcId.ToStringOutput(),
+		Description:         pulumi.String("VPC interface endpoints — HTTPS from compute"),
+		RevokeRulesOnDelete: pulumi.Bool(true),
+		Tags: kconfig.MergeTags(tags, pulumi.StringMap{
+			"Name": pulumi.String("kaizen-vpce-sg"),
+		}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("vpce-sg: %w", err)
+	}
+
+	// Endpoint SG ingress: HTTPS from ECS Fargate services.
+	if _, err = ec2.NewSecurityGroupRule(ctx, "kaizen-vpce-in-ecs", &ec2.SecurityGroupRuleArgs{
+		Type:                  pulumi.String("ingress"),
+		SecurityGroupId:       endpointSg.ID().ToStringOutput(),
+		Protocol:              pulumi.String("tcp"),
+		FromPort:              pulumi.Int(443),
+		ToPort:                pulumi.Int(443),
+		SourceSecurityGroupId: args.EcsSecurityGroupId.ToStringOutput(),
+		Description:           pulumi.String("HTTPS from ECS Fargate services"),
+	}); err != nil {
+		return nil, fmt.Errorf("vpce-in-ecs: %w", err)
+	}
+
+	// Endpoint SG ingress: HTTPS from M4b Policy service.
+	if _, err = ec2.NewSecurityGroupRule(ctx, "kaizen-vpce-in-m4b", &ec2.SecurityGroupRuleArgs{
+		Type:                  pulumi.String("ingress"),
+		SecurityGroupId:       endpointSg.ID().ToStringOutput(),
+		Protocol:              pulumi.String("tcp"),
+		FromPort:              pulumi.Int(443),
+		ToPort:                pulumi.Int(443),
+		SourceSecurityGroupId: args.M4bSecurityGroupId.ToStringOutput(),
+		Description:           pulumi.String("HTTPS from M4b Policy service"),
+	}); err != nil {
+		return nil, fmt.Errorf("vpce-in-m4b: %w", err)
+	}
+
+	// ECS egress: HTTPS to VPC endpoints.
+	if _, err = ec2.NewSecurityGroupRule(ctx, "kaizen-ecs-out-vpce", &ec2.SecurityGroupRuleArgs{
+		Type:                  pulumi.String("egress"),
+		SecurityGroupId:       args.EcsSecurityGroupId.ToStringOutput(),
+		Protocol:              pulumi.String("tcp"),
+		FromPort:              pulumi.Int(443),
+		ToPort:                pulumi.Int(443),
+		SourceSecurityGroupId: endpointSg.ID().ToStringOutput(),
+		Description:           pulumi.String("HTTPS to VPC endpoints"),
+	}); err != nil {
+		return nil, fmt.Errorf("ecs-out-vpce: %w", err)
+	}
+
+	// M4b egress: HTTPS to VPC endpoints.
+	if _, err = ec2.NewSecurityGroupRule(ctx, "kaizen-m4b-out-vpce", &ec2.SecurityGroupRuleArgs{
+		Type:                  pulumi.String("egress"),
+		SecurityGroupId:       args.M4bSecurityGroupId.ToStringOutput(),
+		Protocol:              pulumi.String("tcp"),
+		FromPort:              pulumi.Int(443),
+		ToPort:                pulumi.Int(443),
+		SourceSecurityGroupId: endpointSg.ID().ToStringOutput(),
+		Description:           pulumi.String("HTTPS to VPC endpoints"),
+	}); err != nil {
+		return nil, fmt.Errorf("m4b-out-vpce: %w", err)
+	}
+
+	// ── S3 Gateway Endpoint ─────────────────────────────────────────────
+	// Gateway endpoints route traffic via prefix lists in route tables,
+	// so they don't need security groups or subnet placement.
+	s3Endpoint, err := ec2.NewVpcEndpoint(ctx, "kaizen-s3-endpoint", &ec2.VpcEndpointArgs{
+		VpcId:           args.VpcId.ToStringOutput(),
+		ServiceName:     pulumi.String(fmt.Sprintf("com.amazonaws.%s.s3", region.Name)),
+		VpcEndpointType: pulumi.String("Gateway"),
+		RouteTableIds:   args.PrivateRouteTableIds,
+		Tags: kconfig.MergeTags(tags, pulumi.StringMap{
+			"Name": pulumi.String("kaizen-s3-endpoint"),
+		}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s3 endpoint: %w", err)
+	}
+
+	// ── Interface Endpoints ─────────────────────────────────────────────
+	// All interface endpoints share the same SG, subnets, and private DNS.
+	sgIds := pulumi.StringArray{endpointSg.ID().ToStringOutput()}
+
+	interfaceEndpoints := []struct {
+		name    string
+		service string
+	}{
+		{"kaizen-ecr-dkr-endpoint", fmt.Sprintf("com.amazonaws.%s.ecr.dkr", region.Name)},
+		{"kaizen-ecr-api-endpoint", fmt.Sprintf("com.amazonaws.%s.ecr.api", region.Name)},
+		{"kaizen-logs-endpoint", fmt.Sprintf("com.amazonaws.%s.logs", region.Name)},
+		{"kaizen-secretsmanager-endpoint", fmt.Sprintf("com.amazonaws.%s.secretsmanager", region.Name)},
+	}
+
+	for _, ep := range interfaceEndpoints {
+		if _, err = ec2.NewVpcEndpoint(ctx, ep.name, &ec2.VpcEndpointArgs{
+			VpcId:             args.VpcId.ToStringOutput(),
+			ServiceName:       pulumi.String(ep.service),
+			VpcEndpointType:   pulumi.String("Interface"),
+			SubnetIds:         args.PrivateSubnetIds,
+			SecurityGroupIds:  sgIds,
+			PrivateDnsEnabled: pulumi.Bool(true),
+			Tags: kconfig.MergeTags(tags, pulumi.StringMap{
+				"Name": pulumi.String(ep.name),
+			}),
+		}); err != nil {
+			return nil, fmt.Errorf("%s: %w", ep.name, err)
+		}
+	}
+
+	return &VpcEndpointOutputs{
+		EndpointSecurityGroupId: endpointSg.ID(),
+		S3EndpointId:            s3Endpoint.ID(),
+	}, nil
+}


### PR DESCRIPTION
## Summary

- **VPC Endpoints** (`infra/pkg/network/vpc_endpoints.go`): S3 gateway endpoint (route table-based), plus ECR dkr/api, CloudWatch Logs, and Secrets Manager interface endpoints with shared security group and private DNS
- **IAM Roles** (`infra/pkg/network/iam.go`): ECS task role (Secrets Manager + S3 + X-Ray), ECS execution role (ECR pull + CW Logs + secret injection), CI deploy role (GitHub Actions OIDC + ECS/ECR/PassRole)
- **VPC update** (`infra/pkg/network/vpc.go`): Exports `PrivateRouteTableIds` for S3 gateway endpoint association
- **Wiring** (`infra/main.go`): Both modules integrated into the Pulumi stack

### Architecture decisions
- VPC endpoint security group uses SG-to-SG references (not CIDR) for least-privilege — only ECS and M4b SGs can reach endpoints
- S3 uses a gateway endpoint (free, route-table based) while ECR/CW/SM use interface endpoints (ENI-based, PrivateLink)
- IAM policies are resource-scoped where possible: S3 to specific bucket ARNs, Secrets Manager to `kaizen/{env}/*` path, ECR to `kaizen-*` repos
- CI deploy role trusts GitHub Actions OIDC scoped to `*kaizen-experimentation*` repos

### Opportunities (not implemented)
- Add STS VPC endpoint for role assumption within the VPC
- Add KMS VPC endpoint if switching from SSE-S3 to SSE-KMS
- Consider per-service task roles instead of shared role for tighter permission boundaries
- The OIDC provider subject filter could be tightened to specific branches

Closes #352

## Test plan
- [ ] `pulumi preview` succeeds on dev stack
- [ ] VPC endpoint security group allows HTTPS from ECS/M4b SGs
- [ ] S3 gateway endpoint associated with all 3 private route tables
- [ ] Interface endpoints have private DNS enabled
- [ ] Task role can access Secrets Manager, S3 buckets, X-Ray
- [ ] Execution role can pull ECR images and write CW Logs
- [ ] CI deploy role trust policy only allows GitHub Actions OIDC
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
