### PR TITLE
docs(adrs): sync stale Proposed statuses against shipped implementations

### DIFF
--- a/docs/adrs/012-constrained-arm-selection-lp.md
+++ b/docs/adrs/012-constrained-arm-selection-lp.md
@@ -1,6 +1,6 @@
 # ADR-012: Constrained Arm Selection via Linear Programming
 
-**Status**: Accepted (In Progress)
+**Status**: Accepted and Implemented
 **Date**: 2026-03-24
 **Deciders**: Agent-4 (M4b Bandit Policy)
 **Cluster**: A — Multi-Stakeholder Optimization

--- a/docs/adrs/013-meta-experiments-objective-functions.md
+++ b/docs/adrs/013-meta-experiments-objective-functions.md
@@ -1,6 +1,6 @@
 # ADR-013: Meta-Experiments on Objective Functions
 
-**Status**: Accepted (Planned — Sprint 5.4)
+**Status**: Accepted and Implemented
 **Date**: 2026-03-24
 **Deciders**: Agent-1 (M1 Assignment), Agent-4 (M4b Bandit Policy), Agent-5 (M5 Management)
 **Cluster**: A — Multi-Stakeholder Optimization

--- a/docs/adrs/016-slate-bandit-optimization.md
+++ b/docs/adrs/016-slate-bandit-optimization.md
@@ -1,6 +1,6 @@
 # ADR-016: Slate-Level Bandit Optimization and Off-Policy Evaluation
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-4 (Bandit) / Agent-1 (Assignment)
 - **Supersedes**: None (extends ADR-002 LMAX core; complements existing interleaving in M1)

--- a/docs/adrs/017-offline-rl-long-term-effects.md
+++ b/docs/adrs/017-offline-rl-long-term-effects.md
@@ -1,6 +1,6 @@
 # ADR-017: Offline Reinforcement Learning for Long-Term Causal Effect Estimation
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-4 (Analysis) / Agent-3 (Metrics)
 - **Supersedes**: None (corrects a theoretical limitation of the existing surrogate metric framework)

--- a/docs/adrs/018-e-value-framework-online-fdr.md
+++ b/docs/adrs/018-e-value-framework-online-fdr.md
@@ -1,6 +1,6 @@
 # ADR-018: E-Value Framework and Online FDR Control
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-4 (Analysis)
 - **Supersedes**: Partially supersedes BH-FDR correction in `experimentation-stats` for concurrent experiment programs

--- a/docs/adrs/019-portfolio-experiment-optimization.md
+++ b/docs/adrs/019-portfolio-experiment-optimization.md
@@ -1,6 +1,6 @@
 # ADR-019: Portfolio-Level Experiment Program Optimization
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-5 (Management) / Platform Architecture
 - **Supersedes**: None

--- a/docs/adrs/020-adaptive-sample-size-recalculation.md
+++ b/docs/adrs/020-adaptive-sample-size-recalculation.md
@@ -1,6 +1,6 @@
 # ADR-020: Adaptive Sample Size Recalculation via Promising-Zone Designs
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-4 (Analysis) / Agent-5 (Management)
 - **Supersedes**: None (extends existing power analysis and GST framework)

--- a/docs/adrs/021-feedback-loop-interference.md
+++ b/docs/adrs/021-feedback-loop-interference.md
@@ -1,6 +1,6 @@
 # ADR-021: Feedback Loop Interference Detection and Mitigation
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-3 (Metrics) / Agent-4 (Analysis)
 - **Supersedes**: None (extends existing interference detection: JSD, Jaccard, Gini)

--- a/docs/adrs/022-switchback-experiment-designs.md
+++ b/docs/adrs/022-switchback-experiment-designs.md
@@ -1,6 +1,6 @@
 # ADR-022: Switchback Experiment Designs for Interference-Prone Treatments
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-4 (Analysis) / Agent-1 (Assignment)
 - **Supersedes**: None (new experiment type)

--- a/docs/adrs/023-synthetic-control-methods.md
+++ b/docs/adrs/023-synthetic-control-methods.md
@@ -1,6 +1,6 @@
 # ADR-023: Synthetic Control Methods for Quasi-Experimental Evaluation
 
-- **Status**: Proposed
+**Status**: Accepted and Implemented
 - **Date**: 2026-03-19
 - **Author**: Agent-4 (Analysis) / Agent-3 (Metrics)
 - **Supersedes**: None (new analysis capability)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -17,18 +17,18 @@ This directory contains the architectural decisions that shaped the experimentat
 | [009](009-bucket-reuse.md) | Automated bucket reuse with 24h cooldown | Accepted | M1, M5 |
 | [010](010-connectrpc.md) | ConnectRPC for Go, tonic for Rust, shared proto contracts | Accepted | All modules |
 | [011](011-multi-objective-bandit-reward.md) | Multi-objective reward composition for bandit policies | **Accepted and Implemented** | M4b, M5, M6 |
