### PR TITLE
🎨 Palette: Improve Feature Flags UX and resolve double-header bug

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-05-22 - Standardized Search UI Pattern
 **Learning:** Using a consistent visual pattern for search inputs (magnifying glass icon + inset text) creates a predictable experience for users scanning filtered lists. Achieving precise vertical alignment between the absolute-positioned icon and the input text requires consistent vertical padding (e.g., `py-1.5` or `py-2`) depending on the line height.
 **Action:** Always wrap search inputs in a `relative` container with an absolute-positioned magnifying glass SVG. Use `pl-9` to clear the icon and ensure `pointer-events-none` on the icon to avoid interfering with input focus.
+
+## 2026-06-15 - Actionable Empty States
+**Learning:** A blank screen or a simple "No items found" message can be a dead-end for users. Providing a direct "Call to Action" (CTA) link in empty states reduces friction and guides users toward the next logical step in their workflow, provided they have the necessary permissions.
+**Action:** Always include a primary action link or button in empty state components for list pages. Ensure the visibility of this CTA is gated by appropriate user permissions to maintain RBAC consistency.

--- a/ui/src/__tests__/flag-pages.test.tsx
+++ b/ui/src/__tests__/flag-pages.test.tsx
@@ -7,6 +7,7 @@ import FlagListPage from '@/app/flags/page';
 import FlagDetailPage from '@/app/flags/[id]/page';
 import CreateFlagPage from '@/app/flags/new/page';
 import EditFlagPage from '@/app/flags/[id]/edit/page';
+import { NavHeader } from '@/components/nav-header';
 import { AuthProvider } from '@/lib/auth-context';
 import { ToastProvider } from '@/lib/toast-context';
 import type { AuthUser } from '@/lib/auth-context';
