### PR TITLE
docs(integration-outline): clarify Web SDK scope and flag↔experiment direction

### DIFF
--- a/docs/guides/customer-integration-outline.md
+++ b/docs/guides/customer-integration-outline.md
@@ -46,7 +46,9 @@
   - 2.1.1 Experiment, Variant, Treatment, Holdout
   - 2.1.2 Assignment Unit (user, device, session, account, household)
   - 2.1.3 Metric, Guardrail, Decision Criterion
-  - 2.1.4 Feature Flag vs. Experiment (and when a flag graduates)
+  - 2.1.4 Feature Flag vs. Experiment
+    - Caller-driven promotion: `PromoteToExperiment` RPC (flag → experiment)
+    - System-driven graduation: M7 reconciler updates the flag once a promoted experiment concludes (experiment → permanent flag state). Not a separate RPC.
 - 2.2 Lifecycle states
   - `draft` → `review` → `running` → `analyzing` → `decided` → `archived`
 - 2.3 Bucketing model
@@ -107,10 +109,14 @@
 
 Each SDK chapter follows the same template: install → initialize → assign → expose → flag → shutdown → troubleshoot.
 
-- 6.1 Web SDK (TypeScript / React)
+- 6.1 Web SDK (TypeScript)
+  - `@experimentation/sdk-web` is framework-agnostic; React is not a dependency.
   - Client-side vs. SSR assignment
   - Hydration safety, flicker mitigation
   - Bundle size and lazy evaluation
+  - Appendix: React integration patterns
+    - Direct gRPC-web (the M6 pattern, via `@connectrpc/connect-web`)
+    - Custom `useExperimentVariant()` hook wrapping `ExperimentClient`
 - 6.2 iOS SDK (Swift)
   - App launch path, cold-start budget
   - Backgrounding, offline queue
@@ -161,7 +167,9 @@ Each SDK chapter follows the same template: install → initialize → assign �
 - 8.3 Percentage rollouts and sticky bucketing
 - 8.4 Targeting rules and rule order
 - 8.5 Kill switches and emergency rollback
-- 8.6 Graduating a flag from experiment to permanent
+- 8.6 Graduating an experiment-backed flag to its permanent state
+  - Triggered automatically by the M7 reconciler when the promoted experiment concludes — no caller-driven `GraduateToFlag` RPC exists.
+  - What the reconciler writes back onto the flag row, and how to observe it.
 - 8.7 Flag hygiene and stale-flag reports
 
 ---


### PR DESCRIPTION
Three precise amendments to `docs/guides/customer-integration-outline.md` driven by verification of the actual code (#452, #453).

## §2.1.4 — Feature Flag vs. Experiment

The previous title was "and when a flag graduates," which conflated two distinct flows. Split into:

- **Caller-driven promotion**: `PromoteToExperiment` RPC (flag → experiment). Confirmed flag→experiment direction in `proto/experimentation/flags/v1/flags_service.proto:20` (request takes `flag_id`, returns `Experiment`); implementation at `crates/experimentation-flags/src/grpc.rs:616+`.
- **System-driven graduation**: the M7 reconciler updates the flag row once a promoted experiment concludes (experiment → permanent flag state). **Not a separate RPC.** Searched the proto tree for `GraduateToFlag`, `PromoteToFlag`, `ConvertToFlag`, `ExperimentToFlag` — zero hits.

## §6.1 — Web SDK title

Renamed `Web SDK (TypeScript / React)` → `Web SDK (TypeScript)`. Added a React-integration appendix bullet.

Evidence the SDK is framework-agnostic:

| Question | Answer | Source |
| --- | --- | --- |
| Package name | `@experimentation/sdk-web` | `sdks/web/package.json` |
| Runtime dependencies | **None** (`"dependencies": {}`) | `sdks/web/package.json` |
| React in `peerDependencies` / `devDependencies`? | No | `sdks/web/package.json` |
| Public API React types? | None — `ExperimentClient`, `AssignmentProvider`, plain TS interfaces | `sdks/web/src/index.ts` |
| Separate `sdk-react` package anywhere? | No — `sdks/` contains only `web/`, `android/`, `ios/`, `server-go/`, `server-python/` | filesystem |
| Does M6 UI consume `@experimentation/sdk-web`? | No — M6 uses `@connectrpc/connect-web` directly | `ui/package.json` |

Calling the chapter "TypeScript / React" implies a wrapper exists. It doesn't, and the production UI proves the vanilla path works for React consumers (M6 just calls gRPC-web directly). The appendix documents both real patterns:

- **Direct gRPC-web** (the M6 pattern, via `@connectrpc/connect-web`).
- **Custom `useExperimentVariant()` hook** wrapping `ExperimentClient` — ~10 lines.

## §8.6 — "Graduating a flag from experiment to permanent"

Reworded the title and added bullets making explicit that graduation is reconciler-driven, not RPC-driven. The asymmetry with `PromoteToExperiment` is intentional per ADR-024 Phase 3.

## Test plan

- [x] `git diff` — outline-only edits, three sections touched
- [x] No code or proto changes — nothing to lint/build
- [ ] CI on this PR (markdown linter + link check, if any)
- [ ] Wave 2 chapter authors (§6.1, §8.6) inherit the corrected scope automatically when this merges

## Closes

- Closes #452 (PromoteToExperiment direction — no rename needed; the outline was the source of confusion, fixed here)
- Closes #453 (Web SDK scope — Option 1 selected: vanilla TS + React appendix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
