### PR TITLE
🎨 Palette: Make portfolio table headers keyboard-accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,6 +41,10 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 **Learning:** Interactive table rows that toggle visibility of details must be explicitly marked as buttons and support keyboard navigation. Without `role="button"` and `onKeyDown` handlers for Enter/Space, these features remain "mouse-only" and inaccessible to screen reader or keyboard-only users.
 **Action:** Always add `role="button"`, `tabIndex={0}`, `aria-expanded`, and keyboard handlers to custom interactive containers that lack native button semantics. Use `focus-within` with a ring to provide clear focus indicators.
 
+## 2026-05-21 - Keyboard Accessibility for Sortable Headers
+**Learning:** Table headers used for sorting must be semantic and keyboard-accessible. Moving click handlers from the `<th>` to an internal `<button>` ensures they are in the tab order and provide standard focus indicators.
+**Action:** Always wrap sortable header content in a `<button>` within the `<th>`. Use `aria-sort` on the `<th>` to communicate state, and ensure decorative sort icons are hidden from screen readers.
+
 ## 2026-05-22 - Standardized Search UI Pattern
 **Learning:** Using a consistent visual pattern for search inputs (magnifying glass icon + inset text) creates a predictable experience for users scanning filtered lists. Achieving precise vertical alignment between the absolute-positioned icon and the input text requires consistent vertical padding (e.g., `py-1.5` or `py-2`) depending on the line height.
 **Action:** Always wrap search inputs in a `relative` container with an absolute-positioned magnifying glass SVG. Use `pl-9` to clear the icon and ensure `pointer-events-none` on the icon to avoid interfering with input focus.

--- a/ui/src/__tests__/portfolio-accessibility.test.tsx
+++ b/ui/src/__tests__/portfolio-accessibility.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExperimentPortfolioTable } from '../components/experiment-portfolio-table';
+import { describe, it, expect, vi } from 'vitest';
+import type { PortfolioExperiment } from '../lib/types';
+
+const mockExperiments: PortfolioExperiment[] = [
+  {
+    experimentId: 'exp-1',
+    name: 'Experiment 1',
+    effectSize: 0.1,
+    variance: 0.01,
+    allocatedTrafficPct: 0.5,
+    priorityScore: 0.8,
+    userSegments: ['all'],
+  },
+];
+
+describe('ExperimentPortfolioTable Accessibility', () => {
+  it('renders sortable headers as buttons', () => {
+    render(<ExperimentPortfolioTable experiments={mockExperiments} />);
+
+    const headers = ['Experiment', 'Effect Size', 'Variance', 'Traffic %', 'Priority Score'];
+    headers.forEach(headerText => {
+      const button = screen.getByRole('button', { name: new RegExp(headerText, 'i') });
+      expect(button).toBeDefined();
+    });
+  });
+
+  it('toggles sort on click', () => {
+    render(<ExperimentPortfolioTable experiments={mockExperiments} />);
+
+    const experimentHeader = screen.getByRole('button', { name: /Experiment/i });
+    const th = experimentHeader.closest('th');
+
+    expect(th?.getAttribute('aria-sort')).toBe('none');
+
+    fireEvent.click(experimentHeader);
+    expect(th?.getAttribute('aria-sort')).toBe('descending');
+
+    fireEvent.click(experimentHeader);
+    expect(th?.getAttribute('aria-sort')).toBe('ascending');
+  });
+});

--- a/ui/src/components/experiment-portfolio-table.tsx
+++ b/ui/src/components/experiment-portfolio-table.tsx
@@ -45,20 +45,20 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
   const sorted = sortExperiments(experiments, sortKey, sortDir);
 
   function SortIndicator({ col }: { col: SortKey }) {
-    if (col !== sortKey) return <span className="ml-1 text-gray-300">↕</span>;
+    if (col !== sortKey) return <span className="ml-1 text-gray-300 transition-colors group-hover:text-gray-400" aria-hidden="true">↕</span>;
     return (
-      <span className="ml-1 text-indigo-600" aria-hidden="true">
+      <span className="ml-1 text-indigo-600 font-bold" aria-hidden="true">
         {sortDir === 'asc' ? '↑' : '↓'}
       </span>
     );
   }
 
