### PR TITLE
chore(coordination): wire Sprint 5.1 + 5.6 for multi-agent execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,5 @@ Thumbs.db
 tsconfig.tsbuildinfo
 
 # Legacy status files (replaced by GitHub Issues)
-docs/coordination/status/
+docs/coordination/status/*
 !docs/coordination/status/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ tsconfig.tsbuildinfo
 
 # Legacy status files (replaced by GitHub Issues)
 docs/coordination/status/
+!docs/coordination/status/README.md

--- a/.multiclaude/agents/agent-2-pipeline.md
+++ b/.multiclaude/agents/agent-2-pipeline.md
@@ -35,3 +35,13 @@ If blocked, add the `blocked` label and comment explaining the blocker.
 
 ## Contract Tests to Write
 - M2 ↔ M3: ModelRetrainingEvent Kafka roundtrip (serialization, deserialization, field coverage)
+
+## Sprint 5.1 Add-On Work (post-Phase-5)
+
+The SFD gap analysis added two new Sprint 5.1 items to your queue. Both extend the M2 ingestion pipeline.
+
+### Sprint 5.1: Measurement Foundations
+- **[#424](https://github.com/wunderkennd/kaizen-experimentation/issues/424) Heartbeat Sessionization** — sole owner. Add `HeartbeatEvent` proto, `heartbeat_events` Kafka topic (128 partitions), and `HeartbeatSessionizer` in `crates/experimentation-ingest/`. Aggregate 10-second heartbeats into the existing `PlaybackMetrics` `QoEEvent` shape. Spec: [`docs/issues/heartbeat-sessionization.md`](../../docs/issues/heartbeat-sessionization.md). Cluster A.
+- **[#425](https://github.com/wunderkennd/kaizen-experimentation/issues/425) EBVS Detection** — classification logic in the `HeartbeatSessionizer` (you OR the client sets `ebvs_detected: bool`). Spec: [`docs/issues/ebvs-detection.md`](../../docs/issues/ebvs-detection.md). Multi-agent (Agent-3, -4, -6 own the rest).
+
+Find them with `gh issue list --label "agent-2,sprint-5.1" --state open`.

--- a/.multiclaude/agents/agent-3-metrics.md
+++ b/.multiclaude/agents/agent-3-metrics.md
@@ -51,3 +51,17 @@ If blocked, add the `blocked` label and comment explaining the blocker.
 - M3 ↔ M4a: Provider metric wire-format (MetricStakeholder, experiment_level_metrics schema)
 - M3 ↔ M2: ModelRetrainingEvent Kafka roundtrip
 - M3 ↔ M5: MLRATE trigger during STARTING lifecycle
+
+## Sprint 5.1 + 5.6 Add-On Work (post-Phase-5)
+
+Two new ADRs (026, 027) and the SFD gap items extend your queue beyond the original Phase 5 plan.
+
+### Sprint 5.1: Measurement Foundations
+- **[#425](https://github.com/wunderkennd/kaizen-experimentation/issues/425) EBVS Detection** — add `ebvs_rate.sql.tmpl` to M3 templates and register EBVS rate as a platform-level metric definition (type: PROPORTION). Spec: [`docs/issues/ebvs-detection.md`](../../docs/issues/ebvs-detection.md).
+
+### Sprint 5.6: Metric Definition Layer (ADR-026)
+- **[#432](https://github.com/wunderkennd/kaizen-experimentation/issues/432) Phase 1: Structured proto types + M3 templates** — co-owned with Agent-4 (proto). You own the Spark SQL templates: `filtered_mean.sql.tmpl`, `composite.sql.tmpl`, `windowed_count.sql.tmpl`. Spec: [`docs/adrs/026-custom-metrics-layer.md`](../../docs/adrs/026-custom-metrics-layer.md).
+- **[#435](https://github.com/wunderkennd/kaizen-experimentation/issues/435) Phase 2: MetricQL parser + AST + Spark SQL compiler** — sole owner. Build the MetricQL grammar, parser, AST, and compiler with `@metric_ref` semantics + cycle detection.
+- **[#437](https://github.com/wunderkennd/kaizen-experimentation/issues/437) Phase 3: CUSTOM migration tooling** — co-owned with Agent-5/Agent-6. You build the migration scanner/classifier and the side-by-side shadow runner.
+
+Find them with `gh issue list --label "agent-3,sprint-5.1" --state open` and `--label "agent-3,sprint-5.6"`.

--- a/.multiclaude/agents/agent-4-analysis-bandit.md
+++ b/.multiclaude/agents/agent-4-analysis-bandit.md
@@ -73,3 +73,16 @@ If a dependency blocks you, add the `blocked` label to your Issue and comment wi
 3. **P2**: ADR-011 (multi-objective), ADR-020 (adaptive N)
 4. **P3**: ADR-012 (LP constraints), ADR-022 (switchback), ADR-023 (SCM), ADR-016 (slate bandits)
 5. **P4**: ADR-017 P2 (ORL/MDP), ADR-018 P3 (MAD)
+
+## Sprint 5.1 + 5.6 Add-On Work (post-Phase-5)
+
+ADR-027 (TOST Equivalence Testing) and ADR-026 (Custom Metrics Layer) joined your queue post-Phase-5. ADR-027 in particular is a fresh statistical method that lives alongside the original 10 ADRs in `experimentation-stats`.
+
+### Sprint 5.1: Measurement Foundations
+- **[#422](https://github.com/wunderkennd/kaizen-experimentation/issues/422) ADR-027 TOST Core** — sole owner. New `tost.rs` module: `tost_equivalence_test()` (Welch's-t internals), `tost_cuped_equivalence_test()` (CUPED composition), `tost_sample_size()` (power analysis). Golden files vs R `TOSTER` to 6 decimal places. Proto extensions: `EquivalenceTestConfig`. Spec: [`docs/adrs/027-tost-equivalence-testing.md`](../../docs/adrs/027-tost-equivalence-testing.md).
+- **[#425](https://github.com/wunderkennd/kaizen-experimentation/issues/425) EBVS Detection** — own the proto change only (`ebvs_detected: bool` field 9 on `PlaybackMetrics`). Other agents own classification, SQL, UI.
+
+### Sprint 5.6: Metric Definition Layer (ADR-026)
+- **[#432](https://github.com/wunderkennd/kaizen-experimentation/issues/432) Phase 1: Structured proto types + M3 templates** — co-owned with Agent-3. You own the proto schema additions: `FILTERED_MEAN`, `COMPOSITE`, `WINDOWED_COUNT` enum values + per-type config messages. Agent-3 owns the SQL templates.
+
+Find them with `gh issue list --label "agent-4,sprint-5.1" --state open` and `--label "agent-4,sprint-5.6"`.

--- a/.multiclaude/agents/agent-5-management.md
+++ b/.multiclaude/agents/agent-5-management.md
@@ -57,3 +57,17 @@ If blocked, add the `blocked` label and comment explaining the blocker.
 - M5 ↔ M6: Meta-experiment config rendering
 - M5 ↔ M1: Switchback/META config in StreamConfigUpdates
 - M5 ↔ M3: MLRATE STARTING trigger
+
+## Sprint 5.1 + 5.6 Add-On Work (post-Phase-5)
+
+ADR-027 (TOST) and ADR-026 (Custom Metrics) added M5 validation work post-Phase-5.
+
+### Sprint 5.1: Measurement Foundations
+- **[#423](https://github.com/wunderkennd/kaizen-experimentation/issues/423) ADR-027 TOST — M5 Validation** — co-owned with Agent-6. Validate `EquivalenceTestConfig` at experiment creation: `delta > 0`, `delta_relative` requires MEAN/RATIO metric, power warning on insufficient sample size. Conclusion logic switches from "reject H₀ → ship" to "equivalence established → safe to migrate." Spec: [`docs/adrs/027-tost-equivalence-testing.md`](../../docs/adrs/027-tost-equivalence-testing.md) Section 5.
+
+### Sprint 5.6: Metric Definition Layer (ADR-026)
+- **[#433](https://github.com/wunderkennd/kaizen-experimentation/issues/433) Phase 1: M5 validation for new structured types** — sole owner. Validate `FILTERED_MEAN` (filter parses), `COMPOSITE` (operands resolve, no cycles), `WINDOWED_COUNT` (window > 0, anchor event exists).
+- **[#436](https://github.com/wunderkennd/kaizen-experimentation/issues/436) Phase 2: M5 MetricQL validation** — co-owned with Agent-6. M5 validation accepts MetricQL strings, runs through parser + semantic checker before persistence.
+- **[#437](https://github.com/wunderkennd/kaizen-experimentation/issues/437) Phase 3: deprecation logic** — co-owned with Agent-3/Agent-6. `CreateMetric`/`UpdateMetric` emit deprecation warnings on CUSTOM type.
+
+Find them with `gh issue list --label "agent-5,sprint-5.1" --state open` and `--label "agent-5,sprint-5.6"`.

--- a/.multiclaude/agents/agent-6-ui.md
+++ b/.multiclaude/agents/agent-6-ui.md
@@ -55,3 +55,18 @@ If blocked, add the `blocked` label and comment explaining the blocker.
 - M6 ↔ M5: Meta-experiment config rendering
 - M6 ↔ M5: Adaptive N zone badge rendering
 - M6 ↔ M3: Provider metric wire-format
+
+## Sprint 5.1 + 5.6 Add-On Work (post-Phase-5)
+
+ADR-027 (TOST) and ADR-026 (Custom Metrics) added new UI work post-Phase-5, plus the EBVS dashboard panel.
+
+### Sprint 5.1: Measurement Foundations
+- **[#423](https://github.com/wunderkennd/kaizen-experimentation/issues/423) ADR-027 TOST — M6 Equivalence Results View** — co-owned with Agent-5. Render the (1−2α) CI against the [−δ, +δ] equivalence margin (shaded). Green/Yellow/Red badge for Equivalent / Inconclusive / Not Equivalent. Power indicator at current sample size. Spec: [`docs/adrs/027-tost-equivalence-testing.md`](../../docs/adrs/027-tost-equivalence-testing.md) Section 6.
+- **[#425](https://github.com/wunderkennd/kaizen-experimentation/issues/425) EBVS Detection** — add EBVS rate time-series panel to the QoE dashboard. Make EBVS rate available as a guardrail metric in the experiment creation form. Spec: [`docs/issues/ebvs-detection.md`](../../docs/issues/ebvs-detection.md).
+
+### Sprint 5.6: Metric Definition Layer (ADR-026)
+- **[#434](https://github.com/wunderkennd/kaizen-experimentation/issues/434) Phase 1: M6 UI for new structured metric types** — sole owner. Metric creation form gains FILTERED_MEAN (WHERE editor + value column), COMPOSITE (multi-select + operator), WINDOWED_COUNT (anchor + window) controls. Live validation via M5.
+- **[#436](https://github.com/wunderkennd/kaizen-experimentation/issues/436) Phase 2: M6 MetricQL expression editor** — co-owned with Agent-5. Monaco-based editor with MetricQL syntax highlighting, `@metric_` autocomplete, inline diagnostics, dry-run preview.
+- **[#437](https://github.com/wunderkennd/kaizen-experimentation/issues/437) Phase 3: UI removal** — co-owned with Agent-3/Agent-5. Hide CUSTOM option from metric creation form after sunset window.
+
+Find them with `gh issue list --label "agent-6,sprint-5.1" --state open` and `--label "agent-6,sprint-5.6"`.

--- a/docs/coordination/sprint-5.1-and-5.6-multi-agent.md
+++ b/docs/coordination/sprint-5.1-and-5.6-multi-agent.md
@@ -1,0 +1,133 @@
+# Sprint 5.1 + 5.6 Multi-Agent Coordination
+
+How the next two open sprints are split across agents and the three orchestration tools (Claude sub-agents, Multiclaude, Gas Town).
+
+## Sprint 5.1: Measurement Foundations (4 open Issues)
+
+| Issue | Title | Lead Agent(s) | Cluster |
+|---|---|---|---|
+| [#422](https://github.com/wunderkennd/kaizen-experimentation/issues/422) | ADR-027 TOST — Core Implementation | Agent-4 | B |
+| [#423](https://github.com/wunderkennd/kaizen-experimentation/issues/423) | ADR-027 TOST — M5 Validation + M6 Equivalence Results View | Agent-5, Agent-6 | B |
+| [#424](https://github.com/wunderkennd/kaizen-experimentation/issues/424) | Heartbeat Sessionization | Agent-2 | A |
+| [#425](https://github.com/wunderkennd/kaizen-experimentation/issues/425) | EBVS Detection | Agent-2, Agent-3, Agent-4, Agent-6 | (cross-cluster) |
+
+**Critical path**: #422 (TOST core) blocks #423 (M5/M6). #424 (sessionizer) provides the integration point for #425's EBVS classification logic, so #424 should land before #425's classification work — though the proto change in #425 (Agent-4) can land in parallel.
+
+## Sprint 5.6: Metric Definition Layer (6 open Issues)
+
+| Issue | Title | Lead Agent(s) | Phase |
+|---|---|---|---|
+| [#432](https://github.com/wunderkennd/kaizen-experimentation/issues/432) | Phase 1: structured proto types + M3 templates | Agent-3, Agent-4 | 1 |
+| [#433](https://github.com/wunderkennd/kaizen-experimentation/issues/433) | Phase 1: M5 validation | Agent-5 | 1 |
+| [#434](https://github.com/wunderkennd/kaizen-experimentation/issues/434) | Phase 1: M6 UI | Agent-6 | 1 |
+| [#435](https://github.com/wunderkennd/kaizen-experimentation/issues/435) | Phase 2: MetricQL parser/compiler | Agent-3 | 2 |
+| [#436](https://github.com/wunderkennd/kaizen-experimentation/issues/436) | Phase 2: M5 validation + M6 editor | Agent-5, Agent-6 | 2 |
+| [#437](https://github.com/wunderkennd/kaizen-experimentation/issues/437) | Phase 3: migration + deprecation | Agent-3, Agent-5, Agent-6 | 3 |
+
+**Critical path**: #432 (Phase 1 proto) blocks #433 + #434 (M5/M6 for new types). Phase 2 (#435 → #436) blocks Phase 3 (#437).
+
+---
+
+## Tool routing
+
+Match the work shape to the right orchestration tool. All three read GitHub Issues as the source of truth — no separate task list.
+
+### Claude sub-agents (in-session, parallel)
+Best for: **multi-file mechanical edits** that benefit from tight feedback during an active session.
+- Spawn via the `Agent` tool with `subagent_type: general-purpose`.
+- Each gets its own worktree; merge back via PR.
+- Already used in this repo for: ADR consolidation, status sync, format backfills.
+- Rule of thumb: if it would take you ≤30 min to do alone, dispatch a sub-agent.
+
+### Multiclaude (autonomous, overnight)
+Best for: **single-Issue implementations** with clear acceptance criteria, runnable while you're away.
+- Launch from a labeled Issue:
+  ```bash
+  just work-on 422            # Single Issue
+  just autonomous-sprint 5.1  # All open Sprint 5.1 Issues, one worker each
+  ```
+- Workers consume from `gh issue list --label "agent-N,sprint-5.X" --state open`.
+- The current `.multiclaude/config.json` is **infra-defaults** (`branch_prefix: "infra-"`, `ci.required_checks` for `cd infra`). For product agent work (Sprint 5.1 / 5.6), the per-task prompt from `just work-on` overrides naming via `agent-N/feat/adr-XXX-description`. The CI checks in config.json are infra-only and **do not gate product PRs** — those are gated by the `.github/workflows/ci.yml` workflow on push.
+- Status files land at `docs/coordination/status/<agent>-status.md` — see [`status/README.md`](status/README.md).
+
+### Gas Town (interactive, daytime)
+Best for: **complex deals you want to steer in real time** — e.g., ambiguous design decisions, cross-agent handoffs, debug sessions.
+- Launch via the justfile:
+  ```bash
+  just interactive            # gt up + gt mayor attach
+  ```
+- Inside the Mayor session, dispatch a polecat onto an Issue:
+  ```
+  Pick up Issue #422 for the kaizen rig
+  ```
+- The Mayor coordinates polecats; you steer through tmux. Detach with `Ctrl-b d` when done; `just interactive-stop` shuts the rig.
+
+### Daily rhythm
+```
+morning  → just morning           # Triage overnight Multiclaude runs + open PRs
+work     → just interactive       # Gas Town for the day
+evening  → just evening 5.1       # Hand off to Multiclaude for overnight
+```
+
+---
+
+## Per-agent quick start
+
+### Agent-2 (Pipeline)
+```bash
+gh issue list --label "agent-2,sprint-5.1" --state open
+# → #424 Heartbeat, #425 EBVS classification
+```
+Read [`.multiclaude/agents/agent-2-pipeline.md`](../../.multiclaude/agents/agent-2-pipeline.md) for context. Sprint 5.1 is your only post-Phase-5 add-on.
+
+### Agent-3 (Metrics)
+```bash
+gh issue list --label "agent-3" --state open
+# → #425 EBVS SQL, #432 Phase 1 templates, #435 MetricQL, #437 migration
+```
+Heaviest Sprint 5.6 load. Phase 1 → Phase 2 → Phase 3 is sequential.
+
+### Agent-4 (Stats/Bandit)
+```bash
+gh issue list --label "agent-4" --state open
+# → #422 TOST core (P0 for Sprint 5.1), #425 EBVS proto, #432 Phase 1 proto
+```
+TOST core (#422) is on the Sprint 5.1 critical path — start here.
+
+### Agent-5 (Management)
+```bash
+gh issue list --label "agent-5" --state open
+# → #423 TOST validation, #433 Phase 1 validation, #436 MetricQL validation, #437 deprecation
+```
+Blocked on Agent-4 for #423 (TOST core), and on Agent-3/Agent-4 for #433 (Phase 1 proto).
+
+### Agent-6 (UI)
+```bash
+gh issue list --label "agent-6" --state open
+# → #423 TOST UI, #425 EBVS dashboard, #434 Phase 1 form, #436 MetricQL editor, #437 UI removal
+```
+Heaviest UI load across both sprints. Phase 1 form (#434) and TOST results (#423) are the largest items.
+
+### Agent-1, Agent-7
+No new work in Sprint 5.1 or 5.6.
+
+---
+
+## Verification commands
+
+```bash
+# All open Sprint 5.1 Issues
+gh issue list --label sprint-5.1 --state open
+
+# All open Sprint 5.6 Issues
+gh issue list --label sprint-5.6 --state open
+
+# All blocked Issues across both sprints
+gh issue list --label "blocked" --state open
+
+# Multiclaude worker status
+multiclaude status
+
+# Gas Town rig status
+gt status
+```

--- a/docs/coordination/status/README.md
+++ b/docs/coordination/status/README.md
@@ -1,0 +1,25 @@
+# Worker Status Files
+
+Multiclaude autonomous workers write per-agent status files here, matching the pattern from `.multiclaude/config.json`:
+
+```
+docs/coordination/status/
+  infra-1-status.md   ← infra worker 1
+  infra-2-status.md   ← infra worker 2
+  ...
+  agent-1-status.md   ← (planned) product worker 1
+  agent-4-status.md   ← (planned) product worker 4
+  ...
+```
+
+Each file is the worker's heartbeat — its current Issue, branch, blockers, and next step. The supervisor reads these every `worker.health_check_interval_seconds` (120s as of writing) to detect stuck workers.
+
+## When reviewing status files
+
+- `Last updated > 30 min ago` and worker still attached → likely stuck. Run `multiclaude worker nudge <agent>`.
+- `blocked` in the status text → check the linked Issue for the blocker.
+- `Open question:` lines → the worker is asking the supervisor (you) for input. Reply via Issue comment.
+
+## Why this dir is committed (with this README) rather than ignored
+
+The directory must exist for `multiclaude start` to write into it on first launch. Status files themselves are gitignored via `.multiclaude/state/` rules; only this README is tracked.


### PR DESCRIPTION
## Summary

Three concrete fixes so the next two open sprints (5.1 Measurement Foundations + 5.6 Metric Definition Layer) flow cleanly through Claude sub-agents, Multiclaude, and Gas Town.

## Already done out-of-band (via gh API, not in this PR)

- **Created `sprint-5.1` and `sprint-5.6` labels** on the repo
- **Applied them to all 10 open Issues** (#422–#425, #432–#437)
- Enables `gh issue list --label sprint-5.X --state open` for tool routing

## In this PR

### 1. Agent definition coverage for ADR-026 + ADR-027

The 5 affected agent definitions in `.multiclaude/agents/` had Phase 5 ADR coverage stopping at 011-025. Appended a "Sprint 5.1 + 5.6 Add-On Work" section to each — agent-2, agent-3, agent-4, agent-5, agent-6 — listing their assigned Issues with links to specs and cross-agent dependency notes. Autonomous workers will now have ADR-026/ADR-027 context when they pick up these Issues.

| Agent | Issues now covered |
|---|---|
| Agent-2 | #424 (Heartbeat sole owner), #425 (EBVS classification) |
| Agent-3 | #425 (EBVS SQL), #432 (Phase 1 templates), #435 (MetricQL), #437 (migration) |
| Agent-4 | #422 (TOST core sole owner), #425 (EBVS proto), #432 (Phase 1 proto) |
| Agent-5 | #423 (TOST validation), #433 (Phase 1 validation), #436 (MetricQL validation), #437 (deprecation) |
| Agent-6 | #423 (TOST UI), #425 (EBVS dashboard), #434 (Phase 1 form), #436 (MetricQL editor), #437 (UI removal) |

### 2. Status directory + README

`docs/coordination/status/` is referenced by `.multiclaude/config.json`'s `status_file_pattern` for Multiclaude supervisor health checks, but didn't exist on `main`. Created the directory with a tracked `README.md` explaining its purpose.

Required two commits:
- First commit: added `!docs/coordination/status/README.md` negation under the existing `docs/coordination/status/` ignore rule — but trailing-slash dir patterns prevent git from traversing the dir, so the negation never fired
- Second commit: switched to `docs/coordination/status/*` (glob form), which allows git to enter the dir and apply the negation correctly

### 3. Master coordination doc

New `docs/coordination/sprint-5.1-and-5.6-multi-agent.md` maps every open Issue to:
- Lead agent(s) and cross-agent collaborators
- Critical-path dependencies (e.g., Phase 1 proto blocks Phase 1 M5/M6)
- Which orchestration tool fits which work shape (sub-agents / Multiclaude / Gas Town)
- Per-agent quick-start commands

## What this PR explicitly does NOT touch

`.multiclaude/config.json` is **infra-mode defaults** (`branch_prefix: "infra-"`, `ci.required_checks` for `cd infra`). The justfile's `just work-on <issue>` recipe overrides naming per-task for product agent work, and the actual CI gate is `.github/workflows/ci.yml` (which #427 just made path-aware). Generalizing the config to multi-mode is a larger refactor and out of scope here.

## Test plan

- [x] `gh issue list --label sprint-5.1 --state open` returns #422–#425
- [x] `gh issue list --label sprint-5.6 --state open` returns #432–#437
- [x] Each agent's `gh issue list --label "agent-N,sprint-5.X"` returns only that agent's slice
- [x] `docs/coordination/status/README.md` is tracked, but `docs/coordination/status/anything-else.md` would be ignored
- [x] CI: docs-only, should skip rust + go via path filter from #427
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
