### PR TITLE
feat(qoe): add EBVS detection as first-class PlaybackMetrics field

### DIFF
--- a/crates/experimentation-ingest/benches/ingest_bench.rs
+++ b/crates/experimentation-ingest/benches/ingest_bench.rs
@@ -93,6 +93,7 @@ fn valid_qoe_event() -> QoEEvent {
             peak_resolution_height: 1080,
             startup_failure_rate: 0.0,
             playback_duration_ms: 60_000,
+            ebvs_detected: false,
         }),
         cdn_provider: "akamai".into(),
         abr_algorithm: "buffer-based-v2".into(),
@@ -358,6 +359,7 @@ fn bench_full_ingest_qoe(c: &mut Criterion) {
                     peak_resolution_height: 1080,
                     startup_failure_rate: 0.0,
                     playback_duration_ms: 60_000,
+                    ebvs_detected: false,
                 }),
                 timestamp: now_proto(),
                 ..Default::default()

--- a/crates/experimentation-ingest/src/classification.rs
+++ b/crates/experimentation-ingest/src/classification.rs
@@ -1,0 +1,154 @@
+//! EBVS (Exit Before Video Start) classification.
+//!
+//! Issue #425: EBVS is a first-class QoE failure mode distinct from startup
+//! failure (player crash). EBVS signals that the user attempted to watch
+//! content but exited before playback began — e.g., TTFF was too slow.
+//!
+//! The classifier is a pure function so it can be invoked:
+//! - Client-side by SDKs that aggregate `QoEEvent` locally.
+//! - Server-side by the `HeartbeatSessionizer` (#424) during aggregation.
+//! - By M2 as a backfill for events missing the field.
+
+use experimentation_proto::common::PlaybackMetrics;
+
+/// Default EBVS threshold (10 seconds) per Issue #425.
+///
+/// TTFF exceeding this with no playback is treated as EBVS.
+pub const EBVS_DEFAULT_THRESHOLD_MS: i64 = 10_000;
+
+/// Classify whether a playback session exited before video started.
+///
+/// Returns `true` iff no playback occurred (`playback_duration_ms == 0`) and
+/// first-frame delivery did not complete in time — either never reached
+/// (`ttff_ms == 0`) or exceeded the threshold.
+///
+/// If `playback_duration_ms > 0`, playback actually started, so the session
+/// is never classified as EBVS regardless of TTFF.
+///
+/// Negative inputs are coerced to `0` (range validation lives in
+/// [`validation::validate_playback_metrics`](crate::validation::validate_playback_metrics)).
+pub fn classify_ebvs(ttff_ms: i64, playback_duration_ms: i64, threshold_ms: i64) -> bool {
+    if playback_duration_ms > 0 {
+        return false;
+    }
+    let ttff = ttff_ms.max(0);
+    let threshold = threshold_ms.max(0);
+    ttff == 0 || ttff > threshold
+}
+
+/// Populate `ebvs_detected` on a `PlaybackMetrics` from its TTFF and duration.
+///
+/// Idempotent: overwrites the existing `ebvs_detected` value. Use this in
+/// server-side pipelines when the client did not set the field.
+pub fn set_ebvs_detected(metrics: &mut PlaybackMetrics, threshold_ms: i64) {
+    metrics.ebvs_detected = classify_ebvs(
+        metrics.time_to_first_frame_ms,
+        metrics.playback_duration_ms,
+        threshold_ms,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── classify_ebvs ────────────────────────────────────────────────────
+
+    #[test]
+    fn playback_started_is_not_ebvs_even_with_high_ttff() {
+        // User waited through slow start and eventually watched — not EBVS.
+        assert!(!classify_ebvs(15_000, 60_000, EBVS_DEFAULT_THRESHOLD_MS));
+    }
+
+    #[test]
+    fn playback_started_with_any_duration_is_not_ebvs() {
+        assert!(!classify_ebvs(250, 1, EBVS_DEFAULT_THRESHOLD_MS));
+    }
+
+    #[test]
+    fn zero_ttff_zero_duration_is_ebvs() {
+        // Never reached first frame, never played — classic EBVS.
+        assert!(classify_ebvs(0, 0, EBVS_DEFAULT_THRESHOLD_MS));
+    }
+
+    #[test]
+    fn ttff_above_threshold_zero_duration_is_ebvs() {
+        assert!(classify_ebvs(10_001, 0, EBVS_DEFAULT_THRESHOLD_MS));
+    }
+
+    #[test]
+    fn ttff_exactly_threshold_zero_duration_is_not_ebvs() {
+        // Boundary: threshold is non-strict. User got first frame just in time
+        // but didn't proceed — treated as a short-play / abandoned start, not EBVS.
+        assert!(!classify_ebvs(
+            EBVS_DEFAULT_THRESHOLD_MS,
+            0,
+            EBVS_DEFAULT_THRESHOLD_MS
+        ));
+    }
+
+    #[test]
+    fn ttff_under_threshold_zero_duration_is_not_ebvs() {
+        // First frame arrived quickly, but user exited before duration accrued.
+        // This is a "short play" or instant-bounce, not EBVS.
+        assert!(!classify_ebvs(500, 0, EBVS_DEFAULT_THRESHOLD_MS));
+    }
+
+    #[test]
+    fn negative_ttff_treated_as_zero() {
+        // Defensive: negative TTFF (malformed) is coerced — still counts as
+        // "never reached first frame" when duration is 0.
+        assert!(classify_ebvs(-100, 0, EBVS_DEFAULT_THRESHOLD_MS));
+    }
+
+    #[test]
+    fn custom_threshold_honored() {
+        // With a 5s threshold, a 7s TTFF with no playback is EBVS.
+        assert!(classify_ebvs(7_000, 0, 5_000));
+        // With the default 10s threshold, the same event is NOT EBVS.
+        assert!(!classify_ebvs(7_000, 0, EBVS_DEFAULT_THRESHOLD_MS));
+    }
+
+    // ── set_ebvs_detected ────────────────────────────────────────────────
+
+    fn base_metrics() -> PlaybackMetrics {
+        PlaybackMetrics {
+            time_to_first_frame_ms: 0,
+            rebuffer_count: 0,
+            rebuffer_ratio: 0.0,
+            avg_bitrate_kbps: 0,
+            resolution_switches: 0,
+            peak_resolution_height: 0,
+            startup_failure_rate: 0.0,
+            playback_duration_ms: 0,
+            ebvs_detected: false,
+        }
+    }
+
+    #[test]
+    fn set_ebvs_detected_marks_session_that_never_played() {
+        let mut m = base_metrics();
+        set_ebvs_detected(&mut m, EBVS_DEFAULT_THRESHOLD_MS);
+        assert!(m.ebvs_detected);
+    }
+
+    #[test]
+    fn set_ebvs_detected_does_not_flag_session_with_playback() {
+        let mut m = base_metrics();
+        m.time_to_first_frame_ms = 500;
+        m.playback_duration_ms = 60_000;
+        set_ebvs_detected(&mut m, EBVS_DEFAULT_THRESHOLD_MS);
+        assert!(!m.ebvs_detected);
+    }
+
+    #[test]
+    fn set_ebvs_detected_overrides_prior_value() {
+        let mut m = base_metrics();
+        // Client erroneously marked a full playback as EBVS.
+        m.time_to_first_frame_ms = 250;
+        m.playback_duration_ms = 60_000;
+        m.ebvs_detected = true;
+        set_ebvs_detected(&mut m, EBVS_DEFAULT_THRESHOLD_MS);
+        assert!(!m.ebvs_detected, "server-side recompute must override client");
+    }
+}

--- a/crates/experimentation-ingest/src/lib.rs
+++ b/crates/experimentation-ingest/src/lib.rs
@@ -1,4 +1,5 @@
 //! Event validation and deduplication for the ingestion pipeline (M2).
 
+pub mod classification;
 pub mod validation;
 pub mod dedup;

--- a/crates/experimentation-ingest/src/validation.rs
+++ b/crates/experimentation-ingest/src/validation.rs
@@ -411,6 +411,7 @@ mod tests {
             peak_resolution_height: 1080,
             startup_failure_rate: 0.0,
             playback_duration_ms: 60000,
+            ebvs_detected: false,
         }
     }
 
