### PR TITLE
feat(coordination): bridge GitHub Issues to Gas Town Beads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,11 @@ tsconfig.tsbuildinfo
 # Legacy status files (replaced by GitHub Issues)
 docs/coordination/status/*
 !docs/coordination/status/README.md
+
+# ============================================
+# Beads (Gas Town ↔ GitHub Issues projection)
+# ============================================
+# `bd init` writes its own .beads/.gitignore that excludes the Dolt DB,
+# runtime locks, and logs. The portable export .beads/issues.jsonl is NOT
+# ignored there — commit it intentionally via `just beads-export` so teammates
+# can `bd import` after `git pull`.

--- a/docs/coordination/sprint-5.1-and-5.6-multi-agent.md
+++ b/docs/coordination/sprint-5.1-and-5.6-multi-agent.md
@@ -65,9 +65,62 @@ Best for: **complex deals you want to steer in real time** — e.g., ambiguous d
 ### Daily rhythm
 ```
 morning  → just morning           # Triage overnight Multiclaude runs + open PRs
+                                   #   └ also close-syncs beads whose GH Issue closed
 work     → just interactive       # Gas Town for the day
 evening  → just evening 5.1       # Hand off to Multiclaude for overnight
+                                   #   └ also forward-syncs sprint Issues into beads
 ```
+
+---
+
+## Beads ↔ GitHub Issues sync
+
+GitHub Issues remain the **source of truth** for humans, Multiclaude, and CI. Gas Town requires its own work unit (beads) for `gt sling`, `gt convoy list`, `gt ready`, and the merge queue. We bridge the two with a **one-way projection**: open Issues → beads. Each bead carries `external_ref = "gh-<N>"` so it knows which Issue it mirrors.
+
+### One-time setup
+```bash
+just beads-init                   # creates the Dolt-backed tracker at <repo>/.beads/
+```
+
+### Before dispatching to Gas Town
+```bash
+just beads-sync 5.1               # materialize open Sprint 5.1 Issues as beads (idempotent)
+just beads-sync 5.6               # same for 5.6
+just beads-status                 # show linked beads + their current status
+```
+`just evening <sprint>` calls `beads-sync` automatically before launching autonomous workers, so you don't need to sync manually in the overnight flow.
+
+### Closing the loop
+When a PR merges with `Closes #N`, GitHub auto-closes Issue #N. The bead is closed by **close-sync**, which detects GH state changes and mirrors them:
+
+```bash
+just beads-close-sync             # manual
+# or:
+just morning                      # runs close-sync automatically
+# or:
+just beads-hooks-install          # installs a local git post-merge hook (per-worktree, opt-in)
+```
+
+**No outbound writes to GitHub.** The PR's `Closes #N` already records the outcome on the Issue. Adding bead-ID comments would be noise. Beads are a read-side projection; GitHub is authoritative.
+
+### Sharing beads with teammates
+Local beads live in a Dolt DB (not git-tracked). The portable form is `.beads/issues.jsonl`, auto-exported after each sync.
+
+```bash
+git add .beads/issues.jsonl && git commit
+# teammates:
+git pull && bd import             # ingest JSONL into their local Dolt DB
+```
+
+### Using beads inside Gas Town
+Once synced, standard `gt` commands work:
+```bash
+gt ready                          # what's unblocked across town?
+gt sling kz-1o7 kaizen            # dispatch Agent-4 onto TOST core (#422)
+gt convoy list                    # see auto-created convoys
+bd dep add kz-60o blocks kz-1o7   # record "TOST core blocks M5 validation"
+```
+The `kz-<hash>` IDs are stable bead names; the `gh-<N>` external ref gives you the round-trip to GitHub.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -872,8 +872,11 @@ beads-hooks-install:
     touch "$HOOK"
     chmod +x "$HOOK"
     REPO_ROOT=$(git rev-parse --show-toplevel)
+    # Add shebang if file is empty (brand-new hook)
+    if [ ! -s "$HOOK" ]; then
+      printf '#!/bin/sh\n' > "$HOOK"
+    fi
     {
-      printf '\n%s\n' "$MARKER"
       printf '%s\n' "# Auto-close beads whose linked GH Issue has closed on GitHub"
       printf '%s\n' "if [ -x \"$REPO_ROOT/scripts/beads-close-sync.sh\" ]; then"
       printf '%s\n' "  \"$REPO_ROOT/scripts/beads-close-sync.sh\" >/dev/null 2>&1 || true"

--- a/justfile
+++ b/justfile
@@ -719,6 +719,11 @@ morning:
     echo "--- Pulling latest main ---"
     git checkout main 2>/dev/null && git pull origin main 2>/dev/null
     echo ""
+    if bd list --all --json >/dev/null 2>&1; then
+      echo "--- Close-syncing beads (mirroring GH Issue closures) ---"
+      just beads-close-sync 2>/dev/null || true
+      echo ""
+    fi
     echo "Next steps:"
     echo "  just autonomous-stop     # stop overnight workers"
     echo "  just interactive         # start Gas Town for the day"
@@ -731,6 +736,9 @@ evening sprint_num:
     echo "=== Evening Handoff ==="
     (cd "$(eval echo {{kaizen_repo}})" && gt down 2>/dev/null) || true
     git checkout main && git pull origin main
+    if bd list --all --json >/dev/null 2>&1; then
+      just beads-sync {{sprint_num}} || echo "⚠ beads-sync failed; continuing with autonomous-sprint"
+    fi
     just autonomous-sprint {{sprint_num}}
     echo ""
     echo "Workers running. Detach with Ctrl-b d. Check tomorrow with 'just morning'."
@@ -777,6 +785,103 @@ work-on issue:
     echo "$TASK" | head -3
     echo "..."
     multiclaude worker create "$TASK. Branch: use the agent-N/feat/adr-XXX naming convention. PR must include 'Closes #{{issue}}'."
+
+# --- Beads (GitHub Issues ↔ Gas Town projection) ---
+# GitHub Issues remain the source of truth. Beads are a read-side projection
+# into Gas Town so `gt sling`, `gt convoy`, and `gt ready` have work to see.
+# Forward sync is explicit (pre-dispatch); close-sync runs in `just morning`.
+
+# One-time setup: initialize .beads/ with kz- prefix
+beads-init:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -d .beads ]; then
+      echo "✓ .beads/ already initialized"
+      exit 0
+    fi
+    if ! command -v bd >/dev/null 2>&1; then
+      echo "✗ bd not installed. Run: go install github.com/steveyegge/beads/cmd/bd@latest" >&2
+      exit 1
+    fi
+    echo "=== Initializing beads tracker (prefix: kz) ==="
+    bd init --prefix kz --skip-agents --skip-hooks
+    echo ""
+    echo "Next:"
+    echo "  just beads-sync 5.1    # materialize open Sprint 5.1 Issues as beads"
+    echo "  just beads-sync 5.6    # materialize open Sprint 5.6 Issues as beads"
+
+# Forward-sync: materialize open GH Issues in a sprint as beads (idempotent)
+beads-sync sprint_num:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{sprint_num}}" in
+      0|5.0) LABEL="sprint-5.0" ;;
+      1|5.1) LABEL="sprint-5.1" ;;
+      2|5.2) LABEL="sprint-5.2" ;;
+      3|5.3) LABEL="sprint-5.3" ;;
+      4|5.4) LABEL="sprint-5.4" ;;
+      5|5.5) LABEL="sprint-5.5" ;;
+      6|5.6) LABEL="sprint-5.6" ;;
+      all)   LABEL="--all" ;;
+      *) echo "Unknown sprint: {{sprint_num}} (use 0-6, 5.0-5.6, or 'all')"; exit 1 ;;
+    esac
+    bash scripts/beads-sync.sh "$LABEL"
+
+# Close-sync: close beads whose linked GH Issue has been closed
+beads-close-sync:
+    @bash scripts/beads-close-sync.sh
+
+# Show mirrored beads with current status
+beads-status:
+    #!/usr/bin/env bash
+    if ! bd list --all --json >/dev/null 2>&1; then
+      echo "(beads not initialized — run 'just beads-init')"
+      exit 0
+    fi
+    echo "status	bead_id	gh_ref	title"
+    bd list --all --json 2>/dev/null \
+      | jq -r '.[]
+          | select(.external_ref != null)
+          | select(.external_ref | startswith("gh-"))
+          | "\(.status)\t\(.id)\t\(.external_ref)\t\(.title)"' \
+      | sort
+
+# Export beads to git-tracked .beads/issues.jsonl for team sharing
+beads-export:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    GIT_COMMON=$(git rev-parse --git-common-dir)
+    BEADS_ROOT="$(cd "$(dirname "$GIT_COMMON")" && pwd)/.beads"
+    bd export -o "$BEADS_ROOT/issues.jsonl"
+    echo "✓ Exported to $BEADS_ROOT/issues.jsonl — commit to share with the team"
+
+# Install a local post-merge git hook that runs beads-close-sync after git pull
+# (Local only — not shared via git. Run this once per worktree if you want
+# automatic close-sync on every pull. Otherwise `just morning` covers it.)
+beads-hooks-install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HOOK_DIR="$(git rev-parse --git-path hooks)"
+    HOOK="$HOOK_DIR/post-merge"
+    MARKER="# BEGIN beads-close-sync"
+    if [ -f "$HOOK" ] && grep -qF "$MARKER" "$HOOK"; then
+      echo "✓ post-merge hook already installed"
+      exit 0
+    fi
+    mkdir -p "$HOOK_DIR"
+    touch "$HOOK"
+    chmod +x "$HOOK"
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+    {
+      printf '\n%s\n' "$MARKER"
+      printf '%s\n' "# Auto-close beads whose linked GH Issue has closed on GitHub"
+      printf '%s\n' "if [ -x \"$REPO_ROOT/scripts/beads-close-sync.sh\" ]; then"
+      printf '%s\n' "  \"$REPO_ROOT/scripts/beads-close-sync.sh\" >/dev/null 2>&1 || true"
+      printf '%s\n' "fi"
+      printf '%s\n' "# END beads-close-sync"
+    } >> "$HOOK"
+    echo "✓ Installed post-merge hook at $HOOK"
+    echo "  It runs scripts/beads-close-sync.sh silently after every git pull."
 
 # --- Interactive Mode (Gas Town) ---
 

--- a/scripts/beads-close-sync.sh
+++ b/scripts/beads-close-sync.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Close beads whose linked GitHub Issue has been closed on GitHub.
+#
+# Walks every open bead with external_ref = "gh-*", checks the linked Issue's
+# state, and closes the bead if the Issue is CLOSED. Safe to run repeatedly
+# (no-op when nothing has changed). Intended for:
+#   - `just morning` (catch overnight closures)
+#   - git post-merge hook (catch PR-driven closures on pull)
+#   - manual invocation after a PR merge
+#
+# Never writes to GitHub — the PR's "Closes #N" already records the outcome there.
+
+set -euo pipefail
+
+if ! command -v bd >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "✗ gh CLI not found" >&2
+  exit 1
+fi
+
+GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -z "$GIT_COMMON" ]; then
+  exit 0
+fi
+BEADS_ROOT="$(cd "$(dirname "$GIT_COMMON")" && pwd)/.beads"
+
+if [ ! -d "$BEADS_ROOT" ]; then
+  exit 0
+fi
+
+echo "=== Close-syncing beads whose GH Issue closed ==="
+
+OPEN_BEADS=$(bd list --json 2>/dev/null \
+  | jq -r '.[]
+      | select(.external_ref != null)
+      | select(.external_ref | startswith("gh-"))
+      | select(.status != "closed")
+      | "\(.id)\t\(.external_ref)"' \
+  || true)
+
+if [ -z "$OPEN_BEADS" ]; then
+  echo "  No open beads with GitHub refs."
+  exit 0
+fi
+
+CLOSED=0
+while IFS=$'\t' read -r BEAD_ID REF; do
+  [ -z "$BEAD_ID" ] && continue
+  NUM="${REF#gh-}"
+
+  STATE=$(gh issue view "$NUM" --json state -q '.state' 2>/dev/null || echo "")
+  if [ "$STATE" = "CLOSED" ]; then
+    REASON=$(gh issue view "$NUM" --json stateReason -q '.stateReason' 2>/dev/null || echo "COMPLETED")
+    bd close "$BEAD_ID" --reason "GH Issue #$NUM closed ($REASON)" >/dev/null 2>&1 || true
+    echo "  ✓ $BEAD_ID closed (mirrors #$NUM $REASON)"
+    CLOSED=$((CLOSED + 1))
+  fi
+done < <(printf '%s\n' "$OPEN_BEADS")
+
+echo ""
+echo "Summary: closed=$CLOSED"
+
+if [ "$CLOSED" -gt 0 ]; then
+  bd export -o "$BEADS_ROOT/issues.jsonl" 2>/dev/null || true
+fi

--- a/scripts/beads-sync.sh
+++ b/scripts/beads-sync.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Forward-sync open GitHub Issues to Gas Town beads.
+#
+# Creates a bead for each open GitHub Issue matching the given label, with
+# external_ref = "gh-<N>". Idempotent: existing beads are left alone (we only
+# create new links, not update bodies — use `bd edit` if you need that).
+#
+# Usage:
+#   scripts/beads-sync.sh sprint-5.1
+#   scripts/beads-sync.sh --all
+#
+# Prerequisites:
+#   - bd CLI installed (go install github.com/steveyegge/beads/cmd/bd@latest)
+#   - .beads/ initialized (run `just beads-init`)
+#   - gh CLI authenticated
+
+set -euo pipefail
+
+LABEL="${1:-}"
+if [ -z "$LABEL" ]; then
+  echo "Usage: $0 <sprint-label> | --all" >&2
+  echo "  e.g., $0 sprint-5.1" >&2
+  exit 1
+fi
+
+if ! command -v bd >/dev/null 2>&1; then
+  echo "✗ bd CLI not found." >&2
+  echo "  Install: go install github.com/steveyegge/beads/cmd/bd@latest" >&2
+  exit 1
+fi
+
+# Resolve the .beads/ location — auto-discovery via bd works across worktrees,
+# but the JSONL export needs an explicit path at the main repo root.
+GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || true)
+if [ -z "$GIT_COMMON" ]; then
+  echo "✗ Not in a git repository." >&2
+  exit 1
+fi
+BEADS_ROOT="$(cd "$(dirname "$GIT_COMMON")" && pwd)/.beads"
+
+if [ ! -d "$BEADS_ROOT" ]; then
+  echo "✗ .beads/ not initialized at $BEADS_ROOT" >&2
+  echo "  Run: just beads-init" >&2
+  exit 1
+fi
+
+echo "=== Syncing open GitHub Issues → Gas Town beads ==="
+
+# Build set of existing gh- external refs (idempotency guard)
+EXISTING_REFS=$(bd list --all --json 2>/dev/null \
+  | jq -r '.[] | select(.external_ref != null) | select(.external_ref | startswith("gh-")) | .external_ref' \
+  || true)
+
+# Query Issues
+if [ "$LABEL" = "--all" ]; then
+  echo "Scope: all open Issues"
+  ISSUES_JSON=$(gh issue list --state open --limit 100 \
+    --json number,title,body,labels,assignees --jq '.[] | @json')
+else
+  echo "Scope: label=$LABEL"
+  ISSUES_JSON=$(gh issue list --label "$LABEL" --state open --limit 100 \
+    --json number,title,body,labels,assignees --jq '.[] | @json')
+fi
+
+if [ -z "$ISSUES_JSON" ]; then
+  echo "  No open Issues found."
+  exit 0
+fi
+
+CREATED=0
+SKIPPED=0
+
+# Use process substitution so counters survive the loop (no subshell)
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  NUM=$(echo "$line" | jq -r '.number')
+  TITLE=$(echo "$line" | jq -r '.title')
+  BODY=$(echo "$line" | jq -r '.body // ""')
+  LABELS=$(echo "$line" | jq -r '[.labels[].name] | join(",")')
+  REF="gh-$NUM"
+
+  if echo "$EXISTING_REFS" | grep -qx "$REF"; then
+    echo "  ⊝ #$NUM already linked"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Create the bead. Body via stdin to avoid arg-length issues on long bodies.
+  BEAD_ID=$(printf '%s' "$BODY" | bd create "$TITLE" \
+    --external-ref "$REF" \
+    --body-file - \
+    --json 2>/dev/null \
+    | jq -r '.id')
+
+  if [ -z "$BEAD_ID" ] || [ "$BEAD_ID" = "null" ]; then
+    echo "  ✗ Failed to create bead for #$NUM" >&2
+    continue
+  fi
+
+  # Mirror sprint/agent/cluster labels onto the bead for bd queries
+  if [ -n "$LABELS" ]; then
+    IFS=',' read -ra LBL_ARR <<< "$LABELS"
+    for l in "${LBL_ARR[@]}"; do
+      bd label add "$BEAD_ID" "$l" >/dev/null 2>&1 || true
+    done
+  fi
+
+  echo "  ✓ #$NUM → $BEAD_ID"
+  CREATED=$((CREATED + 1))
+done < <(printf '%s\n' "$ISSUES_JSON")
+
+echo ""
+echo "Summary: created=$CREATED already-linked=$SKIPPED"
+
+# Export to git-tracked JSONL so teammates can `bd import` after pull
+if [ "$CREATED" -gt 0 ]; then
+  bd export -o "$BEADS_ROOT/issues.jsonl" 2>/dev/null || true
+  echo "Exported to $BEADS_ROOT/issues.jsonl (commit to share with team)"
+fi


### PR DESCRIPTION
## Summary

Adds a **one-way projection** from open GitHub Issues into Gas Town beads so Gas Town's dispatch/convoy/merge-queue features have work units to operate on — without turning two systems into co-authoritative state.

- **GitHub stays source-of-truth** for humans, Multiclaude, and CI.
- **Beads is a derived read-model**, keyed by `external_ref = "gh-<N>"`.
- **Close-sync is one-way (GH → bead)** only. The PR's `Closes #N` already records the outcome on GitHub; writing back would just be noise.

## What's included

| File | Purpose |
|---|---|
| `scripts/beads-sync.sh` | Forward-sync: materialize open GH Issues for a label as beads (idempotent, mirrors labels, exports to `.beads/issues.jsonl`) |
| `scripts/beads-close-sync.sh` | Reverse close detection: closes beads whose linked GH Issue is CLOSED |
| `justfile` | New recipes: `beads-init`, `beads-sync`, `beads-close-sync`, `beads-status`, `beads-export`, `beads-hooks-install`. `morning`/`evening` wired to call sync automatically. |
| `docs/coordination/sprint-5.1-and-5.6-multi-agent.md` | New "Beads ↔ GitHub Issues sync" section |
| `.gitignore` | Doc comment explaining `bd init` writes its own `.beads/.gitignore` |

## Design choices worth flagging for review

1. **Worktree-safe.** Both scripts resolve `.beads/` via `git rev-parse --git-common-dir` so they work from any worktree — `bd init` places `.beads/` at the main repo root, and worktrees previously failed the naive `[ -d .beads ]` check.
2. **No outbound GH writes.** We considered posting bead IDs as comments on Issues — decided against, since GH already knows its own state via `Closes #N` in merged PRs. Keeps the contract clean: beads reads from GH, GH never cares about beads.
3. **JSONL for team sharing.** `.beads/issues.jsonl` is committed intentionally via `just beads-export`; teammates run `bd import` after `git pull`. The Dolt DB itself is excluded by the auto-generated `.beads/.gitignore`.
4. **Opt-in post-merge hook.** `just beads-hooks-install` writes a local `post-merge` hook per-worktree — not shared via git — for users who want automatic close-sync on every `git pull`. `just morning` covers the non-hook flow.

## Live verification

```
$ just beads-status
status  bead_id  gh_ref   title
open    kz-1o7   gh-422   ADR-027: TOST Equivalence Testing — Core Implementation
open    kz-60o   gh-423   ADR-027: TOST — M5 Validation + M6 Equivalence Results View
open    kz-5lv   gh-432   ADR-026 Phase 1: Structured proto types…
open    kz-ra9   gh-433   ADR-026 Phase 1: M5 validation…
open    kz-2e8   gh-434   ADR-026 Phase 1: M6 UI…
open    kz-4hd   gh-435   ADR-026 Phase 2: MetricQL parser…
open    kz-753   gh-436   ADR-026 Phase 2: M5 validation + M6 editor
open    kz-rcc   gh-437   ADR-026 Phase 3: Migration + deprecation
```

All 8 open Sprint 5.1/5.6 Issues materialized. Idempotent re-run skips already-linked refs. `just beads-close-sync` correctly no-ops when nothing has closed.

## Test plan

- [ ] `just beads-init` produces `.beads/` at the main repo root (not inside a worktree)
- [ ] `just beads-sync 5.1` creates beads for open Issues with `--external-ref gh-<N>`
- [ ] Re-running `just beads-sync 5.1` reports "already linked" and creates nothing new
- [ ] Closing a GH Issue then running `just beads-close-sync` closes the bead
- [ ] `just morning` runs close-sync automatically (no manual invocation needed)
- [ ] `just evening 5.1` runs forward-sync before launching Multiclaude workers
- [ ] `just beads-hooks-install` installs a local post-merge hook; re-running is idempotent
- [ ] Scripts work from within any worktree, not just the main checkout

## Follow-ups (not in this PR)

- Commit `.beads/issues.jsonl` once for teammates to `bd import`
- Encode critical-path deps with `bd dep add` (e.g., `#422 blocks #423`, `#432 blocks #433/#434`) — documented in the sprint playbook but not yet in the beads graph
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
