### PR TITLE
🎨 Palette: Standardize Experiments page empty state

### DIFF
--- a/ui/src/__tests__/experiment-empty-state.test.tsx
+++ b/ui/src/__tests__/experiment-empty-state.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import ExperimentListPage from '@/app/page';
+import { AuthProvider } from '@/lib/auth-context';
+import type { AuthUser } from '@/lib/auth-context';
+
+const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe('Experiment List Empty State', () => {
+  it('renders empty state with CTA for experimenter', async () => {
+    server.use(
+      http.post(`${MGMT_SVC}/ListExperiments`, () => {
+        return HttpResponse.json({ experiments: [], nextPageToken: '' });
+      }),
+    );
+
+    const experimenter: AuthUser = { email: 'exp@streamco.com', role: 'experimenter' };
+    render(
+      <AuthProvider initialUser={experimenter}>
+        <ExperimentListPage />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('No experiments yet.')).toBeInTheDocument();
+    expect(screen.getByTestId('create-first-experiment')).toBeInTheDocument();
+    expect(screen.getByTestId('create-first-experiment')).toHaveAttribute('href', '/experiments/new');
+  });
+
+  it('renders empty state without CTA for viewer', async () => {
+    server.use(
+      http.post(`${MGMT_SVC}/ListExperiments`, () => {
+        return HttpResponse.json({ experiments: [], nextPageToken: '' });
+      }),
+    );
+
+    const viewer: AuthUser = { email: 'viewer@streamco.com', role: 'viewer' };
+    render(
+      <AuthProvider initialUser={viewer}>
+        <ExperimentListPage />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('No experiments yet.')).toBeInTheDocument();
+    expect(screen.queryByTestId('create-first-experiment')).not.toBeInTheDocument();
+  });
+
+  it('renders page heading even when empty', async () => {
+    server.use(
+      http.post(`${MGMT_SVC}/ListExperiments`, () => {
+        return HttpResponse.json({ experiments: [], nextPageToken: '' });
+      }),
+    );
+
+    render(
+      <AuthProvider initialUser={{ email: 'test@streamco.com', role: 'viewer' }}>
+        <ExperimentListPage />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Experiments', level: 1 })).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -87,8 +87,22 @@ export default function ExperimentListPage() {
 
   if (experiments.length === 0) {
     return (
-      <div className="py-12 text-center">
-        <p className="text-sm text-gray-500">No experiments yet. Create your first experiment to get started.</p>
+      <div>
+        <h1 className="mb-6 text-2xl font-bold text-gray-900">Experiments</h1>
+        <div className="py-12 text-center" data-testid="empty-state">
+          <p className="text-sm text-gray-500">No experiments yet.</p>
+          {canCreate && (
+            <div className="mt-6">
+              <Link
+                href="/experiments/new"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                data-testid="create-first-experiment"
+              >
+                Create your first experiment
+              </Link>
+            </div>
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Enhanced the Experiments page empty state by adding a consistent heading and a permission-gated Call-to-Action button. This change standardizes the onboarding experience and ensures users with creation privileges have a clear next step.

Included a new test suite `ui/src/__tests__/experiment-empty-state.test.tsx` to verify the behavior across different RBAC roles.

---
*PR created automatically by Jules for task [17483894206876219353](https://jules.google.com/task/17483894206876219353) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
