### PR TITLE
docs: label M2 ports and refresh proto comment for shipped Rust M7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Full-stack SVOD experimentation platform. 7 modules, 3 languages (Rust/Go/TypeSc
 | Module | Language | Owner | Port | Purpose |
 | --- | --- | --- | --- | --- |
 | M1 Assignment | Rust | Agent-1 | 50051 | Variant allocation, interleaving, bandit arm delegation, SDKs |
-| M2 Pipeline | Rust+Go | Agent-2 | 50052/50058 | Event validation/dedup/Kafka (Rust), orchestration (Go) |
+| M2 Pipeline | Rust+Go | Agent-2 | 50052 (ingest) / 50058 (orch) | Event validation/dedup/Kafka (Rust ingest), orchestration (Go) |
 | M3 Metrics | Go | Agent-3 | 50056 | Spark SQL orchestration, metric computation, Delta Lake |
 | M4a Analysis | Rust | Agent-4 | 50053 | All statistical computation (experimentation-stats crate) |
 | M4b Bandit | Rust | Agent-4 | 50054 | Thompson, LinUCB, Neural (Candle), LMAX single-thread core |

--- a/proto/experimentation/flags/v1/flags_service.proto
+++ b/proto/experimentation/flags/v1/flags_service.proto
@@ -6,8 +6,8 @@ import "experimentation/common/v1/experiment.proto";
 
 option go_package = "github.com/org/experimentation/gen/go/flags/v1;flagsv1";
 
-// FeatureFlagService is implemented in Go (M7).
-// Uses experimentation-hash Rust library via CGo for deterministic evaluation
+// FeatureFlagService is implemented in Rust (M7, ADR-024).
+// Uses the experimentation-hash crate directly for deterministic evaluation
 // identical to M1 Assignment Service. No statistical computation.
 service FeatureFlagService {
   rpc CreateFlag(CreateFlagRequest) returns (Flag);


### PR DESCRIPTION
Two small correctness fixes surfaced by Wave 1 of the customer integration guide audit (#449).

## Changes

- **`CLAUDE.md`** — M2 row port column gains explicit labels. Old: `50052/50058`. New: `50052 (ingest) / 50058 (orch)`. Wave 2 §6.6 (gRPC direct producers) and Wave 3 §9 (event ingestion) cite specific ports — without labels they had to infer.
- **`proto/experimentation/flags/v1/flags_service.proto`** — the doc comment on `service FeatureFlagService` was written before ADR-024 shipped. It described an M7 implemented in Go using `experimentation-hash` via CGo. Both `services/flags/` and `crates/experimentation-ffi/` were deleted when ADR-024 landed; the comment now reflects the Rust implementation.

The proto change is **comment-only** — zero schema impact, no consumer migration.

## Source of truth for port labels

| Service | Port | Source |
| --- | --- | --- |
| M2 Pipeline (Rust ingest) | 50052 | `justfile:461` (`PORT=50052` for `m2-pipeline-start`); `justfile:593` (`M2 Pipeline: localhost:50052`) |
| M2 Orchestration (Go) | 50058 | `services/orchestration/cmd/main.go:25` (`port = "50058"`); `justfile:515`; `justfile:594` |

Note: the Rust ingest binary's hardcoded default in `crates/experimentation-pipeline/src/main.rs:90` is `50051`, which collides with M1 Assignment. The justfile masks the bug by overriding to `50052`. Filed as a separate issue (latent collision risk in any deployment that doesn't set `PORT`).

## Test plan

- [x] `git diff` reviewed — both edits are surgical, single-line, comment/label-only
- [x] `buf lint proto/` — no new lint errors introduced (pre-existing duplicate-symbol noise from stale `.claude/worktrees/` directories is unrelated)
- [ ] CI on this PR — workspace build, proto codegen, and downstream Rust/Go consumers should all be unaffected since no symbol changed

## Closes

- Closes #450 (M2 port labeling)
- Closes #451 (M7 Rust port confirmation — CLAUDE.md was already accurate after #446 hook update; this PR completes the proto-comment loose end)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