-  function thProps(col: SortKey, label: string, align: 'left' | 'right' = 'left') {
+  function thProps(col: SortKey, align: 'left' | 'right' = 'left') {
+    const isActive = col === sortKey;
     return {
       scope: 'col' as const,
-      className: `cursor-pointer select-none py-3 text-xs font-medium uppercase tracking-wide text-gray-500 hover:text-gray-700 ${align === 'right' ? 'text-right pr-4' : 'pl-4 pr-3'}`,
-      onClick: () => handleSort(col),
-      'aria-sort': (col === sortKey
+      className: `py-3 text-xs font-medium uppercase tracking-wide text-gray-500 ${align === 'right' ? 'text-right pr-4' : 'pl-4 pr-3'}`,
+      'aria-sort': (isActive
         ? sortDir === 'asc' ? 'ascending' : 'descending'
         : 'none') as React.AriaAttributes['aria-sort'],
     };
@@ -77,20 +77,50 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
       <table className="min-w-full divide-y divide-gray-200">
         <thead className="bg-gray-50">
           <tr>
-            <th {...thProps('name', 'Experiment')}>
-              Experiment <SortIndicator col="name" />
+            <th {...thProps('name')}>
+              <button
+                type="button"
+                onClick={() => handleSort('name')}
+                className="group inline-flex items-center gap-1 rounded-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 hover:text-gray-700"
+              >
+                Experiment <SortIndicator col="name" />
+              </button>
             </th>
-            <th {...thProps('effectSize', 'Effect Size', 'right')}>
-              Effect Size <SortIndicator col="effectSize" />
+            <th {...thProps('effectSize', 'right')}>
+              <button
+                type="button"
+                onClick={() => handleSort('effectSize')}
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 hover:text-gray-700"
+              >
+                Effect Size <SortIndicator col="effectSize" />
+              </button>
             </th>
-            <th {...thProps('variance', 'Variance', 'right')}>
-              Variance <SortIndicator col="variance" />
+            <th {...thProps('variance', 'right')}>
+              <button
+                type="button"
+                onClick={() => handleSort('variance')}
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 hover:text-gray-700"
+              >
+                Variance <SortIndicator col="variance" />
+              </button>
             </th>
-            <th {...thProps('allocatedTrafficPct', 'Traffic %', 'right')}>
-              Traffic % <SortIndicator col="allocatedTrafficPct" />
+            <th {...thProps('allocatedTrafficPct', 'right')}>
+              <button
+                type="button"
+                onClick={() => handleSort('allocatedTrafficPct')}
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 hover:text-gray-700"
+              >
+                Traffic % <SortIndicator col="allocatedTrafficPct" />
+              </button>
             </th>
-            <th {...thProps('priorityScore', 'Priority Score', 'right')}>
-              Priority Score <SortIndicator col="priorityScore" />
+            <th {...thProps('priorityScore', 'right')}>
+              <button
+                type="button"
+                onClick={() => handleSort('priorityScore')}
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 hover:text-gray-700"
+              >
+                Priority Score <SortIndicator col="priorityScore" />
+              </button>
             </th>
             <th scope="col" className="py-3 pr-4 text-right text-xs font-medium uppercase tracking-wide text-gray-500">
               Conflicts


### PR DESCRIPTION
### 🎨 Palette: Make portfolio table headers keyboard-accessible

#### 💡 What:
- Enhanced the `ExperimentPortfolioTable` by converting static, clickable table headers into semantic HTML `<button>` elements.
- Applied standard focus styles (`focus:ring-2 focus:ring-indigo-500`) to provide clear visual affordances for keyboard users.
- Ensured proper use of `aria-sort` on the `<th>` elements to communicate the sort state to assistive technologies.
- Added `aria-hidden="true"` to the decorative sort indicators (`↕`, `↑`, `↓`) to reduce screen reader noise.
- Added a new unit test suite in `ui/src/__tests__/portfolio-accessibility.test.tsx` to ensure ongoing accessibility.

#### 🎯 Why:
- Previously, the portfolio table headers were only interactive via mouse clicks and were not discoverable or usable for keyboard-only or screen reader users. This change aligns the table with modern web accessibility standards.

#### ♿ Accessibility:
- Semantic buttons are now in the tab order.
- `aria-sort` correctly reflects the active sorting column and direction.
- Decorative icons are hidden from screen readers to prevent redundant announcements.

---
*PR created automatically by Jules for task [8975756040306083257](https://jules.google.com/task/8975756040306083257) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
