### PR TITLE
feat(infra): service dependency ordering + health gates

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -184,7 +184,16 @@ func main() {
 		ctx.Export("ecsClusterId", clusterOutputs.ClusterId)
 		ctx.Export("ecsClusterArn", clusterOutputs.ClusterArn)
 
-		// ── 11. ECS Fargate Services ────────────────────────────────────────
+		// ── 11. ECS Fargate Services (tiered startup ordering) ──────────────
+		//
+		// Service dependency graph:
+		//   Tier 0: M5 (foundation — owns PG schema via migration)
+		//   Tier 1: M1, M2, M2-Orch (core — depend on M5 healthy)
+		//           M4b is logically Tier 1 but EC2-based (section 12)
+		//   Tier 2: M3, M4a, M6, M7 (dependent — after Tier 1 + M4b)
+		//
+		// Pulumi DependsOn + WaitForSteadyState enforce deployment ordering.
+		// Health-gate init containers enforce runtime ordering via polling.
 		svcOutputs, err := compute.NewServices(ctx, &compute.ServicesArgs{
 			Environment:       env,
 			ClusterArn:        clusterOutputs.ClusterArn,
@@ -202,11 +211,15 @@ func main() {
 			return err
 		}
 
-		// ── 12. M4b Operational Resources ───────────────────────────────────
+		// ── 12. M4b Operational Resources (Tier 1 — depends on M5) ──────────
+		// M4b is logically Tier 1: it starts after M5 is healthy.
+		// Pulumi DependsOn ensures M4b ops are created only after M5's ECS
+		// service reaches steady state.
 		_, err = compute.NewM4bService(ctx, &compute.M4bServiceArgs{
 			Environment:         env,
 			CloudMapNamespaceId: sdOutputs.NamespaceId,
 			AsgName:             clusterOutputs.M4bAsgName,
+			DependsOnResources:  []pulumi.Resource{svcOutputs.M5ServiceResource},
 		})
 		if err != nil {
 			return err

--- a/infra/pkg/cicd/ecr.go
+++ b/infra/pkg/cicd/ecr.go
@@ -30,6 +30,13 @@ var ServiceNames = []string{
 	"flags",
 }
 
+// UtilityImageNames lists infrastructure utility images that need ECR
+// repositories. These are not application services — they support service
+// orchestration (e.g., health-gate init containers for startup ordering).
+var UtilityImageNames = []string{
+	"healthgate",
+}
+
 // lifecyclePolicy defines the ECR lifecycle rules:
 //   - Rule 1: expire untagged images after 7 days
 //   - Rule 2: keep only the last 10 tagged images
@@ -67,10 +74,11 @@ func NewECRRepositories(ctx *pulumi.Context, env string) (*ECROutputs, error) {
 		return nil, fmt.Errorf("building ECR lifecycle policy: %w", err)
 	}
 
-	urls := make(map[string]pulumi.StringOutput, len(ServiceNames))
-	arns := make(map[string]pulumi.StringOutput, len(ServiceNames))
+	allImages := append(ServiceNames, UtilityImageNames...)
+	urls := make(map[string]pulumi.StringOutput, len(allImages))
+	arns := make(map[string]pulumi.StringOutput, len(allImages))
 
-	for _, svc := range ServiceNames {
+	for _, svc := range allImages {
 		repoName := fmt.Sprintf("kaizen-%s", svc)
 		resourceName := fmt.Sprintf("ecr-%s", svc)
 

--- a/infra/pkg/compute/m4b.go
+++ b/infra/pkg/compute/m4b.go
@@ -29,6 +29,11 @@ type M4bServiceArgs struct {
 	// AsgName is the Auto Scaling Group name for M4b, used as the alarm
 	// dimension. Passed from ClusterOutputs.
 	AsgName pulumi.StringOutput
+
+	// DependsOnResources lists Pulumi resources that must reach steady state
+	// before M4b operational resources are created. Typically includes the M5
+	// ECS service (M4b is logically Tier 1, depends on M5 being healthy).
+	DependsOnResources []pulumi.Resource
 }
 
 // M4bServiceOutputs holds the outputs from M4b operational resources.
@@ -71,6 +76,8 @@ func NewM4bService(ctx *pulumi.Context, args *M4bServiceArgs) (*M4bServiceOutput
 	}
 
 	// ── Cloud Map: m4b-policy.kaizen.local:50054 ──────────────────────────
+	// Cloud Map registration depends on upstream resources (M5 service)
+	// so M4b isn't discoverable until its dependencies are healthy.
 
 	serviceArn, err := newM4bCloudMapService(ctx, prefix, args, tags)
 	if err != nil {
@@ -237,6 +244,12 @@ func newM4bCloudMapService(
 	args *M4bServiceArgs,
 	tags pulumi.StringMap,
 ) (pulumi.StringOutput, error) {
+	// Build resource options including DependsOn from upstream services.
+	var cmOpts []pulumi.ResourceOption
+	if len(args.DependsOnResources) > 0 {
+		cmOpts = append(cmOpts, pulumi.DependsOn(args.DependsOnResources))
+	}
+
 	svc, err := servicediscovery.NewService(ctx, "m4b-cloud-map-service", &servicediscovery.ServiceArgs{
 		Name:        pulumi.String("m4b-policy"),
 		Description: pulumi.String("M4b Policy service — LMAX bandit evaluation (port 50054)"),
@@ -258,7 +271,7 @@ func newM4bCloudMapService(
 			FailureThreshold: pulumi.Int(1),
 		},
 		Tags: tags,
-	})
+	}, cmOpts...)
 	if err != nil {
 		return pulumi.StringOutput{}, fmt.Errorf("creating M4b Cloud Map service: %w", err)
 	}

--- a/infra/pkg/compute/services.go
+++ b/infra/pkg/compute/services.go
@@ -12,6 +12,8 @@ package compute
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/cloudwatch"
@@ -57,11 +59,30 @@ type ServicesOutputs struct {
 	TaskRoleArn pulumi.StringOutput
 	// ExecRoleArn is the IAM role used by ECS to pull images and push logs.
 	ExecRoleArn pulumi.StringOutput
+	// M5ServiceResource exposes the M5 ECS service for dependency wiring.
+	// Downstream modules (e.g., M4b) can use pulumi.DependsOn with this.
+	M5ServiceResource pulumi.Resource
+	// Tier1Resources lists all Tier 1 ECS service resources, used for
+	// external dependency wiring (e.g., M4b Cloud Map depends on Tier 1).
+	Tier1Resources []pulumi.Resource
 }
 
 // ---------------------------------------------------------------------------
 // Service specification table
 // ---------------------------------------------------------------------------
+
+// Startup tiers control service deployment ordering. Higher tiers wait for
+// all services in lower tiers to reach steady state before deploying.
+//
+//	Tier 0: M5 — owns PostgreSQL schema via migration, must start first.
+//	Tier 1: M1, M2, M2-Orch — core assignment/pipeline services, depend on M5.
+//	        M4b (EC2) is logically Tier 1 but created separately in main.go.
+//	Tier 2: M3, M4a, M6, M7 — depend on Tier 1 services + M4b.
+const (
+	TierFoundation = 0
+	TierCore       = 1
+	TierDependent  = 2
+)
 
 // serviceSpec defines one Fargate service declaratively.
 type serviceSpec struct {
@@ -73,57 +94,99 @@ type serviceSpec struct {
 	ports     []int  // container ports
 	lang      string // "rust", "go", "ts" — determines health check
 	healthCmd []string
+	tier      int         // startup tier (TierFoundation, TierCore, TierDependent)
+	deps      []healthDep // upstream services to health-gate on at runtime
+}
+
+// healthDep describes an upstream service endpoint that a health-gate init
+// container must verify before the main container starts.
+type healthDep struct {
+	name  string // human-readable label (for log messages)
+	host  string // Cloud Map DNS name
+	port  int
+	proto string // "http" (wget) or "tcp" (nc)
+	path  string // HTTP health path (e.g., "/healthz"); ignored for "tcp"
+}
+
+// m5Dep is the health dependency on M5 Management (HTTP healthz).
+var m5Dep = healthDep{name: "M5", host: "m5-management.kaizen.local", port: 50055, proto: "http", path: "/healthz"}
+
+// tier1Deps are the health dependencies on Tier 1 services (M1, M2, M4b).
+// Used by Tier 2 services. M4b is included because it is logically Tier 1.
+var tier1Deps = []healthDep{
+	{name: "M1", host: "m1-assignment.kaizen.local", port: 50051, proto: "tcp"},
+	{name: "M2", host: "m2-pipeline.kaizen.local", port: 50052, proto: "tcp"},
+	{name: "M4b", host: "m4b-policy.kaizen.local", port: 50054, proto: "tcp"},
 }
 
 func serviceSpecs() []serviceSpec {
 	return []serviceSpec{
+		// ── Tier 0: Foundation ── M5 starts first (owns PG schema via migration)
+		{
+			key: "m5", name: "m5-management", ecrKey: "management",
+			cpu: "512", memoryMB: "1024", ports: []int{50055, 50060},
+			lang:      "go",
+			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:50055/healthz || exit 1"},
+			tier:      TierFoundation,
+			deps:      nil, // No upstream dependencies.
+		},
+		// ── Tier 1: Core ── M1, M2, M2-Orch start after M5 is healthy
 		{
 			key: "m1", name: "m1-assignment", ecrKey: "assignment",
 			cpu: "512", memoryMB: "1024", ports: []int{50051},
 			lang:      "rust",
 			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50051"},
+			tier:      TierCore,
+			deps:      []healthDep{m5Dep},
 		},
 		{
 			key: "m2", name: "m2-pipeline", ecrKey: "pipeline",
 			cpu: "512", memoryMB: "1024", ports: []int{50052},
 			lang:      "rust",
 			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50052"},
+			tier:      TierCore,
+			deps:      []healthDep{m5Dep},
 		},
 		{
 			key: "m2-orch", name: "m2-orchestration", ecrKey: "orchestration",
 			cpu: "256", memoryMB: "512", ports: []int{50058},
 			lang:      "go",
 			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:50058/healthz || exit 1"},
+			tier:      TierCore,
+			deps:      []healthDep{m5Dep},
 		},
+		// ── Tier 2: Dependent ── M3, M4a, M6, M7 start after Tier 1 + M4b
 		{
 			key: "m3", name: "m3-metrics", ecrKey: "metrics",
 			cpu: "1024", memoryMB: "2048", ports: []int{50056, 50059},
 			lang:      "go",
 			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:50056/healthz || exit 1"},
+			tier:      TierDependent,
+			deps:      tier1Deps,
 		},
 		{
 			key: "m4a", name: "m4a-analysis", ecrKey: "analysis",
 			cpu: "1024", memoryMB: "2048", ports: []int{50053},
 			lang:      "rust",
 			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50053"},
-		},
-		{
-			key: "m5", name: "m5-management", ecrKey: "management",
-			cpu: "512", memoryMB: "1024", ports: []int{50055, 50060},
-			lang:      "go",
-			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:50055/healthz || exit 1"},
+			tier:      TierDependent,
+			deps:      tier1Deps,
 		},
 		{
 			key: "m6", name: "m6-ui", ecrKey: "ui",
 			cpu: "512", memoryMB: "1024", ports: []int{3000},
 			lang:      "ts",
 			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:3000/ || exit 1"},
+			tier:      TierDependent,
+			deps:      tier1Deps,
 		},
 		{
 			key: "m7", name: "m7-flags", ecrKey: "flags",
 			cpu: "256", memoryMB: "512", ports: []int{50057},
 			lang:      "rust",
 			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50057"},
+			tier:      TierDependent,
+			deps:      tier1Deps,
 		},
 	}
 }
@@ -149,14 +212,23 @@ func serviceEndpoints() map[string]string {
 // ---------------------------------------------------------------------------
 
 type containerDef struct {
-	Name             string       `json:"name"`
-	Image            string       `json:"image"`
-	Essential        bool         `json:"essential"`
-	PortMappings     []portMap    `json:"portMappings"`
-	LogConfiguration logCfg       `json:"logConfiguration"`
-	Environment      []envKV      `json:"environment"`
-	Secrets          []secretRef  `json:"secrets"`
-	HealthCheck      *healthCheck `json:"healthCheck,omitempty"`
+	Name             string                `json:"name"`
+	Image            string                `json:"image"`
+	Essential        bool                  `json:"essential"`
+	PortMappings     []portMap             `json:"portMappings,omitempty"`
+	LogConfiguration logCfg                `json:"logConfiguration"`
+	Environment      []envKV               `json:"environment"`
+	Secrets          []secretRef           `json:"secrets,omitempty"`
+	HealthCheck      *healthCheck          `json:"healthCheck,omitempty"`
+	DependsOn        []containerDependency `json:"dependsOn,omitempty"`
+	Command          []string              `json:"command,omitempty"`
+}
+
+// containerDependency defines an intra-task dependency between containers.
+// Used to chain the health-gate init container to the main application container.
+type containerDependency struct {
+	ContainerName string `json:"containerName"`
+	Condition     string `json:"condition"` // "SUCCESS", "HEALTHY", "START", "COMPLETE"
 }
 
 type portMap struct {
@@ -192,9 +264,16 @@ type healthCheck struct {
 // ---------------------------------------------------------------------------
 
 // NewServices creates 8 ECS Fargate task definitions and services for the
-// Kaizen platform. Each service gets Cloud Map registration, structured
-// logging via awslogs, environment variables for service discovery, and
-// secrets injected from Secrets Manager.
+// Kaizen platform, deployed in dependency tiers:
+//
+//	Tier 0 (Foundation): M5 — deployed first, waits for steady state.
+//	Tier 1 (Core):       M1, M2, M2-Orch — deployed after Tier 0 is healthy.
+//	Tier 2 (Dependent):  M3, M4a, M6, M7 — deployed after Tier 1 is healthy.
+//
+// Each service gets Cloud Map registration, structured logging via awslogs,
+// environment variables for service discovery, secrets injected from Secrets
+// Manager, and (for Tier 1+) health-gate init containers that poll upstream
+// services before the main container starts.
 func NewServices(ctx *pulumi.Context, args *ServicesArgs) (*ServicesOutputs, error) {
 	prefix := fmt.Sprintf("kaizen-%s", args.Environment)
 
@@ -234,24 +313,87 @@ func NewServices(ctx *pulumi.Context, args *ServicesArgs) (*ServicesOutputs, err
 		return nil, fmt.Errorf("creating log group: %w", err)
 	}
 
-	// --- Create services ---
+	// --- Create services tier by tier ---
 
 	specs := serviceSpecs()
+	tierMap := groupSpecsByTier(specs)
 	serviceArns := make(map[string]pulumi.StringOutput, len(specs))
+	ecsServices := make(map[string]*ecs.Service, len(specs))
 
-	for _, spec := range specs {
-		svcArn, err := newFargateService(ctx, prefix, region.Name, spec, args, execRole, taskRole, logGroup)
-		if err != nil {
-			return nil, fmt.Errorf("creating service %s: %w", spec.name, err)
+	// Ordered tier keys for deterministic iteration.
+	tierKeys := sortedTierKeys(tierMap)
+
+	for _, tier := range tierKeys {
+		tierSpecs := tierMap[tier]
+
+		// Collect Pulumi resource dependencies from the previous tier.
+		var pulumiDeps []pulumi.Resource
+		if tier > 0 {
+			if prevSpecs, ok := tierMap[tier-1]; ok {
+				for _, prev := range prevSpecs {
+					if svc, ok := ecsServices[prev.key]; ok {
+						pulumiDeps = append(pulumiDeps, svc)
+					}
+				}
+			}
 		}
-		serviceArns[spec.key] = svcArn
+
+		// Tier 0 and Tier 1 block Pulumi until steady state so downstream
+		// tiers only deploy after upstream tasks are actually healthy.
+		waitForSteady := tier < TierDependent
+
+		for _, spec := range tierSpecs {
+			svc, err := newFargateService(ctx, prefix, region.Name, spec, args,
+				execRole, taskRole, logGroup, pulumiDeps, waitForSteady)
+			if err != nil {
+				return nil, fmt.Errorf("creating service %s: %w", spec.name, err)
+			}
+			serviceArns[spec.key] = svc.ID().ToStringOutput()
+			ecsServices[spec.key] = svc
+		}
+	}
+
+	// Collect Tier 1 resources for external wiring (M4b depends on these).
+	var tier1Resources []pulumi.Resource
+	if coreSpecs, ok := tierMap[TierCore]; ok {
+		for _, s := range coreSpecs {
+			if svc, ok := ecsServices[s.key]; ok {
+				tier1Resources = append(tier1Resources, svc)
+			}
+		}
+	}
+
+	var m5Resource pulumi.Resource
+	if svc, ok := ecsServices["m5"]; ok {
+		m5Resource = svc
 	}
 
 	return &ServicesOutputs{
-		ServiceArns: serviceArns,
-		TaskRoleArn: taskRole.Arn,
-		ExecRoleArn: execRole.Arn,
+		ServiceArns:       serviceArns,
+		TaskRoleArn:       taskRole.Arn,
+		ExecRoleArn:       execRole.Arn,
+		M5ServiceResource: m5Resource,
+		Tier1Resources:    tier1Resources,
 	}, nil
+}
+
+// groupSpecsByTier partitions service specs by their startup tier.
+func groupSpecsByTier(specs []serviceSpec) map[int][]serviceSpec {
+	m := make(map[int][]serviceSpec)
+	for _, s := range specs {
+		m[s.tier] = append(m[s.tier], s)
+	}
+	return m
+}
+
+// sortedTierKeys returns tier numbers in ascending order.
+func sortedTierKeys(m map[int][]serviceSpec) []int {
+	keys := make([]int, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
 }
 
 // ---------------------------------------------------------------------------
@@ -260,6 +402,10 @@ func NewServices(ctx *pulumi.Context, args *ServicesArgs) (*ServicesOutputs, err
 
 // newFargateService creates the Cloud Map service, task definition, and ECS
 // service for a single Fargate-based module.
+//
+// pulumiDeps are ECS service resources from a lower tier that this service
+// depends on (Pulumi deployment ordering). waitForSteady makes Pulumi block
+// until the ECS service reaches steady state (tasks healthy).
 func newFargateService(
 	ctx *pulumi.Context,
 	prefix string,
@@ -269,7 +415,9 @@ func newFargateService(
 	execRole *iam.Role,
 	taskRole *iam.Role,
 	logGroup *cloudwatch.LogGroup,
-) (pulumi.StringOutput, error) {
+	pulumiDeps []pulumi.Resource,
+	waitForSteady bool,
+) (*ecs.Service, error) {
 	resourcePrefix := fmt.Sprintf("%s-%s", prefix, spec.name)
 
 	// --- Cloud Map service ---
@@ -297,7 +445,7 @@ func newFargateService(
 		},
 	})
 	if err != nil {
-		return pulumi.StringOutput{}, fmt.Errorf("Cloud Map service %s: %w", spec.name, err)
+		return nil, fmt.Errorf("Cloud Map service %s: %w", spec.name, err)
 	}
 
 	// --- Task definition ---
@@ -321,12 +469,12 @@ func newFargateService(
 		},
 	})
 	if err != nil {
-		return pulumi.StringOutput{}, fmt.Errorf("task definition %s: %w", spec.name, err)
+		return nil, fmt.Errorf("task definition %s: %w", spec.name, err)
 	}
 
 	// --- ECS service ---
 
-	ecsSvc, err := ecs.NewService(ctx, fmt.Sprintf("svc-%s", spec.name), &ecs.ServiceArgs{
+	svcArgs := &ecs.ServiceArgs{
 		Name:           pulumi.String(resourcePrefix),
 		Cluster:        args.ClusterArn,
 		TaskDefinition: taskDef.Arn,
@@ -347,6 +495,12 @@ func newFargateService(
 		DeploymentMinimumHealthyPercent: pulumi.Int(100),
 		DeploymentMaximumPercent:        pulumi.Int(200),
 
+		// Circuit breaker: auto-rollback if new tasks fail to stabilize.
+		DeploymentCircuitBreaker: &ecs.ServiceDeploymentCircuitBreakerArgs{
+			Enable:   pulumi.Bool(true),
+			Rollback: pulumi.Bool(true),
+		},
+
 		// Enable ECS Exec for debugging via `aws ecs execute-command`.
 		EnableExecuteCommand: pulumi.Bool(true),
 
@@ -356,14 +510,36 @@ func newFargateService(
 			"Project":     pulumi.String("kaizen"),
 			"Environment": pulumi.String(args.Environment),
 			"Service":     pulumi.String(spec.name),
+			"Tier":        pulumi.Sprintf("%d", spec.tier),
 			"ManagedBy":   pulumi.String("pulumi"),
 		},
-	})
-	if err != nil {
-		return pulumi.StringOutput{}, fmt.Errorf("ECS service %s: %w", spec.name, err)
 	}
 
-	return ecsSvc.ID().ToStringOutput(), nil
+	// WaitForSteadyState blocks Pulumi until ECS tasks are running and healthy.
+	// Applied to Tier 0 and Tier 1 so downstream tiers only deploy after
+	// upstream services are truly ready (not just API-created).
+	if waitForSteady {
+		svcArgs.WaitForSteadyState = pulumi.Bool(true)
+	}
+
+	// Health-gate containers add a grace period for the init container to
+	// poll upstream dependencies before the main container's health check runs.
+	if len(spec.deps) > 0 {
+		svcArgs.HealthCheckGracePeriodSeconds = pulumi.Int(120)
+	}
+
+	// Build Pulumi resource options: DependsOn from previous tier.
+	var opts []pulumi.ResourceOption
+	if len(pulumiDeps) > 0 {
+		opts = append(opts, pulumi.DependsOn(pulumiDeps))
+	}
+
+	ecsSvc, err := ecs.NewService(ctx, fmt.Sprintf("svc-%s", spec.name), svcArgs, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("ECS service %s: %w", spec.name, err)
+	}
+
+	return ecsSvc, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +548,10 @@ func newFargateService(
 
 // buildContainerDefsJSON constructs the JSON container definitions string,
 // composing Pulumi outputs from ECR, Secrets Manager, and CloudWatch.
+//
+// For services with upstream dependencies (tier > 0), an additional
+// "health-gate" init container is prepended. The main container's dependsOn
+// ensures it waits for the gate to exit successfully before starting.
 func buildContainerDefsJSON(
 	spec serviceSpec,
 	args *ServicesArgs,
@@ -380,20 +560,45 @@ func buildContainerDefsJSON(
 ) pulumi.StringOutput {
 	ecrURL := args.ECRRepositoryURLs[spec.ecrKey]
 
-	return pulumi.All(
+	// Collect all Pulumi outputs we need to resolve.
+	allOutputs := []interface{}{
 		ecrURL,
 		logGroup.Name,
 		args.DatabaseSecretArn,
 		args.KafkaSecretArn,
 		args.RedisSecretArn,
 		args.AuthSecretArn,
-	).ApplyT(func(vals []interface{}) (string, error) {
+	}
+
+	// If this service has deps, we also need the healthgate ECR URL.
+	hasGate := len(spec.deps) > 0
+	if hasGate {
+		if gateURL, ok := args.ECRRepositoryURLs["healthgate"]; ok {
+			allOutputs = append(allOutputs, gateURL)
+		}
+	}
+
+	return pulumi.All(allOutputs...).ApplyT(func(vals []interface{}) (string, error) {
 		imageURL := vals[0].(string)
 		logGroupName := vals[1].(string)
 		dbSecretArn := vals[2].(string)
 		kafkaSecretArn := vals[3].(string)
 		redisSecretArn := vals[4].(string)
 		authSecretArn := vals[5].(string)
+
+		var gateImageURL string
+		if hasGate && len(vals) > 6 {
+			gateImageURL = vals[6].(string)
+		}
+
+		logConfig := logCfg{
+			LogDriver: "awslogs",
+			Options: map[string]string{
+				"awslogs-group":         logGroupName,
+				"awslogs-region":        awsRegion,
+				"awslogs-stream-prefix": spec.name,
+			},
+		}
 
 		// Port mappings.
 		ports := make([]portMap, len(spec.ports))
@@ -430,21 +635,41 @@ func buildContainerDefsJSON(
 			{Name: "AUTH_SECRET", ValueFrom: authSecretArn},
 		}
 
-		def := containerDef{
-			Name:      spec.name,
-			Image:     imageURL + ":latest",
-			Essential: true,
-			PortMappings: ports,
-			LogConfiguration: logCfg{
-				LogDriver: "awslogs",
-				Options: map[string]string{
-					"awslogs-group":         logGroupName,
-					"awslogs-region":        awsRegion,
-					"awslogs-stream-prefix": spec.name,
+		// Build the container list.
+		var containers []containerDef
+
+		// Health-gate init container: polls upstream service endpoints, exits 0
+		// when all are reachable. Main container waits for SUCCESS condition.
+		if hasGate && gateImageURL != "" {
+			gateCmd := buildHealthGateCmd(spec.deps)
+			gate := containerDef{
+				Name:      "health-gate",
+				Image:     gateImageURL + ":latest",
+				Essential: false,
+				Command:   []string{"sh", "-c", gateCmd},
+				LogConfiguration: logCfg{
+					LogDriver: "awslogs",
+					Options: map[string]string{
+						"awslogs-group":         logGroupName,
+						"awslogs-region":        awsRegion,
+						"awslogs-stream-prefix": spec.name + "-health-gate",
+					},
 				},
-			},
-			Environment: envVars,
-			Secrets:     secrets,
+				Environment: []envKV{
+					{Name: "ENVIRONMENT", Value: args.Environment},
+				},
+			}
+			containers = append(containers, gate)
+		}
+
+		mainDef := containerDef{
+			Name:             spec.name,
+			Image:            imageURL + ":latest",
+			Essential:        true,
+			PortMappings:     ports,
+			LogConfiguration: logConfig,
+			Environment:      envVars,
+			Secrets:          secrets,
 			HealthCheck: &healthCheck{
 				Command:     spec.healthCmd,
 				Interval:    30,
@@ -454,12 +679,55 @@ func buildContainerDefsJSON(
 			},
 		}
 
-		b, err := json.Marshal([]containerDef{def})
+		// Chain main container to health-gate via container-level dependsOn.
+		if hasGate && gateImageURL != "" {
+			mainDef.DependsOn = []containerDependency{
+				{ContainerName: "health-gate", Condition: "SUCCESS"},
+			}
+		}
+
+		containers = append(containers, mainDef)
+
+		b, err := json.Marshal(containers)
 		if err != nil {
 			return "", fmt.Errorf("marshaling container defs for %s: %w", spec.name, err)
 		}
 		return string(b), nil
 	}).(pulumi.StringOutput)
+}
+
+// buildHealthGateCmd generates a shell script that polls each upstream
+// dependency endpoint until reachable. Returns a single-line sh -c argument.
+//
+// HTTP deps are checked via wget (validates the health endpoint returns 2xx).
+// TCP deps are checked via nc (validates the port accepts connections).
+func buildHealthGateCmd(deps []healthDep) string {
+	var b strings.Builder
+	b.WriteString("set -e; ")
+	for _, dep := range deps {
+		switch dep.proto {
+		case "http":
+			fmt.Fprintf(&b,
+				`echo "Waiting for %s at %s:%d%s..."; `+
+					`until wget -q --spider -T 2 http://%s:%d%s 2>/dev/null; do sleep 5; done; `+
+					`echo "%s ready"; `,
+				dep.name, dep.host, dep.port, dep.path,
+				dep.host, dep.port, dep.path,
+				dep.name,
+			)
+		default: // "tcp" — gRPC or other TCP-based services
+			fmt.Fprintf(&b,
+				`echo "Waiting for %s at %s:%d..."; `+
+					`until printf "" | nc -w 2 %s %d > /dev/null 2>&1; do sleep 5; done; `+
+					`echo "%s ready"; `,
+				dep.name, dep.host, dep.port,
+				dep.host, dep.port,
+				dep.name,
+			)
+		}
+	}
+	b.WriteString(`echo "All dependencies healthy"`)
+	return b.String()
 }
 
 // ---------------------------------------------------------------------------

--- a/infra/pkg/compute/services_test.go
+++ b/infra/pkg/compute/services_test.go
@@ -1,0 +1,325 @@
+package compute
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Tier assignments
+// ---------------------------------------------------------------------------
+
+func TestServiceSpecsTierAssignment(t *testing.T) {
+	specs := serviceSpecs()
+
+	// Expected tier assignments per the dependency graph:
+	//   Tier 0: M5
+	//   Tier 1: M1, M2, M2-Orch
+	//   Tier 2: M3, M4a, M6, M7
+	expected := map[string]int{
+		"m5":      TierFoundation,
+		"m1":      TierCore,
+		"m2":      TierCore,
+		"m2-orch": TierCore,
+		"m3":      TierDependent,
+		"m4a":     TierDependent,
+		"m6":      TierDependent,
+		"m7":      TierDependent,
+	}
+
+	for _, spec := range specs {
+		want, ok := expected[spec.key]
+		if !ok {
+			t.Errorf("unexpected service key %q in specs", spec.key)
+			continue
+		}
+		if spec.tier != want {
+			t.Errorf("service %q: tier = %d, want %d", spec.key, spec.tier, want)
+		}
+		delete(expected, spec.key)
+	}
+
+	for key := range expected {
+		t.Errorf("missing service %q in specs", key)
+	}
+}
+
+func TestAllEightFargateServicesPresent(t *testing.T) {
+	specs := serviceSpecs()
+	if len(specs) != 8 {
+		t.Fatalf("expected 8 Fargate service specs, got %d", len(specs))
+	}
+
+	keys := make(map[string]bool, len(specs))
+	for _, s := range specs {
+		if keys[s.key] {
+			t.Errorf("duplicate service key: %q", s.key)
+		}
+		keys[s.key] = true
+	}
+}
+
+func TestTierCounts(t *testing.T) {
+	specs := serviceSpecs()
+	counts := map[int]int{}
+	for _, s := range specs {
+		counts[s.tier]++
+	}
+
+	tests := []struct {
+		tier int
+		want int
+	}{
+		{TierFoundation, 1}, // M5 only
+		{TierCore, 3},       // M1, M2, M2-Orch
+		{TierDependent, 4},  // M3, M4a, M6, M7
+	}
+
+	for _, tt := range tests {
+		if got := counts[tt.tier]; got != tt.want {
+			t.Errorf("tier %d: got %d services, want %d", tt.tier, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dependency graph integrity
+// ---------------------------------------------------------------------------
+
+func TestTier0HasNoDeps(t *testing.T) {
+	specs := serviceSpecs()
+	for _, s := range specs {
+		if s.tier == TierFoundation && len(s.deps) > 0 {
+			t.Errorf("tier 0 service %q should have no deps, has %d", s.key, len(s.deps))
+		}
+	}
+}
+
+func TestTier1DependsOnM5(t *testing.T) {
+	specs := serviceSpecs()
+	for _, s := range specs {
+		if s.tier != TierCore {
+			continue
+		}
+		if len(s.deps) == 0 {
+			t.Errorf("tier 1 service %q has no deps (should depend on M5)", s.key)
+			continue
+		}
+
+		found := false
+		for _, d := range s.deps {
+			if strings.Contains(d.host, "m5-management") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("tier 1 service %q deps do not include M5", s.key)
+		}
+	}
+}
+
+func TestTier2DependsOnTier1Services(t *testing.T) {
+	specs := serviceSpecs()
+
+	requiredHosts := map[string]bool{
+		"m1-assignment.kaizen.local": true,
+		"m2-pipeline.kaizen.local":   true,
+		"m4b-policy.kaizen.local":    true,
+	}
+
+	for _, s := range specs {
+		if s.tier != TierDependent {
+			continue
+		}
+		if len(s.deps) == 0 {
+			t.Errorf("tier 2 service %q has no deps", s.key)
+			continue
+		}
+
+		foundHosts := map[string]bool{}
+		for _, d := range s.deps {
+			foundHosts[d.host] = true
+		}
+
+		for host := range requiredHosts {
+			if !foundHosts[host] {
+				t.Errorf("tier 2 service %q missing dep on %s", s.key, host)
+			}
+		}
+	}
+}
+
+func TestNoCyclicDependencies(t *testing.T) {
+	// Services in tier N should never depend on services in tier >= N.
+	specs := serviceSpecs()
+
+	// Build a map of Cloud Map host → tier.
+	hostTier := map[string]int{}
+	for _, s := range specs {
+		host := s.name + ".kaizen.local"
+		hostTier[host] = s.tier
+	}
+	// M4b is logically Tier 1 (not in Fargate specs).
+	hostTier["m4b-policy.kaizen.local"] = TierCore
+
+	for _, s := range specs {
+		for _, d := range s.deps {
+			depTier, ok := hostTier[d.host]
+			if !ok {
+				continue // External dep, skip.
+			}
+			if depTier >= s.tier {
+				t.Errorf("service %q (tier %d) depends on %s (tier %d): would create cycle",
+					s.key, s.tier, d.host, depTier)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Health-gate command generation
+// ---------------------------------------------------------------------------
+
+func TestBuildHealthGateCmdHTTP(t *testing.T) {
+	deps := []healthDep{
+		{name: "M5", host: "m5-management.kaizen.local", port: 50055, proto: "http", path: "/healthz"},
+	}
+	cmd := buildHealthGateCmd(deps)
+
+	if !strings.Contains(cmd, "wget") {
+		t.Error("HTTP dep should use wget")
+	}
+	if !strings.Contains(cmd, "m5-management.kaizen.local") {
+		t.Error("command should contain M5 host")
+	}
+	if !strings.Contains(cmd, "50055") {
+		t.Error("command should contain M5 port")
+	}
+	if !strings.Contains(cmd, "/healthz") {
+		t.Error("command should contain health path")
+	}
+	if !strings.Contains(cmd, "All dependencies healthy") {
+		t.Error("command should end with success message")
+	}
+}
+
+func TestBuildHealthGateCmdTCP(t *testing.T) {
+	deps := []healthDep{
+		{name: "M1", host: "m1-assignment.kaizen.local", port: 50051, proto: "tcp"},
+	}
+	cmd := buildHealthGateCmd(deps)
+
+	if !strings.Contains(cmd, "nc") {
+		t.Error("TCP dep should use nc")
+	}
+	if !strings.Contains(cmd, "m1-assignment.kaizen.local") {
+		t.Error("command should contain M1 host")
+	}
+	if !strings.Contains(cmd, "50051") {
+		t.Error("command should contain M1 port")
+	}
+}
+
+func TestBuildHealthGateCmdMultipleDeps(t *testing.T) {
+	cmd := buildHealthGateCmd(tier1Deps)
+
+	// Should contain all 3 tier 1 deps.
+	for _, dep := range tier1Deps {
+		if !strings.Contains(cmd, dep.host) {
+			t.Errorf("command missing dep host: %s", dep.host)
+		}
+	}
+	if !strings.Contains(cmd, "set -e") {
+		t.Error("command should start with set -e for fail-fast")
+	}
+}
+
+func TestBuildHealthGateCmdEmpty(t *testing.T) {
+	cmd := buildHealthGateCmd(nil)
+	// Empty deps should just have the success message.
+	if !strings.Contains(cmd, "All dependencies healthy") {
+		t.Error("empty deps should still produce success message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GroupByTier
+// ---------------------------------------------------------------------------
+
+func TestGroupSpecsByTier(t *testing.T) {
+	specs := serviceSpecs()
+	grouped := groupSpecsByTier(specs)
+
+	if len(grouped) != 3 {
+		t.Fatalf("expected 3 tiers, got %d", len(grouped))
+	}
+
+	// Verify total count across all tiers.
+	total := 0
+	for _, tierSpecs := range grouped {
+		total += len(tierSpecs)
+	}
+	if total != 8 {
+		t.Errorf("total services across tiers: got %d, want 8", total)
+	}
+}
+
+func TestSortedTierKeys(t *testing.T) {
+	m := map[int][]serviceSpec{
+		2: {{key: "m3"}},
+		0: {{key: "m5"}},
+		1: {{key: "m1"}},
+	}
+	keys := sortedTierKeys(m)
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 keys, got %d", len(keys))
+	}
+	if keys[0] != 0 || keys[1] != 1 || keys[2] != 2 {
+		t.Errorf("keys not sorted: %v", keys)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Service spec consistency
+// ---------------------------------------------------------------------------
+
+func TestAllSpecsHaveRequiredFields(t *testing.T) {
+	specs := serviceSpecs()
+	for _, s := range specs {
+		if s.key == "" {
+			t.Error("spec has empty key")
+		}
+		if s.name == "" {
+			t.Errorf("spec %q has empty name", s.key)
+		}
+		if s.ecrKey == "" {
+			t.Errorf("spec %q has empty ecrKey", s.key)
+		}
+		if s.cpu == "" {
+			t.Errorf("spec %q has empty cpu", s.key)
+		}
+		if s.memoryMB == "" {
+			t.Errorf("spec %q has empty memoryMB", s.key)
+		}
+		if len(s.ports) == 0 {
+			t.Errorf("spec %q has no ports", s.key)
+		}
+		if s.lang == "" {
+			t.Errorf("spec %q has empty lang", s.key)
+		}
+		if len(s.healthCmd) == 0 {
+			t.Errorf("spec %q has no healthCmd", s.key)
+		}
+	}
+}
+
+func TestM5IsFirstInSpecOrder(t *testing.T) {
+	specs := serviceSpecs()
+	if len(specs) == 0 {
+		t.Fatal("no specs")
+	}
+	if specs[0].key != "m5" {
+		t.Errorf("first spec should be M5 (tier 0), got %q", specs[0].key)
+	}
+}


### PR DESCRIPTION
## Summary

Implements tiered ECS service startup ordering and health gates for the Kaizen platform (I.2.5).

- **Tier 0 (Foundation):** M5 starts first — owns PostgreSQL schema via migration
- **Tier 1 (Core):** M1, M2, M2-Orch, M4b start after M5 is healthy
- **Tier 2 (Dependent):** M3, M4a, M6, M7 start after Tier 1 + M4b are healthy

### Three-layer dependency enforcement

| Layer | Mechanism | When |
|-------|-----------|------|
| Pulumi `DependsOn` | Tier N+1 resources aren't created until Tier N resources exist | Deploy-time |
| `WaitForSteadyState` | Pulumi blocks until ECS tasks are running + healthy (not just API-created) | Deploy-time |
| Health-gate init containers | BusyBox sidecar polls upstream Cloud Map endpoints via `wget` (HTTP) / `nc` (TCP) | Runtime |

### Changes

- **`pkg/compute/services.go`** — Core implementation: tier constants, `healthDep` type, `buildHealthGateCmd()`, tiered `NewServices()` with `DependsOn`/`WaitForSteadyState`, health-gate init container injection, deployment circuit breaker, `HealthCheckGracePeriodSeconds`
- **`pkg/compute/m4b.go`** — Added `DependsOnResources` to `M4bServiceArgs`, wired through to Cloud Map service creation
- **`pkg/cicd/ecr.go`** — Added `UtilityImageNames` with `healthgate` ECR repo (separate from `ServiceNames` to preserve semantics)
- **`main.go`** — Wired M4b ops to depend on M5 service resource, documented dependency graph
- **`pkg/compute/services_test.go`** — 15 tests: tier assignments, dependency graph integrity (no cycles), health-gate command generation, spec completeness

### Opportunities (not implemented)

- ECR pull-through cache for public images (currently healthgate requires CI/CD push)
- ECS Service Connect as an alternative to health-gate polling
- CloudWatch alarm on health-gate container failures

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./pkg/compute/...` — 15/15 pass (tier assignments, deps, health-gate commands)
- [x] `go test ./...` — all existing tests still pass (ECR, MSK, CloudWatch, etc.)
- [ ] `pulumi preview` on dev stack — verify resource ordering
- [ ] Deploy to dev — verify all 9 services reach RUNNING state in tier order

Closes #366
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
