### PR TITLE
🎨 Palette: Standardize navigation and permission gating in Flag UI

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,6 +37,14 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 **Learning:** Even if an audit entry doesn't have "changed values", users still benefit from row expansion to access the Experiment ID and other metadata without leaving the page.
 **Action:** Design tables such that all rows are interactive/expandable if they contain hidden technical identifiers that are useful for developer workflows.
 
+## 2026-06-25 - Standardizing Navigation with Breadcrumbs
+**Learning:** Manual "Back" links are inconsistent and can be brittle. A standardized `Breadcrumb` component provides a predictable navigation path and improves spatial awareness. Adding a `data-testid="back-link"` to the parent item in the breadcrumb trail ensures compatibility with legacy tests while promoting a modern navigation pattern.
+**Action:** Replace manual "Back" links with the `Breadcrumb` component. Ensure the parent item includes the `back-link` test ID for automation.
+
+## 2026-06-26 - Informative Permission Gating
+**Learning:** Hiding primary action buttons (like "New Flag") when a user lacks permissions can be confusing, as it leaves the user wondering why the feature is missing. Showing a disabled button with a descriptive tooltip (e.g., "Requires Experimenter role") provides better affordance and educates the user on RBAC requirements.
+**Action:** Prefer showing a disabled button with an explanatory tooltip over hiding it entirely for permission-gated actions. Ensure defensive checks are in place for the `user` object when generating tooltip messages.
+
 ## 2026-04-15 - Keyboard Accessibility for Expandable Rows
 **Learning:** Interactive table rows that toggle visibility of details must be explicitly marked as buttons and support keyboard navigation. Without `role="button"` and `onKeyDown` handlers for Enter/Space, these features remain "mouse-only" and inaccessible to screen reader or keyboard-only users.
 **Action:** Always add `role="button"`, `tabIndex={0}`, `aria-expanded`, and keyboard handlers to custom interactive containers that lack native button semantics. Use `focus-within` with a ring to provide clear focus indicators.

--- a/ui/src/app/flags/[id]/edit/page.tsx
+++ b/ui/src/app/flags/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import type { Flag, FlagType } from '@/lib/types';
 import { getFlag, updateFlag } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -97,11 +98,11 @@ function EditFlagContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href={`/flags/${flagId}`} className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to {flag.name}
-        </Link>
-      </div>
+      <Breadcrumb items={[
+        { label: 'Flags', href: '/flags' },
+        { label: flag.name, href: `/flags/${flagId}` },
+        { label: 'Edit' },
+      ]} />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Edit Flag</h1>
 

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getFlag, promoteToExperiment } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
 import { CopyButton } from '@/components/copy-button';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -76,11 +77,10 @@ function FlagDetailContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href="/flags" className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to Flags
-        </Link>
-      </div>
+      <Breadcrumb items={[
+        { label: 'Flags', href: '/flags' },
+        { label: flag.name },
+      ]} />
 
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-bold text-gray-900" data-testid="flag-name">{flag.name}</h1>

--- a/ui/src/app/flags/new/page.tsx
+++ b/ui/src/app/flags/new/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import type { FlagType } from '@/lib/types';
 import { createFlag } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -55,11 +56,10 @@ function CreateFlagContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href="/flags" className="text-sm text-indigo-600 hover:text-indigo-800">
-          &larr; Back to Flags
-        </Link>
-      </div>
+      <Breadcrumb items={[
+        { label: 'Flags', href: '/flags' },
+        { label: 'New Flag' },
+      ]} />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Create Feature Flag</h1>
 

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -6,6 +6,7 @@ import type { Flag, FlagType } from '@/lib/types';
 import { listFlags } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { ROLE_LABELS } from '@/lib/auth';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -15,7 +16,7 @@ const FLAG_TYPE_BADGE: Record<FlagType, string> = {
 };
 
 function FlagListContent() {
-  const { canAtLeast } = useAuth();
+  const { canAtLeast, user } = useAuth();
   const [flags, setFlags] = useState<Flag[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -89,7 +90,7 @@ function FlagListContent() {
             {filtered.length}
           </span>
         </div>
-        {canAtLeast('experimenter') && (
+        {canAtLeast('experimenter') ? (
           <Link
             href="/flags/new"
             className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
@@ -97,6 +98,14 @@ function FlagListContent() {
           >
             New Flag
           </Link>
+        ) : (
+          <span
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+            title={`Requires Experimenter role (you are ${user ? ROLE_LABELS[user.role] : 'Unknown'})`}
+            data-testid="new-flag-disabled"
+          >
+            New Flag
+          </span>
         )}
       </div>
 

--- a/ui/src/app/portfolio/page.tsx
+++ b/ui/src/app/portfolio/page.tsx
@@ -7,6 +7,7 @@ import { getPortfolioAllocation, getPortfolioMetrics, getParetoFrontier } from '
 import type { PortfolioAllocationResult, PortfolioMetricsResult, ParetoFrontierResult } from '@/lib/types';
 import { ExperimentPortfolioTable } from '@/components/experiment-portfolio-table';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Code-split: chart bundles loaded only when page renders
 const BudgetAllocationChart = dynamic(
@@ -120,10 +121,7 @@ export default function PortfolioDashboard() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <span className="text-gray-900 font-medium">Portfolio</span>
-      </nav>
+      <Breadcrumb items={[{ label: 'Portfolio' }]} />
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/ui/src/components/breadcrumb.tsx
+++ b/ui/src/components/breadcrumb.tsx
@@ -19,7 +19,11 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
           <li key={item.label} className="flex items-center">
             {index > 0 && <span className="mx-2" aria-hidden="true">/</span>}
             {item.href ? (
-              <Link href={item.href} className="hover:text-indigo-600">
+              <Link
+                href={item.href}
+                className="hover:text-indigo-600"
+                data-testid={index === items.length - 2 ? 'back-link' : undefined}
+              >
                 {item.label}
               </Link>
             ) : (


### PR DESCRIPTION
This change implements several micro-UX improvements focused on consistency and accessibility:

1.  **Standardized Navigation**: Replaced manual "Back" links in Feature Flag pages and the Portfolio Dashboard with the `Breadcrumb` component. This provides a consistent navigation experience across the platform.
2.  **Test Compatibility**: Updated the `Breadcrumb` component to automatically add `data-testid="back-link"` to parent items, ensuring existing integration tests continue to pass.
3.  **Informative Permission Gating**: Instead of hiding the "New Flag" button for users without creation permissions, it now renders in a disabled state with a tooltip explaining the required role. This follows the established pattern in the Experiments list and provides better feedback to users.
4.  **Defensive RBAC Rendering**: Added null-checks when accessing the `user` object for role-based tooltips to prevent potential runtime errors during session transitions.
5.  **UX Documentation**: Added entries to `.Jules/palette.md` regarding breadcrumb standardization and informative permission gating.

Verified with unit tests, linting, and visual inspection using Playwright.

---
*PR created automatically by Jules for task [4693362756692280525](https://jules.google.com/task/4693362756692280525) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
