### PR TITLE
feat(infra): Grafana dashboards + ADOT X-Ray sidecar

### DIFF
--- a/infra/dashboards/ecs-compute.json
+++ b/infra/dashboards/ecs-compute.json
@@ -1,0 +1,204 @@
+{
+  "dashboard": {
+    "uid": "kaizen-ecs-compute",
+    "title": "Kaizen - ECS Compute",
+    "description": "CPU utilization, memory utilization, and task count per ECS service.",
+    "tags": ["kaizen", "ecs", "compute"],
+    "timezone": "utc",
+    "editable": true,
+    "refresh": "30s",
+    "time": { "from": "now-1h", "to": "now" },
+    "templating": {
+      "list": [
+        {
+          "name": "datasource",
+          "type": "datasource",
+          "query": "prometheus",
+          "current": { "text": "AMP", "value": "AMP" }
+        },
+        {
+          "name": "service",
+          "type": "query",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "query": "label_values(ecs_service_cpu_utilization, service)",
+          "multi": true,
+          "includeAll": true,
+          "current": { "text": "All", "value": "$__all" },
+          "refresh": 2
+        }
+      ]
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "CPU Utilization by Service",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "avg(ecs_service_cpu_utilization{service=~\"$service\"}) by (service)",
+            "legendFormat": "{{service}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 60 },
+                { "color": "red", "value": 80 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Memory Utilization by Service",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 10 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "avg(ecs_service_memory_utilization{service=~\"$service\"}) by (service)",
+            "legendFormat": "{{service}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 70 },
+                { "color": "red", "value": 85 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Running Task Count by Service",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "ecs_service_running_task_count{service=~\"$service\"}",
+            "legendFormat": "{{service}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal" } }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Desired vs Running Tasks",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(ecs_service_desired_task_count{service=~\"$service\"})",
+            "legendFormat": "Desired",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(ecs_service_running_task_count{service=~\"$service\"})",
+            "legendFormat": "Running",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "CPU Utilization Heatmap",
+        "type": "bargauge",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "avg(ecs_service_cpu_utilization{service=~\"$service\"}) by (service)",
+            "legendFormat": "{{service}}",
+            "refId": "A",
+            "instant": true
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 60 },
+                { "color": "red", "value": 80 }
+              ]
+            }
+          }
+        },
+        "options": { "orientation": "horizontal", "displayMode": "gradient" }
+      },
+      {
+        "id": 6,
+        "title": "Memory Utilization Heatmap",
+        "type": "bargauge",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "avg(ecs_service_memory_utilization{service=~\"$service\"}) by (service)",
+            "legendFormat": "{{service}}",
+            "refId": "A",
+            "instant": true
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 70 },
+                { "color": "red", "value": 85 }
+              ]
+            }
+          }
+        },
+        "options": { "orientation": "horizontal", "displayMode": "gradient" }
+      }
+    ],
+    "schemaVersion": 39,
+    "version": 1
+  },
+  "overwrite": true
+}

