### PR TITLE
🎨 Palette: Standardize navigation with Breadcrumbs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -68,3 +68,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-06-20 - Loading Feedback for Resource Updates
 **Learning:** For forms that update resources (like Edit Flag), providing a loading spinner in the "Save" button is as important as in creation or promotion flows. It signals that the system is processing the update and prevents redundant save attempts during network latency.
 **Action:** Always include an `animate-spin` SVG and a "Saving..." state in the submit button of resource edit forms.
+
+## 2026-05-26 - Breadcrumb Navigation and Test Compatibility
+**Learning:** Standardizing navigation to a `Breadcrumb` component provides better spatial awareness and a consistent UI across the platform. However, legacy tests often rely on specific `data-testid="back-link"` identifiers on manual navigation links. Conditionally applying this identifier to the penultimate breadcrumb item (the one leading "back") allows for modernization without breaking existing automation.
+**Action:** Use the `Breadcrumb` component for navigation in detail and form pages. Apply `data-testid="back-link"` to the breadcrumb item at `index === items.length - 2` to maintain compatibility with legacy back-navigation tests.

--- a/ui/src/app/flags/[id]/edit/page.tsx
+++ b/ui/src/app/flags/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import type { Flag, FlagType } from '@/lib/types';
 import { getFlag, updateFlag } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -97,11 +98,12 @@ function EditFlagContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href={`/flags/${flagId}`} className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to {flag.name}
-        </Link>
-      </div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Flags', href: '/flags' },
+        { label: flag.name, href: `/flags/${flagId}` },
+        { label: 'Edit' },
+      ]} />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Edit Flag</h1>
 

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -8,6 +8,7 @@ import { getFlag, promoteToExperiment } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
 import { CopyButton } from '@/components/copy-button';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -76,11 +77,11 @@ function FlagDetailContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href="/flags" className="text-sm text-indigo-600 hover:text-indigo-800" data-testid="back-link">
-          &larr; Back to Flags
-        </Link>
-      </div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Flags', href: '/flags' },
+        { label: flag.name },
+      ]} />
 
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-bold text-gray-900" data-testid="flag-name">{flag.name}</h1>

--- a/ui/src/app/flags/new/page.tsx
+++ b/ui/src/app/flags/new/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import type { FlagType } from '@/lib/types';
 import { createFlag } from '@/lib/api';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
 
@@ -55,11 +56,11 @@ function CreateFlagContent() {
 
   return (
     <div>
-      <div className="mb-2">
-        <Link href="/flags" className="text-sm text-indigo-600 hover:text-indigo-800">
-          &larr; Back to Flags
-        </Link>
-      </div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Flags', href: '/flags' },
+        { label: 'New' },
+      ]} />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Create Feature Flag</h1>
 

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -6,6 +6,7 @@ import type { Flag, FlagType } from '@/lib/types';
 import { listFlags } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -61,27 +62,10 @@ function FlagListContent() {
     return <RetryableError message={error} onRetry={fetchData} context="feature flags" />;
   }
 
-  if (flags.length === 0) {
-    return (
-      <div className="py-12 text-center" data-testid="empty-state">
-        <p className="text-sm text-gray-500">No feature flags found.</p>
-        {canAtLeast('experimenter') && (
-          <div className="mt-6">
-            <Link
-              href="/flags/new"
-              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-              data-testid="create-first-flag"
-            >
-              Create your first feature flag
-            </Link>
-          </div>
-        )}
-      </div>
-    );
-  }
-
   return (
     <div>
+      <Breadcrumb items={[{ label: 'Experiments', href: '/' }, { label: 'Flags' }]} />
+
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-gray-900">Feature Flags</h1>
@@ -100,93 +84,112 @@ function FlagListContent() {
         )}
       </div>
 
