### PR TITLE
docs(adrs): address review feedback on ADRs 011-013

### DIFF
--- a/docs/adrs/011-multi-objective-bandit-reward.md
+++ b/docs/adrs/011-multi-objective-bandit-reward.md
@@ -72,6 +72,8 @@ metric_values = {metric_1: r_1, ..., metric_k: r_k}
 
 The `sigmoid()` mapping converts the composed real-valued reward to (0, 1) for Beta-Bernoulli posterior compatibility. Composer and normalizer state are persisted in RocksDB alongside posterior parameters via the existing snapshot mechanism, surviving crashes and restarts.
 
+The `sigmoid()` mapping is required only for Beta-Bernoulli posteriors, which expect rewards in (0, 1). Future Thompson Sampling variants using Gaussian posteriors would not require this mapping; the composer's output could be passed directly. The mapping is conditional on the policy's posterior type, not a universal requirement.
+
 ### State Growth
 
 For a typical multi-objective experiment with 3 objectives and 10 arms, the composer adds ~200 bytes of state per metric per experiment. At 100 concurrent experiments, total additional RocksDB snapshot overhead is ~60KB — negligible relative to existing posterior state.
@@ -97,6 +99,10 @@ For a typical multi-objective experiment with 3 objectives and 10 arms, the comp
 ---
 
 ## Implementation Details
+
+### Default Behavior
+
+When `BanditConfig.reward_objectives` is empty, the existing scalar reward path is used and `composition_method` is ignored. Single-objective experiments are not affected by this ADR — they continue to use the pre-existing `Posterior::update(scalar_reward)` flow without modification.
 
 ### Proto Schema
 

--- a/docs/adrs/012-constrained-arm-selection-lp.md
+++ b/docs/adrs/012-constrained-arm-selection-lp.md
@@ -35,6 +35,8 @@ subject to:
   Σⱼ aⱼᵢ · qᵢ ≥ bⱼ         ∀j ∈ G        (general linear constraints)
 ```
 
+Each `GlobalConstraint` proto message corresponds to one row j of the constraint matrix; its `coefficients` map provides aⱼᵢ for each arm i, and `rhs` is bⱼ. The `GlobalConstraint.label` field is human-readable and used only for diagnostics (M6 surfaces, infeasibility logs).
+
 ### Constraint Types
 
 **Per-arm constraints** (`ArmConstraint`): Floor and/or ceiling on individual arm selection probabilities. Use case: provider minimum impression guarantee, maximum arm concentration limit.
@@ -51,9 +53,11 @@ subject to:
 
 Per-arm constraints express *selection probability* requirements, but business constraints are typically about *population-level impression counts*. The solver maintains running impression counts per arm with EMA decay (α = 0.01) on the LMAX thread. These running counts feed into the constraint satisfaction check: if arm `i`'s running impression share is already above its floor, the constraint is slack and does not distort **q**.
 
+The `α = 0.01` rate gives an effective half-life of roughly 70 selections, balancing constraint responsiveness (fast enough to react to policy shifts) against noise-induced oscillation. This is a tunable per-experiment parameter; future work may auto-calibrate it from the experiment's expected traffic rate.
+
 ### Feasibility Handling
 
-If the constraint polytope is empty (conflicting constraints make simultaneous satisfaction impossible), the solver returns `CONSTRAINT_INFEASIBLE` and falls back to the raw probabilities **p**. This is logged as a warning and surfaced to the experiment owner via M6. Common cause: floor constraints that sum to >1.0.
+If the constraint polytope is empty (conflicting constraints make simultaneous satisfaction impossible), the solver returns `CONSTRAINT_INFEASIBLE` and falls back to the raw probabilities **p**. Infeasibility is logged as a warning event and surfaced in M6 via the `ConstraintStatusTable` component (PR from Agent-6, work/fancy-koala) — the table renders a `CONSTRAINT INFEASIBLE` red badge on the affected experiment with a tooltip listing which specific constraints conflict (e.g., "floor constraints sum to 1.15 > 1.0"). Common cause: floor constraints that sum to >1.0.
 
 ### IPW Validity
 

--- a/docs/adrs/013-meta-experiments-objective-functions.md
+++ b/docs/adrs/013-meta-experiments-objective-functions.md
@@ -83,11 +83,23 @@ Treatment effect estimation for the primary metric uses two-level IPW:
 weight = 1 / (P(variant) × P(arm | variant))
 ```
 
+The variance estimator under two-stage IPW is non-trivial; M4a uses the influence-function-based estimator described in Wager & Athey (2018, JASA) to handle the compound randomization. For variants where the bandit assignment probability `P(arm | variant)` collapses to near-zero on some arms, the IPW weight is clipped at the 99th percentile to prevent variance explosion (a standard practice for off-policy evaluation).
+
 M4a's `RunAnalysis` for META experiments computes:
 - **Cross-variant business outcome comparison**: treatment effects on the primary metric (retention, LTV) between meta-variants. This is the key output.
 - **Per-variant bandit efficiency**: convergence speed, cumulative regret, arm concentration.
 - **Per-variant ecosystem health**: provider fairness metrics (from ADR-014) under each configuration.
 - **Pareto frontier visualization**: for 3+ variants, scatter plot of (engagement, diversity) with dominated region shading.
+
+### Multiple-Comparison Handling
+
+A meta-experiment with K ≥ 3 variants produces K(K-1)/2 pairwise comparisons on the primary metric. Without correction, the family-wise error rate inflates linearly with K.
+
+Two approaches are supported:
+- **Default (interim)**: Bonferroni adjustment on the K-1 comparisons against a designated control variant. Conservative but simple.
+- **Once ADR-018 ships**: e-value framework with online FDR control (Ramdas/Wang). Handles arbitrary stopping and gives anytime-valid inference, which composes cleanly with the meta-experiment's typical 4–8 week duration.
+
+M4a will surface both raw and adjusted p-values so reviewers can verify either approach. The choice is configurable via `MetaExperimentConfig.multiple_comparison_method`.
 
 ---
 
