### PR TITLE
docs(adrs): backfill 001-010 to modern inline metadata format

### DIFF
--- a/docs/adrs/001-language-selection.md
+++ b/docs/adrs/001-language-selection.md
@@ -1,10 +1,9 @@
 # ADR-001: Language Selection — Rust for Hot Paths, Go for Orchestration, TypeScript for UI Only
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 The platform requires three categories of work: low-latency request handling and numerical computation (assignment, analysis, bandit policy, event ingestion), orchestration and CRUD (experiment management, metric job scheduling, feature flags), and browser-rendered visualization (dashboards, charts). We need to select languages that match each workload's characteristics.

--- a/docs/adrs/002-lmax-bandit-core.md
+++ b/docs/adrs/002-lmax-bandit-core.md
@@ -1,10 +1,9 @@
 # ADR-002: LMAX-Inspired Single-Threaded Policy Core for Bandit Service
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 The Bandit Policy Service (M4b) maintains mutable state: posterior parameters (Thompson Sampling), Cholesky decompositions (LinUCB), and neural network weights (Neural Contextual). This state is read on every SelectArm request (~10K rps) and mutated on every RewardEvent (~5K rps). Concurrent access to this state is the core design challenge.

--- a/docs/adrs/003-rocksdb-policy-state.md
+++ b/docs/adrs/003-rocksdb-policy-state.md
@@ -1,10 +1,9 @@
 # ADR-003: RocksDB for Bandit Policy State (Crash-Only Design)
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 The Bandit Policy Service (M4b) needs durable state for crash recovery. The crash-only design principle (from NautilusTrader) requires that the recovery path and the startup path are identical: load last snapshot, replay events from Kafka. State must be persisted on every reward update as a side effect of normal operation — no separate "save on shutdown" path.

--- a/docs/adrs/004-gst-alongside-msprt.md
+++ b/docs/adrs/004-gst-alongside-msprt.md
@@ -1,10 +1,9 @@
 # ADR-004: Group Sequential Tests Alongside mSPRT
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 The platform already supports mSPRT (always-valid inference with arbitrary peeking). Spotify Confidence offers both always-valid approaches and group sequential tests (GSTs), reasoning that GSTs are more powerful when teams can pre-commit to a fixed analysis schedule. Our platform serves teams with different monitoring patterns.

--- a/docs/adrs/005-component-state-machine.md
+++ b/docs/adrs/005-component-state-machine.md
@@ -1,10 +1,9 @@
 # ADR-005: Component State Machine with Transitional States
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 NautilusTrader defines both stable and transitional states for all components, preventing race conditions during state changes. Our experiment lifecycle has a gap: between "start experiment" and "experiment is running," several asynchronous validations must complete (config validation, bandit warm-up, metric availability check, segment power check). Similarly, between "conclude experiment" and "results available," final analysis must complete. Without transitional states, clients can observe inconsistent states.

--- a/docs/adrs/006-cargo-workspace.md
+++ b/docs/adrs/006-cargo-workspace.md
@@ -1,10 +1,9 @@
 # ADR-006: Cargo Workspace with Crate Layering
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 NautilusTrader organizes its Rust codebase into focused crates with explicit dependency boundaries and feature flags gating optional functionality. Our platform has four Rust service binaries that share significant domain logic (hashing, statistics, bandit algorithms). Without shared crates, we'd either duplicate code or create monolithic binaries.

--- a/docs/adrs/007-sdk-provider-abstraction.md
+++ b/docs/adrs/007-sdk-provider-abstraction.md
@@ -1,10 +1,9 @@
 # ADR-007: SDK Provider Abstraction with Fallback Chain
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 GrowthBook users learned to wrap the SDK in a provider abstraction so the underlying platform can be swapped without changing call sites. Our SDKs must work across web, iOS, Android, and server environments with varying network reliability. Mobile clients in particular cannot depend on the Assignment Service being reachable.

--- a/docs/adrs/008-auto-pause-guardrails.md
+++ b/docs/adrs/008-auto-pause-guardrails.md
@@ -1,10 +1,9 @@
 # ADR-008: Auto-Pause as Default Guardrail Behavior
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 Spotify developers roll back approximately 42% of experiments to prevent business metric regressions. This indicates that guardrail breaches are common and that fast automated response is critical. The question is whether guardrail breaches should alert (human decides) or auto-pause (machine acts, human overrides).

--- a/docs/adrs/009-bucket-reuse.md
+++ b/docs/adrs/009-bucket-reuse.md
@@ -1,10 +1,9 @@
 # ADR-009: Automated Bucket Reuse with Cooldown Period
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 Spotify builds bucket reuse directly into their platform to prevent traffic exhaustion at high experiment volume. Without bucket reuse, a platform running 100+ experiments per quarter on a 10,000-bucket layer would exhaust its hash space within 2-3 quarters. Manual bucket management is operationally burdensome.

--- a/docs/adrs/010-connectrpc.md
+++ b/docs/adrs/010-connectrpc.md
@@ -1,10 +1,9 @@
 # ADR-010: ConnectRPC as the RPC Framework
 
-## Status
-Accepted
+**Status**: Accepted
+**Date**: 2026-03-03
 
-## Date
-2026-03-03
+---
 
 ## Context
 We need an RPC framework that works across Go (M3, M5, M7), Rust (M1, M2, M4a, M4b), and TypeScript (M6 UI). The framework must support streaming (M1 config updates), unary RPCs (most operations), and browser clients (M6 dashboard).


### PR DESCRIPTION
## Summary

Backfill ADRs 001-010 to use the modern inline `**Field**: value` metadata format already adopted by ADRs 011-015, 024, 027, and the updated `TEMPLATE.md`. Eliminates the format split between the foundational (pre-cluster) ADRs and the Phase 5 ADRs.

### What changed
- For each of `docs/adrs/001-*.md` through `docs/adrs/010-*.md`, the legacy heading-style metadata block:
  ```
  ## Status
  Accepted

  ## Date
  2026-03-03
  ```
  was replaced with the modern inline form plus a `---` rule:
  ```
  **Status**: Accepted
  **Date**: 2026-03-03

  ---
  ```
- No `**Cluster**:` line was added — these ADRs are pre-cluster foundational decisions.
- No `**Deciders**:` line was added — none of 001-010 had an `## Author` field to convert.
- No status values were changed; all 10 ADRs remain `Accepted`.
- No content sections (`## Context`, `## Decision`, `## Consequences`, etc.) were modified.

### Scope guarantees
- Only the 10 files in `docs/adrs/00*.md` and `docs/adrs/010-connectrpc.md` were touched.
- README index, TEMPLATE, and ADRs 011+ were not modified.
- Diff stat: `10 files changed, 30 insertions(+), 40 deletions(-)` — purely metadata.

Closes the format split surfaced in #426.

## Test plan

- [ ] Verify `git diff main...HEAD --stat` shows only the 10 ADR files
- [ ] Spot-check one ADR (e.g., 001) renders metadata identically to ADR-015 / ADR-024 in the GitHub Markdown preview
- [ ] Confirm no status/date values drifted from the originals
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