@@ -711,6 +712,7 @@ mod tests {
             peak_resolution_height: 8640,
             startup_failure_rate: 1.0,
             playback_duration_ms: 86_400_000,
+            ebvs_detected: false,
         };
         assert!(validate_playback_metrics(&m).is_ok());
     }

--- a/crates/experimentation-pipeline/src/service.rs
+++ b/crates/experimentation-pipeline/src/service.rs
@@ -736,6 +736,7 @@ mod tests {
                 peak_resolution_height: 1080,
                 startup_failure_rate: 0.0,
                 playback_duration_ms: 60000,
+                ebvs_detected: false,
             }),
             timestamp: now_proto(),
             ..Default::default()

--- a/crates/experimentation-pipeline/tests/m2_m3_event_contract.rs
+++ b/crates/experimentation-pipeline/tests/m2_m3_event_contract.rs
@@ -115,6 +115,7 @@ fn make_qoe_event(
             peak_resolution_height: 1080,
             startup_failure_rate: 0.0,
             playback_duration_ms: 3_600_000,
+            ebvs_detected: false,
         }),
         cdn_provider: "akamai".into(),
         abr_algorithm: "buffer-based-v2".into(),
@@ -611,6 +612,7 @@ fn test_qoe_playback_metrics_zero_values() {
             peak_resolution_height: 0,
             startup_failure_rate: 0.0,
             playback_duration_ms: 0,
+            ebvs_detected: false,
         }),
         ..Default::default()
     };

