### PR TITLE
🎨 Palette: Standardize Search UI in Feature Flags

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-04-15 - Keyboard Accessibility for Expandable Rows
 **Learning:** Interactive table rows that toggle visibility of details must be explicitly marked as buttons and support keyboard navigation. Without `role="button"` and `onKeyDown` handlers for Enter/Space, these features remain "mouse-only" and inaccessible to screen reader or keyboard-only users.
 **Action:** Always add `role="button"`, `tabIndex={0}`, `aria-expanded`, and keyboard handlers to custom interactive containers that lack native button semantics. Use `focus-within` with a ring to provide clear focus indicators.
+
+## 2026-05-22 - Standardized Search UI Pattern
+**Learning:** Using a consistent visual pattern for search inputs (magnifying glass icon + inset text) creates a predictable experience for users scanning filtered lists. Achieving precise vertical alignment between the absolute-positioned icon and the input text requires consistent vertical padding (e.g., `py-1.5` or `py-2`) depending on the line height.
+**Action:** Always wrap search inputs in a `relative` container with an absolute-positioned magnifying glass SVG. Use `pl-9` to clear the icon and ensure `pointer-events-none` on the icon to avoid interfering with input focus.

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -90,16 +90,27 @@ function FlagListContent() {
         )}
       </div>
 
-      <div className="mb-4">
-        <input
-          type="text"
-          placeholder="Search by name or description..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-          data-testid="flag-search"
-          aria-label="Search flags"
-        />
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[300px] max-w-md">
+          <svg
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search by name or description..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            data-testid="flag-search"
+            aria-label="Search flags"
+          />
+        </div>
       </div>
 
       {filtered.length === 0 ? (


### PR DESCRIPTION
### 🎨 Palette: Standardize Search UI in Feature Flags

#### 💡 What:
Enhanced the Search UI in the Feature Flags list to match the established visual pattern used elsewhere in the platform (e.g., Experiments and Audit Log). This includes adding a magnifying glass icon and refining the input styling.

#### 🎯 Why:
Consistency in repetitive UI elements like search bars builds user trust and makes the interface feel predictable. The previous implementation was a plain input field that lacked the standard visual affordances of the rest of the application.

#### ♿ Accessibility:
- Added `aria-hidden="true"` to the decorative magnifying glass SVG to hide it from screen readers.
- Maintained clear focus indicators using `focus:ring-1 focus:ring-indigo-500`.
- Ensured the input remains fully accessible via keyboard.

#### ✅ Verification:
- Verified visually using Playwright (screenshots generated).
- Ran `pnpm lint` and `pnpm type-check` (all passed).
- Ran all 38 tests in `flag-pages.test.tsx` (all passed).

---
*PR created automatically by Jules for task [10739313854094981748](https://jules.google.com/task/10739313854094981748) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