@@ -151,7 +163,7 @@ When `experiment_type == META`, `StartExperiment` validates:
 3. Each variant's `reward_objectives` weights sum to 1.0 (±1e-6)
 4. Each variant's `metric_ids` resolve to existing metric definitions
 5. All referenced metric_ids have `aggregation_level = USER`
-6. The experiment's `primary_metric_id` is NOT present in any variant's `reward_objectives` (warn, not block — in case the user intentionally wants this)
+6. The experiment's `primary_metric_id` MUST NOT be present in any variant's `reward_objectives`. Reject — a circular metric (primary metric is also a reward objective) produces tautological results: each variant's bandit is literally optimizing for what the meta-experiment is measuring, so cross-variant differences reflect bandit convergence rate rather than the value of the underlying objective configuration. To override this for an explicit research purpose, the experiment owner must set `MetaExperimentConfig.allow_circular_metric = true` (a future flag; not yet implemented).
 7. If LP constraints are specified per variant, constraint consistency is validated (floors don't sum to >1.0)
 
 ### M1 Assignment Changes
@@ -189,7 +201,7 @@ On `SelectArm(experiment_id, variant_id, context)`:
 - **Business outcome comparison**: Primary metric treatment effects between variants (forest plot)
 - **Ecosystem health comparison**: Provider fairness metrics per variant (from ADR-014)
 - **Bandit efficiency per variant**: Convergence curves, cumulative regret, arm concentration
-- **Pareto frontier visualization** (3+ variants): D3 scatter plot with engagement vs. diversity axes, dominated region shading, variant labels
+- **Pareto frontier visualization** (3+ variants): D3 scatter plot of two user-selected metrics (configurable per meta-experiment) with dominated region shading and variant labels. The axis selection defaults to the first two reward objectives shared across all variants; users can change axes interactively to explore other objective trade-offs.
 
 ### M6 UI — Create Experiment Form
 


### PR DESCRIPTION
## Summary

Targeted edits to ADRs 011, 012, and 013 from the design review surfaced in #426. No status changes; all three ADRs remain at their current Accepted (level). Only the three target files are modified — no README index or other ADR touched.

## Per-edit changes

### ADR-011 (Multi-Objective Bandit Reward Composition)

- **011-A** — In `LMAX Core Integration`, added a paragraph after the `sigmoid()` description clarifying that the mapping is required only for Beta-Bernoulli posteriors, not a universal requirement. Future Gaussian-posterior Thompson variants would not need it.
- **011-B** — Added a `Default Behavior` subsection at the start of `Implementation Details` documenting that empty `reward_objectives` falls back to the existing scalar reward path and `composition_method` is ignored. Single-objective experiments are explicitly unaffected.

### ADR-012 (Constrained Arm Selection via LP)

- **012-A** — In `Optimization Problem`, added a clarifying sentence after the constraint matrix block tying each `GlobalConstraint` proto message to one row j: `coefficients` provides aⱼᵢ, `rhs` is bⱼ, and `label` is human-readable diagnostic-only.
- **012-B** — In `Population-Level Enforcement`, justified the `α = 0.01` EMA decay rate as roughly a 70-selection half-life, balancing responsiveness vs. oscillation. Noted it's tunable per-experiment.
- **012-C** — In `Feasibility Handling`, replaced the vague "surfaced via M6" phrasing with a concrete reference to the `ConstraintStatusTable` component (Agent-6, work/fancy-koala) including the `CONSTRAINT INFEASIBLE` red badge and tooltip behavior with a worked example.

### ADR-013 (Meta-Experiments on Objective Functions)

- **013-A** — Added a new `Multiple-Comparison Handling` subsection after Two-Level IPW. Documents Bonferroni against a control as the interim default, with an ADR-018 e-value/online-FDR upgrade path. Notes M4a will surface both raw and adjusted p-values and the choice is configurable via `MetaExperimentConfig.multiple_comparison_method`.
- **013-B** — Generalized the Pareto frontier visualization from hardcoded "engagement vs. diversity axes" to user-selected metrics, with the default being the first two reward objectives shared across all variants and interactive axis switching.
- **013-C** — Added a sentence after the Two-Level IPW formula citing Wager & Athey (2018, JASA) for the influence-function-based variance estimator and noting that IPW weights are clipped at the 99th percentile to prevent variance explosion (standard off-policy evaluation practice).
- **013-D** — Hardened M5 STARTING validation rule 6 from a warning to a hard block: a circular metric (primary metric also a reward objective) is now rejected because cross-variant differences would reflect bandit convergence rate rather than objective configuration value. An `allow_circular_metric` override flag is mentioned as a future escape hatch.
- **013-E** — Verification only; `EXPERIMENT_TYPE_META = 9` already correct in `proto/experimentation/common/v1/experiment.proto:66`. No edit needed.

## Diff scope

```
docs/adrs/011-multi-objective-bandit-reward.md        |  6 ++++++
docs/adrs/012-constrained-arm-selection-lp.md         |  6 +++++-
docs/adrs/013-meta-experiments-objective-functions.md | 16 ++++++++++++++--
3 files changed, 25 insertions(+), 3 deletions(-)
```

## Test plan

- [ ] `git diff main...HEAD` confirms only the three target ADR files are modified
- [ ] No Status field on any of ADRs 011, 012, 013 was changed
- [ ] README index (`docs/adrs/README.md`) is untouched
- [ ] Each of the eight intended edits is present in the diff
- [ ] Markdown renders correctly on GitHub for all three files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
