### PR TITLE
docs(adrs): add ADRs 011-013, sync index status, modernize template

### DIFF
--- a/docs/adrs/011-multi-objective-bandit-reward.md
+++ b/docs/adrs/011-multi-objective-bandit-reward.md
@@ -1,0 +1,249 @@
+# ADR-011: Multi-Objective Bandit Reward Composition
+
+**Status**: Accepted and Implemented
+**Date**: 2026-03-24
+**Deciders**: Agent-4 (M4b Bandit Policy)
+**Cluster**: A — Multi-Stakeholder Optimization
+
+---
+
+## Context
+
+The Kaizen platform's bandit policy service (M4b) optimized a single scalar reward signal — typically a user engagement metric like watch-time or play-start rate. SVOD recommendation is a three-sided market involving subscribers, content providers, and the platform itself. These stakeholders have competing objectives:
+
+- **Subscribers** want personalized, engaging content.
+- **Content providers** want fair exposure across their catalog, not winner-take-all concentration.
+- **The platform** wants long-term retention, catalog utilization, and content diversity.
+
+Optimizing a single engagement metric creates pathological outcomes: catalog concentration on a few popular titles, provider inequity, filter bubbles, and reduced content diversity — all of which harm long-term platform health even as short-term engagement metrics improve.
+
+The platform needed the ability to compose bandit rewards from multiple stakeholder objectives simultaneously, with configurable strategies for handling the inherent trade-offs between competing goals.
+
+---
+
+## Decision
+
+Extend the LMAX single-threaded policy core (Thread 3, ADR-002) with a `RewardComposer` that transforms multi-metric reward vectors into scalar rewards for posterior updates. Three composition strategies are provided, selectable per experiment via `BanditConfig.composition_method`.
+
+### Composition Strategies
+
+**Weighted Scalarization** (`REWARD_COMPOSITION_WEIGHTED_SUM`):
+```
+reward = Σ wᵢ × normalized(rᵢ)
+```
+Weights `wᵢ` must sum to 1.0 (±1e-6). Produces optimal arms on convex regions of the Pareto frontier. Simplest to reason about; appropriate when objectives are roughly aligned.
+
+**Epsilon-Constraint (Lagrangian)** (`REWARD_COMPOSITION_EPSILON_CONSTRAINT`):
+```
+reward = normalized(r_primary) + Σ_{secondary} credit(rᵢ, floorᵢ)
+```
+Maximizes a designated primary objective while treating secondaries as soft constraints with floor thresholds. Credit is awarded when a secondary exceeds its floor, penalty when below. Appropriate when one objective dominates but others must not degrade below acceptable levels.
+
+**Tchebycheff** (`REWARD_COMPOSITION_TCHEBYCHEFF`):
+```
+reward = −max_i { wᵢ × max(0, idealᵢ − normalized(rᵢ)) }
+```
+Minimizes the maximum weighted deviation from an ideal point (running maximum per metric). Reaches Pareto-optimal solutions on non-convex frontiers where weighted scalarization cannot. Requires a warmup period (~100 observations) to establish stable ideal point estimates.
+
+### Metric Normalization
+
+Raw metric values arrive on different scales (watch-time in minutes, diversity scores in [0,1], provider Gini in [0,1]). A `MetricNormalizer` maintains per-metric running mean and variance via exponential moving average (EMA, α = 0.01):
+
+```
+normalized(r) = (r − μ_ema) / σ_ema
+```
+
+Normalization clamps to ±10σ to prevent outlier-driven instability. The normalizer also tracks a running-maximum ideal point per metric for Tchebycheff.
+
+### LMAX Core Integration
+
+All composition runs on the existing dedicated LMAX Thread 3. The reward update path extends from:
+```
+reward = scalar → posterior.update(reward)
+```
+to:
+```
+metric_values = {metric_1: r_1, ..., metric_k: r_k}
+  → normalizer.normalize(metric_values)
+  → composer.compose(normalized_values)
+  → sigmoid(composed_reward)
+  → posterior.update(mapped_reward)
+```
+
+The `sigmoid()` mapping converts the composed real-valued reward to (0, 1) for Beta-Bernoulli posterior compatibility. Composer and normalizer state are persisted in RocksDB alongside posterior parameters via the existing snapshot mechanism, surviving crashes and restarts.
+
+### State Growth
+
+For a typical multi-objective experiment with 3 objectives and 10 arms, the composer adds ~200 bytes of state per metric per experiment. At 100 concurrent experiments, total additional RocksDB snapshot overhead is ~60KB — negligible relative to existing posterior state.
+
+---
+
+## Consequences
+
+### Benefits
+
+1. **Three-sided market optimization**: Bandits can now balance subscriber engagement, provider fairness, and platform health simultaneously.
+2. **Zero-lock integration**: Composition runs on the existing LMAX single-threaded core with no new synchronization primitives.
+3. **Crash-safe**: Normalizer and composer state persists through RocksDB snapshots alongside policy posteriors.
+4. **Backward-compatible**: Single-objective experiments are unaffected. Multi-objective only activates when `BanditConfig.reward_objectives` is non-empty.
+5. **Pareto coverage**: Tchebycheff composition reaches non-convex Pareto-optimal solutions that weighted scalarization cannot.
+
+### Trade-offs
+
+1. **Normalization warmup**: EMA normalization requires ~50–100 observations before mean/variance estimates stabilize. During warmup, composed rewards may be noisy.
+2. **Tchebycheff ideal instability**: The running-maximum ideal point can be distorted by outliers early in the experiment. Clamping at ±10σ mitigates but does not eliminate this.
+3. **IPW interaction**: When combined with ADR-012 LP constraints, the *adjusted* arm probabilities (not raw) must be used for IPW analysis. The composer itself does not affect assignment probabilities — only the reward signal.
+
+---
+
+## Implementation Details
+
+### Proto Schema
+
+```protobuf
+// bandit.proto additions (PR #196)
+
+enum RewardCompositionMethod {
+  REWARD_COMPOSITION_UNSPECIFIED = 0;
+  REWARD_COMPOSITION_WEIGHTED_SUM = 1;
+  REWARD_COMPOSITION_EPSILON_CONSTRAINT = 2;
+  REWARD_COMPOSITION_TCHEBYCHEFF = 3;
+}
+
+message RewardObjective {
+  string metric_id = 1;
+  double weight = 2;
+  optional double floor = 3;       // epsilon-constraint floor threshold
+  bool is_primary = 4;             // epsilon-constraint primary designator
+}
+
+// BanditConfig extensions
+message BanditConfig {
+  // ... existing fields 1-7 ...
+  repeated RewardObjective reward_objectives = 8;
+  RewardCompositionMethod composition_method = 9;
+}
+```
+
+### Crate Layout
+
+```
+crates/experimentation-bandit/src/
+  reward_composer.rs    — RewardComposer, MetricNormalizer (serialize/deserialize)
+  multi_objective.rs    — MetricStats (EMA), RewardObjective, CompositionMethod, sigmoid()
+  lib.rs                — pub mod reward_composer; pub mod multi_objective;
+```
+
+### Public API
+
+```rust
+// MetricNormalizer — per-metric EMA running statistics
+pub struct MetricNormalizer { /* keyed by metric name, serialize/deserialize */ }
+impl MetricNormalizer {
+    pub fn normalize(&mut self, metric: &str, value: f64) -> f64;
+    pub fn ideal(&self, metric: &str) -> Option<f64>;  // Tchebycheff ideal point
+}
+
+// RewardComposer — strategy dispatch
+pub struct RewardComposer { /* objectives, method, normalizer */ }
+impl RewardComposer {
+    pub fn compose(&mut self, metric_values: &HashMap<String, f64>) -> f64;
+}
+
+// ThompsonSamplingPolicy extensions
+impl ThompsonSamplingPolicy {
+    pub fn new_multi_objective(objectives: Vec<RewardObjective>, method: CompositionMethod) -> Self;
+    pub fn update_multi_objective(&mut self, arm: &str, metrics: &HashMap<String, f64>);
+}
+```
+
+### PolicyCore Integration
+
+```rust
+// crates/experimentation-policy/src/core.rs
+
+impl PolicyCore {
+    // Registers an experiment with multi-objective composition
+    fn register_multi_objective_experiment(&mut self, exp_id: &str, config: &BanditConfig);
+
+    // Extended reward handler — composes metric vector before posterior update
+    fn handle_reward_update(&mut self, update: RewardUpdate) {
+        if let Some(metrics) = &update.metric_values {
+            let composer = self.reward_composers.get_mut(&update.experiment_id);
+            let scalar = composer.compose(metrics);
+            let mapped = sigmoid(scalar);
+            self.policies.get_mut(&update.experiment_id)
+                .update(update.arm_id, mapped);
+        } else {
+            // Single-objective fallback
+            self.policies.get_mut(&update.experiment_id)
+                .update(update.arm_id, update.reward);
+        }
+    }
+
+    // Snapshot includes composer state
+    fn write_snapshot(&self) -> SnapshotEnvelope {
+        SnapshotEnvelope {
+            policy_state: self.serialize_policies(),
+            reward_composer_state: self.serialize_composers(),  // NEW
+        }
+    }
+}
+```
+
+---
+
+## Validation
+
+### Unit Tests (18)
+
+- MetricStats EMA convergence to known mean/variance
+- Normalization direction (positive value → positive normalized when > mean)
+- WeightedSum output matches manual computation
+- EpsilonConstraint penalty when below floor, credit when above
+- Tchebycheff balance: equal deviations produce equal penalty
+- Serialize/deserialize roundtrip for normalizer and composer
+- Weight validation: reject weights not summing to 1.0
+
+### Proptest Invariants (4)
+
+1. WeightedSum output is always finite for finite inputs
+2. EpsilonConstraint output is always finite for finite inputs
+3. Tchebycheff output is always finite for finite inputs
+4. Tchebycheff output is non-positive after warmup (≥100 observations)
+
+### Convergence Test
+
+2-arm Thompson Sampling bandit with 2-metric weighted-sum reward (engagement w=0.6, quality w=0.4). Arm "high" (μ_eng=0.8, μ_qual=0.7) vs arm "low" (μ_eng=0.3, μ_qual=0.4). After 1000 rounds with Gaussian noise, arm "high" selected >60% of the time.
+
+### Crash Recovery Test
+
+50 multi-objective reward events → kill -9 → restart → normalizer restored with ≥45 observations (within Kafka replay tolerance).
+
+---
+
+## Dependencies
+
+- **ADR-002** (LMAX core): Composer runs on Thread 3.
+- **ADR-003** (RocksDB snapshots): Composer state persisted alongside posteriors.
+- **ADR-014** (Provider Metrics): Provider-side metrics become available as reward objectives.
+- **Enables ADR-012**: LP constraints operate on arm probabilities downstream of composed rewards.
+- **Enables ADR-013**: Meta-experiments test different composition configurations.
+
+---
+
+## Merged PRs
+
+| PR | Description |
+|----|-------------|
+| #196 | Proto schema: `RewardObjective`, `RewardCompositionMethod`, `BanditConfig` fields 8–9 |
+| #221 | Multi-objective reward composition: `reward_composer.rs`, `multi_objective.rs`, PolicyCore integration |
+| #228 | Reconciliation fixes + convergence test |
+
+---
+
+## References
+
+- Qassimi et al.: MOC-MAB (Scientific Reports, 2025) — multi-objective contextual bandits
+- Spotify calibrated bandits (RecSys 2025) — multi-stakeholder recommendation bandits
+- Jannach & Abdollahpouri: Multi-stakeholder RecSys survey (Frontiers, 2023)

