### PR TITLE
a11y(ui): use focus-within for keyboard navigation on MetricRow

### DIFF
--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -41,7 +41,7 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
   return (
     <>
       <tr
-        className="cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+        className="cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
         onClick={() => setExpanded(!expanded)}
         onKeyDown={handleKeyDown}
         tabIndex={0}


### PR DESCRIPTION
## Summary

Improves keyboard-navigation visual feedback on the Metric Browser table rows. Replaces `focus:` styling on the `<tr>` with `focus-within:` so the row indicates an active state when keyboard focus lands on the row OR on any descendant element. Also adds `focus-within:bg-gray-50` to mirror the hover state, making keyboard users see the same affordance as mouse users.

## Why this needed a rebase

The original PR proposed several UX changes that have already landed on `main` via [#415](https://github.com/wunderkennd/kaizen-experimentation/pull/415):

- `clearFilters` callback + `hasActiveFilters` boolean
- Toolbar and empty-state "Clear filters" buttons
- `py-1.5` padding standardization on search input + select

After rebasing onto current `main`, only the `focus-within` improvement on `MetricRow` was novel — that's all that remains in this PR.

Authorship of the original commit (Jules bot) is preserved.

## Test plan

- [x] Visually verified the focus ring still appears on Tab navigation
- [ ] CI green (rust + go now skipped via path filter from #427 — only typescript + small jobs run)