-| [012](012-constrained-arm-selection-lp.md) | Constrained arm selection via LP post-processing layer | **Accepted (In Progress)** | M4b, M1, M5, M6 |
-| [013](013-meta-experiments-objective-functions.md) | Meta-experiments on objective function parameters | **Accepted (Planned — Sprint 5.4)** | M1, M4a, M4b, M5, M6 |
+| [012](012-constrained-arm-selection-lp.md) | Constrained arm selection via LP post-processing layer | **Accepted and Implemented** | M4b, M1, M5, M6 |
+| [013](013-meta-experiments-objective-functions.md) | Meta-experiments on objective function parameters | **Accepted and Implemented** | M1, M4a, M4b, M5, M6 |
 | [014](014-provider-side-metrics.md) | Provider-side metrics as first-class experiment measures | **Accepted** | M3, M4a, M5, M6 |
 | [015](015-anytime-valid-regression-adjustment.md) | Anytime-valid regression adjustment (sequential CUPED) | **Accepted** | M4a, M3, M5, M6 |
-| [016](016-slate-bandit-optimization.md) | Slate-level bandit optimization and off-policy evaluation | **Proposed** | M4b, M4a, M1 |
-| [017](017-offline-rl-long-term-effects.md) | Offline RL for long-term causal effect estimation | **Proposed** | M4a, M3 |
-| [018](018-e-value-framework-online-fdr.md) | E-value framework and online FDR control | **Proposed** | M4a, M4b, M5 |
-| [019](019-portfolio-experiment-optimization.md) | Portfolio-level experiment program optimization | **Proposed** | M5, M4a, M6 |
-| [020](020-adaptive-sample-size-recalculation.md) | Adaptive sample size recalculation via promising-zone designs | **Proposed** | M4a, M5, M6 |
-| [021](021-feedback-loop-interference.md) | Feedback loop interference detection and mitigation | **Proposed** | M4a, M2, M3, M5, M6 |
-| [022](022-switchback-experiment-designs.md) | Switchback experiment designs for interference-prone treatments | **Proposed** | M1, M4a, M5, M6 |
-| [023](023-synthetic-control-methods.md) | Synthetic control methods for quasi-experimental evaluation | **Proposed** | M4a, M3, M5, M6 |
+| [016](016-slate-bandit-optimization.md) | Slate-level bandit optimization and off-policy evaluation | **Accepted and Implemented** | M4b, M4a, M1 |
+| [017](017-offline-rl-long-term-effects.md) | Offline RL for long-term causal effect estimation | **Accepted and Implemented** | M4a, M3 |
+| [018](018-e-value-framework-online-fdr.md) | E-value framework and online FDR control | **Accepted and Implemented** | M4a, M4b, M5 |
+| [019](019-portfolio-experiment-optimization.md) | Portfolio-level experiment program optimization | **Accepted and Implemented** | M5, M4a, M6 |
+| [020](020-adaptive-sample-size-recalculation.md) | Adaptive sample size recalculation via promising-zone designs | **Accepted and Implemented** | M4a, M5, M6 |
+| [021](021-feedback-loop-interference.md) | Feedback loop interference detection and mitigation | **Accepted and Implemented** | M4a, M2, M3, M5, M6 |
+| [022](022-switchback-experiment-designs.md) | Switchback experiment designs for interference-prone treatments | **Accepted and Implemented** | M1, M4a, M5, M6 |
+| [023](023-synthetic-control-methods.md) | Synthetic control methods for quasi-experimental evaluation | **Accepted and Implemented** | M4a, M3, M5, M6 |
 | [024](024-m7-rust-port.md) | Port M7 Feature Flag Service from Go to Rust | **Accepted and Implemented** | M7, CI, SDKs |
 | [025](025-m5-conditional-rust-port.md) | Conditional port of M5 Management Service from Go to Rust | **Proposed (conditional)** | M5 |
 | [026](026-custom-metrics-layer.md) | Custom metrics definition layer (composite, derived, joined metrics beyond the 6 built-in types) | **Proposed** | M5, M3, M4a |
@@ -50,10 +50,10 @@ ADR-014 ✓ (Provider Metrics)         ADR-011 ✓ (Multi-Objective Reward)
     │                                     │
     ├──────────────┐    ┌─────────────────┤
     │              ▼    ▼                 │
-    │        ADR-012 ⏳ (LP Constraints)  │
+    │        ADR-012 ✓ (LP Constraints)  │
     │              │                      │
     │              ▼                      │
-    │        ADR-013 ⬜ (Meta-Experiments) │
+    │        ADR-013 ✓ (Meta-Experiments) │
     │              │                      │
     └──────────────┘                      │
 ```
@@ -70,7 +70,7 @@ ADR-015 ✓ (AVLM / Sequential CUPED)
     │
     ├──────────────────────────────────────┐
     ▼                                      ▼
-ADR-020 ⬜ (Adaptive Sample Size)    ADR-018 ⬜ (E-Values / Online FDR)
+ADR-020 ✓ (Adaptive Sample Size)    ADR-018 ✓ (E-Values / Online FDR)
     uses AVLM variance estimate          parallel inference track
 ```
 