--- a/docs/adrs/012-constrained-arm-selection-lp.md
+++ b/docs/adrs/012-constrained-arm-selection-lp.md
@@ -1,0 +1,236 @@
+# ADR-012: Constrained Arm Selection via Linear Programming
+
+**Status**: Accepted (In Progress)
+**Date**: 2026-03-24
+**Deciders**: Agent-4 (M4b Bandit Policy)
+**Cluster**: A — Multi-Stakeholder Optimization
+
+---
+
+## Context
+
+After ADR-011 introduced multi-objective reward composition, the bandit policy produces arm selection probabilities **p** that maximize composed reward. However, these raw probabilities are unconstrained — they can produce outcomes that violate hard business requirements:
+
+- A content provider contract guarantees ≥5% impression share. Thompson Sampling may allocate 0% to arms serving that provider's content if engagement is low.
+- A regulatory requirement mandates minimum representation of local-language content. The bandit has no awareness of this constraint.
+- A fairness policy requires no single arm to exceed 40% of total traffic. An arm with high reward may receive 80%+.
+
+These are *hard constraints* that cannot be expressed as soft reward objectives (ADR-011) — violating a provider contract has legal consequences regardless of how much engagement improves. The platform needed a deterministic post-processing layer between the bandit's raw probabilities and the actual selection distribution that enforces constraint satisfaction while minimizing distortion to the bandit's learned preferences.
+
+---
+
+## Decision
+
+Implement an `LpConstraintSolver` that runs on the LMAX Thread 3 after arm probability computation and before arm selection. The solver finds the selection distribution **q** closest to the bandit's raw distribution **p** (in KL-divergence) that satisfies all configured constraints.
+
+### Optimization Problem
+
+```
+minimize   KL(q ‖ p) = Σᵢ qᵢ · log(qᵢ / pᵢ)
+subject to:
+  Σᵢ qᵢ = 1                              (probability simplex)
+  qᵢ ≥ 0                    ∀i            (non-negativity)
+  qᵢ ≥ floor_i              ∀i ∈ F        (per-arm floor constraints)
+  qᵢ ≤ ceil_i               ∀i ∈ C        (per-arm ceiling constraints)
+  Σⱼ aⱼᵢ · qᵢ ≥ bⱼ         ∀j ∈ G        (general linear constraints)
+```
+
+### Constraint Types
+
+**Per-arm constraints** (`ArmConstraint`): Floor and/or ceiling on individual arm selection probabilities. Use case: provider minimum impression guarantee, maximum arm concentration limit.
+
+**Global linear constraints** (`GlobalConstraint`): Arbitrary linear inequalities over the probability vector. Use case: "arms tagged as local-language content must collectively receive ≥20% traffic" — a single linear constraint `Σ_{i ∈ local} qᵢ ≥ 0.20`.
+
+### Solver Algorithms
+
+**Simple per-arm constraints only** (no general linear): O(K log K) water-filling algorithm. Sort arms by `pᵢ`, iteratively redistribute probability mass from unconstrained arms to those below their floor. Guaranteed to find the KL-minimizing solution.
+
+**General linear constraints**: Interior-point method with warm start from the previous solution. Target: <50μs for K ≤ 100 arms and ≤ 10 linear constraints. Warm starting from the previous time step's solution amortizes convergence cost — the constraint polytope shifts slowly as population-level statistics update.
+
+### Population-Level Enforcement
+
+Per-arm constraints express *selection probability* requirements, but business constraints are typically about *population-level impression counts*. The solver maintains running impression counts per arm with EMA decay (α = 0.01) on the LMAX thread. These running counts feed into the constraint satisfaction check: if arm `i`'s running impression share is already above its floor, the constraint is slack and does not distort **q**.
+
+### Feasibility Handling
+
+If the constraint polytope is empty (conflicting constraints make simultaneous satisfaction impossible), the solver returns `CONSTRAINT_INFEASIBLE` and falls back to the raw probabilities **p**. This is logged as a warning and surfaced to the experiment owner via M6. Common cause: floor constraints that sum to >1.0.
+
+### IPW Validity
+
+The *adjusted* probabilities **q** (not the raw **p**) are logged as `assignment_probability` in exposure events. This is critical: downstream IPW-adjusted analysis in M4a must use the actual selection probabilities to produce unbiased treatment effect estimates. If **p** were logged instead, the IPW estimator would be biased because the logged probability would not match the true selection mechanism.
+
+---
+
+## Consequences
+
+### Benefits
+
+1. **Hard constraint satisfaction**: Provider contracts, regulatory requirements, and fairness policies are enforced deterministically, not approximately via reward shaping.
+2. **Minimal distortion**: KL-divergence minimization preserves the bandit's learned preferences as much as possible while satisfying constraints.
+3. **Zero-lock integration**: Solver runs on the existing LMAX Thread 3 after probability computation, before selection. No new threads or synchronization.
+4. **IPW-correct**: Adjusted probabilities logged for valid downstream causal inference.
+5. **Warm-started convergence**: Interior-point solver warm starts from previous solution, amortizing cost over time.
+
+### Trade-offs
+
+1. **Regret increase**: Constraint satisfaction necessarily increases bandit regret relative to the unconstrained optimum. The KL-minimization ensures this increase is minimal.
+2. **Infeasibility edge case**: Contradictory constraints produce fallback to raw probabilities. Experiment creators must validate constraint consistency.
+3. **Interior-point complexity**: The general linear solver is more complex than the water-filling algorithm. The <50μs target may require careful tuning for experiments with many arms and constraints.
+4. **EMA decay sensitivity**: The α = 0.01 decay rate determines how quickly population-level counts respond to allocation changes. Too fast → noisy constraint checking. Too slow → delayed constraint satisfaction.
+
+---
+
+## Implementation Details
+
+### Proto Schema
+
+```protobuf
+// bandit.proto additions (PR #196)
+
+message ArmConstraint {
+  string arm_id = 1;
+  optional double min_fraction = 2;   // floor: qᵢ ≥ min_fraction
+  optional double max_fraction = 3;   // ceiling: qᵢ ≤ max_fraction
+}
+
+message GlobalConstraint {
+  string label = 1;                              // human-readable name
+  map<string, double> coefficients = 2;          // arm_id → coefficient aⱼᵢ
+  double rhs = 3;                                // right-hand side bⱼ
+}
+
+// BanditConfig extensions
+message BanditConfig {
+  // ... existing fields 1-9 ...
+  repeated ArmConstraint arm_constraints = 10;
+  repeated GlobalConstraint global_constraints = 11;
+}
+```
+
+### Planned Crate Layout
+
+```
+crates/experimentation-bandit/src/
+  lp_constraint.rs    — LpConstraintSolver, water-filling, interior-point
+  lib.rs              — pub mod lp_constraint;
+```
+
+### Planned Public API
+
+```rust
+pub struct LpConstraintSolver {
+    arm_constraints: Vec<ArmConstraint>,
+    global_constraints: Vec<GlobalConstraint>,
+    running_counts: HashMap<String, f64>,  // EMA impression counts
+    previous_q: Option<Vec<f64>>,          // warm start
+}
+
+pub enum ConstraintResult {
+    Feasible(Vec<f64>),        // adjusted probabilities q
+    Infeasible,                // constraint polytope empty
+}
+
+impl LpConstraintSolver {
+    pub fn new(arm_constraints: Vec<ArmConstraint>, global_constraints: Vec<GlobalConstraint>) -> Self;
+    pub fn solve(&mut self, raw_probabilities: &[f64], arm_ids: &[String]) -> ConstraintResult;
+    pub fn update_counts(&mut self, selected_arm: &str);  // EMA update after selection
+}
+```
+
+### LMAX Core Integration (Planned)
+
+```rust
+// In PolicyCore::handle_select_arm() on Thread 3:
+
+let raw_p = self.policy.arm_probabilities(&context);
+
+let final_p = if let Some(solver) = self.constraint_solvers.get_mut(&experiment_id) {
+    match solver.solve(&raw_p, &arm_ids) {
+        ConstraintResult::Feasible(q) => q,
+        ConstraintResult::Infeasible => {
+            warn!("Constraint infeasible for {}, using raw probabilities", experiment_id);
+            raw_p
+        }
+    }
+} else {
+    raw_p  // no constraints configured
+};
+
+let selected = sample_from(&final_p, &mut rng);
+solver.update_counts(&selected);
+
+// Log final_p (not raw_p) as assignment_probability
+exposure.assignment_probability = final_p[selected_index];
+```
+
+### Performance Targets
+
+| Scenario | Target | Algorithm |
+|----------|--------|-----------|
+| Per-arm only, K ≤ 20 | <5μs | Water-filling O(K log K) |
+| Per-arm only, K ≤ 100 | <15μs | Water-filling O(K log K) |
+| General linear, K ≤ 100, ≤ 10 constraints | <50μs | Interior-point (warm-started) |
+
+### State Growth
+
+Running counts add ~40 bytes per arm per experiment. At 100 concurrent experiments with 10 arms each, total additional state is ~40KB.
+
+---
+
+## Validation (Planned)
+
+### Proptest Invariants
+
+1. **Simplex**: `Σ qᵢ = 1.0` (±1e-9) for all feasible outputs
+2. **Non-negativity**: `qᵢ ≥ 0` for all i
+3. **Floor satisfaction**: `qᵢ ≥ floor_i - ε` for all constrained arms when feasible
+4. **Ceiling satisfaction**: `qᵢ ≤ ceil_i + ε` for all constrained arms when feasible
+5. **KL minimality**: No single-coordinate perturbation of **q** reduces KL(q‖p) while maintaining feasibility (first-order optimality check)
+
+### Golden-File Tests
+
+- Water-filling on 5-arm example with 2 floor constraints: verify against analytically computed solution
+- Interior-point on 10-arm example with 3 linear constraints: verify against Python `scipy.optimize.minimize` reference
+
+### Integration Tests
+
+- M4b ↔ M1 contract: `SelectArm` response includes LP-adjusted probabilities
+- IPW roundtrip: adjusted probabilities logged in exposure events, consumed by M4a for unbiased estimation
+
+---
+
+## Dependencies
+
+- **ADR-002** (LMAX core): Solver runs on Thread 3.
+- **ADR-003** (RocksDB): Running counts and previous solution persisted in snapshots.
+- **ADR-011** (Multi-objective reward): LP operates on probabilities produced after reward composition. The two layers are sequential: compose reward → update posterior → compute raw **p** → LP adjust to **q**.
+- **ADR-014** (Provider metrics): Provider impression share metrics feed constraint definitions.
+- **Enables ADR-013**: Meta-experiments can compare different constraint configurations.
+
+---
+
+## Current Status
+
+- Proto schema landed in PR #196 (`ArmConstraint`, `GlobalConstraint`, `BanditConfig` fields 10–11).
+- Implementation in progress (Sprint 5.2/5.3). Agent-4 status: LP constraint solver on LMAX core.
+- M6 UI: `ConstraintStatusTable` component implemented (PR from Agent-6, work/fancy-koala) showing constraint name, current value, limit, SATISFIED/VIOLATED badge.
+- Contract test defined: M4b ↔ M1 LP constraint adjusted probabilities.
+
+---
+
+## Rejected Alternatives
+
+| Alternative | Reason Rejected |
+|-------------|----------------|
+| Reward shaping (add penalty for constraint violation to reward) | Soft — does not guarantee satisfaction. A large penalty distorts learning; a small penalty allows violations. |
+| Constrained Thompson Sampling (reject samples violating constraints) | Rejection sampling is inefficient when constraints are tight; can require thousands of rejections per selection. |
+| Action masking (remove arms violating constraints from selection set) | Too coarse — completely eliminates arms rather than reducing their probability. Cannot express "at least 5%" type constraints. |
+| Simplex projection (Euclidean distance instead of KL) | KL-divergence better preserves the information structure of probability distributions. Euclidean projection can produce unintuitive results (e.g., zero-probability arms receiving mass). |
+
+---
+
+## References
+
+- LinkedIn BanditLP (KDD 2025) — LP post-processing for constrained bandit allocation
+- Chen et al.: Interpolating fairness constraints in bandit optimization (NeurIPS 2024)
+- Boyd & Vandenberghe: Convex Optimization (2004) — KL-projection onto polyhedra, interior-point methods

