### PR TITLE
Standardize breadcrumb navigation across the platform

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -65,6 +65,10 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 **Learning:** Promoting a feature flag to an experiment involves a network request and a navigation transition. Providing a loading spinner in the "Promote" button and disabling it during the process prevents duplicate submissions and gives clear feedback to the user.
 **Action:** Always implement a loading state (spinner + disabled state) for primary action buttons that trigger resource promotion or major state transitions outside of modals.
 
+## 2026-05-01 - Standardizing Breadcrumb Navigation
+**Learning:** Manual "Back" links (e.g., "Back to Flags") are inconsistent and don't scale as the application's hierarchy grows. A standardized `Breadcrumb` component provides a predictable spatial map for users, especially when navigating into nested resource edits. Ensuring these breadcrumbs maintain legacy `data-testid="back-link"` support on the parent item prevents breakage of existing navigation tests.
+**Action:** Use the `Breadcrumb` component for all detail and edit pages. Always include the full hierarchy (e.g., Home > Resource > Item > Action) to orient the user.
+
 ## 2026-06-20 - Loading Feedback for Resource Updates
 **Learning:** For forms that update resources (like Edit Flag), providing a loading spinner in the "Save" button is as important as in creation or promotion flows. It signals that the system is processing the update and prevents redundant save attempts during network latency.
 **Action:** Always include an `animate-spin` SVG and a "Saving..." state in the submit button of resource edit forms.

--- a/ui/src/app/flags/[id]/edit/page.tsx
+++ b/ui/src/app/flags/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import type { Flag, FlagType } from '@/lib/types';
 import { getFlag, updateFlag } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -97,11 +98,13 @@ function EditFlagContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href={`/flags/${flagId}`} className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to {flag.name}
-        </Link>
-      </div>
+      <Breadcrumb
+        items={[
+          { label: 'Flags', href: '/flags' },
+          { label: flag.name, href: `/flags/${flagId}` },
+          { label: 'Edit' },
+        ]}
+      />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Edit Flag</h1>
 

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getFlag, promoteToExperiment } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
 import { CopyButton } from '@/components/copy-button';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -76,11 +77,12 @@ function FlagDetailContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href="/flags" className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to Flags
-        </Link>
-      </div>
+      <Breadcrumb
+        items={[
+          { label: 'Flags', href: '/flags' },
+          { label: flag.name },
+        ]}
+      />
 
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-bold text-gray-900" data-testid="flag-name">{flag.name}</h1>

--- a/ui/src/app/portfolio/page.tsx
+++ b/ui/src/app/portfolio/page.tsx
@@ -7,6 +7,7 @@ import { getPortfolioAllocation, getPortfolioMetrics, getParetoFrontier } from '
 import type { PortfolioAllocationResult, PortfolioMetricsResult, ParetoFrontierResult } from '@/lib/types';
 import { ExperimentPortfolioTable } from '@/components/experiment-portfolio-table';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Code-split: chart bundles loaded only when page renders
 const BudgetAllocationChart = dynamic(
@@ -120,10 +121,7 @@ export default function PortfolioDashboard() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <span className="text-gray-900 font-medium">Portfolio</span>
-      </nav>
+      <Breadcrumb items={[{ label: 'Portfolio' }]} />
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/ui/src/app/portfolio/provider-health/page.tsx
+++ b/ui/src/app/portfolio/provider-health/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { getProviderHealth } from '@/lib/api';
 import type { ProviderHealthResult, ProviderHealthSeries } from '@/lib/types';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Code-split: chart bundle loaded only when page is rendered
 const CatalogCoverageChart = dynamic(
@@ -97,12 +98,12 @@ export default function ProviderHealthPage() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <Link href="/portfolio" className="hover:text-gray-700">Portfolio</Link>
-        <span aria-hidden="true">/</span>
-        <span className="text-gray-900 font-medium">Provider Health</span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: 'Portfolio', href: '/portfolio' },
+          { label: 'Provider Health' },
+        ]}
+      />
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/ui/src/components/breadcrumb.tsx
+++ b/ui/src/components/breadcrumb.tsx
@@ -19,7 +19,11 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
           <li key={item.label} className="flex items-center">
             {index > 0 && <span className="mx-2" aria-hidden="true">/</span>}
             {item.href ? (
-              <Link href={item.href} className="hover:text-indigo-600">
+              <Link
+                href={item.href}
+                className="hover:text-indigo-600"
+                data-testid={index === items.length - 2 ? 'back-link' : undefined}
+              >
                 {item.label}
               </Link>
             ) : (


### PR DESCRIPTION
Standardized breadcrumb navigation across Feature Flags and Portfolio pages using the `Breadcrumb` component, ensuring legacy test compatibility and improved user orientation.

---
*PR created automatically by Jules for task [15000612382531229962](https://jules.google.com/task/15000612382531229962) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