@@ -36,14 +37,22 @@ vi.mock('next/link', () => ({
 
 describe('Flag List Page', () => {
   async function renderAndWait() {
-    render(<FlagListPage />);
+    render(
+      <AuthProvider>
+        <FlagListPage />
+      </AuthProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByText('dark_mode_rollout')).toBeInTheDocument();
     });
   }
 
   it('shows loading spinner initially', () => {
-    render(<FlagListPage />);
+    render(
+      <AuthProvider>
+        <FlagListPage />
+      </AuthProvider>,
+    );
     expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
 
@@ -64,11 +73,16 @@ describe('Flag List Page', () => {
       ),
     );
 
-    render(<FlagListPage />);
+    render(
+      <AuthProvider>
+        <FlagListPage />
+      </AuthProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
     });
     expect(screen.getByText('No feature flags found.')).toBeInTheDocument();
+    expect(screen.getByText('Create your first feature flag')).toBeInTheDocument();
   });
 
   it('shows RetryableError on 500 and retries', async () => {
@@ -78,7 +92,11 @@ describe('Flag List Page', () => {
       ),
     );
 
-    render(<FlagListPage />);
+    render(
+      <AuthProvider>
+        <FlagListPage />
+      </AuthProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
     });
@@ -165,8 +183,17 @@ describe('Flag List Page', () => {
     });
   });
 
+
   it('has Flags nav link pointing to /flags', async () => {
-    await renderAndWait();
+    render(
+      <AuthProvider>
+        <NavHeader />
+        <FlagListPage />
+      </AuthProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('dark_mode_rollout')).toBeInTheDocument();
+    });
     const navLink = screen.getByTestId('nav-flags');
     expect(navLink).toHaveAttribute('href', '/flags');
     expect(navLink).toHaveTextContent('Flags');
@@ -192,9 +219,11 @@ describe('Flag Detail Page', () => {
 
   async function renderAndWait() {
     render(
-      <ToastProvider>
-        <FlagDetailPage />
-      </ToastProvider>,
+      <AuthProvider>
+        <ToastProvider>
+          <FlagDetailPage />
+        </ToastProvider>
+      </AuthProvider>,
     );
     await waitFor(() => {
       expect(screen.getByTestId('flag-name')).toBeInTheDocument();
@@ -203,9 +232,11 @@ describe('Flag Detail Page', () => {
 
   it('shows loading spinner initially', () => {
     render(
-      <ToastProvider>
-        <FlagDetailPage />
-      </ToastProvider>,
+      <AuthProvider>
+        <ToastProvider>
+          <FlagDetailPage />
+        </ToastProvider>
+      </AuthProvider>,
     );
     expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
@@ -235,9 +266,11 @@ describe('Flag Detail Page', () => {
   it('renders 404 error for nonexistent flag', async () => {
     mockFlagId = 'nonexistent-flag';
     render(
-      <ToastProvider>
-        <FlagDetailPage />
-      </ToastProvider>,
+      <AuthProvider>
+        <ToastProvider>
+          <FlagDetailPage />
+        </ToastProvider>
+      </AuthProvider>,
     );
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
@@ -247,9 +280,11 @@ describe('Flag Detail Page', () => {
   it('renders variants table for multi-variant flag', async () => {
     mockFlagId = 'flag-string-ab';
     render(
-      <ToastProvider>
-        <FlagDetailPage />
-      </ToastProvider>,
+      <AuthProvider>
+        <ToastProvider>
+          <FlagDetailPage />
+        </ToastProvider>
+      </AuthProvider>,
     );
     await waitFor(() => {
       expect(screen.getByTestId('flag-name')).toHaveTextContent('checkout_flow_variant');
@@ -331,7 +366,11 @@ describe('Create Flag Page', () => {
   });
 
   it('renders the create flag form', () => {
-    render(<CreateFlagPage />);
+    render(
+      <AuthProvider>
+        <CreateFlagPage />
+      </AuthProvider>,
+    );
 
     expect(screen.getByRole('heading', { name: 'Create Feature Flag' })).toBeInTheDocument();
     expect(screen.getByTestId('flag-name-input')).toBeInTheDocument();
@@ -344,12 +383,20 @@ describe('Create Flag Page', () => {
   });
 
   it('submit is disabled when name is empty', () => {
-    render(<CreateFlagPage />);
+    render(
+      <AuthProvider>
+        <CreateFlagPage />
+      </AuthProvider>,
+    );
     expect(screen.getByTestId('create-submit')).toBeDisabled();
   });
 
   it('creates a flag and redirects to detail page', async () => {
-    render(<CreateFlagPage />);
+    render(
+      <AuthProvider>
+        <CreateFlagPage />
+      </AuthProvider>,
+    );
     const user = userEvent.setup();
 
     await user.type(screen.getByTestId('flag-name-input'), 'test_new_flag');
@@ -367,7 +414,11 @@ describe('Create Flag Page', () => {
       ),
     );
 
-    render(<CreateFlagPage />);
+    render(
+      <AuthProvider>
+        <CreateFlagPage />
+      </AuthProvider>,
+    );
     const user = userEvent.setup();
 
     await user.type(screen.getByTestId('flag-name-input'), 'fail_flag');
@@ -379,13 +430,21 @@ describe('Create Flag Page', () => {
   });
 
   it('has cancel link back to /flags', () => {
-    render(<CreateFlagPage />);
+    render(
+      <AuthProvider>
+        <CreateFlagPage />
+      </AuthProvider>,
+    );
     const cancelLink = screen.getByText('Cancel').closest('a');
     expect(cancelLink).toHaveAttribute('href', '/flags');
   });
 
   it('renders all flag type options', () => {
-    render(<CreateFlagPage />);
+    render(
+      <AuthProvider>
+        <CreateFlagPage />
+      </AuthProvider>,
+    );
     const select = screen.getByTestId('flag-type-select');
     const options = within(select).getAllByRole('option');
     expect(options.map((o) => o.textContent)).toEqual(['BOOLEAN', 'STRING', 'NUMERIC', 'JSON']);
@@ -401,14 +460,22 @@ describe('Edit Flag Page', () => {
   });
 
   async function renderAndWait() {
-    render(<EditFlagPage />);
+    render(
+      <AuthProvider>
+        <EditFlagPage />
+      </AuthProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('edit-flag-form')).toBeInTheDocument();
     });
   }
 
   it('shows loading spinner initially', () => {
-    render(<EditFlagPage />);
+    render(
+      <AuthProvider>
+        <EditFlagPage />
+      </AuthProvider>,
+    );
     expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
 
@@ -455,7 +522,11 @@ describe('Edit Flag Page', () => {
 
   it('shows 404 error for nonexistent flag', async () => {
     mockFlagId = 'nonexistent-flag';
-    render(<EditFlagPage />);
+    render(
+      <AuthProvider>
+        <EditFlagPage />
+      </AuthProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
     });

--- a/ui/src/app/flags/[id]/edit/page.tsx
+++ b/ui/src/app/flags/[id]/edit/page.tsx
@@ -6,8 +6,7 @@ import Link from 'next/link';
 import type { Flag, FlagType } from '@/lib/types';
 import { getFlag, updateFlag } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
-import { AuthProvider, useAuth } from '@/lib/auth-context';
-import { NavHeader } from '@/components/nav-header';
+import { useAuth } from '@/lib/auth-context';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -213,14 +212,5 @@ function EditFlagContent() {
 }
 
 export default function EditFlagPage() {
-  return (
-    <AuthProvider>
-      <div className="min-h-screen bg-gray-50">
-        <NavHeader />
-        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-          <EditFlagContent />
-        </main>
-      </div>
-    </AuthProvider>
-  );
+  return <EditFlagContent />;
 }

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -6,8 +6,7 @@ import Link from 'next/link';
 import type { Flag, FlagType, ExperimentType } from '@/lib/types';
 import { getFlag, promoteToExperiment } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
-import { AuthProvider, useAuth } from '@/lib/auth-context';
-import { NavHeader } from '@/components/nav-header';
+import { useAuth } from '@/lib/auth-context';
 import { CopyButton } from '@/components/copy-button';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
@@ -248,14 +247,5 @@ function FlagDetailContent() {
 }
 
 export default function FlagDetailPage() {
-  return (
-    <AuthProvider>
-      <div className="min-h-screen bg-gray-50">
-        <NavHeader />
-        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-          <FlagDetailContent />
-        </main>
-      </div>
-    </AuthProvider>
-  );
+  return <FlagDetailContent />;
 }

--- a/ui/src/app/flags/new/page.tsx
+++ b/ui/src/app/flags/new/page.tsx
@@ -5,8 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import type { FlagType } from '@/lib/types';
 import { createFlag } from '@/lib/api';
-import { AuthProvider, useAuth } from '@/lib/auth-context';
-import { NavHeader } from '@/components/nav-header';
+import { useAuth } from '@/lib/auth-context';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -172,14 +171,5 @@ function CreateFlagContent() {
 }
 
 export default function CreateFlagPage() {
-  return (
-    <AuthProvider>
-      <div className="min-h-screen bg-gray-50">
-        <NavHeader />
-        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-          <CreateFlagContent />
-        </main>
-      </div>
-    </AuthProvider>
-  );
+  return <CreateFlagContent />;
 }

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -5,8 +5,7 @@ import Link from 'next/link';
 import type { Flag, FlagType } from '@/lib/types';
 import { listFlags } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
-import { AuthProvider, useAuth } from '@/lib/auth-context';
-import { NavHeader } from '@/components/nav-header';
+import { useAuth } from '@/lib/auth-context';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -66,6 +65,16 @@ function FlagListContent() {
     return (
       <div className="py-12 text-center" data-testid="empty-state">
         <p className="text-sm text-gray-500">No feature flags found.</p>
+        {canAtLeast('experimenter') && (
+          <div className="mt-4">
+            <Link
+              href="/flags/new"
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            >
+              Create your first feature flag
+            </Link>
+          </div>
+        )}
       </div>
     );
   }
@@ -106,7 +115,7 @@ function FlagListContent() {
             placeholder="Search by name or description..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-3 text-sm shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
             data-testid="flag-search"
             aria-label="Search flags"
           />
@@ -168,14 +177,5 @@ function FlagListContent() {
 }
 
 export default function FlagListPage() {
-  return (
-    <AuthProvider>
-      <div className="min-h-screen bg-gray-50">
-        <NavHeader />
-        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-          <FlagListContent />
-        </main>
-      </div>
-    </AuthProvider>
-  );
+  return <FlagListContent />;
 }


### PR DESCRIPTION
This PR implements several micro-UX improvements to the Feature Flags module:

1. **Bug Fix: Double Header & Layout Inconsistency**: The Feature Flags pages were re-implementing `NavHeader` and `AuthProvider`, causing a double-header visual bug and inconsistent padding. These have been removed to allow the pages to inherit the standard layout from `RootLayout`.
2. **Standardization: Search Input**: The search input vertical padding was updated to `py-1.5` to match the project's design system, ensuring the magnifying glass icon is perfectly centered.
3. **UX Enhancement: Actionable Empty State**: Added a primary CTA link to the empty state of the Feature Flags list. This guides new users to create their first flag directly from the empty state, improving discoverability and onboarding.
4. **Test Maintenance**: Restored and updated the `flag-pages.test.tsx` suite. Tests that were broken by the layout simplification now correctly wrap components in the necessary providers, maintaining high test coverage.
5. **Journaling**: Added a new entry to Palette's journal regarding "Actionable Empty States".

All tests passed, and visual verification was performed with Playwright screenshots.

---
*PR created automatically by Jules for task [11768915906457778669](https://jules.google.com/task/11768915906457778669) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
