### PR TITLE
🎨 Palette: Add CopyButton to technical identifiers in Flag Detail page

### DIFF
--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -121,7 +121,14 @@ function FlagDetailContent() {
           </div>
           <div>
             <dt className="font-medium text-gray-500">Default Value</dt>
-            <dd className="text-gray-900"><code className="text-xs">{flag.defaultValue}</code></dd>
+            <dd className="flex items-center gap-2 text-gray-900">
+              <code className="text-xs">{flag.defaultValue}</code>
+              <CopyButton
+                value={flag.defaultValue}
+                label="Copy default value"
+                successMessage="Default value copied to clipboard"
+              />
+            </dd>
           </div>
           <div>
             <dt className="font-medium text-gray-500">Rollout Percentage</dt>
@@ -141,7 +148,14 @@ function FlagDetailContent() {
           {flag.targetingRuleId && (
             <div>
               <dt className="font-medium text-gray-500">Targeting Rule</dt>
-              <dd className="text-gray-900"><code className="text-xs">{flag.targetingRuleId}</code></dd>
+              <dd className="flex items-center gap-2 text-gray-900">
+                <code className="text-xs">{flag.targetingRuleId}</code>
+                <CopyButton
+                  value={flag.targetingRuleId}
+                  label="Copy targeting rule ID"
+                  successMessage="Targeting rule ID copied to clipboard"
+                />
+              </dd>
             </div>
           )}
         </dl>
@@ -172,7 +186,16 @@ function FlagDetailContent() {
                         />
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-sm"><code>{v.value}</code></td>
+                    <td className="px-4 py-3 text-sm">
+                      <div className="flex items-center gap-2">
+                        <code>{v.value}</code>
+                        <CopyButton
+                          value={v.value}
+                          label={`Copy variant value ${v.value}`}
+                          successMessage="Variant value copied to clipboard"
+                        />
+                      </div>
+                    </td>
                     <td className="px-4 py-3 text-sm">{(v.trafficFraction * 100).toFixed(0)}%</td>
                   </tr>
                 ))}


### PR DESCRIPTION
💡 What: Added 'Copy to Clipboard' functionality to the Default Value, Targeting Rule ID, and Variant Values in the Feature Flag Detail page.
🎯 Why: These technical identifiers are frequently needed by developers when integrating flags into their code or debugging specific configurations. Providing a one-click copy button reduces friction and errors.
📸 Before/After: Added CopyButtons next to the <code> blocks for each field. The layout remains clean and consistent with existing patterns used for Experiment and Flag IDs.
♿ Accessibility: Each button includes a specific 'aria-label' (e.g., "Copy targeting rule ID") to provide context for screen reader users. The implementation uses the accessible `CopyButton` component which handles focus states and visual feedback correctly.

---
*PR created automatically by Jules for task [6070877977107146123](https://jules.google.com/task/6070877977107146123) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
