### PR TITLE
🎨 Palette: Standardize navigation with Breadcrumb component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -61,6 +61,10 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 **Learning:** Consistency in search UI (icon positioning and padding) and actionable empty states (CTAs and clear-filters) significantly reduces user friction when navigating large datasets like feature flags or audit logs. Decorative icons should always be hidden from screen readers using `aria-hidden="true"`.
 **Action:** Apply the `relative` container with `pl-9` padding and `aria-hidden` SVG pattern to all search inputs. Always provide a way to reset filters in empty result states.
 
+## 2026-06-25 - Safe Breadcrumb Refactoring
+**Learning:** Standardizing the `Breadcrumb` component to automatically include a `data-testid="back-link"` for the parent link allows for a clean migration from manual "Back" links without breaking legacy tests that depend on that specific identifier for navigation verification.
+**Action:** When migrating to shared navigation components, bake in support for legacy test identifiers to maintain CI stability while improving UX consistency.
+
 ## 2026-04-20 - Loading State for Feature Flag Promotion
 **Learning:** Promoting a feature flag to an experiment involves a network request and a navigation transition. Providing a loading spinner in the "Promote" button and disabling it during the process prevents duplicate submissions and gives clear feedback to the user.
 **Action:** Always implement a loading state (spinner + disabled state) for primary action buttons that trigger resource promotion or major state transitions outside of modals.

--- a/ui/src/app/flags/[id]/edit/page.tsx
+++ b/ui/src/app/flags/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import type { Flag, FlagType } from '@/lib/types';
 import { getFlag, updateFlag } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -97,11 +98,13 @@ function EditFlagContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href={`/flags/${flagId}`} className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to {flag.name}
-        </Link>
-      </div>
+      <Breadcrumb
+        items={[
+          { label: 'Flags', href: '/flags' },
+          { label: flag.name, href: `/flags/${flagId}` },
+          { label: 'Edit' },
+        ]}
+      />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Edit Flag</h1>
 

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getFlag, promoteToExperiment } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
 import { CopyButton } from '@/components/copy-button';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -76,11 +77,12 @@ function FlagDetailContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href="/flags" className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to Flags
-        </Link>
-      </div>
+      <Breadcrumb
+        items={[
+          { label: 'Flags', href: '/flags' },
+          { label: flag.name },
+        ]}
+      />
 
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-bold text-gray-900" data-testid="flag-name">{flag.name}</h1>

--- a/ui/src/app/flags/new/page.tsx
+++ b/ui/src/app/flags/new/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import type { FlagType } from '@/lib/types';
 import { createFlag } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -55,11 +56,12 @@ function CreateFlagContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href="/flags" className="text-sm text-indigo-600 hover:text-indigo-800">
-          &larr; Back to Flags
-        </Link>
-      </div>
+      <Breadcrumb
+        items={[
+          { label: 'Flags', href: '/flags' },
+          { label: 'New Flag' },
+        ]}
+      />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Create Feature Flag</h1>
 

--- a/ui/src/app/portfolio/page.tsx
+++ b/ui/src/app/portfolio/page.tsx
@@ -7,6 +7,7 @@ import { getPortfolioAllocation, getPortfolioMetrics, getParetoFrontier } from '
 import type { PortfolioAllocationResult, PortfolioMetricsResult, ParetoFrontierResult } from '@/lib/types';
 import { ExperimentPortfolioTable } from '@/components/experiment-portfolio-table';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Code-split: chart bundles loaded only when page renders
 const BudgetAllocationChart = dynamic(
@@ -120,10 +121,7 @@ export default function PortfolioDashboard() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <span className="text-gray-900 font-medium">Portfolio</span>
-      </nav>
+      <Breadcrumb items={[{ label: 'Portfolio' }]} />
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/ui/src/app/portfolio/provider-health/page.tsx
+++ b/ui/src/app/portfolio/provider-health/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { getProviderHealth } from '@/lib/api';
 import type { ProviderHealthResult, ProviderHealthSeries } from '@/lib/types';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Code-split: chart bundle loaded only when page is rendered
 const CatalogCoverageChart = dynamic(
@@ -97,12 +98,12 @@ export default function ProviderHealthPage() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <Link href="/portfolio" className="hover:text-gray-700">Portfolio</Link>
-        <span aria-hidden="true">/</span>
-        <span className="text-gray-900 font-medium">Provider Health</span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: 'Portfolio', href: '/portfolio' },
+          { label: 'Provider Health' },
+        ]}
+      />
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/ui/src/components/breadcrumb.tsx
+++ b/ui/src/components/breadcrumb.tsx
@@ -19,7 +19,11 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
           <li key={item.label} className="flex items-center">
             {index > 0 && <span className="mx-2" aria-hidden="true">/</span>}
             {item.href ? (
-              <Link href={item.href} className="hover:text-indigo-600">
+              <Link
+                href={item.href}
+                className="hover:text-indigo-600"
+                data-testid={index === items.length - 2 ? 'back-link' : undefined}
+              >
                 {item.label}
               </Link>
             ) : (


### PR DESCRIPTION
I have standardized the application's navigation by refactoring manual "Back" links and inconsistent breadcrumb patterns into a unified `Breadcrumb` component. 

Key changes:
- Updated `ui/src/components/breadcrumb.tsx` to automatically apply `data-testid="back-link"` to the parent link, ensuring existing automated tests continue to function.
- Migrated the Feature Flags section (`[id]`, `[id]/edit`, `new`) to use the standard Breadcrumb hierarchy.
- Migrated the Portfolio section (`page.tsx`, `provider-health`) to use the Breadcrumb component.
- Verified that all changes pass existing tests and look correct via Playwright visual verification.
- Ensured no build artifacts or logs are included in the submission.

---
*PR created automatically by Jules for task [14328467541016959868](https://jules.google.com/task/14328467541016959868) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->