-      <div className="mb-4 flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 min-w-[300px] max-w-md">
-          <svg
-            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <input
-            type="text"
-            placeholder="Search by name or description..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-3 text-sm shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-            data-testid="flag-search"
-            aria-label="Search flags"
-          />
-        </div>
-        {search && (
-          <button
-            onClick={() => setSearch('')}
-            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
-            data-testid="clear-search-toolbar"
-          >
-            Clear filters
-          </button>
-        )}
-      </div>
-
-      {filtered.length === 0 ? (
-        <div className="py-12 text-center" data-testid="no-filter-matches">
-          <p className="text-sm text-gray-500">No flags match your search.</p>
-          <button
-            onClick={() => setSearch('')}
-            className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
-          >
-            Clear filters
-          </button>
+      {flags.length === 0 ? (
+        <div className="py-12 text-center" data-testid="empty-state">
+          <p className="text-sm text-gray-500">No feature flags found.</p>
+          {canAtLeast('experimenter') && (
+            <div className="mt-6">
+              <Link
+                href="/flags/new"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                data-testid="create-first-flag"
+              >
+                Create your first feature flag
+              </Link>
+            </div>
+          )}
         </div>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Default</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Enabled</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Rollout %</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Variants</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {filtered.map((f) => (
-                <tr key={f.flagId} className="hover:bg-gray-50" data-testid={`flag-row-${f.flagId}`}>
-                  <td className="px-4 py-3">
-                    <Link href={`/flags/${f.flagId}`} className="font-medium text-indigo-600 hover:text-indigo-800">
-                      {f.name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${FLAG_TYPE_BADGE[f.type] || 'bg-gray-100 text-gray-800'}`}>
-                      {f.type}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600">
-                    <code className="text-xs">{f.defaultValue}</code>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${f.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
-                      {f.enabled ? 'On' : 'Off'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600">
-                    {(f.rolloutPercentage * 100).toFixed(0)}%
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600">
-                    {f.variants.length}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <>
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <div className="relative flex-1 min-w-[300px] max-w-md">
+              <svg
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                type="text"
+                placeholder="Search by name or description..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-3 text-sm shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                data-testid="flag-search"
+                aria-label="Search flags"
+              />
+            </div>
+            {search && (
+              <button
+                onClick={() => setSearch('')}
+                className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+                data-testid="clear-search-toolbar"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
+
+          {filtered.length === 0 ? (
+            <div className="py-12 text-center" data-testid="no-filter-matches">
+              <p className="text-sm text-gray-500">No flags match your search.</p>
+              <button
+                onClick={() => setSearch('')}
+                className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+              >
+                Clear filters
+              </button>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Default</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Enabled</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Rollout %</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Variants</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {filtered.map((f) => (
+                    <tr key={f.flagId} className="hover:bg-gray-50" data-testid={`flag-row-${f.flagId}`}>
+                      <td className="px-4 py-3">
+                        <Link href={`/flags/${f.flagId}`} className="font-medium text-indigo-600 hover:text-indigo-800">
+                          {f.name}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${FLAG_TYPE_BADGE[f.type] || 'bg-gray-100 text-gray-800'}`}>
+                          {f.type}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">
+                        <code className="text-xs">{f.defaultValue}</code>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${f.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
+                          {f.enabled ? 'On' : 'Off'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">
+                        {(f.rolloutPercentage * 100).toFixed(0)}%
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">
+                        {f.variants.length}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/ui/src/components/breadcrumb.tsx
+++ b/ui/src/components/breadcrumb.tsx
@@ -19,7 +19,11 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
           <li key={item.label} className="flex items-center">
             {index > 0 && <span className="mx-2" aria-hidden="true">/</span>}
             {item.href ? (
-              <Link href={item.href} className="hover:text-indigo-600">
+              <Link
+                href={item.href}
+                className="hover:text-indigo-600"
+                data-testid={index === items.length - 2 ? 'back-link' : undefined}
+              >
                 {item.label}
               </Link>
             ) : (


### PR DESCRIPTION
This PR standardizes navigation within the Feature Flags section by replacing manual "Back to..." links with a more descriptive and functional `Breadcrumb` component. This improvement enhances spatial awareness for users while maintaining compatibility with legacy tests.

Key Changes:
- **`Breadcrumb` Component**: Added a conditional `data-testid="back-link"` to the penultimate item to ensure existing automation tests continue to function.
- **Feature Flags List**: Added breadcrumbs and ensured the page heading and count badge remain visible in empty states, preventing layout shifts and providing a consistent entry point.
- **Detail & Form Pages**: Replaced manual navigation buttons in `[id]/page.tsx`, `new/page.tsx`, and `[id]/edit/page.tsx` with semantic breadcrumbs.
- **Journal Update**: Documented the pattern for balancing modern navigation components with legacy test requirements in `.Jules/palette.md`.

♿ Accessibility:
- Semantic `<nav>` and `<ol>` structure for breadcrumbs.
- `aria-current="page"` used for the active route.
- Improved hierarchy and navigation flow for screen readers and keyboard users.

---
*PR created automatically by Jules for task [8501851800248269070](https://jules.google.com/task/8501851800248269070) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->