### PR TITLE
fix(pipeline): use 50052 as M2 ingest default port (avoid M1 collision)

### DIFF
--- a/crates/experimentation-pipeline/Dockerfile
+++ b/crates/experimentation-pipeline/Dockerfile
@@ -10,5 +10,5 @@ RUN cargo build --release --package experimentation-pipeline
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/experimentation-pipeline /usr/local/bin/service
-EXPOSE 50051
+EXPOSE 50052
 CMD ["service"]

--- a/crates/experimentation-pipeline/src/main.rs
+++ b/crates/experimentation-pipeline/src/main.rs
@@ -23,8 +23,31 @@ use crate::kafka::{EventProducer, KafkaConfig};
 use crate::metrics::PipelineMetrics;
 use crate::service::IngestionServiceImpl;
 
+/// Default gRPC port for the M2 ingest service. Owned by M2 per `CLAUDE.md`.
+/// Must not collide with M1 Assignment (50051).
+const DEFAULT_PORT: &str = "50052";
+
 fn env_or(name: &str, default: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for #460: the M2 Pipeline default port must not collide
+    /// with M1 Assignment, which owns 50051. Per `CLAUDE.md`, the M2 ingest
+    /// service owns 50052. The previous default — `"50051"` — meant any
+    /// deployment that did not explicitly set `PORT` would race M1 for the
+    /// port. Local dev was fine only because `justfile` overrides `PORT=50052`.
+    #[test]
+    fn default_port_does_not_collide_with_m1_assignment() {
+        let port: u16 = DEFAULT_PORT.parse().expect("DEFAULT_PORT must be a valid u16");
+        const M1_ASSIGNMENT_PORT: u16 = 50051;
+        const M2_INGEST_PORT: u16 = 50052;
+        assert_ne!(port, M1_ASSIGNMENT_PORT, "M2 default collides with M1 Assignment");
+        assert_eq!(port, M2_INGEST_PORT, "M2 default must be 50052 per CLAUDE.md");
+    }
 }
 
 /// Serve Prometheus metrics + health check endpoints on a separate HTTP endpoint.
@@ -87,7 +110,7 @@ async fn main() {
     // Tracing: JSON format with thread IDs, file/line numbers, env-filterable
     experimentation_core::telemetry::init_tracing("experimentation-pipeline");
 
-    let port: u16 = env_or("PORT", "50051").parse().expect("PORT must be u16");
+    let port: u16 = env_or("PORT", DEFAULT_PORT).parse().expect("PORT must be u16");
     let metrics_port: u16 = env_or("METRICS_PORT", "9090")
         .parse()
         .expect("METRICS_PORT must be u16");


### PR DESCRIPTION
Closes #460.

## Summary

The M2 Pipeline (Rust ingest) binary defaulted `PORT` to **50051**, which is owned by M1 Assignment per `CLAUDE.md`. Today the collision is invisible because `justfile:461` overrides `PORT=50052` in every shipped path. Any production deployment that ships the Dockerfile without setting `PORT` would race M1 for 50051.

## Changes

### `crates/experimentation-pipeline/src/main.rs`

- Extract the literal into a named constant:
  ```rust
  /// Default gRPC port for the M2 ingest service. Owned by M2 per `CLAUDE.md`.
  /// Must not collide with M1 Assignment (50051).
  const DEFAULT_PORT: &str = "50052";
  ```
- Reference it from `main()`: `env_or("PORT", DEFAULT_PORT)`.
- Add a unit-test under `#[cfg(test)] mod tests` that asserts the default is **not** 50051 and **is** 50052. The test fails loudly if anyone changes the literal back: it's the regression guard for #460.

### `crates/experimentation-pipeline/Dockerfile`

- `EXPOSE 50051` → `EXPOSE 50052`. `EXPOSE` is metadata only (it doesn't bind anything), but the wrong value misleads tooling like docker-compose port mapping, ECS task discovery, and humans reading the Dockerfile.

## TDD trail

1. **RED**: wrote `default_port_does_not_collide_with_m1_assignment` referencing a not-yet-existent `DEFAULT_PORT` → compile error.
2. **RED part 2**: extracted `const DEFAULT_PORT: &str = \"50051\"` (preserving the bug). Test now compiled and failed correctly:
   ```
   thread 'tests::default_port_does_not_collide_with_m1_assignment' panicked at:
     assertion `left != right` failed: M2 default collides with M1 Assignment
       left: 50051
      right: 50051
   ```
3. **GREEN**: changed the constant to `\"50052\"`. Test passes; full crate suite is green.

## Test plan

- [x] `cargo test -p experimentation-pipeline` — 45 unittests in main.rs (incl. the new one), 47 in `m2_m3_event_contract`, 13 of 16 in `m3_m5_guardrail_contract` (3 ignored), 17 of 24 in `reward_consumer_integration` (7 ignored — Kafka integration, by design). 0 failures.
- [x] `cargo check --workspace` — clean.
- [ ] CI on this PR — `cargo test --workspace`, proto, Go services, UI.

## Out of scope

`crates/experimentation-analysis/Dockerfile:13` and `crates/experimentation-policy/Dockerfile:13` also `EXPOSE 50051` despite owning 50053 and 50054 respectively. Same bug class, but different agents (agent-4) and different services. Worth filing as separate issues — not bundling because:

1. Issue #460 was scoped to the M2 pipeline binary specifically.
2. Both are docs-metadata bugs (EXPOSE is non-binding); fixing them in this PR would expand scope past the issue's acceptance criteria.

I can file follow-up issues if you'd like — they're 2-line PRs each.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
