### PR TITLE
ci: gate Rust and Go jobs on relevant path changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ───────── Stage 0: Detect Changes ─────────
+  # Produces boolean outputs that downstream language jobs gate on, so a
+  # docs-only PR does not trigger 25-minute Rust or Go runs. Anything
+  # touching ci.yml itself triggers all jobs (catch self-changes safely).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'proto/**'
+              - '.github/workflows/ci.yml'
+            go:
+              - 'services/**'
+              - 'proto/**'
+              - '.github/workflows/ci.yml'
+
   # ───────── Stage 1: Schema Validation ─────────
   schema:
     runs-on: ubuntu-latest
@@ -51,7 +78,8 @@ jobs:
   # ───────── Stage 2: Rust Build & Test ─────────
   rust:
     runs-on: ubuntu-latest
-    needs: schema
+    needs: [changes, schema]
+    if: needs.changes.outputs.rust == 'true'
     timeout-minutes: 45
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -122,7 +150,15 @@ jobs:
   # ───────── Stage 3: Go Build & Test ─────────
   go:
     runs-on: ubuntu-latest
-    needs: [schema, rust]
+    needs: [changes, schema, rust]
+    # Run when go/proto changed. The always() guard lets this proceed even
+    # when `rust` is skipped (rust files unchanged) — schema must succeed
+    # because go downloads its proto/gen/ artifact.
+    if: |
+      always() &&
+      needs.changes.outputs.go == 'true' &&
+      needs.schema.result == 'success' &&
+      (needs.rust.result == 'success' || needs.rust.result == 'skipped')
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

Adds path-based filtering so the **Rust** and **Go** CI jobs only run when files in their respective domains have changed. Docs-only PRs no longer burn ~30 CI-minutes on irrelevant builds.

The recent stretch of docs PRs ([#420](https://github.com/wunderkennd/kaizen-experimentation/pull/420), [#421](https://github.com/wunderkennd/kaizen-experimentation/pull/421), [#426](https://github.com/wunderkennd/kaizen-experimentation/pull/426)) each spent ~25 minutes on Rust clippy + tests despite touching zero Rust source.

## How it works

A new Stage 0 `changes` job runs first using [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter):

```yaml
changes:
  outputs: { rust, go }
  filters:
    rust: crates/** | Cargo.{toml,lock} | rust-toolchain.toml | proto/** | .github/workflows/ci.yml
    go:   services/** | proto/** | .github/workflows/ci.yml
```

Then `rust` and `go` gate themselves:

```yaml
rust:
  needs: [changes, schema]
  if: needs.changes.outputs.rust == 'true'

go:
  needs: [changes, schema, rust]
  if: |
    always() &&
    needs.changes.outputs.go == 'true' &&
    needs.schema.result == 'success' &&
    (needs.rust.result == 'success' || needs.rust.result == 'skipped')
```

## Design notes

| Concern | Mitigation |
|---|---|
| `proto/**` belongs in **both** filters | Rust generates types via `tonic-build` at compile time; Go downloads schema's `proto/gen/` artifact. Either breaks if proto moves while the consuming lang stays static. |
| Self-edits to `ci.yml` could silently disable jobs | Both filters include `.github/workflows/ci.yml`, so any workflow change triggers a full run. |
| Go's implicit `needs: rust` would skip Go when Rust is skipped | Use `always()` with an explicit `(success or skipped)` check on `needs.rust.result`. |
| First validation of the new workflow | This very PR touches `ci.yml`, which the new filter forces both Rust and Go to run on — so the workflow change validates itself in one shot. |

## Out of scope

- `schema`, `infra`, `typescript`, `hash-parity`, `docker` keep their current always-on behavior. Adding similar filters is a small follow-up if you want it.
- The matrix `docker` job builds 7 images regardless of which actually changed; per-image filtering is a deeper restructure.

## Test plan

- [x] Self-trigger: this PR modifies `ci.yml`, which under the new filter forces both `rust` and `go` to run → validates the changes job, the filter rules, and the gating logic in one shot
- [ ] Future docs-only PR: confirms `rust` and `go` are skipped while `schema`, `infra`, `typescript` still run
- [ ] Future Rust-only PR: confirms `go` proceeds via the `(success or skipped)` guard if go files happen to also change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