@@ -81,7 +81,7 @@ ADR-020 ⬜ (Adaptive Sample Size)    ADR-018 ⬜ (E-Values / Online FDR)
 Extends bandits to combinatorial slate actions and corrects the surrogate paradigm for continual treatments.
 
 ```
-ADR-016 ⬜ (Slate Bandits)          ADR-017 ⬜ (Offline RL / Surrogates)
+ADR-016 ✓ (Slate Bandits)          ADR-017 ✓ (Offline RL / Surrogates)
     extends ADR-002 LMAX               corrects surrogate calibration
     complements ADR-011/012            standalone, foundational
 ```
@@ -93,7 +93,7 @@ ADR-016 ⬜ (Slate Bandits)          ADR-017 ⬜ (Offline RL / Surrogates)
 Enables experimentation on interventions that cannot be user-level randomized.
 
 ```
-ADR-022 ⬜ (Switchback)             ADR-023 ⬜ (Synthetic Control)
+ADR-022 ✓ (Switchback)             ADR-023 ✓ (Synthetic Control)
     temporal randomization              observational counterfactual
     new experiment type                 new experiment type
 ```
@@ -105,10 +105,10 @@ ADR-022 ⬜ (Switchback)             ADR-023 ⬜ (Synthetic Control)
 Portfolio-level optimization and feedback loop detection.
 
 ```
-ADR-019 ⬜ (Portfolio Optimization)
+ADR-019 ✓ (Portfolio Optimization)
     │  depends on ADR-017 (annualization), ADR-018 (FDR)
     │
-ADR-021 ⬜ (Feedback Loop Interference)
+ADR-021 ✓ (Feedback Loop Interference)
     │  extends existing interference detection
     │  standalone
 ```


### PR DESCRIPTION
## Summary

10 ADRs (012, 013, 016, 017, 018, 019, 020, 021, 022, 023) had implementation Issues batch-closed on 2026-04-06 but their `**Status**:` fields lagged behind. Promoted all 10 to **Accepted and Implemented** with code-presence verification per ADR.

## Per-ADR evidence

| ADR | Title | Was | Now | Code Evidence |
|---|---|---|---|---|
| 012 | LP Constraints | Accepted (In Progress) | **Accepted and Implemented** | `crates/experimentation-bandit/src/lp_constraints.rs` (#301) |
| 013 | Meta-Experiments | Accepted (Planned 5.4) | **Accepted and Implemented** | `services/management/internal/handlers/lifecycle.go` `validateMetaForStart` + `EXPERIMENT_TYPE_META` validation tests (#309) |
| 016 | Slate Bandits | Proposed | **Accepted and Implemented** | `crates/experimentation-bandit/src/slate.rs` + M1 `GetSlateAssignment` contract tests (#307, #308) |
| 017 | Offline RL / Surrogates | Proposed | **Accepted and Implemented** | `crates/experimentation-stats/src/orl.rs` + `surrogate.rs` (#281, #312) |
| 018 | E-Values / Online FDR | Proposed | **Accepted and Implemented** | `crates/experimentation-stats/src/evalue.rs` (#283, #305, #314, #315) |
| 019 | Portfolio | Proposed | **Accepted and Implemented** | `crates/experimentation-stats/src/portfolio.rs` + `crates/experimentation-management/src/portfolio.rs` (#310) |
| 020 | Adaptive Sample Size | Proposed | **Accepted and Implemented** | `crates/experimentation-stats/src/adaptive_n.rs` + PR #227 (#298 — all AC checked) |
| 021 | Feedback Loop Interference | Proposed | **Accepted and Implemented** | `crates/experimentation-stats/src/feedback_loop.rs` + PR #222 (#299) |
| 022 | Switchback | Proposed | **Accepted and Implemented** | `crates/experimentation-stats/src/switchback.rs` + `crates/experimentation-assignment/src/switchback.rs` (#302, #303) |
| 023 | Synthetic Control | Proposed | **Accepted and Implemented** | `crates/experimentation-stats/src/synthetic_control.rs` + golden tests (#304) |

Cluster diagrams in `docs/adrs/README.md` updated — all 10 now show ✓ markers.

## Held back (no change)

- **ADR-025** stays `Proposed (conditional)` — Issue #317 evaluated trigger as 2/5 < 3 required.
- **ADR-026** stays `Proposed` — work tracked in #432–#437 (Sprint 5.6).
- **ADR-027** stays `Proposed` — work tracked in #422–#425 (Sprint 5.1).

## Test plan

- [x] All 10 ADR file Status fields say `**Status**: Accepted and Implemented`
- [x] README Decision Index status column matches each file
- [x] Cluster diagrams display ✓ markers for the 10 newly-promoted ADRs
- [x] No content changes outside Status / index / cluster markers (`git diff --stat`: 11 files, 27+/27− symmetric)
- [x] CI (docs-only — should skip rust + go via the path filter from #427)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