--- a/infra/dashboards/kafka-streaming.json
+++ b/infra/dashboards/kafka-streaming.json
@@ -1,0 +1,185 @@
+{
+  "dashboard": {
+    "uid": "kaizen-kafka-streaming",
+    "title": "Kaizen - Kafka Streaming",
+    "description": "Consumer lag and messages per second for MSK Kafka topics.",
+    "tags": ["kaizen", "kafka", "streaming"],
+    "timezone": "utc",
+    "editable": true,
+    "refresh": "30s",
+    "time": { "from": "now-1h", "to": "now" },
+    "templating": {
+      "list": [
+        {
+          "name": "datasource",
+          "type": "datasource",
+          "query": "prometheus",
+          "current": { "text": "AMP", "value": "AMP" }
+        },
+        {
+          "name": "consumer_group",
+          "type": "query",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "query": "label_values(kafka_consumergroup_lag, consumergroup)",
+          "multi": true,
+          "includeAll": true,
+          "current": { "text": "All", "value": "$__all" },
+          "refresh": 2
+        },
+        {
+          "name": "topic",
+          "type": "query",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "query": "label_values(kafka_consumergroup_lag, topic)",
+          "multi": true,
+          "includeAll": true,
+          "current": { "text": "All", "value": "$__all" },
+          "refresh": 2
+        }
+      ]
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "Consumer Lag by Group + Topic",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(kafka_consumergroup_lag{consumergroup=~\"$consumer_group\", topic=~\"$topic\"}) by (consumergroup, topic)",
+            "legendFormat": "{{consumergroup}} / {{topic}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 5000 },
+                { "color": "red", "value": 10000 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Messages In Per Second (by Topic)",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 12, "x": 0, "y": 10 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(rate(kafka_topic_partition_current_offset{topic=~\"$topic\"}[5m])) by (topic)",
+            "legendFormat": "{{topic}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Messages Out Per Second (by Consumer Group)",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 12, "x": 12, "y": 10 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(rate(kafka_consumergroup_current_offset{consumergroup=~\"$consumer_group\", topic=~\"$topic\"}[5m])) by (consumergroup, topic)",
+            "legendFormat": "{{consumergroup}} / {{topic}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Max Consumer Lag (Guardrail Alerts)",
+        "type": "stat",
+        "gridPos": { "h": 5, "w": 8, "x": 0, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "max(kafka_consumergroup_lag{consumergroup=\"guardrail_alerts\"})",
+            "legendFormat": "Max Lag",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 5000 },
+                { "color": "red", "value": 10000 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Partition Count by Topic",
+        "type": "bargauge",
+        "gridPos": { "h": 5, "w": 8, "x": 8, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "count(kafka_topic_partition_current_offset{topic=~\"$topic\"}) by (topic)",
+            "legendFormat": "{{topic}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": { "unit": "short" }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Under-Replicated Partitions",
+        "type": "stat",
+        "gridPos": { "h": 5, "w": 8, "x": 16, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(kafka_server_replicamanager_underreplicatedpartitions)",
+            "legendFormat": "Under-replicated",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 1 }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "schemaVersion": 39,
+    "version": 1
+  },
+  "overwrite": true
+}

--- a/infra/dashboards/m4b-bandit.json
+++ b/infra/dashboards/m4b-bandit.json
@@ -1,0 +1,207 @@
+{
+  "dashboard": {
+    "uid": "kaizen-m4b-bandit",
+    "title": "Kaizen - M4b Bandit Engine",
+    "description": "RocksDB write latency, reward rate, LMAX ring buffer, and EC2 health for the M4b Policy service.",
+    "tags": ["kaizen", "m4b", "bandit", "rocksdb"],
+    "timezone": "utc",
+    "editable": true,
+    "refresh": "30s",
+    "time": { "from": "now-1h", "to": "now" },
+    "templating": {
+      "list": [
+        {
+          "name": "datasource",
+          "type": "datasource",
+          "query": "prometheus",
+          "current": { "text": "AMP", "value": "AMP" }
+        }
+      ]
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "RocksDB Write Latency (p50/p95/p99)",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 12, "x": 0, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, sum(rate(m4b_rocksdb_write_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "p50",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(m4b_rocksdb_write_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "p95",
+            "refId": "B"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum(rate(m4b_rocksdb_write_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "p99",
+            "refId": "C"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.001 },
+                { "color": "red", "value": 0.01 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "RocksDB Write Rate",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 12, "x": 12, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(rate(m4b_rocksdb_write_duration_seconds_count[5m]))",
+            "legendFormat": "Writes/sec",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Reward Update Rate by Algorithm",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 12, "x": 0, "y": 10 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(rate(m4b_reward_updates_total[5m])) by (algorithm)",
+            "legendFormat": "{{algorithm}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ops",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Cumulative Reward by Algorithm",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 12, "x": 12, "y": 10 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(m4b_cumulative_reward) by (algorithm)",
+            "legendFormat": "{{algorithm}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "LMAX Ring Buffer Utilization",
+        "type": "gauge",
+        "gridPos": { "h": 6, "w": 8, "x": 0, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "m4b_lmax_ring_buffer_utilization_ratio",
+            "legendFormat": "Buffer Fill %",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percentunit",
+            "min": 0,
+            "max": 1,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.7 },
+                { "color": "red", "value": 0.9 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Arm Selection Latency (p99)",
+        "type": "stat",
+        "gridPos": { "h": 6, "w": 8, "x": 8, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.99, sum(rate(m4b_arm_selection_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "p99",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.001 },
+                { "color": "red", "value": 0.005 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 7,
+        "title": "Cold-Start Experiments",
+        "type": "stat",
+        "gridPos": { "h": 6, "w": 8, "x": 16, "y": 20 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "sum(m4b_cold_start_experiments_active)",
+            "legendFormat": "Active",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "blue", "value": null },
+                { "color": "green", "value": 1 }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "schemaVersion": 39,
+    "version": 1
+  },
+  "overwrite": true
+}

--- a/infra/dashboards/rds-database.json
+++ b/infra/dashboards/rds-database.json
@@ -1,0 +1,206 @@
+{
+  "dashboard": {
+    "uid": "kaizen-rds-database",
+    "title": "Kaizen - RDS Database",
+    "description": "PostgreSQL connections, query latency, CPU, and storage metrics.",
+    "tags": ["kaizen", "rds", "database"],
+    "timezone": "utc",
+    "editable": true,
+    "refresh": "30s",
+    "time": { "from": "now-1h", "to": "now" },
+    "templating": {
+      "list": [
+        {
+          "name": "datasource",
+          "type": "datasource",
+          "query": "prometheus",
+          "current": { "text": "AMP", "value": "AMP" }
+        }
+      ]
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "Active Connections",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "aws_rds_database_connections_average",
+            "legendFormat": "Active Connections",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 150 },
+                { "color": "red", "value": 180 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "CPU Utilization",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "aws_rds_cpuutilization_average",
+            "legendFormat": "CPU %",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "min": 0,
+            "max": 100,
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 60 },
+                { "color": "red", "value": 80 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Read Latency",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "aws_rds_read_latency_average",
+            "legendFormat": "Read Latency",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.005 },
+                { "color": "red", "value": 0.02 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Write Latency",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "aws_rds_write_latency_average",
+            "legendFormat": "Write Latency",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.005 },
+                { "color": "red", "value": 0.02 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Freeable Memory",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "aws_rds_freeable_memory_average",
+            "legendFormat": "Freeable Memory",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "bytes",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Free Storage Space",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "aws_rds_free_storage_space_average",
+            "legendFormat": "Free Storage",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "bytes",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      },
+      {
+        "id": 7,
+        "title": "IOPS (Read + Write)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "aws_rds_read_iops_average",
+            "legendFormat": "Read IOPS",
+            "refId": "A"
+          },
+          {
+            "expr": "aws_rds_write_iops_average",
+            "legendFormat": "Write IOPS",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "iops",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }
+          }
+        }
+      }
+    ],
+    "schemaVersion": 39,
+    "version": 1
+  },
+  "overwrite": true
+}

--- a/infra/dashboards/service-latency.json
+++ b/infra/dashboards/service-latency.json
@@ -1,0 +1,199 @@
+{
+  "dashboard": {
+    "uid": "kaizen-service-latency",
+    "title": "Kaizen - Service Latency",
+    "description": "p50/p95/p99 latency per service. SLO targets: M1 < 5ms, M5 < 50ms, M7 < 10ms.",
+    "tags": ["kaizen", "latency", "slo"],
+    "timezone": "utc",
+    "editable": true,
+    "refresh": "30s",
+    "time": { "from": "now-1h", "to": "now" },
+    "templating": {
+      "list": [
+        {
+          "name": "service",
+          "type": "query",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "query": "label_values(http_request_duration_seconds_bucket, service)",
+          "multi": true,
+          "includeAll": true,
+          "current": { "text": "All", "value": "$__all" },
+          "refresh": 2
+        },
+        {
+          "name": "datasource",
+          "type": "datasource",
+          "query": "prometheus",
+          "current": { "text": "AMP", "value": "AMP" }
+        }
+      ]
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "p50 Latency by Service",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{service=~\"$service\"}[5m])) by (le, service))",
+            "legendFormat": "{{service}} p50",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "pointSize": 5 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.01 },
+                { "color": "red", "value": 0.05 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "p95 Latency by Service",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{service=~\"$service\"}[5m])) by (le, service))",
+            "legendFormat": "{{service}} p95",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "pointSize": 5 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.02 },
+                { "color": "red", "value": 0.1 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "p99 Latency by Service",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{service=~\"$service\"}[5m])) by (le, service))",
+            "legendFormat": "{{service}} p99",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "pointSize": 5 },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.05 },
+                { "color": "red", "value": 0.2 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "SLO Compliance - M1 Assignment (< 5ms)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 8, "x": 0, "y": 24 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "1 - (sum(rate(http_request_duration_seconds_bucket{service=\"assignment\", le=\"0.005\"}[5m])) / sum(rate(http_request_duration_seconds_count{service=\"assignment\"}[5m])))",
+            "legendFormat": "SLO violation rate",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percentunit",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 0.01 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "SLO Compliance - M5 Management (< 50ms)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 8, "x": 8, "y": 24 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "1 - (sum(rate(http_request_duration_seconds_bucket{service=\"management\", le=\"0.050\"}[5m])) / sum(rate(http_request_duration_seconds_count{service=\"management\"}[5m])))",
+            "legendFormat": "SLO violation rate",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percentunit",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 0.01 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "SLO Compliance - M7 Flags (< 10ms)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 8, "x": 16, "y": 24 },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "targets": [
+          {
+            "expr": "1 - (sum(rate(http_request_duration_seconds_bucket{service=\"flags\", le=\"0.010\"}[5m])) / sum(rate(http_request_duration_seconds_count{service=\"flags\"}[5m])))",
+            "legendFormat": "SLO violation rate",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percentunit",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 0.01 }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "schemaVersion": 39,
+    "version": 1
+  },
+  "overwrite": true
+}

--- a/infra/pkg/compute/services.go
+++ b/infra/pkg/compute/services.go
@@ -430,7 +430,17 @@ func buildContainerDefsJSON(
 			{Name: "AUTH_SECRET", ValueFrom: authSecretArn},
 		}
 
-		def := containerDef{
+		// Tell the app container to send OTLP traces to the ADOT sidecar.
+		envVars = append(envVars, envKV{
+			Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+			Value: "http://localhost:4317",
+		})
+		envVars = append(envVars, envKV{
+			Name:  "OTEL_SERVICE_NAME",
+			Value: spec.name,
+		})
+
+		appDef := containerDef{
 			Name:      spec.name,
 			Image:     imageURL + ":latest",
 			Essential: true,
@@ -454,7 +464,29 @@ func buildContainerDefsJSON(
 			},
 		}
 
-		b, err := json.Marshal([]containerDef{def})
+		// ADOT collector sidecar: receives OTLP on :4317, exports to X-Ray.
+		adotDef := containerDef{
+			Name:      "aws-otel-collector",
+			Image:     "public.ecr.aws/aws-observability/aws-otel-collector:latest",
+			Essential: false,
+			PortMappings: []portMap{
+				{ContainerPort: 4317, Protocol: "tcp"},
+			},
+			LogConfiguration: logCfg{
+				LogDriver: "awslogs",
+				Options: map[string]string{
+					"awslogs-group":         logGroupName,
+					"awslogs-region":        awsRegion,
+					"awslogs-stream-prefix": spec.name + "-otel",
+				},
+			},
+			Environment: []envKV{
+				{Name: "AOT_CONFIG_CONTENT", Value: adotConfigYAML(spec.name)},
+			},
+			Secrets: nil,
+		}
+
+		b, err := json.Marshal([]containerDef{appDef, adotDef})
 		if err != nil {
 			return "", fmt.Errorf("marshaling container defs for %s: %w", spec.name, err)
 		}
@@ -592,6 +624,15 @@ func newTaskRole(ctx *pulumi.Context, prefix string) (*iam.Role, error) {
 		return nil, fmt.Errorf("attaching SSM policy: %w", err)
 	}
 
+	// X-Ray: allow ADOT sidecar to push traces.
+	_, err = iam.NewRolePolicyAttachment(ctx, "ecs-task-xray", &iam.RolePolicyAttachmentArgs{
+		Role:      role.Name,
+		PolicyArn: pulumi.String("arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attaching X-Ray policy: %w", err)
+	}
+
 	// S3 read/write for metrics data (M3 Delta Lake, MLflow artifacts).
 	_, err = iam.NewRolePolicy(ctx, "ecs-task-s3", &iam.RolePolicyArgs{
 		Name: pulumi.Sprintf("%s-task-s3", prefix),
@@ -625,6 +666,38 @@ func newTaskRole(ctx *pulumi.Context, prefix string) (*iam.Role, error) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// adotConfigYAML returns the ADOT collector configuration for a given service.
+// The collector receives OTLP gRPC on port 4317 and exports traces to X-Ray.
+func adotConfigYAML(serviceName string) string {
+	return fmt.Sprintf(`receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 256
+  resource:
+    attributes:
+      - key: service.name
+        value: %s
+        action: upsert
+
+exporters:
+  awsxray:
+    region: us-east-1
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resource, batch]
+      exporters: [awsxray]
+`, serviceName)
+}
 
 // logRetentionDays returns the CloudWatch log retention period based on env.
 func logRetentionDays(env string) int {


### PR DESCRIPTION
## Summary

- Add 5 Grafana dashboard JSON models in `infra/dashboards/` for platform observability
- Integrate ADOT (AWS Distro for OpenTelemetry) collector sidecar into all 8 ECS Fargate task definitions
- Grant `AWSXRayDaemonWriteAccess` IAM policy to ECS task role for X-Ray trace export

### Dashboards

| Dashboard | File | Key Metrics |
|-----------|------|-------------|
| Service Latency | `service-latency.json` | p50/p95/p99 per service, SLO compliance (M1 < 5ms, M5 < 50ms, M7 < 10ms) |
| Kafka Streaming | `kafka-streaming.json` | Consumer lag by group/topic, messages in/out per second, under-replicated partitions |
| RDS Database | `rds-database.json` | Active connections, CPU%, read/write latency, freeable memory, IOPS |
| M4b Bandit | `m4b-bandit.json` | RocksDB write latency (p50/p95/p99), reward rate by algorithm, LMAX buffer utilization |
| ECS Compute | `ecs-compute.json` | CPU/memory utilization per service, running vs desired task count |

### ADOT Sidecar

- Image: `public.ecr.aws/aws-observability/aws-otel-collector:latest`
- Receives OTLP gRPC on `localhost:4317` (awsvpc shared network namespace)
- Exports traces to AWS X-Ray via `awsxray` exporter
- Non-essential container (app continues if collector crashes)
- Each app container gets `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME` env vars

### Files Changed

- `infra/dashboards/*.json` — 5 new dashboard models (importable into AMG)
- `infra/pkg/compute/services.go` — ADOT sidecar container def, X-Ray IAM policy, OTEL env vars

### Future opportunities (not in scope)

- Provision dashboards into AMG via Grafana API/Pulumi resource
- Add ADOT sidecar to M4b EC2 task definition (separate compute path in `m4b.go`)
- Configure ADOT metrics pipeline alongside traces (currently traces only)

Closes #369

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./...` — all existing tests pass
- [x] Dashboard JSON files validated (well-formed JSON)
- [ ] Manual: import dashboards into AMG workspace and verify panels render
- [ ] Manual: deploy to dev, verify X-Ray traces appear in AWS console
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