--- a/proto/experimentation/common/v1/qoe.proto
+++ b/proto/experimentation/common/v1/qoe.proto
@@ -25,6 +25,13 @@ message PlaybackMetrics {
   double startup_failure_rate = 7;
   // Total playback duration in milliseconds.
   int64 playback_duration_ms = 8;
+  // True if the session ended before video playback began (Exit Before Video Start).
+  // Classification: playback_duration_ms == 0 AND
+  //   (time_to_first_frame_ms == 0 — never reached first frame, OR
+  //    time_to_first_frame_ms exceeds the configured EBVS threshold, default 10_000ms).
+  // Distinct from startup_failure_rate (player crash) — EBVS is user-voluntary exit
+  // during a slow start. Set by the client SDK or the HeartbeatSessionizer (#424).
+  bool ebvs_detected = 9;
 }
 
 // QoEEvent is published to the qoe_events Kafka topic.

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -83,6 +83,9 @@ func (r *SQLRenderer) RenderRatioDeltaMethod(p TemplateParams) (string, error) {
 func (r *SQLRenderer) RenderCupedCovariate(p TemplateParams) (string, error)  { return r.Render("cuped_covariate.sql.tmpl", p) }
 func (r *SQLRenderer) RenderGuardrailMetric(p TemplateParams) (string, error) { return r.Render("guardrail_metric.sql.tmpl", p) }
 func (r *SQLRenderer) RenderQoEMetric(p TemplateParams) (string, error)      { return r.Render("qoe_metric.sql.tmpl", p) }
+// RenderEBVSRate renders the EBVS (Exit Before Video Start) rate as a per-user
+// PROPORTION metric (Issue #425). Reads from delta.qoe_events.ebvs_detected.
+func (r *SQLRenderer) RenderEBVSRate(p TemplateParams) (string, error)       { return r.Render("ebvs_rate.sql.tmpl", p) }
 func (r *SQLRenderer) RenderContentConsumption(p TemplateParams) (string, error) { return r.Render("content_consumption.sql.tmpl", p) }
 func (r *SQLRenderer) RenderDailyTreatmentEffect(p TemplateParams) (string, error) { return r.Render("daily_treatment_effect.sql.tmpl", p) }
 func (r *SQLRenderer) RenderLifecycleMean(p TemplateParams) (string, error)  { return r.Render("lifecycle_mean.sql.tmpl", p) }

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -182,6 +182,27 @@ func TestRenderQoEMetric_ContainsKeyFields(t *testing.T) {
 	assert.NotContains(t, sql, "delta.metric_events", "QoE metric should NOT read from metric_events")
 }
 
+func TestRenderEBVSRate(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+	p := testParams
+	p.MetricID = "ebvs_rate"
+	sql, err := r.RenderEBVSRate(p)
+	require.NoError(t, err)
+	assert.Equal(t, readGolden(t, "ebvs_rate_expected.sql"), sql)
+}
+
+func TestRenderEBVSRate_ContainsKeyFields(t *testing.T) {
+	r, _ := NewSQLRenderer()
+	p := TemplateParams{ExperimentID: "test-exp-ebvs", MetricID: "ebvs_rate", ComputationDate: "2024-06-01"}
+	sql, _ := r.RenderEBVSRate(p)
+	assert.Contains(t, sql, "delta.qoe_events")
+	assert.Contains(t, sql, "ebvs_detected")
+	assert.Contains(t, sql, "CASE WHEN qoe_sessions.ebvs_detected THEN 1 ELSE 0 END")
+	assert.Contains(t, sql, "NULLIF(COUNT(*), 0)", "denominator must guard against zero-session variants")
+	assert.NotContains(t, sql, "delta.metric_events", "EBVS rate reads qoe_events, not metric_events")
+}
+
 func TestRenderContentConsumption(t *testing.T) {
 	r, err := NewSQLRenderer()
 	require.NoError(t, err)

--- a/services/metrics/internal/spark/template_validation_test.go
+++ b/services/metrics/internal/spark/template_validation_test.go
@@ -148,6 +148,16 @@ func allTemplateSpecs() []templateSpec {
 			absent: []string{"delta.metric_events"}, // QoE reads from qoe_events, not metric_events
 		},
 		{
+			name:   "ebvs_rate",
+			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderEBVSRate(p) },
+			contains: []string{
+				"delta.qoe_events", "ebvs_detected",
+				"CASE WHEN qoe_sessions.ebvs_detected THEN 1 ELSE 0 END",
+				"NULLIF(COUNT(*), 0)",
+			},
+			absent: []string{"delta.metric_events"}, // EBVS rate reads from qoe_events
+		},
+		{
 			name:   "lifecycle_mean",
 			render: func(r *SQLRenderer, p TemplateParams) (string, error) { return r.RenderLifecycleMean(p) },
 			contains: []string{
@@ -516,8 +526,9 @@ func TestTemplateValidation_PercentileValues(t *testing.T) {
 // catch any new templates that are added without validation coverage.
 func TestTemplateValidation_TemplateCount(t *testing.T) {
 	specs := allTemplateSpecs()
-	// 27 renderable templates: 17 original + 10 provider-side metrics from ADR-014.
+	// 28 renderable templates: 17 original + 10 provider-side metrics from ADR-014
+	// + 1 EBVS rate (Issue #425).
 	// (exposure_join is a sub-template, not directly rendered.)
-	assert.Equal(t, 27, len(specs),
-		"allTemplateSpecs should cover all 27 renderable templates; if you added a new template, add it to allTemplateSpecs()")
+	assert.Equal(t, 28, len(specs),
+		"allTemplateSpecs should cover all 28 renderable templates; if you added a new template, add it to allTemplateSpecs()")
 }

--- a/services/metrics/internal/spark/templates/ebvs_rate.sql.tmpl
+++ b/services/metrics/internal/spark/templates/ebvs_rate.sql.tmpl
@@ -1,0 +1,22 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+qoe_sessions AS (
+    SELECT qe.user_id, eu.variant_id, eu.assignment_probability, qe.ebvs_detected
+    FROM delta.qoe_events qe
+    INNER JOIN exposed_users eu ON qe.user_id = eu.user_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    qoe_sessions.user_id,
+    qoe_sessions.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CAST(SUM(CASE WHEN qoe_sessions.ebvs_detected THEN 1 ELSE 0 END) AS DOUBLE)
+        / NULLIF(COUNT(*), 0) AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    MIN(qoe_sessions.assignment_probability) AS assignment_probability
+FROM qoe_sessions
+GROUP BY qoe_sessions.user_id, qoe_sessions.variant_id

--- a/services/metrics/testdata/golden/ebvs_rate_expected.sql
+++ b/services/metrics/testdata/golden/ebvs_rate_expected.sql
@@ -1,0 +1,22 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+qoe_sessions AS (
+    SELECT qe.user_id, eu.variant_id, eu.assignment_probability, qe.ebvs_detected
+    FROM delta.qoe_events qe
+    INNER JOIN exposed_users eu ON qe.user_id = eu.user_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    qoe_sessions.user_id,
+    qoe_sessions.variant_id,
+    'ebvs_rate' AS metric_id,
+    CAST(SUM(CASE WHEN qoe_sessions.ebvs_detected THEN 1 ELSE 0 END) AS DOUBLE)
+        / NULLIF(COUNT(*), 0) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    MIN(qoe_sessions.assignment_probability) AS assignment_probability
+FROM qoe_sessions
+GROUP BY qoe_sessions.user_id, qoe_sessions.variant_id


### PR DESCRIPTION
Closes #425.

## Summary

Adds `ebvs_detected` (field 9) to `PlaybackMetrics` so Exit Before Video Start becomes a queryable, guardrail-able classification rather than an ad-hoc SQL pattern against `time_to_first_frame_ms` and `playback_duration_ms`.

## What's in this PR

| Area | Change |
| --- | --- |
| **Proto** (Agent-4 scope) | `bool ebvs_detected = 9` added to `PlaybackMetrics` in `proto/experimentation/common/v1/qoe.proto`. Additive — `buf lint` and `buf breaking` against `main` both pass. |
| **Classification** (Agent-2 scope) | New `experimentation-ingest::classification` module: pure `classify_ebvs(ttff_ms, playback_duration_ms, threshold_ms) -> bool` + `set_ebvs_detected(&mut metrics, threshold)` helper. Default threshold = `EBVS_DEFAULT_THRESHOLD_MS = 10_000` per Issue #425. Usable client-side by SDKs that aggregate `QoEEvent` locally OR server-side by the `HeartbeatSessionizer` when #424 lands. |
| **M3 metric definition** (Agent-3 scope) | `ebvs_rate.sql.tmpl` + `RenderEBVSRate` renderer + golden file. Shape = per-user PROPORTION over `qoe_events.ebvs_detected`. `NULLIF(COUNT(*), 0)` guards against zero-session variants. Registered in `allTemplateSpecs` (template count 27 → 28). |
| **Test fixtures** | Backfilled `ebvs_detected: false` across 7 `PlaybackMetrics` struct literals (validation, pipeline service, m2↔m3 contract tests, benches) — required because prost-generated structs are exhaustive. |

## Classification semantics

```rust
ebvs_detected = playback_duration_ms == 0
  AND (time_to_first_frame_ms == 0            // never reached first frame
       OR time_to_first_frame_ms > threshold) // TTFF exceeded threshold
```

- Any `playback_duration_ms > 0` means the user got past video-start → **not** EBVS regardless of TTFF.
- Threshold comparison is strict (`>`), so TTFF exactly at the threshold with no playback is a "short play" / abandoned-start, not EBVS. This keeps the boundary unambiguous.
- Distinct from `startup_failure_rate` (player crash) — EBVS is user-voluntary exit during a slow start.

## Test coverage

- **11 new Rust unit tests** for `classify_ebvs` + `set_ebvs_detected`:
  playback-started cases, zero-TTFF boundary, threshold-equal boundary, custom threshold, negative-TTFF defensiveness, idempotent override.
- **2 new Go tests** for `RenderEBVSRate` (golden equality + field assertions).
- **+1 spec** in `allTemplateSpecs` plus updated template-count assertion.
- All previously-green tests still pass: `cargo test -p experimentation-ingest -p experimentation-pipeline` (193 passed), `go test ./services/metrics/...` (all packages ok).
- `buf lint proto/` clean, `buf breaking proto/ --against main` clean.

## Out of scope — follow-ups

- **Agent-6 (M6 UI)**: QoE dashboard EBVS time-series panel + guardrail-metric dropdown option. Not in this PR (keeps the diff focused on schema + M2/M3 glue).
- **Sessionizer integration**: When #424 (`HeartbeatSessionizer`) lands, call `set_ebvs_detected(&mut metrics, config.ebvs_threshold_ms)` during aggregation. The helper is ready.
- **Pre-existing bench breakage**: `crates/experimentation-ingest/benches/ingest_bench.rs` was already failing on `main` (missing `switchback_block_index` on `ExposureEvent`). Not touched in this PR — `cargo test --workspace` (no `--benches`) still green. Worth a separate chore PR.

## Test plan

- [x] `cargo test -p experimentation-ingest -p experimentation-pipeline` — 193 passed / 0 failed
- [x] `go test ./services/metrics/...` — all packages ok
- [x] `buf lint proto/` — clean
- [x] `buf breaking proto/ --against '.git#branch=main,subdir=proto'` — clean (additive)
- [x] New classification tests cover boundary conditions (`>` vs `>=`, negative TTFF, idempotent recompute)
- [x] Golden SQL matches template output byte-for-byte
- [ ] Follow-up: `cargo test --workspace` in CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
