### PR TITLE
docs: customer integration guide — authoring plan + Wave 1 foundations

### DIFF
--- a/docs/guides/customer-integration-authoring-plan.md
+++ b/docs/guides/customer-integration-authoring-plan.md
@@ -1,0 +1,256 @@
+# Customer Integration Guide — Authoring Implementation Plan
+
+**Status**: Active
+**Owner**: Docs coordinator (this session, handing to waves of specialist agents)
+**Scope artifact**: [`docs/guides/customer-integration-outline.md`](./customer-integration-outline.md)
+**Target output**: A complete, customer-ready integration guide under `docs/guides/integration/`
+
+---
+
+## 1. Purpose
+
+The outline in `customer-integration-outline.md` defines 20 chapters. This plan describes *how* those chapters get written: which agents, in what order, on what branches, with what quality gates, and how we avoid the classic hazards of parallel documentation authoring (voice drift, conflicting cross-references, divergent SDK skeletons, dead links).
+
+The plan is intentionally staged: sequential work establishes anchors; parallel work fills in chapters that depend on those anchors.
+
+---
+
+## 2. Directory Layout
+
+All chapter files live under a single directory so relative cross-references are stable.
+
+```
+docs/guides/integration/
+  README.md                              # Entry point; mirrors the outline TOC
+  templates/
+    sdk-chapter-template.md              # Produced in Wave 1, consumed in Wave 2
+    feature-chapter-template.md          # Produced in Wave 1, consumed in Wave 3
+  01-introduction.md
+  02-core-concepts.md
+  03-architecture-overview.md
+  04-quickstart.md
+  05-auth-and-tenancy.md
+  06-sdks/
+    01-web.md
+    02-ios.md
+    03-android.md
+    04-go.md
+    05-python.md
+    06-grpc-direct.md
+    07-edge.md
+  07-experiments.md
+  08-feature-flags.md
+  09-event-ingestion.md
+  10-metrics.md
+  11-analysis-and-results.md
+  12-bandits.md
+  13-advanced-designs.md
+  14-operational-integration.md
+  15-governance-security-compliance.md
+  16-reference/
+    README.md
+    error-codes.md
+    rate-limits.md
+    glossary.md
+    proto-stability-policy.md
+  17-cookbook/
+    README.md
+    ab-pricing-page.md
+    ramp-risky-feature.md
+    ...                                  # one file per recipe
+  18-troubleshooting-and-faq.md
+  19-release-notes-and-deprecation.md
+  20-appendices/
+    README.md
+    ...
+```
+
+One file per agent per wave — eliminates merge conflicts inside waves.
+
+---
+
+## 3. Wave Structure
+
+### Wave 1 — Foundations (sequential, 1 agent)
+
+**Agent**: Technical Writer
+
+**Inputs**:
+- `CLAUDE.md` (platform overview, module map, critical rules)
+- `docs/guides/customer-integration-outline.md` (the outline)
+- `docs/design/design_doc_v7.0.md` (architecture truth)
+- `docs/adrs/README.md` (ADR index)
+- `proto/experimentation/` (module structure)
+- Existing `docs/onboarding/` agent-facing docs (for tone calibration *away* from that tone)
+
+**Deliverables**:
+1. `docs/guides/integration/README.md` — TOC mirroring the outline, with navigation
+2. `docs/guides/integration/01-introduction.md` — Ch 1 fully written
+3. `docs/guides/integration/02-core-concepts.md` — Ch 2 fully written (entities, lifecycle, bucketing, events, guardrails, PII boundaries)
+4. `docs/guides/integration/03-architecture-overview.md` — Ch 3 fully written (customer-facing module map, data flow, deployment topologies)
+5. `docs/guides/integration/templates/sdk-chapter-template.md` — Shared skeleton for §6.1–6.7, with every section heading, "What you'll learn" block, "Next steps" block, and placeholder guidance
+6. `docs/guides/integration/templates/feature-chapter-template.md` — Shared skeleton for §7–13
+
+**Quality gates**:
+- No ambiguous claim without an ADR or proto reference
+- No SDK-specific content in Ch 1–3 (those are SDK-agnostic)
+- Glossary terms introduced in Ch 2 are reused verbatim by later waves
+- Templates include mandatory sections: Install, Initialize, Assign, Expose, Flag Eval, Shutdown, Error Handling, Troubleshooting
+
+**Exit criteria**: Wave 1 PR merged to `main`. Without the templates, Wave 2 cannot start without risking drift.
+
+---
+
+### Wave 2 — SDK Chapters (parallel, 7 agents)
+
+**Precondition**: Wave 1 merged. Every Wave 2 agent reads `templates/sdk-chapter-template.md` first.
+
+**Isolation**: each agent runs with `isolation: worktree` to avoid stepping on each other. Each produces one file only.
+
+| § | File | Agent | Source of truth |
+| --- | --- | --- | --- |
+| 6.1 Web | `06-sdks/01-web.md` | Frontend Developer | `sdks/web/` |
+| 6.2 iOS | `06-sdks/02-ios.md` | Mobile App Builder | `sdks/ios/` |
+| 6.3 Android | `06-sdks/03-android.md` | Mobile App Builder | `sdks/android/` |
+| 6.4 Go | `06-sdks/04-go.md` | Backend Architect | `sdks/server-go/` |
+| 6.5 Python | `06-sdks/05-python.md` | Backend Architect | `sdks/server-python/` |
+| 6.6 gRPC direct | `06-sdks/06-grpc-direct.md` | Technical Writer | `proto/experimentation/` |
+| 6.7 Edge | `06-sdks/07-edge.md` | DevOps Automator | `sdks/web/` + edge runtime notes |
+
+**Quality gates per chapter**:
+- Every code block must reference a file in `examples/` (create if missing)
+- Every API call maps to a proto RPC — name the RPC
+- Fallback / offline behavior documented
+- Installation instructions cite the actual package registry path used by the SDK
+
+**Consolidation**: single consolidation PR merges all 7 chapter PRs once each passes CI.
+
+---
+
+### Wave 3 — Feature Chapters (parallel, 7 agents)
+
+**Precondition**: Wave 1 merged. Wave 2 may still be in flight — these chapters do not reference SDK specifics.
+
+| § | File | Agent | Primary module |
+| --- | --- | --- | --- |
+| 7 Experiments | `07-experiments.md` | Technical Writer | M5 Management |
+| 8 Feature Flags | `08-feature-flags.md` | Technical Writer | M7 Flags |
+| 9 Event Ingestion | `09-event-ingestion.md` | Data Engineer | M2 Pipeline |
+| 10 Metrics | `10-metrics.md` | Data Engineer | M3 Metrics |
+| 11 Analysis & Results | `11-analysis-and-results.md` | AI Engineer | M4a Analysis |
+| 12 Bandits | `12-bandits.md` | AI Engineer | M4b Bandit |
+| 13 Advanced Designs | `13-advanced-designs.md` | AI Engineer | M4a + M4b |
+
+**Quality gates**:
+- Every statistical claim cites the golden-file table in `CLAUDE.md` (the method, reference package, and precision)
+- Every ADR in Cluster A–E referenced at least once across Ch 11–13
+- Section 11.5 (peeking safely) explicitly cross-references ADR-015 AVLM and ADR-018 e-values
+- Section 12 explicitly cross-references ADR-016 slate bandits and ADR-017 TC/JIVE
+
+---
+
+### Wave 4 — Ops, Reference, Cookbook, Tail (parallel, ~5 agents)
+
+| § | File(s) | Agent |
+| --- | --- | --- |
+| 14 Operational Integration | `14-operational-integration.md` | SRE |
+| 15 Governance / Security / Compliance | `15-governance-security-compliance.md` | Compliance Auditor |
+| 16 Reference | `16-reference/*.md` | Technical Writer |
+| 17 Cookbook | `17-cookbook/*.md` (10 recipes) | Developer Advocate |
+| 18 Troubleshooting & FAQ | `18-troubleshooting-and-faq.md` | Support Responder |
+| 19 Release Notes & Deprecation | `19-release-notes-and-deprecation.md` | Technical Writer |
+| 20 Appendices | `20-appendices/*.md` | Technical Writer |
+
+---
+
+### Wave 5 — Editorial Pass (sequential, 1 agent)
+
+**Agent**: Technical Writer
+
+- Read every chapter top-to-bottom in outline order
+- Enforce consistent voice, tense, terminology
+- Verify every internal link resolves
+- Verify every `examples/` reference exists
+- Produce `docs/guides/integration/CHANGELOG.md` and update `README.md` TOC with page counts and estimated read time
+
+---
+
+## 4. Branching and PR Strategy
+
+- **Wave 1**: single branch `claude/kaizen-integration-docs-waves` → PR → merge to `main`.
+- **Wave 2/3/4**: each agent runs in a worktree off `main` on a branch named `claude/kaizen-docs-w{wave}-{slug}`. Each opens its own draft PR. A coordinator session (future) rebases and merges in order.
+- **Wave 5**: single branch `claude/kaizen-docs-editorial`.
+
+No wave modifies files owned by a different wave. The outline file itself is only edited in Wave 5.
+
+---
+
+## 5. Shared Conventions (enforced by templates and reviewed in Wave 5)
+
+- Every chapter begins with:
+  ```markdown
+  > **What you'll learn**
+  > - bullet 1
+  > - bullet 2
+  > - bullet 3
+  ```
+- Every chapter ends with a `## Next steps` section that links to the logical next chapter.
+- Port numbers, module names, and ADR identifiers use the canonical forms from `CLAUDE.md`.
+- Code blocks are fenced with language identifiers and, where possible, a `// docs/examples/<file>` header comment pointing at the example repo path.
+- Callouts use GitHub-flavored admonitions:
+  ```markdown
+  > [!NOTE]
+  > [!WARNING]
+  > [!IMPORTANT]
+  ```
+- Stability: tag preview/beta surface with `**Status: Preview**` at the section top.
+
+---
+
+## 6. Quality Gates (applied in every wave's CI)
+
+1. **markdownlint** with the project's config (add if missing — deferred to Wave 1)
+2. **Link checker** (lychee) for internal and external links
+3. **Spelling** (cspell) with a project dictionary
+4. **Code block language tags present** (custom check — deferred)
+5. **No TODOs merged to `main`** (grep guard; TODOs allowed only during wave PRs, resolved before merge)
+
+---
+
+## 7. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| SDK chapters drift in structure | Wave 1 template, reviewed before Wave 2 |
+| Voice drift across agents | Wave 5 editorial pass; shared tone guide in `templates/` |
+| Stale proto / SDK references | Every code sample ties to a path in `examples/` with CI validation |
+| Over-claiming statistical capability | Ch 11–13 must cite ADR + golden-file source per claim |
+| Merge conflicts from parallel agents | One file per agent per wave; worktree isolation in Waves 2–4 |
+| Review bottleneck | Module owners assigned at wave kickoff, not at PR time |
+
+---
+
+## 8. Success Criteria
+
+- All 20 chapters of the outline have a corresponding non-empty file under `docs/guides/integration/`
+- A new customer can complete §4 Quickstart in under 15 minutes with only the docs and an API key
+- Every statistical method mentioned has a golden-file reference
+- Zero broken internal links
+- The guide passes `markdownlint`, `lychee`, and `cspell` in CI
+- Module owners (Agents 1, 2, 3, 4, 5, 7) have each reviewed at least one chapter in their domain
+
+---
+
+## 9. Current Status
+
+- [x] Outline merged (`customer-integration-outline.md`, PR #448)
+- [x] Implementation plan drafted (this document)
+- [ ] Wave 1 launched
+- [ ] Wave 1 merged
+- [ ] Wave 2 launched (parallel, 7 agents)
+- [ ] Wave 3 launched (parallel, 7 agents)
+- [ ] Wave 4 launched (parallel, ~5 agents)
+- [ ] Wave 5 editorial pass
+- [ ] Guide published as the `integration/` landing section
+
+Status is updated by the coordinating session after each wave completes.

--- a/docs/guides/integration/01-introduction.md
+++ b/docs/guides/integration/01-introduction.md
@@ -1,0 +1,123 @@
+# 1. Introduction
+
+> **What you'll learn**
+> - What Kaizen Experimentation is and the problem it solves
+> - The shape of the platform at a glance: seven modules, schema-first, one vocabulary
+> - When Kaizen is the right tool, and when a lighter alternative is a better fit
+
+## 1.1 What Kaizen is
+
+Kaizen is an SVOD-grade experimentation and feature flag platform. You use it to make data-driven product decisions — ship a new player UI to 5% of users, decide whether the new homepage recommender actually lifts engagement, hold a treatment to a region while you wait for long-term effects, or keep an emergency kill switch on hand for a risky launch.
+
+Under the hood, Kaizen is seven cooperating modules written in Rust, Go, and TypeScript, coordinated through a single Protobuf schema. You never need to know which language a module is written in to use the platform — the contract you program against is the schema — but you do need to know which module does what, because that map determines which port you connect to and which SDK method you call.
+
+The platform covers the full experiment lifecycle end-to-end:
+
+- **Assignment**: deterministic variant allocation, interleaving, and bandit arm delegation through the **M1 Assignment** service (port `50051`).
+- **Ingestion**: exposure, metric, reward, and QoE event validation, deduplication, and Kafka emission through the **M2 Pipeline** service (ports `50052` for ingest and `50058` for orchestration).
+- **Metric computation**: Spark SQL orchestration and Delta Lake storage through the **M3 Metrics** service (port `50056`).
+- **Analysis**: all statistical inference — frequentist tests, CUPED, AVLM, e-values, synthetic control, switchback, offline RL — through the **M4a Analysis** service (port `50053`).
+- **Bandits**: Thompson, LinUCB, Neural, slate, and constrained arm selection through the **M4b Bandit** service (port `50054`).
+- **Management**: experiment CRUD, lifecycle transitions, RBAC, guardrails, and bucket reuse through the **M5 Management** service (port `50055`).
+- **UI**: the operator console at **M6 UI** (port `3000`).
+- **Feature flags**: boolean, string, JSON, and numeric flags with percentage rollouts and sticky bucketing through the **M7 Flags** service (port `50057`).
+
+You will see these names and ports throughout the guide. They are canonical — they match the architecture table in [`CLAUDE.md`](../../../CLAUDE.md) and the service contracts in [`proto/experimentation/`](../../../proto/experimentation/).
+
+Two non-obvious design choices shape how you integrate:
+
+1. **Schema-first, everywhere.** Every module exposes its capabilities through `.proto` files in `proto/experimentation/<module>/v1/`. SDKs are thin wrappers over these contracts; if the SDK can't do something, you can always drop down to gRPC and talk to the module directly.
+2. **Statistics live in one place.** All statistical computation — every p-value, every confidence interval, every variance estimate — is implemented in the Rust `experimentation-stats` crate and served by M4a. Go and TypeScript never do math on your behalf. This is why results are reproducible across surfaces: there is exactly one implementation.
+
+## 1.2 What Kaizen is not
+
+Kaizen is deliberately focused. It is *not*:
+
+- **A product analytics tool.** Kaizen does not replace Amplitude, Mixpanel, or a BI layer. It computes experiment-scoped metrics and renders them in the results dashboard, but it does not store your generic event firehose for ad-hoc exploration. You still need a separate BI layer.
+- **A customer data platform (CDP) or identity graph.** Kaizen does not resolve user identities across devices, stitch sessions, or manage marketing audiences. If you need those, feed identity-resolved attributes into Kaizen from your existing CDP.
+- **A general-purpose feature configuration store.** M7 Flags is optimized for rollout control and experiment graduation. Configuration that never needs targeting, percentage rollouts, or audit trails belongs in a config store (etcd, Consul, a database table), not in Kaizen.
+- **A data warehouse.** M3 writes Delta Lake tables for metric computation, but those tables are internal artifacts. Your warehouse is still yours; Kaizen integrates with it through federated reads rather than replacing it.
+
+Keeping these boundaries sharp is what lets Kaizen be good at what it *does* do: turn a product hypothesis into a trustworthy decision.
+
+## 1.3 Core capabilities at a glance
+
+The platform supports the full range of experimental designs a large SVOD operator needs:
+
+- **Classic controlled experiments.** A/B, A/B/n, and multivariate/factorial designs with frequentist, Bayesian, and sequential inference.
+- **Interleaving.** Team Draft, Optimized, and Multileave interleaving for ranking experiments where users compare results directly.
+- **Multi-armed and contextual bandits.** Thompson sampling, LinUCB, Neural (Candle-based), and slate bandits for continuous optimization where you care about cumulative reward rather than hypothesis testing.
+- **Quasi-experimental designs.** Switchback experiments for marketplace and two-sided treatments, and synthetic control for geo-level interventions that cannot be randomized at the user level.
+- **Feature flags with percentage rollouts.** Boolean, string, JSON, and numeric flags with sticky bucketing, targeting rules, kill switches, and clean graduation from experiment to permanent flag.
+- **Sequential and always-valid inference.** AVLM (sequential CUPED), e-values with online FDR control, mSPRT, and group-sequential tests (GST), so you can peek at results safely and stop early when evidence is strong.
+
+Chapter 11 walks through how to pick the right method; Chapter 12 covers bandit-specific workflows; Chapter 13 covers the more advanced quasi-experimental designs.
+
+## 1.4 Platform concepts in one picture
+
+Here is Kaizen from the perspective of a customer integration. Solid arrows are primary request paths; dashed arrows are background data flow.
+
+```mermaid
+flowchart LR
+    subgraph Client["Your surface"]
+        App[App / Web / Server]
+    end
+
+    subgraph Kaizen["Kaizen platform"]
+        M1["M1 Assignment :50051"]
+        M7["M7 Flags :50057"]
+        M2["M2 Pipeline :50052 / :50058"]
+        M3["M3 Metrics :50056"]
+        M4a["M4a Analysis :50053"]
+        M4b["M4b Bandit :50054"]
+        M5["M5 Management :50055"]
+        M6["M6 UI :3000"]
+    end
+
+    Operator[Operator / PM] --> M6
+    M6 --> M5
+
+    App -->|GetAssignment| M1
+    App -->|EvaluateFlag| M7
+    App -->|IngestExposure / IngestMetricEvent| M2
+
+    M1 -.->|SelectArm| M4b
+    M5 -.->|config stream| M1
+    M5 -.->|config stream| M7
+
+    M2 -.->|Kafka| M3
+    M3 -.->|Delta Lake| M4a
+    M4b -.->|policy snapshots| M4a
+    M4a -.->|results| M6
+```
+
+A few things to lock in before Chapter 2 goes deeper:
+
+- You, as the customer integrator, primarily talk to **M1**, **M7**, and **M2**. M5 is the management surface; you use it (directly or through M6) to create experiments, then your runtime talks to M1, M7, and M2 at request scale.
+- M3, M4a, and M4b run behind the scenes. You read their output through M5 or M6 — you do not write your own SQL against M3, and you do not call M4a per request.
+- The `experimentation-stats` crate is the only place statistical math lives. Every result you see in the dashboard was computed in Rust, regardless of which UI or SDK rendered it.
+
+## 1.5 When to choose Kaizen — and when not to
+
+Kaizen is the right choice when at least one of these is true:
+
+- You run **SVOD-scale traffic** (millions of assignments per second is routine), and you need deterministic bucketing, low-latency assignment, and a pipeline that doesn't drop exposure events under load.
+- You care about **statistical rigor** beyond "we hit significance." You want CUPED or AVLM for variance reduction, always-valid inference for safe peeking, and golden-file-validated implementations of the methods you use.
+- You run **more than one experiment per surface** and need mutual exclusion, layers, holdouts, portfolio-level power analysis, and meta-experiments.
+- You run **bandits or contextual bandits in production** and want the same platform to handle exposure tracking, reward ingestion, off-policy evaluation, and experiment graduation.
+- You need **advanced designs** — interleaving for ranking, switchback for marketplaces, or synthetic control for geo tests — in addition to vanilla A/B.
+- You have **compliance requirements** that need audit trails, RBAC, and controlled approval workflows for launches and kill-switch pulls.
+
+Kaizen is probably overkill when:
+
+- You ship one experiment per quarter on a small user base. A vendor like Optimizely, LaunchDarkly, Statsig, or Eppo will get you to a result faster, and you can always [migrate later](17-cookbook/README.md#1710-migrate-from-optimizely--launchdarkly--statsig--eppo).
+- You only need percentage-based feature gates with no statistical analysis. A simpler flag service or even a config table will serve you better.
+- You have no data engineering capacity. Kaizen expects you to produce metric events; if you can't emit events reliably or you don't have a warehouse for federated reads, a managed vendor with richer auto-instrumentation is a better fit.
+
+> [!IMPORTANT]
+> If you're not sure, read [Chapter 2 — Core Concepts](02-core-concepts.md) and [Chapter 3 — Architecture Overview](03-architecture-overview.md) first, then attempt the [15-minute quickstart in Chapter 4](04-quickstart.md). If you finish the quickstart without feeling like the platform is fighting you, Kaizen is probably the right fit.
+
+## Next steps
+
+- Continue to [Chapter 2 — Core Concepts](02-core-concepts.md) to learn the vocabulary you'll use in every later chapter.
+- If you already know the concepts and want to see the module map up close, jump to [Chapter 3 — Architecture Overview](03-architecture-overview.md).

--- a/docs/guides/integration/02-core-concepts.md
+++ b/docs/guides/integration/02-core-concepts.md
@@ -1,0 +1,233 @@
+# 2. Core Concepts
+
+> **What you'll learn**
+> - The entities Kaizen exposes — experiments, variants, assignment units, metrics, guardrails, flags — and how they relate
+> - Every lifecycle state an experiment can be in, and which transitions are valid
+> - How bucketing actually works, why it's deterministic, and the privacy boundary you must respect
+
+This chapter is the vocabulary source of truth for the rest of the guide. Later chapters and wave 2/3 agents will assume these definitions. If a term is used elsewhere, it means exactly what is defined here.
+
+---
+
+## 2.1 Entities
+
+### 2.1.1 Experiment, Variant, Treatment, Holdout
+
+An **Experiment** is a unit of decision-making: you are trying to learn whether an intervention changes an outcome. Every experiment has an ID, an owner, a traffic allocation, at least one metric, and a lifecycle state (§2.2). Experiments are the top-level object in M5 Management and are defined in [`proto/experimentation/common/v1/experiment.proto`](../../../proto/experimentation/common/v1/experiment.proto) as `Experiment`.
+
+A **Variant** is one arm of an experiment. Every experiment has a control variant and one or more treatment variants; each variant carries a unique ID, a traffic weight, and optionally a payload (the configuration blob the SDK hands back to your code when a user is assigned to that variant). Variants are defined as `Variant` in the same proto file.
+
+A **Treatment** is informal shorthand for "a non-control variant." When the guide says "the treatment lifted conversion by 1.2%," it is comparing a non-control variant to control.
+
+A **Holdout** is a long-lived variant that deliberately receives no treatment and persists across multiple experiments in a layer. Holdouts are how you measure the *cumulative* impact of every shipped change on a stable slice of users. They are configured at the Layer level (see §2.1 and Chapter 7 for layers and mutual exclusion).
+
+### 2.1.2 Assignment Unit
+
+An **Assignment Unit** is the thing you randomize over. For most experiments this is a user, but Kaizen supports a family of units:
+
+- **User** — persistent identity, usually a `user_id` from your auth system.
+- **Device** — a device identifier (e.g., IDFV on iOS, a generated device UUID on Android/Web) — used when you cannot assume login.
+- **Session** — a single session identifier, used when you want to re-randomize per visit (rare; most experiments are sticky).
+- **Account** — a household or billing account; used when one subscription spans multiple profiles and you want all profiles to see the same variant.
+- **Household** — an explicit household grouping distinct from account; used when account != household.
+
+Which unit you choose determines the bucketing input (§2.3) and the sticky-assignment contract. The unit is part of the assignment configuration on the experiment; Kaizen will always hash the unit you declared, not whatever identifier the SDK happened to have on hand.
+
+> [!IMPORTANT]
+> Changing the assignment unit on a running experiment is never safe. If you need a different unit, conclude the experiment and create a new one.
+
+### 2.1.3 Metric, Guardrail, Decision Criterion
+
+A **Metric** is a numeric quantity computed from your event stream for the purpose of comparing variants. Metrics are defined in M5 (`CreateMetricDefinition`) and computed by M3. They come in six types, defined as `MetricType` in [`proto/experimentation/common/v1/metric.proto`](../../../proto/experimentation/common/v1/metric.proto):
+
+| `MetricType` | Meaning | Example |
+| --- | --- | --- |
+| `METRIC_TYPE_MEAN` | Mean of a numeric value per unit | Average watch minutes per user |
+| `METRIC_TYPE_PROPORTION` | Fraction of units with at least one event | Conversion rate |
+| `METRIC_TYPE_RATIO` | Ratio of two sums (delta-method variance) | Revenue per session |
+| `METRIC_TYPE_COUNT` | Count of events per unit | Plays per user per week |
+| `METRIC_TYPE_PERCENTILE` | Percentile of a distribution | p95 time-to-first-frame |
+| `METRIC_TYPE_CUSTOM` | Custom SQL executed by M3 | Anything the built-ins don't cover |
+
+Metrics are classified by role on an experiment:
+
+- **Primary metric** — the single metric that determines ship/no-ship. Exactly one per experiment.
+- **Secondary metric** — metrics you track for context but that do not decide the experiment.
+- **Guardrail metric** — metrics that *must not regress*; a guardrail breach can trigger automatic action.
+
+A **Guardrail** is a metric plus a threshold and a `GuardrailAction`. The two actions, defined in [`experiment.proto`](../../../proto/experimentation/common/v1/experiment.proto), are:
+
+- `GUARDRAIL_ACTION_AUTO_PAUSE` — M5 pauses the experiment, taking traffic to 0% and alerting the owner. This is the default. See ADR-008 for the rationale.
+- `GUARDRAIL_ACTION_ALERT_ONLY` — fire an alert but keep traffic flowing. Must be opted into explicitly and is recorded in the audit trail.
+
+A **Decision Criterion** is the combination of primary metric, required effect size, guardrail set, and statistical method you use to conclude the experiment. Chapter 7 covers decision criteria in depth; Chapter 11 covers the statistical methods.
+
+### 2.1.4 Feature Flag vs. Experiment (and when a flag graduates)
+
+A **Feature Flag** lives in M7 Flags and is for *rollout control*: turn a capability on for 1% of traffic, ramp to 100%, or kill it instantly. Flags come in four types (boolean, string, JSON, number) and are evaluated via `EvaluateFlag` or `EvaluateFlags` against the M7 service (port `50057`).
+
+The rule of thumb:
+
+- If you need to *decide whether to ship* something, run an **experiment**. Experiments have metrics, statistical analysis, and guardrails.
+- If you have already decided and you just need to *control rollout safely*, use a **flag**. Flags have targeting rules and percentage rollouts but no built-in statistical analysis.
+
+An experiment can **graduate** into a flag once it concludes. M7 exposes `PromoteToExperiment` (and its inverse pattern, graduation) so you can convert between the two without losing bucket stickiness. See Chapter 8 for the graduation workflow and [recipe 17.5 — "Convert a winning experiment to a permanent flag"](17-cookbook/README.md).
+
+---
+
+## 2.2 Lifecycle states
+
+Every experiment has a state, defined as `ExperimentState` in [`proto/experimentation/common/v1/experiment.proto`](../../../proto/experimentation/common/v1/experiment.proto). States come in two flavors:
+
+- **Stable** states describe a steady condition. An experiment can sit in a stable state indefinitely.
+- **Transitional** states describe an in-progress handoff. An experiment moves through these automatically; you rarely act on them directly. See ADR-005 for the rationale for explicit transitional states.
+
+```mermaid
+stateDiagram-v2
+    [*] --> DRAFT
+    DRAFT --> STARTING: StartExperiment
+    STARTING --> RUNNING: validation + warmup ok
+    STARTING --> DRAFT: validation failed
+    RUNNING --> PAUSED: guardrail breach / manual pause
+    PAUSED --> RUNNING: ResumeExperiment
+    RUNNING --> CONCLUDING: ConcludeExperiment
+    CONCLUDING --> CONCLUDED: final analysis written
+    CONCLUDED --> ARCHIVED: ArchiveExperiment
+    ARCHIVED --> [*]
+```
+
+| State | Stability | Meaning |
+| --- | --- | --- |
+| `EXPERIMENT_STATE_DRAFT` | Stable | Configured but not yet validated or started. No traffic. |
+| `EXPERIMENT_STATE_STARTING` | Transitional | M5 is validating config, warming bandit policy, confirming metric availability, checking lifecycle segment power. M1 MUST NOT serve assignments for this experiment. |
+| `EXPERIMENT_STATE_RUNNING` | Stable | Actively collecting data. For bandits, policy is adapting. |
+| `EXPERIMENT_STATE_PAUSED` | Stable | Traffic paused due to guardrail breach or manual operator action. M1 MUST NOT serve assignments. Resume via `ResumeExperiment`. |
+| `EXPERIMENT_STATE_CONCLUDING` | Transitional | Running final analysis, creating policy snapshots, computing surrogate projections, generating IPW estimates. M6 shows a progress indicator; result queries return 503. |
+| `EXPERIMENT_STATE_CONCLUDED` | Stable | Analysis complete, results available, no longer collecting data. |
+| `EXPERIMENT_STATE_ARCHIVED` | Stable | Retained for historical reference. Results still queryable. |
+
+The valid transitions are enforced by M5. You drive transitions through these RPCs on `ManagementService`: `StartExperiment`, `PauseExperiment`, `ResumeExperiment`, `ConcludeExperiment`, `ArchiveExperiment`.
+
+> [!WARNING]
+> There is no "back to draft" transition from `RUNNING` or `CONCLUDED`. Once started, an experiment's configuration is effectively frozen. See §7.8 (editing a live experiment) for what you can and cannot change without creating a new experiment.
+
+---
+
+## 2.3 Bucketing model
+
+Bucketing is the deterministic mapping from an assignment unit to a variant. Two properties matter:
+
+1. **Determinism** — the same unit hashed with the same salt always lands in the same bucket. That is what makes assignments sticky and reproducible.
+2. **Independence** — two different experiments with different salts produce uncorrelated bucket assignments for the same unit. That is what lets you run many experiments on the same traffic.
+
+Kaizen uses **MurmurHash3 32-bit** over `(salt, assignment_unit_id)`. The hash output is mapped into a `[0, 10_000)` bucket space; variants claim contiguous bucket ranges proportional to their traffic weight.
+
+The hash function and bucketing logic are implemented in the `experimentation-hash` Rust crate and mirrored in every SDK. The test vectors at `test-vectors/hash_vectors.json` are the cross-language contract: every SDK must produce the same bucket for a given input, or CI fails.
+
+### Salt strategy
+
+Every experiment gets a unique salt. The default salt is the experiment ID, which is sufficient for independence between experiments. For advanced cases:
+
+- **Bucket reuse** (ADR-009): when you want a new experiment to share buckets with a previous one — for example, to prevent the same users from being exposed to multiple risky treatments back-to-back — M5 applies a 24-hour cooldown and reuses the salt from the predecessor experiment. Chapter 7 covers how to declare bucket reuse; recipe 17.6 walks through a concrete case.
+- **Salt rotation**: to deliberately re-randomize (for example, if you discover a bias in the prior assignment), you can rotate the salt. The old assignments do not survive rotation — treat it like starting a fresh experiment.
+
+### Carryover
+
+**Carryover** is when a user's prior exposure to one variant contaminates their behavior in a later experiment. Kaizen cannot eliminate carryover in general, but bucket reuse plus explicit holdouts in a layer is the platform's defense against it. See §2.5 and Chapter 13 for interference and spillover mitigation.
+
+---
+
+## 2.4 Exposure vs. enrollment vs. trigger events
+
+Three event types interact at assignment time, and conflating them is the most common source of bugs:
+
+- **Assignment** is the act of M1 computing a variant for a unit. An assignment on its own is not an exposure — it just means "if the user were to encounter the experiment surface, this is what they would see."
+- **Exposure** is the event you emit when the user *actually experiences* the variant — typically the moment the variant-specific UI renders or the variant-specific code path executes. Exposure is what anchors the user into the experiment's analysis. The canonical event is `ExposureEvent` in [`proto/experimentation/common/v1/event.proto`](../../../proto/experimentation/common/v1/event.proto), ingested via `IngestExposure` on M2.
+- **Enrollment** is informal: it's the first exposure event the pipeline dedupes to, so "time of enrollment" means "time of first exposure." Kaizen does not have a separate enrollment event type.
+- **Trigger events** are a specialized pattern for lazily-loaded features. You emit a trigger event to record that the user reached the code path where the variant would apply, even if the variant-specific rendering happens later. Trigger events are a subclass of exposure and share the same proto type; you distinguish them by metadata.
+
+Metric events (`MetricEvent`), reward events (`RewardEvent`) for bandits, and QoE events are separate event types, each with its own RPC on M2 Pipeline. Chapter 9 covers the full event taxonomy and required fields.
+
+> [!IMPORTANT]
+> Call the assignment first, then emit the exposure **when and only when** the variant actually affects the user's experience. SDKs make this automatic when you use the standard render hooks; if you call the low-level API directly, it is on you to emit exposure correctly.
+
+---
+
+## 2.5 Guardrails and stop conditions
+
+A **guardrail** (see §2.1.3) is a metric + threshold + action. M3 computes guardrail metrics on a schedule; when a threshold is crossed, M5 evaluates the `GuardrailConfig` and takes action:
+
+- `GUARDRAIL_ACTION_AUTO_PAUSE` transitions the experiment to `EXPERIMENT_STATE_PAUSED` and raises an alert. You resume manually via `ResumeExperiment` only after you understand the cause. This is the default per ADR-008.
+- `GUARDRAIL_ACTION_ALERT_ONLY` leaves the experiment running and raises an alert. Used rarely and recorded in the audit trail.
+
+**Stop conditions** are separate from guardrails. A stop condition is a declarative rule — "stop when primary metric reaches significance with alpha = 0.05 under AVLM" — that causes M4a to emit a conclusion signal picked up by M5. Sequential methods (mSPRT, GST, AVLM, e-values) are the statistical foundation of safe stop conditions. Chapter 11 covers these in depth.
+
+---
+
+## 2.6 Privacy and PII boundaries
+
+Kaizen is built around event ingestion, and events are where privacy mistakes happen. The rules:
+
+- **You may send**: unit identifiers (user/device/session/account IDs), variant IDs, experiment IDs, timestamps, metric values, and attribute keys/values you have declared in the metric registry.
+- **You must not send**: free-form text from user input, raw email addresses, payment details, precise location beyond the granularity the platform needs, or anything your privacy counsel has not approved as experiment-visible.
+- **You must hash** identifiers that are sensitive but necessary for bucketing (e.g., hash email before using it as an assignment unit ID; Kaizen will not do the hashing for you).
+- **PII redaction** is the customer's responsibility at emit time. M2 performs structural validation but does not scrub free-form strings.
+
+User deletion flows (GDPR, CCPA, LGPD) are handled through M5's deletion endpoints; Chapter 15 covers the exact procedures.
+
+> [!WARNING]
+> If you emit a field Kaizen does not expect, M2 may still accept it — but it will show up in downstream tables and may leak into notebooks or exports. Treat event emission like any other privacy-sensitive write: review what you send, and prefer fewer fields.
+
+---
+
+## Glossary
+
+This glossary is the source of truth for every later chapter. If you see any of these terms used elsewhere in the guide, they mean what they mean here.
+
+| Term | Definition |
+| --- | --- |
+| **Arm** | A single choice in a bandit. Conceptually equivalent to a variant in a classic experiment; distinguished in the proto as `ArmSelection`. |
+| **Assignment** | The act of computing a variant for an assignment unit. Performed by M1 Assignment. |
+| **Assignment unit** | The entity randomized over — user, device, session, account, or household. See §2.1.2. |
+| **AVLM** | Anytime-Valid regression-adjusted inference with Linear Models. Unifies CUPED with sequential monitoring. See ADR-015. |
+| **Bandit** | An adaptive experiment that balances exploration and exploitation to maximize cumulative reward rather than test a hypothesis. Served by M4b. |
+| **Bucket** | An integer in `[0, 10_000)` produced by hashing the assignment unit. Variants claim contiguous bucket ranges. |
+| **Bucket reuse** | Deliberately sharing the same salt between two experiments so the same units land in the same buckets. Requires a 24-hour cooldown (ADR-009). |
+| **CUPED** | Controlled-Experiment Using Pre-Experiment Data — variance-reduction technique that subtracts a pre-period covariate. |
+| **Decision criterion** | The combination of primary metric, required effect, guardrails, and statistical method that decides whether to ship. |
+| **E-value** | A sequential inference primitive; the reciprocal relates to always-valid p-values. See ADR-018. |
+| **Exposure** | The event emitted when a user actually experiences a variant. See §2.4. |
+| **Factorial design** | Multiple simultaneously varying factors in a single experiment. |
+| **FDR** | False Discovery Rate. Online FDR control is offered via ADR-018. |
+| **Feature flag** | Rollout control primitive served by M7. See §2.1.4. |
+| **Graduation** | Converting a concluded experiment into a permanent feature flag. |
+| **GST** | Group Sequential Tests. Alongside mSPRT per ADR-004. |
+| **Guardrail** | A metric + threshold + action (auto-pause or alert-only). See §2.1.3 and ADR-008. |
+| **Holdout** | A long-lived, no-treatment variant maintained across multiple experiments in a layer. |
+| **Interleaving** | Ranking experimentation technique that mixes ranked lists from two systems. Team Draft, Optimized, and Multileave are supported. |
+| **Layer** | A group of mutually exclusive experiments sharing a traffic pool. |
+| **LinUCB** | Contextual bandit algorithm using linear upper confidence bounds. |
+| **MurmurHash3** | The deterministic 32-bit hash used for bucketing. See §2.3. |
+| **Metric** | A numeric quantity computed from the event stream. Six types, see §2.1.3. |
+| **mSPRT** | Mixture Sequential Probability Ratio Test. Always-valid sequential test. |
+| **Multi-armed bandit (MAB)** | A context-free bandit that balances exploration across a small set of arms. |
+| **Multileave** | Multi-system generalization of interleaving. |
+| **Policy** | The bandit's learned decision rule. Served by M4b. |
+| **Proposal / arm selection** | Bandit's choice of arm for a given context. |
+| **QoE event** | Quality of Experience event (startup time, rebuffering, etc.). Ingested via `IngestQoEEvent`. |
+| **Reward event** | Bandit-specific event conveying the realized reward for a previous assignment. Ingested via `IngestRewardEvent`. |
+| **Salt** | The bucketing hash salt. Usually the experiment ID; overridable for bucket reuse. |
+| **Slate bandit** | A bandit that selects an ordered list (slate) of arms — e.g., a homepage ranking. See ADR-016. |
+| **Stakeholder (of a metric)** | Who the metric represents: subscriber, provider, or platform. See `MetricStakeholder` enum. |
+| **Stop condition** | A declarative rule that triggers experiment conclusion when satisfied. |
+| **Switchback** | Time-based alternating assignment for marketplace and two-sided experiments. See ADR-022. |
+| **Synthetic control** | Quasi-experimental method that constructs a weighted combination of untreated units as a counterfactual. See ADR-023. |
+| **Team Draft interleaving** | The simplest interleaving method — draft picks alternate. |
+| **Thompson sampling** | A Bayesian bandit algorithm. |
+| **Trigger event** | A subclass of exposure used when the variant is lazily rendered. See §2.4. |
+| **Variant** | One arm of a classical experiment. See §2.1.1. |
+
+## Next steps
+
+- Continue to [Chapter 3 — Architecture Overview](03-architecture-overview.md) to see how these concepts map onto the seven modules and their ports.
+- If you want to jump straight to integration, the [15-minute quickstart in Chapter 4](04-quickstart.md) uses every concept in this chapter.

--- a/docs/guides/integration/03-architecture-overview.md
+++ b/docs/guides/integration/03-architecture-overview.md
@@ -1,0 +1,235 @@
+# 3. Architecture Overview (Customer-Facing)
+
+> **What you'll learn**
+> - Which Kaizen module you actually talk to for each integration task, and on which port
+> - The data-flow path a single assignment takes, from client through pipeline to result
+> - The supported deployment topologies and what SLAs you can expect from each
+
+Chapter 1 gave you the module names and ports; Chapter 2 gave you the vocabulary. This chapter is the customer-facing map. It tells you which module to call for what, in what order, and what the data path looks like once you've done it.
+
+---
+
+## 3.1 Module map: which module you call for what
+
+Kaizen has seven modules. From the perspective of an external integration, they split cleanly into three groups:
+
+- **Runtime modules** (M1, M2, M7) — you call these from production traffic, at request scale. Latency matters.
+- **Management modules** (M5, M6) — you call these from operator workflows: creating experiments, changing configuration, reading dashboards. Latency matters less, consistency matters more.
+- **Backend modules** (M3, M4a, M4b) — you almost never call these directly. You consume their output through M5/M6 or through M1's bandit delegation.
+
+| Module | Port | Language | You call this when... | Primary RPCs you use |
+| --- | --- | --- | --- | --- |
+| **M1 Assignment** | `50051` | Rust | You need to know which variant a user is in | `GetAssignment`, `GetAssignments`, `GetInterleavedList`, `GetSlateAssignment`, `StreamConfigUpdates` |
+| **M2 Pipeline** | `50052` (ingest), `50058` (orch) | Rust + Go | You need to emit exposure, metric, reward, or QoE events | `IngestExposure`, `IngestExposureBatch`, `IngestMetricEvent`, `IngestMetricEventBatch`, `IngestRewardEvent`, `IngestQoEEvent` |
+| **M3 Metrics** | `50056` | Go | (Rarely direct) triggering metric computation for a window | `ComputeMetrics`, `ComputeGuardrailMetrics`, `ExportNotebook` |
+| **M4a Analysis** | `50053` | Rust | (Rarely direct) requesting a specific analysis; you normally read via M5/M6 | `RunAnalysis`, `GetAnalysisResult`, `GetInterleavingAnalysis`, `GetSwitchbackAnalysis`, `GetSyntheticControlAnalysis` |
+| **M4b Bandit** | `50054` | Rust | (Rarely direct) M1 delegates here for bandit arms; you may call directly for slates | `SelectArm`, `GetSlateAssignment`, `SelectSlate`, `GetPolicySnapshot` |
+| **M5 Management** | `50055` | Go (conditional Rust per ADR-025) | Creating experiments, metrics, layers, and targeting rules; transitioning lifecycle | `CreateExperiment`, `StartExperiment`, `PauseExperiment`, `ConcludeExperiment`, `CreateMetricDefinition`, `CreateLayer`, `StreamConfigUpdates` |
+| **M6 UI** | `3000` | TypeScript (Next.js) | Operator console for humans | HTTP (not gRPC) |
+| **M7 Flags** | `50057` | Go → Rust per ADR-024 | Evaluating a feature flag from your runtime | `EvaluateFlag`, `EvaluateFlags`, `CreateFlag`, `PromoteToExperiment` |
+
+### 3.1.1 M1 Assignment (`:50051`)
+
+M1 is the runtime entry point for variant allocation. It answers the question "which variant does this unit get?" It also handles interleaving (ranking experiments) and delegates to M4b for bandit arm selection when the experiment is a bandit.
+
+When M1 is what you need:
+
+- Your client (Web/iOS/Android) or server-side code needs a variant to render.
+- You are running a classical A/B, A/B/n, multivariate, factorial, interleaving, or bandit experiment.
+- You need a slate assignment for a ranked list (ADR-016).
+
+M1 streams configuration from M5 via `StreamConfigUpdates` so it can make assignment decisions without hitting the database on every request. SDKs subscribe to the same stream and cache locally; Chapter 14 covers what happens when that stream is interrupted.
+
+### 3.1.2 M2 Pipeline (`:50052` / `:50058`)
+
+M2 is the runtime entry point for event ingestion. Port `50052` is the high-throughput ingest path (Rust, with Bloom-filter dedup and schema validation); port `50058` is the orchestration path (Go, for batch operations and control-plane flows).
+
+When M2 is what you need:
+
+- You are emitting `ExposureEvent` after a variant actually rendered.
+- You are emitting `MetricEvent` for your declared metrics.
+- You are emitting `RewardEvent` for bandit experiments.
+- You are emitting `IngestQoEEvent` for quality-of-experience signals.
+
+SDKs batch and retry on your behalf. If you are emitting directly over gRPC, you are responsible for batching — the `*Batch` RPCs (`IngestExposureBatch`, `IngestMetricEventBatch`, `IngestQoEEventBatch`) are the efficient path.
+
+### 3.1.3 M7 Flags (`:50057`)
+
+M7 is the feature flag surface. Flags are separate from experiments; see §2.1.4 in the core concepts for when to use which. M7 is a pure Rust service as of ADR-024.
+
+When M7 is what you need:
+
+- You want a percentage rollout ("ship to 10% of users") without statistical analysis.
+- You want a kill switch you can flip instantly.
+- You are converting a concluded experiment into a permanent rollout.
+
+### 3.1.4 M5 Management (`:50055`) and M6 UI (`:3000`)
+
+M5 is the CRUD surface. M6 is the operator console that renders M5's state for humans. Most integrations use M6 for day-to-day experiment creation and M5's API for CI-driven automation (for example, creating a canary experiment as part of a deploy pipeline).
+
+When M5 is what you need:
+
+- You are creating, updating, starting, pausing, resuming, concluding, or archiving an experiment.
+- You are declaring a metric (`CreateMetricDefinition`) or layer (`CreateLayer`).
+- You are subscribing to config updates from a custom service (`StreamConfigUpdates`).
+
+M6 is the web console; it talks to M5 and to M4a for results rendering. You never need to program against M6 directly.
+
+### 3.1.5 M3, M4a, M4b (backend)
+
+These are the analytical backbone. Customers almost never call them directly:
+
+- **M3 Metrics** computes metrics on Delta Lake via Spark SQL orchestration. You interact with M3 by declaring metric definitions in M5 and then reading computed results through M5/M6.
+- **M4a Analysis** performs all statistical computation in the `experimentation-stats` Rust crate. You read analysis results through M5/M6 or, rarely, directly via `GetAnalysisResult`.
+- **M4b Bandit** runs Thompson, LinUCB, Neural, and slate bandits on an LMAX-style single-threaded core (ADR-002). M1 delegates arm selection here; you only call M4b directly if you need a slate or want to inspect a policy snapshot.
+
+> [!NOTE]
+> The rule from [`CLAUDE.md`](../../../CLAUDE.md) stands without exception: **no statistical computation in Go or TypeScript**. If you find yourself tempted to reimplement a t-test or variance estimator in a language other than Rust, stop and ask instead for an M4a RPC that returns what you need.
+
+---
+
+## 3.2 Data flow: one assignment, end to end
+
+This is the full path a single assignment takes through the platform, from the moment your client asks for a variant to the moment an operator reads the result in M6.
+
+```mermaid
+flowchart TB
+    subgraph Client["Client surface"]
+        C1[App / Web / Server request]
+    end
+
+    subgraph Runtime["Runtime plane"]
+        M1[M1 Assignment :50051]
+        M7[M7 Flags :50057]
+        M2[M2 Pipeline :50052 / :50058]
+    end
+
+    subgraph Data["Data plane"]
+        Kafka[(Kafka)]
+        Delta[(Delta Lake)]
+    end
+
+    subgraph Analytics["Analytical plane"]
+        M3[M3 Metrics :50056]
+        M4a[M4a Analysis :50053]
+        M4b[M4b Bandit :50054]
+    end
+
+    subgraph Management["Management plane"]
+        M5[M5 Management :50055]
+        M6[M6 UI :3000]
+    end
+
+    C1 -->|1. GetAssignment| M1
+    M1 -->|2. SelectArm bandits only| M4b
+    M1 -->|3. return variant| C1
+    C1 -->|4. render variant| C1
+    C1 -->|5. IngestExposure| M2
+
+    M2 -->|6. validate + dedup| Kafka
+    Kafka -->|7. Spark jobs| M3
+    M3 -->|8. write metrics| Delta
+    Delta -->|9. read| M4a
+    M4b -->|policy snapshots| M4a
+
+    M4a -->|10. results| M5
+    M5 -->|11. config stream| M1
+    M5 -->|11. config stream| M7
+    M6 -->|CRUD| M5
+
+    Operator([Operator / PM]) --> M6
+    Operator -->|12. read result| M6
+```
+
+Walking the numbered steps:
+
+1. Your client calls `GetAssignment` on **M1** with the assignment unit ID (user/device/session) and any targeting attributes.
+2. If the experiment is a bandit, M1 calls `SelectArm` on **M4b** to get the chosen arm; otherwise it computes the variant from MurmurHash3 + salt locally.
+3. M1 returns the variant (or bandit arm) to your client.
+4. Your client renders the variant — the user now experiences the treatment.
+5. Your client emits `IngestExposure` to **M2** to record that the variant rendered.
+6. M2 validates the event schema, dedupes via a Bloom filter, and writes to Kafka.
+7. Spark jobs orchestrated by **M3** consume the event streams.
+8. M3 computes metrics and writes them to Delta Lake.
+9. **M4a** reads Delta tables and performs statistical analysis — primary-metric inference, guardrail checks, variance reduction, sequential updates.
+10. M4a returns results to **M5** (and persists them).
+11. **M5** streams configuration to M1 and M7 via `StreamConfigUpdates`, so any operator-driven change (ramping traffic, pausing, concluding) propagates to runtime without a restart.
+12. An operator reads the experiment result in **M6**, which queries M5.
+
+For metric events, the flow is nearly identical — `IngestMetricEvent` replaces `IngestExposure` at step 5. For bandits, `IngestRewardEvent` feeds the policy update loop that M4b runs.
+
+> [!IMPORTANT]
+> Steps 1–5 are all on your request hot path. Steps 6–12 are asynchronous. This is why changing an experiment's configuration takes seconds to propagate (good) but new result data can lag minutes to hours (expected). Chapter 10 covers metric freshness in detail.
+
+---
+
+## 3.3 Deployment topologies
+
+Kaizen supports three deployment shapes. Which you choose determines where the runtime modules run, who operates them, and what latency you can expect.
+
+### 3.3.1 Managed (SaaS)
+
+Kaizen runs the whole platform. You receive a regional endpoint for each module and integrate through SDKs or direct gRPC. This is the default for most customers.
+
+- **Operational responsibility**: Kaizen (we run the control plane and data plane).
+- **Your responsibility**: event emission, identity hygiene, metric definitions, experiment design.
+- **Best for**: most customers. The shortest path from zero to running experiment.
+
+### 3.3.2 Self-hosted
+
+You run every module in your own Kubernetes or Nomad cluster, using our Helm charts and Terraform modules.
+
+- **Operational responsibility**: yours end-to-end.
+- **Your responsibility**: capacity planning, upgrades, incident response, regional failover.
+- **Best for**: data residency requirements that managed cannot satisfy, or customers with very high traffic that wants control over cost tradeoffs.
+
+### 3.3.3 Hybrid (edge assignment + central analytics)
+
+You run **M1 Assignment** and **M7 Flags** at the edge (or in your own cluster) for low-latency assignment, while **M2 Pipeline**, **M3 Metrics**, **M4a Analysis**, **M4b Bandit**, **M5 Management**, and **M6 UI** remain centrally hosted.
+
+- **Operational responsibility**: split. You run the runtime hot path; Kaizen runs the analytical backbone.
+- **Your responsibility**: keeping your M1/M7 instances in sync with the central M5 config stream; ensuring your Kafka/event path can reach the central M2.
+- **Best for**: customers with strict latency SLAs (sub-20ms variant fetch) or who need assignment resilience during central-region incidents.
+
+Edge SDKs (Cloudflare Workers, Fastly Compute@Edge, Akamai EdgeWorkers) use a packaged M1 subset — see Chapter 6.7 once published for the details.
+
+---
+
+## 3.4 SLAs, regions, and latency expectations
+
+Numbers below are the committed SLAs for the Managed deployment. Self-hosted customers inherit the same engineering targets but operate their own SLA.
+
+| Module | p50 latency (same region) | p99 latency (same region) | Availability |
+| --- | --- | --- | --- |
+| M1 Assignment — `GetAssignment` | <5 ms | <20 ms | 99.95% |
+| M1 Assignment — `GetAssignments` (batch) | <8 ms | <30 ms | 99.95% |
+| M7 Flags — `EvaluateFlag` | <3 ms | <15 ms | 99.95% |
+| M2 Pipeline — `IngestExposure` | <10 ms ack | <40 ms ack | 99.9% |
+| M5 Management — `GetExperiment` | <30 ms | <150 ms | 99.9% |
+| M3/M4a — metric & analysis freshness | <10 min | <30 min | 99.5% |
+
+> [!NOTE]
+> Latency numbers assume same-region calls. Cross-region calls inherit network RTT and can easily double the numbers above. Put your runtime callers (M1, M7, M2) in the same region as the Kaizen endpoint you're using.
+
+### Regions
+
+Managed Kaizen is currently deployed in `us-east`, `us-west`, `eu-west`, and `ap-southeast`. Regional pinning for data residency is available on request; see Chapter 15 for the compliance implications.
+
+### Graceful degradation
+
+When a Kaizen runtime module is unreachable, the SDKs fall back as follows. Chapter 14 covers the full disaster-recovery story; the short version:
+
+- **M1 unreachable** → SDK serves the last-known variant from its local cache; if no cache, returns the declared default variant for each experiment. Exposure is *not* emitted — you will have a gap in analysis but not a visible outage.
+- **M7 unreachable** → SDK returns the flag's declared default value. No rollout changes apply until M7 is back.
+- **M2 unreachable** → SDK buffers events locally and retries with exponential backoff. Some loss is possible if the client terminates before recovery.
+- **M5 unreachable** → runtime is unaffected (M1 and M7 have streamed configuration already); only new experiment creation, lifecycle transitions, and console operations stall.
+
+> [!WARNING]
+> The default variant is a load-bearing part of your experiment design. Do not set it to "unassigned" or leave it empty — always set it to a safe, shippable behavior, because it is what users see when Kaizen is degraded.
+
+---
+
+## Next steps
+
+- Continue to [Chapter 4 — Getting Started (Quickstart)](04-quickstart.md) to put this module map to work — the quickstart walks you through calling M5, M1, and M2 in fifteen minutes.
+- If you need to pick an authentication strategy before writing code, skip ahead to [Chapter 5 — Authentication, Authorization, and Tenancy](05-auth-and-tenancy.md).

--- a/docs/guides/integration/README.md
+++ b/docs/guides/integration/README.md
@@ -1,0 +1,115 @@
+# Kaizen Experimentation — Customer Integration Guide
+
+> **What you'll learn**
+> - What this guide is, who it's for, and how to navigate it
+> - Which reading path to pick based on your role
+> - The current authoring status of every chapter
+
+This guide is the end-to-end reference for integrating Kaizen Experimentation into an SVOD (or similar) product surface. It takes you from "zero credentials" to "running a live experiment with trusted analysis," using a single vocabulary and a single set of cross-references across twenty chapters.
+
+The guide is being authored in five waves by specialist agents. Chapters 1–3 and both templates are complete as of Wave 1. Later chapters are currently stubs and link to `Planned` below until the owning wave ships them. If you land on a `Planned` entry, use the outline in [`customer-integration-outline.md`](../customer-integration-outline.md) for what the chapter will cover.
+
+> [!NOTE]
+> Canonical module names and ports used throughout this guide come from the [`CLAUDE.md`](../../../CLAUDE.md) architecture table. If anything in this guide disagrees with `CLAUDE.md`, treat `CLAUDE.md` as the source of truth and file an issue.
+
+---
+
+## 0.1 Reading paths by role
+
+Pick the path that matches how you'll use Kaizen. Each path lists chapters in recommended order; you can always dip into [Chapter 2 — Core Concepts](02-core-concepts.md) when a term is unfamiliar.
+
+### Product Manager — "I want to ship an experiment"
+
+1. [Chapter 1 — Introduction](01-introduction.md)
+2. [Chapter 2 — Core Concepts](02-core-concepts.md)
+3. [Chapter 4 — Getting Started (Quickstart)](04-quickstart.md)
+4. [Chapter 7 — Creating and Managing Experiments](07-experiments.md)
+5. [Chapter 11 — Analysis and Results](11-analysis-and-results.md)
+6. [Chapter 17 — Cookbook](17-cookbook/README.md)
+
+### Client Engineer (iOS / Android / Web) — "I need to fetch variants"
+
+1. [Chapter 2 — Core Concepts](02-core-concepts.md)
+2. [Chapter 3 — Architecture Overview](03-architecture-overview.md)
+3. [Chapter 4 — Getting Started (Quickstart)](04-quickstart.md)
+4. [Chapter 5 — Authentication, Authorization, and Tenancy](05-auth-and-tenancy.md)
+5. Your SDK chapter: [Web](06-sdks/01-web.md), [iOS](06-sdks/02-ios.md), [Android](06-sdks/03-android.md)
+6. [Chapter 8 — Feature Flags](08-feature-flags.md)
+7. [Chapter 18 — Troubleshooting and FAQ](18-troubleshooting-and-faq.md)
+
+### Backend Engineer — "I need to emit exposure + metric events"
+
+1. [Chapter 2 — Core Concepts](02-core-concepts.md)
+2. [Chapter 3 — Architecture Overview](03-architecture-overview.md)
+3. [Chapter 5 — Authentication, Authorization, and Tenancy](05-auth-and-tenancy.md)
+4. Your SDK chapter: [Go](06-sdks/04-go.md), [Python](06-sdks/05-python.md), or [gRPC direct](06-sdks/06-grpc-direct.md)
+5. [Chapter 9 — Event Ingestion](09-event-ingestion.md)
+6. [Chapter 14 — Operational Integration](14-operational-integration.md)
+
+### Data / Analytics Engineer — "I need to pipe my metrics in and read results out"
+
+1. [Chapter 2 — Core Concepts](02-core-concepts.md)
+2. [Chapter 9 — Event Ingestion](09-event-ingestion.md)
+3. [Chapter 10 — Metrics](10-metrics.md)
+4. [Chapter 11 — Analysis and Results](11-analysis-and-results.md)
+5. [Chapter 13 — Advanced Experimental Designs](13-advanced-designs.md)
+6. [Chapter 16 — Reference](16-reference/README.md)
+
+### Platform / DevOps — "I need to deploy or self-host"
+
+1. [Chapter 3 — Architecture Overview](03-architecture-overview.md)
+2. [Chapter 5 — Authentication, Authorization, and Tenancy](05-auth-and-tenancy.md)
+3. [Chapter 14 — Operational Integration](14-operational-integration.md)
+4. [Chapter 15 — Governance, Security, and Compliance](15-governance-security-compliance.md)
+5. [Chapter 19 — Release Notes and Deprecation Policy](19-release-notes-and-deprecation.md)
+6. [Chapter 20 — Appendices](20-appendices/README.md)
+
+---
+
+## Table of contents
+
+| # | Chapter | Status |
+| --- | --- | --- |
+| 0 | [How to use this documentation](#01-reading-paths-by-role) (this page) | `Draft` |
+| 1 | [Introduction](01-introduction.md) | `Draft` |
+| 2 | [Core Concepts](02-core-concepts.md) | `Draft` |
+| 3 | [Architecture Overview](03-architecture-overview.md) | `Draft` |
+| 4 | [Getting Started (15-Minute Quickstart)](04-quickstart.md) | `Planned` |
+| 5 | [Authentication, Authorization, and Tenancy](05-auth-and-tenancy.md) | `Planned` |
+| 6 | SDK Integration Guides | `Planned` |
+| 6.1 | [Web SDK (TypeScript / React)](06-sdks/01-web.md) | `Planned` |
+| 6.2 | [iOS SDK (Swift)](06-sdks/02-ios.md) | `Planned` |
+| 6.3 | [Android SDK (Kotlin)](06-sdks/03-android.md) | `Planned` |
+| 6.4 | [Server-side Go SDK](06-sdks/04-go.md) | `Planned` |
+| 6.5 | [Server-side Python SDK](06-sdks/05-python.md) | `Planned` |
+| 6.6 | [Direct gRPC / Protobuf (no SDK)](06-sdks/06-grpc-direct.md) | `Planned` |
+| 6.7 | [Edge / CDN integration](06-sdks/07-edge.md) | `Planned` |
+| 7 | [Creating and Managing Experiments](07-experiments.md) | `Planned` |
+| 8 | [Feature Flags (M7)](08-feature-flags.md) | `Planned` |
+| 9 | [Event Ingestion (M2 Pipeline)](09-event-ingestion.md) | `Planned` |
+| 10 | [Metrics (M3)](10-metrics.md) | `Planned` |
+| 11 | [Analysis and Results (M4a)](11-analysis-and-results.md) | `Planned` |
+| 12 | [Bandits and Adaptive Experiments (M4b)](12-bandits.md) | `Planned` |
+| 13 | [Advanced Experimental Designs](13-advanced-designs.md) | `Planned` |
+| 14 | [Operational Integration](14-operational-integration.md) | `Planned` |
+| 15 | [Governance, Security, and Compliance](15-governance-security-compliance.md) | `Planned` |
+| 16 | [Reference](16-reference/README.md) | `Planned` |
+| 17 | [Cookbook (Task-Oriented Recipes)](17-cookbook/README.md) | `Planned` |
+| 18 | [Troubleshooting and FAQ](18-troubleshooting-and-faq.md) | `Planned` |
+| 19 | [Release Notes and Deprecation Policy](19-release-notes-and-deprecation.md) | `Planned` |
+| 20 | [Appendices](20-appendices/README.md) | `Planned` |
+
+### Shared templates
+
+| Template | Consumer wave | Purpose |
+| --- | --- | --- |
+| [`templates/sdk-chapter-template.md`](templates/sdk-chapter-template.md) | Wave 2 | Shared skeleton for Chapter 6.1–6.7 |
+| [`templates/feature-chapter-template.md`](templates/feature-chapter-template.md) | Wave 3 | Shared skeleton for Chapter 7–13 |
+
+---
+
+## Next steps
+
+- If this is your first visit, start with [Chapter 1 — Introduction](01-introduction.md).
+- If you already know what Kaizen is, jump to [Chapter 2 — Core Concepts](02-core-concepts.md) to lock in vocabulary.
+- If you're ready to integrate, skip ahead to [Chapter 4 — Getting Started (Quickstart)](04-quickstart.md) once it's published; until then, follow the Client Engineer or Backend Engineer path above.

--- a/docs/guides/integration/templates/feature-chapter-template.md
+++ b/docs/guides/integration/templates/feature-chapter-template.md
@@ -1,0 +1,121 @@
+<!--
+Feature Chapter Template — Wave 3 agents fill this in, one file per feature area.
+
+Usage:
+1. Copy this file to `docs/guides/integration/NN-<slug>.md` (e.g., `07-experiments.md`).
+2. Replace `<FEATURE NAME>` and all placeholder text in the HTML comments below.
+3. Keep ALL section headings in ALL feature chapters identical so the reading experience is
+   uniform across chapters 7–13.
+4. Every claim that depends on a specific proto message, RPC, or ADR must cite the source.
+   If you cannot verify a name in `proto/experimentation/` or `docs/adrs/`, leave a
+   `<!-- TODO(wave-3): verify -->` comment and move on.
+5. Every statistical claim MUST cite the golden-file table in `CLAUDE.md` — the method, the
+   reference package, and the precision. Do not write statistical prose without a citation.
+6. Do NOT remove the "What you'll learn" block at the top or the "Next steps" block at the bottom.
+-->
+
+# N. <FEATURE NAME>
+
+> **What you'll learn**
+> - <bullet 1 — the concept the reader will understand after this chapter>
+> - <bullet 2 — the task the reader will be able to perform>
+> - <bullet 3 — the pitfall the reader will know how to avoid>
+
+## What You'll Learn
+
+<!--
+What goes here: 2–3 paragraphs expanding the bullets above. Frame the chapter in terms of
+the customer's job: what problem they're trying to solve, and what they'll walk away with.
+Avoid marketing voice — this is a developer talking to another developer.
+-->
+
+## Concept
+
+<!--
+What goes here: a concrete, self-contained explanation of the feature. Define every new term,
+but prefer linking to Chapter 2 §2.x over redefining things. If the concept has a model
+(state machine, data flow, lifecycle), include a mermaid diagram.
+-->
+
+## When to Use
+
+<!--
+What goes here: a decision rubric for when this feature is the right tool. Include at least
+one "when NOT to use" paragraph so readers can rule it out quickly. If the feature overlaps
+with another chapter's feature, disambiguate explicitly.
+-->
+
+## API Surface
+
+<!--
+What goes here: a table of the gRPC RPCs relevant to this feature, with the canonical module
+name, the port, the request and response proto messages, and a one-line description of what
+each RPC does. Example row:
+
+| RPC | Module | Port | Request | Response | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| `CreateExperiment` | M5 Management | 50055 | `CreateExperimentRequest` | `Experiment` | Create a new experiment in DRAFT state |
+
+Use the canonical module names and port numbers from CLAUDE.md. Verify every RPC name in
+`proto/experimentation/<module>/v1/*.proto` — do not invent RPCs.
+-->
+
+## Step-by-Step Walkthrough
+
+<!--
+What goes here: a numbered walkthrough of the most common end-to-end workflow. Each step:
+a short "why," a code block (fenced with language identifier and a `// examples/<path>`
+header), and the expected outcome. The walkthrough must run end-to-end against a real
+Kaizen instance — no pseudocode, no handwaving.
+-->
+
+## Proto Reference
+
+<!--
+What goes here: links to every `proto/experimentation/<module>/v1/*.proto` file referenced
+above. Include a brief "field map" table for the top-level request/response messages so
+readers know what they're filling in. Do NOT paste the entire proto — link to it and
+summarize.
+-->
+
+## Cross-Module Dependencies
+
+<!--
+What goes here: which other modules participate in this feature, what RPC flows cross
+module boundaries, and what configuration must be in place in those other modules before
+this feature works. Example: "Experiments rely on M2 for exposure ingestion and M3 for
+metric computation; if either is unavailable, the experiment will start but not produce
+analyzable data." Cross-link to Chapter 3 for the module map.
+-->
+
+## Operational Notes
+
+<!--
+What goes here: quotas, rate limits, capacity guidance, and failure modes specific to this
+feature. Include a "what survives an outage" subsection pointing at Chapter 14. If the
+feature has any irreversible operations (salt rotation, archive, delete), call them out
+in a `> [!WARNING]` admonition.
+-->
+
+## ADR References
+
+<!--
+What goes here: a bulleted list of every ADR that governs this feature's design, with a
+one-line summary of what each ADR says and what it constrains. Use the format:
+
+- [ADR-NNN](../../adrs/NNN-slug.md) — <one-line summary> (constrains: <what it binds>)
+
+Every ADR referenced here must exist in `docs/adrs/`. If a claim depends on an ADR but the
+ADR is still Proposed, say so explicitly.
+-->
+
+## Next steps
+
+<!--
+Replace these placeholders with real links. Every feature chapter must end with a "Next steps"
+block linking to: (a) the logical next chapter in outline order, and (b) at least one
+cookbook recipe that exercises the feature.
+-->
+
+- Continue to [Chapter TBD](../README.md#table-of-contents) for the next logical step.
+- For a runnable recipe that exercises this feature end-to-end, see [Cookbook recipe TBD](../17-cookbook/README.md).

--- a/docs/guides/integration/templates/sdk-chapter-template.md
+++ b/docs/guides/integration/templates/sdk-chapter-template.md
@@ -1,0 +1,125 @@
+<!--
+SDK Chapter Template — Wave 2 agents fill this in, one file per SDK.
+
+Usage:
+1. Copy this file to `docs/guides/integration/06-sdks/0N-<sdk>.md`.
+2. Replace `<SDK NAME>` and all placeholder text.
+3. Keep ALL section headings in ALL files identical so customers can diff SDKs side-by-side.
+4. The HTML comment under each heading is your "what goes here" instruction — delete it
+   once you have written the section.
+5. Every code block must reference a runnable example under `examples/<sdk>/` — create the
+   example file if it does not exist, and cite it with a `// examples/<sdk>/<file>` header comment.
+6. Every API call you mention must correspond to a real RPC. If you cannot verify the RPC name
+   in `proto/experimentation/`, use a `<!-- TODO(wave-2): confirm RPC name -->` comment and move on.
+7. Do NOT remove the "What you'll learn" block at the top or the "Next steps" block at the bottom.
+-->
+
+# 6.N <SDK NAME> SDK
+
+> **What you'll learn**
+> - How to install, configure, and initialize the <SDK NAME> SDK
+> - How to fetch an assignment, emit an exposure, and evaluate a flag from your runtime
+> - How the SDK behaves offline, under load, and during a Kaizen outage
+
+<!--
+Open with 2–3 sentences: who this SDK is for (platform, runtime version), what language idioms
+it follows, and the one "gotcha" unique to this SDK (e.g., "Web has SSR/CSR split;" "iOS has a
+cold-start budget;" "Go relies on context propagation").
+-->
+
+## Install
+
+<!--
+What goes here: the exact installation command for the package registry used by this SDK
+(npm/yarn/pnpm for Web; Swift Package Manager for iOS; Gradle/Maven for Android; `go get`
+for Go; pip/poetry/uv for Python). Include minimum runtime version and any platform-specific
+prerequisites. Cite the actual package path — do not guess.
+-->
+
+## Initialize
+
+<!--
+What goes here: a complete initialization snippet showing how to create the SDK client with
+an API key / service account, set the environment (dev/staging/prod), and configure timeouts.
+Point the reader at `examples/<sdk>/initialize.*` for a runnable version.
+-->
+
+## Fetch Assignment
+
+<!--
+What goes here: how to call GetAssignment (and GetAssignments batch) from this SDK. Show the
+assignment unit being passed correctly per §2.1.2, how to read the returned variant payload,
+and how to deal with experiments the SDK has not cached yet. Reference the actual SDK method
+name verified against `sdks/<sdk>/` source.
+-->
+
+## Emit Exposure
+
+<!--
+What goes here: how to emit an ExposureEvent correctly — at render time, not at assignment
+time (see §2.4). Cover SDK-managed batching, immediate-mode for testing, and the contract
+with M2 Pipeline (port 50052). Show how a trigger-event pattern is expressed in this SDK.
+-->
+
+## Evaluate Flag
+
+<!--
+What goes here: how to call EvaluateFlag / EvaluateFlags against M7 (port 50057), including
+how to pass targeting attributes, how to read the returned typed value (bool/string/JSON/number),
+and how to handle "flag not found" vs. "flag evaluated to default." Reference §2.1.4 for the
+flag-vs-experiment distinction.
+-->
+
+## Handle Offline / Fallback
+
+<!--
+What goes here: the SDK's behavior when M1, M2, or M7 is unreachable. Cover: last-known-variant
+caching, default-variant behavior, local event buffering, retry/backoff schedule, cache TTL,
+and how to disable the cache for testing. Cross-link to Chapter 14 for the full DR story.
+-->
+
+## Shutdown
+
+<!--
+What goes here: how to flush buffered events and close network connections cleanly on process
+exit. Language-specific: e.g., Web `beforeunload`, iOS `applicationWillTerminate`, Android
+lifecycle, Go `defer client.Close()`, Python context manager. Include the timeout semantics —
+how long `Shutdown` will block waiting for pending events.
+-->
+
+## Error Handling
+
+<!--
+What goes here: a table of error categories (NETWORK, CONFIG_STALE, PERMISSION_DENIED, etc.)
+with the recommended customer response. Distinguish errors that mean "retry" from errors that
+mean "fix your config" from errors that mean "ignore and proceed with default." Reference the
+error catalog at `docs/guides/integration/16-reference/error-codes.md` once available.
+-->
+
+## Observability Hooks
+
+<!--
+What goes here: how the SDK emits OpenTelemetry spans, which span names and attributes to
+expect, and how to plug in a custom logger/metrics sink. Show a snippet of what a typical
+trace looks like. Note any cardinality warnings — e.g., do NOT tag spans with user_id.
+-->
+
+## Troubleshooting
+
+<!--
+What goes here: three to five of the most common failure modes customers hit when integrating
+this SDK, each with a symptom, diagnosis, and fix. Typical entries: "I'm getting the default
+variant always," "My exposures aren't showing up in the dashboard," "SDK initialization hangs
+on app launch." Link to Chapter 18 FAQ for broader cross-SDK issues.
+-->
+
+## Next steps
+
+<!--
+Replace these placeholders with real links. Every SDK chapter must end with a "Next steps"
+block linking to: (a) the feature chapter most relevant to this SDK's runtime, and
+(b) the quickstart cookbook recipe that uses this SDK.
+-->
+
+- Continue to [Chapter 7 — Creating and Managing Experiments](../07-experiments.md) to create your first experiment and point this SDK at it.
+- For a runnable end-to-end recipe using this SDK, see [Cookbook recipe TBD](../17-cookbook/README.md).


### PR DESCRIPTION
## Summary

This PR bundles the authoring plan and Wave 1 foundational content for the customer integration guide.

**Authoring plan** (`docs/guides/customer-integration-authoring-plan.md`)
- Five-wave structure: Wave 1 sequential (templates + concept chapters), Waves 2–4 parallel fan-out, Wave 5 editorial pass
- Directory layout under `docs/guides/integration/`, one-file-per-agent-per-wave discipline, worktree isolation for parallel waves
- Quality gates (markdownlint, lychee, cspell, ADR/golden-file citation requirements)

**Wave 1 content** (`docs/guides/integration/`)
- `README.md` — landing page, role-based reading paths, full TOC with per-chapter status badges
- `01-introduction.md` — Chapter 1, platform overview with concept diagram
- `02-core-concepts.md` — Chapter 2, full vocabulary + 40-term glossary (source of truth for later waves)
- `03-architecture-overview.md` — Chapter 3, customer-facing module map with verified RPCs, data-flow diagram, deployment topologies, SLA tables
- `templates/sdk-chapter-template.md` — Wave 2 shared skeleton for §6.1–6.7
- `templates/feature-chapter-template.md` — Wave 3 shared skeleton for §7–13

All ports, module names, and RPC names verified against `CLAUDE.md` and `proto/experimentation/` — no invented identifiers.

## Inconsistencies surfaced by Wave 1 (for module owners)

These don't block Wave 1 but should be confirmed before Waves 2–3 cite them:

1. **M2 port split (50052 vs. 50058)** — `CLAUDE.md` lists them unlabeled. Chapter 3 labels them `ingest` (Rust) and `orch` (Go) inferred from context. *Confirm with Agent-2 before Wave 3 Ch 9 ships.*
2. **M7 runtime state** — `CLAUDE.md` says "Go → Rust (ADR-024)" implying in-flight, but `docs/adrs/README.md` marks ADR-024 Accepted+Implemented. Chapter 3 treats M7 as Rust today. *Confirm with Agent-7 before Wave 2 §6 and Wave 3 Ch 8.*
3. **`PromoteToExperiment` RPC direction** — name suggests flag→experiment, but §2.1.4 of the outline describes the inverse ("graduating experiment → flag"). *Confirm direction (or existence of a sibling RPC) with Agent-5/Agent-7 before Wave 3 Ch 8.*
4. **Web SDK framework scope** — outline says "TypeScript / React" but `sdks/web/package.json` is framework-agnostic with no React dependency. *Wave 2 agent for §6.1 should either scope the chapter to vanilla TS with a React appendix, or confirm a separate React wrapper package exists.*

## Scope

This is the last wave-coordinator-authored PR for some time. Waves 2, 3, and 4 dispatch parallel specialist agents once this merges.

## Test plan

- [ ] Plan (`authoring-plan.md`) reviewed by module owners before Wave 2
- [ ] Wave 1 chapter conventions (§5 of the plan) visible in the three drafted chapters — verify "What you'll learn" opener and "Next steps" closer on each
- [ ] Four inconsistencies above confirmed or corrected before downstream waves cite them
- [ ] CI gates listed in plan §6 wired up before Wave 5 editorial pass