--- a/docs/adrs/013-meta-experiments-objective-functions.md
+++ b/docs/adrs/013-meta-experiments-objective-functions.md
@@ -1,0 +1,262 @@
+# ADR-013: Meta-Experiments on Objective Functions
+
+**Status**: Accepted (Planned — Sprint 5.4)
+**Date**: 2026-03-24
+**Deciders**: Agent-1 (M1 Assignment), Agent-4 (M4b Bandit Policy), Agent-5 (M5 Management)
+**Cluster**: A — Multi-Stakeholder Optimization
+
+---
+
+## Context
+
+ADR-011 (Multi-Objective Reward) and ADR-012 (LP Constraints) give the platform the ability to configure bandit reward composition and constraint parameters. But choosing the *right* configuration is itself an optimization problem:
+
+- Should the engagement weight be 0.7 or 0.5?
+- Is Tchebycheff better than weighted scalarization for this content catalog?
+- Does a 5% provider floor constraint improve long-term retention or hurt it?
+- Does adding a diversity objective reduce churn more than adding a fairness constraint?
+
+These are causal questions about the objective function itself — they cannot be answered by observing a single bandit's behavior. They require *randomizing users over different objective parameterizations* while holding the bandit algorithm constant, then comparing business outcomes (retention, LTV, satisfaction) across parameterization variants.
+
+This is a meta-experiment: an A/B test where the treatment arms are not content recommendations but the reward function configurations that drive the bandit's behavior.
+
+---
+
+## Decision
+
+Introduce `EXPERIMENT_TYPE_META` as a new experiment type with dedicated lifecycle validation, isolated policy state per variant, and two-level IPW analysis.
+
+### Design
+
+A meta-experiment has 2+ variants. Each variant specifies a complete `MetaVariantObjective` configuration: reward objectives, composition method, and optional LP constraints. All variants use the same bandit algorithm (e.g., Thompson Sampling). The experiment randomizes users across variants using standard hash-based bucketing (same as A/B tests). Each variant runs its own independent bandit instance.
+
+```
+Meta-Experiment: "Engagement vs. Balance"
+├── Variant A: WeightedSum(engagement=0.7, diversity=0.3)
+│   └── Independent Thompson Sampling bandit (isolated state)
+├── Variant B: WeightedSum(engagement=0.5, diversity=0.5)
+│   └── Independent Thompson Sampling bandit (isolated state)
+└── Variant C: Tchebycheff(engagement=0.6, diversity=0.4)
+    └── Independent Thompson Sampling bandit (isolated state)
+
+Primary metric: 30-day retention (NOT a bandit reward metric)
+```
+
+The primary outcome metric must be a business outcome (retention, LTV, satisfaction survey score) that is *not* one of the bandit's reward objectives. This prevents circular reasoning — the meta-experiment evaluates which reward configuration produces the best downstream business result, not which configuration maximizes its own reward.
+
+### M1 Assignment Flow
+
+```
+User request → M1 GetAssignment(experiment_id=meta-exp, user_id=U)
+  1. Hash U into meta-experiment variant (standard bucketing)
+  2. Look up variant's MetaVariantObjective config
+  3. Call M4b SelectArm with (experiment_id, variant_id, user_context)
+  4. M4b routes to the variant-specific policy instance
+  5. Return: variant assignment + arm selection + probabilities
+```
+
+The user sees a single recommendation. They are unaware they are in a meta-experiment — the only difference between variants is which reward function drives the bandit's learning.
+
+### M4b Policy Isolation
+
+Each (experiment_id, variant_id) pair gets its own independent policy state on the LMAX Thread 3. Variants do not share posteriors, normalizer state, or composer state. This ensures that each variant's bandit learns independently under its assigned reward configuration.
+
+Policy state key changes from:
+```
+HashMap<ExperimentId, PolicyState>
+```
+to:
+```
+HashMap<(ExperimentId, VariantId), PolicyState>
+```
+
+For non-meta experiments, `VariantId` is a sentinel value (empty string), preserving backward compatibility.
+
+### M4a Two-Level IPW Analysis
+
+Meta-experiments have two levels of randomization:
+1. User → meta-variant (hash-based, known probability from traffic allocation)
+2. User → arm (bandit-selected, logged probability from SelectArm)
+
+Treatment effect estimation for the primary metric uses two-level IPW:
+```
+weight = 1 / (P(variant) × P(arm | variant))
+```
+
+M4a's `RunAnalysis` for META experiments computes:
+- **Cross-variant business outcome comparison**: treatment effects on the primary metric (retention, LTV) between meta-variants. This is the key output.
+- **Per-variant bandit efficiency**: convergence speed, cumulative regret, arm concentration.
+- **Per-variant ecosystem health**: provider fairness metrics (from ADR-014) under each configuration.
+- **Pareto frontier visualization**: for 3+ variants, scatter plot of (engagement, diversity) with dominated region shading.
+
+---
+
+## Consequences
+
+### Benefits
+
+1. **Causal answers about objective design**: Eliminates guesswork in reward function configuration. Data-driven selection of composition strategies and weights.
+2. **Isolated learning**: Each variant's bandit learns independently, preventing cross-contamination of policy state.
+3. **Reuses existing infrastructure**: Hash-based bucketing (M1), standard analysis (M4a), existing UI results rendering (M6). The meta layer is thin.
+4. **Prevents circular metrics**: Requiring the primary metric to differ from reward objectives ensures the meta-experiment measures downstream impact, not tautological reward maximization.
+
+### Trade-offs
+
+1. **Traffic splitting**: A meta-experiment with 3 variants and 10 bandit arms per variant means each variant-arm combination sees 1/30th of total traffic. Bandit learning within each variant is slower than a single unconstrained bandit.
+2. **Duration**: Meta-experiments must run long enough for both bandit convergence *and* business outcome measurement. Typical duration: 4–8 weeks (vs. 1–2 weeks for standard A/B tests).
+3. **Complexity for experiment owners**: Configuring a meta-experiment requires understanding reward composition (ADR-011) and optionally LP constraints (ADR-012). The M6 creation wizard should guide this.
+4. **Policy state footprint**: K variants × N arms × posterior state. For a meta-experiment with 4 variants and 20 arms, this is 4× the state of a single bandit experiment.
+
+---
+
+## Implementation Details
+
+### Proto Schema
+
+```protobuf
+// experiment.proto additions (PR #196)
+
+enum ExperimentType {
+  // ... existing types 0-8 ...
+  EXPERIMENT_TYPE_META = 9;
+}
+
+message MetaExperimentConfig {
+  string base_algorithm = 1;                        // e.g., "THOMPSON_SAMPLING"
+  repeated MetaVariantObjective variant_objectives = 2;
+}
+
+message MetaVariantObjective {
+  string variant_id = 1;
+  repeated RewardObjective reward_objectives = 2;
+  RewardCompositionMethod composition_method = 3;
+  repeated ArmConstraint arm_constraints = 4;       // optional, per-variant LP
+  repeated GlobalConstraint global_constraints = 5;  // optional, per-variant LP
+  string payload_json = 6;                           // additional config as JSON
+}
+
+// Experiment message gains:
+message Experiment {
+  // ... existing fields 1-26 ...
+  MetaExperimentConfig meta_config = 30;
+}
+```
+
+### M5 STARTING Validation
+
+When `experiment_type == META`, `StartExperiment` validates:
+
+1. `meta_config.base_algorithm` is set and maps to a known algorithm
+2. `meta_config.variant_objectives` has one entry per variant defined on the experiment
+3. Each variant's `reward_objectives` weights sum to 1.0 (±1e-6)
+4. Each variant's `metric_ids` resolve to existing metric definitions
+5. All referenced metric_ids have `aggregation_level = USER`
+6. The experiment's `primary_metric_id` is NOT present in any variant's `reward_objectives` (warn, not block — in case the user intentionally wants this)
+7. If LP constraints are specified per variant, constraint consistency is validated (floors don't sum to >1.0)
+
+### M1 Assignment Changes
+
+`GetAssignment` for META experiments:
+1. Hash user to variant using standard bucketing (same as A/B)
+2. Extract the variant's `MetaVariantObjective` from cached config
+3. Call M4b `SelectArm` with `experiment_id`, `variant_id`, and user context
+4. Return `AssignmentResponse` with variant_id, arm_id, and assignment_probability
+
+The variant_id is included in the exposure event for downstream analysis.
+
+### M4b Policy State Changes
+
+```rust
+// Policy state keyed by (experiment, variant) tuple
+type PolicyKey = (String, String);  // (experiment_id, variant_id)
+
+struct PolicyCore {
+    policies: HashMap<PolicyKey, Box<dyn BanditPolicy>>,
+    reward_composers: HashMap<PolicyKey, RewardComposer>,
+    constraint_solvers: HashMap<PolicyKey, LpConstraintSolver>,
+}
+```
+
+On `SelectArm(experiment_id, variant_id, context)`:
+- Look up `(experiment_id, variant_id)` in the policy map
+- If not found and this is a META experiment, lazily initialize from the variant's config
+- Run the variant's independent policy + composer + LP solver pipeline
+- Return arm selection with probabilities
+
+### M6 UI — Meta-Experiment Results Page
+
+- **Objective comparison table**: Side-by-side variant configs (composition method, weights, constraints)
+- **Business outcome comparison**: Primary metric treatment effects between variants (forest plot)
+- **Ecosystem health comparison**: Provider fairness metrics per variant (from ADR-014)
+- **Bandit efficiency per variant**: Convergence curves, cumulative regret, arm concentration
+- **Pareto frontier visualization** (3+ variants): D3 scatter plot with engagement vs. diversity axes, dominated region shading, variant labels
+
+### M6 UI — Create Experiment Form
+
+The meta-experiment creation wizard:
+1. Select `EXPERIMENT_TYPE_META`
+2. Choose base algorithm
+3. For each variant: configure reward objectives, composition method, optional LP constraints
+4. Select primary metric (with validation that it's not a reward metric)
+5. Review: side-by-side comparison of variant configurations
+
+---
+
+## Validation (Planned)
+
+### Unit Tests
+
+- M5: STARTING validation rejects missing base_algorithm, mismatched variant count, non-resolving metric_ids
+- M5: STARTING validation warns when primary_metric overlaps reward objectives
+- M4b: Isolated policy state — reward updates for variant A do not affect variant B posteriors
+- M4a: Two-level IPW weight computation matches manual calculation
+- M1: Hash bucketing assigns user to variant, then delegates to M4b with correct variant_id
+
+### Contract Tests
+
+- M1 ↔ M4b: Meta-experiment variant-specific policy routing (SelectArm with variant_id)
+- M5 ↔ M6: Meta-experiment config rendering (variant objectives displayed correctly)
+- M5 ↔ M1: StreamConfigUpdates includes META experiment configs with variant objectives
+
+### Integration Tests
+
+- End-to-end: Create META experiment → start → assign users → feed variant-specific rewards → run analysis → cross-variant business outcome comparison
+
+---
+
+## Dependencies
+
+- **ADR-011** (Multi-objective reward): Meta-variants configure reward composition. ADR-011 must be implemented before meta-experiments can use multi-objective rewards.
+- **ADR-012** (LP constraints): Meta-variants can optionally include LP constraints. ADR-012 should be implemented for full functionality, but meta-experiments work without it (constraints are optional per variant).
+- **ADR-014** (Provider metrics): Ecosystem health comparison uses provider-side metrics.
+- **Proto PR #196**: `EXPERIMENT_TYPE_META`, `MetaExperimentConfig`, `MetaVariantObjective` landed.
+
+---
+
+## Current Status
+
+- Proto schema landed in PR #196
+- Implementation planned for Sprint 5.4
+- Agent-1: M1 routing logic for META experiments (planned)
+- Agent-4: M4b isolated policy state per (experiment, variant) (planned)
+- Agent-5: M5 STARTING validation for `MetaExperimentConfig` (planned)
+- Agent-6: M6 meta-experiment results page (planned)
+
+---
+
+## Rejected Alternatives
+
+| Alternative | Reason Rejected |
+|-------------|----------------|
+| Manually run separate bandit experiments with different configs | No within-experiment statistical comparison. User populations differ across experiments. Selection bias. |
+| Use the portfolio system (ADR-019) to compare historical experiments | Confounded by time, population shifts, and concurrent platform changes. Not causal. |
+| Contextual bandit with reward config as context feature | Conflates the meta-level question (which config is better?) with the object-level question (which arm is better?). Policy cannot disentangle the two. |
+| Multi-armed bandit over reward configs (bandit of bandits) | Interesting theoretically but operationally complex. Requires convergence at two levels simultaneously. Meta-experiments with A/B randomization are simpler and produce standard causal estimates. |
+
+---
+
+## References
+
+- Netflix incrementality bandits (Data Council 2025) — testing bandit configurations
+- Spotify calibrated bandits (RecSys 2025) — multi-stakeholder objective tuning
+- Lattimore & Szepesvári: Bandit Algorithms (2020) — Chapter 36: meta-learning and algorithm selection

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -16,11 +16,11 @@ This directory contains the architectural decisions that shaped the experimentat
 | [008](008-auto-pause-guardrails.md) | Auto-pause as default guardrail behavior | Accepted | M3, M5 |
 | [009](009-bucket-reuse.md) | Automated bucket reuse with 24h cooldown | Accepted | M1, M5 |
 | [010](010-connectrpc.md) | ConnectRPC for Go, tonic for Rust, shared proto contracts | Accepted | All modules |
-| [011](011-multi-objective-bandit-reward.md) | Multi-objective reward composition for bandit policies | **Proposed** | M4b, M5, M6 |
-| [012](012-constrained-arm-selection-lp.md) | Constrained arm selection via LP post-processing layer | **Proposed** | M4b, M1, M5, M6 |
-| [013](013-meta-experiments-objective-functions.md) | Meta-experiments on objective function parameters | **Proposed** | M1, M4a, M4b, M5, M6 |
-| [014](014-provider-side-metrics.md) | Provider-side metrics as first-class experiment measures | **Proposed** | M3, M4a, M5, M6 |
-| [015](015-anytime-valid-regression-adjustment.md) | Anytime-valid regression adjustment (sequential CUPED) | **Proposed** | M4a, M3, M5, M6 |
+| [011](011-multi-objective-bandit-reward.md) | Multi-objective reward composition for bandit policies | **Accepted and Implemented** | M4b, M5, M6 |
+| [012](012-constrained-arm-selection-lp.md) | Constrained arm selection via LP post-processing layer | **Accepted (In Progress)** | M4b, M1, M5, M6 |
+| [013](013-meta-experiments-objective-functions.md) | Meta-experiments on objective function parameters | **Accepted (Planned — Sprint 5.4)** | M1, M4a, M4b, M5, M6 |
+| [014](014-provider-side-metrics.md) | Provider-side metrics as first-class experiment measures | **Accepted** | M3, M4a, M5, M6 |
+| [015](015-anytime-valid-regression-adjustment.md) | Anytime-valid regression adjustment (sequential CUPED) | **Accepted** | M4a, M3, M5, M6 |
 | [016](016-slate-bandit-optimization.md) | Slate-level bandit optimization and off-policy evaluation | **Proposed** | M4b, M4a, M1 |
 | [017](017-offline-rl-long-term-effects.md) | Offline RL for long-term causal effect estimation | **Proposed** | M4a, M3 |
 | [018](018-e-value-framework-online-fdr.md) | E-value framework and online FDR control | **Proposed** | M4a, M4b, M5 |
@@ -29,7 +29,7 @@ This directory contains the architectural decisions that shaped the experimentat
 | [021](021-feedback-loop-interference.md) | Feedback loop interference detection and mitigation | **Proposed** | M4a, M2, M3, M5, M6 |
 | [022](022-switchback-experiment-designs.md) | Switchback experiment designs for interference-prone treatments | **Proposed** | M1, M4a, M5, M6 |
 | [023](023-synthetic-control-methods.md) | Synthetic control methods for quasi-experimental evaluation | **Proposed** | M4a, M3, M5, M6 |
-| [024](024-m7-rust-port.md) | Port M7 Feature Flag Service from Go to Rust | **Proposed** | M7, CI, SDKs |
+| [024](024-m7-rust-port.md) | Port M7 Feature Flag Service from Go to Rust | **Accepted and Implemented** | M7, CI, SDKs |
 | [025](025-m5-conditional-rust-port.md) | Conditional port of M5 Management Service from Go to Rust | **Proposed (conditional)** | M5 |
 | [026](026-custom-metrics-layer.md) | Custom metrics definition layer (composite, derived, joined metrics beyond the 6 built-in types) | **Proposed** | M5, M3, M4a |
 | [027](027-tost-equivalence-testing.md) | Two One-Sided Tests (TOST) for proving statistical equivalence in infrastructure migrations | **Proposed** | M4a, M5, M6 |

--- a/docs/adrs/TEMPLATE.md
+++ b/docs/adrs/TEMPLATE.md
@@ -1,39 +1,86 @@
 # ADR-NNN: [Short Title]
 
-- **Status**: Proposed | Accepted | Deprecated | Superseded
-- **Date**: YYYY-MM-DD
-- **Author**: [Agent-N / Name]
-- **Supersedes**: (if applicable)
+**Status**: Proposed <!-- Proposed | Accepted | Accepted (In Progress) | Accepted (Planned — Sprint X.Y) | Accepted and Implemented | Deprecated | Superseded -->
+**Date**: YYYY-MM-DD
+**Deciders**: Agent-N ([Module or role])
+**Cluster**: [A–F] — [Cluster name, if applicable]
+
+---
 
 ## Context
 
-What is the issue that we're seeing that motivates this decision or change?
+What gap, requirement, or problem motivates this decision? Ground in research and prior art where applicable.
+
+---
 
 ## Decision
 
-What is the change that we're proposing and/or doing?
+What is the change we're proposing? Break into subsections by topic (design, schema, integration) where useful.
+
+---
 
 ## Consequences
 
-### Positive
+### Benefits
 
-- What becomes easier or possible as a result of this change?
+1. What becomes easier or possible as a result?
 
-### Negative
+### Trade-offs
 
-- What becomes more difficult as a result of this change?
+1. What becomes more difficult, expensive, or constrained?
 
-### Risks
+---
 
-- What could go wrong?
+## Implementation Details
 
-## Alternatives Considered
+### Proto Schema
 
-| Alternative | Pros | Cons | Why rejected |
-|-------------|------|------|--------------|
-| Option A    |      |      |              |
-| Option B    |      |      |              |
+```protobuf
+// Schema changes, if any
+```
+
+### Crate Layout / Public API
+
+Describe the module structure and key types.
+
+### Integration
+
+How this interacts with existing modules (M1, M4b, etc.).
+
+---
+
+## Validation
+
+### Unit Tests / Proptest Invariants
+
+- Key correctness properties to verify.
+
+### Golden-File Tests
+
+- Reference implementation and precision target (e.g., R `TOSTER` package to 6 decimals).
+
+### Integration / Contract Tests
+
+- Cross-module behavior.
+
+---
+
+## Dependencies
+
+- **ADR-XXX** ([Short name]): [relationship]
+- **Enables ADR-YYY**: [what this unlocks]
+
+---
+
+## Rejected Alternatives
+
+| Alternative | Reason Rejected |
+|-------------|-----------------|
+|             |                 |
+
+---
 
 ## References
 
-- Links to relevant design docs, external references, prior art
+- Citations to papers, blog posts, prior art
+- Links to other ADRs, design docs, or issues


### PR DESCRIPTION
## Summary

Three related changes completing the ADR organization work started in [#420](https://github.com/wunderkennd/kaizen-experimentation/pull/420):

### 1. Add ADRs 011/012/013 (Cluster A — Multi-Stakeholder Optimization)

These were authored as drafts locally but never committed. The Decision Index has been linking to them with no underlying file on `main`.

| ADR | Title | Status (per file) |
|---|---|---|
| 011 | Multi-Objective Bandit Reward Composition | Accepted and Implemented (PRs #196, #221, #228) |
| 012 | Constrained Arm Selection via LP | Accepted (In Progress, Sprint 5.2/5.3) |
| 013 | Meta-Experiments on Objective Functions | Accepted (Planned — Sprint 5.4) |

### 2. Sync README Decision Index status column

Six rows in `docs/adrs/README.md` lagged behind the actual ADR file Status fields. Now consistent:

| ADR | Was | Now |
|---|---|---|
| 011 | Proposed | Accepted and Implemented |
| 012 | Proposed | Accepted (In Progress) |
| 013 | Proposed | Accepted (Planned — Sprint 5.4) |
| 014 | Proposed | Accepted |
| 015 | Proposed | Accepted |
| 024 | Proposed | Accepted and Implemented |

### 3. Modernize `TEMPLATE.md`

The template was prescribing a metadata format (`- **Status**: ...` bullet, `Author` field, `Risks` subsection) that no recent authored ADR actually uses. Updated to match the convention used by ADRs 011, 012, 013, 015, 024:

- Inline `**Field**: value` metadata
- `Deciders` (not `Author`) + `Cluster` tag
- Horizontal rules between sections
- Consequences as Benefits/Trade-offs (not Positive/Negative/Risks)
- Added Implementation Details / Validation / Dependencies / Rejected Alternatives sections

## Out of scope (flagged for follow-up)

- **ADRs 001-010** still use the older `## Status` heading format. Backfilling them to the modern convention is a one-PR task but not bundled here.
- **Cluster A diagram** in the README shows a static implementation order; could be annotated with current state (✓ shipped, ⏳ in flight, ⬜ planned).
- **Per-ADR improvements** for 011-013 raised in the design review (sigmoid mapping rationale, multiple-comparison handling for meta-experiments, etc.) — appropriate as separate revisions by the responsible agents.

## Test plan

- [x] All 6 README rows display the correct status
- [x] `TEMPLATE.md` parses as valid markdown
- [x] CI (docs-only — no Rust/Go/TS code touched)

## Depends on
- [#420](https://github.com/wunderkennd/kaizen-experimentation/pull/420) — ADR consolidation (merged)
- [#421](https://github.com/wunderkennd/kaizen-experimentation/pull/421) — ADR-027 + index entry (merged)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
