### PR TITLE
feat(metrics): ADR-026 Phase 1 — FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT

### DIFF
--- a/docs/superpowers/plans/2026-05-05-adr-026-phase1.md
+++ b/docs/superpowers/plans/2026-05-05-adr-026-phase1.md
@@ -1,0 +1,1233 @@
+# ADR-026 Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue [#432](https://github.com/wunderkennd/kaizen-experimentation/issues/432) — three new structured `MetricType` values (`FILTERED_MEAN`, `COMPOSITE`, `WINDOWED_COUNT`) with proto schema, M3 SQL templates, renderer plumbing, and golden-file tests.
+
+**Architecture:** Follow the approved design at `docs/superpowers/specs/2026-05-04-adr-026-phase1-design.md` — hybrid `oneof type_config` on `MetricDefinition` (Option C). Existing flat type-config fields untouched. Three new templates use custom CTEs where the existing `exposure_join` template doesn't fit. Renderer's `RenderForType` switch gains three new arms with positive-allow-list operator validation, per-operand `metric_id` checks, and a WEIGHTED_SUM `weight > 0` guard.
+
+**Tech Stack:** Protobuf 3, `buf` (lint + breaking-change validation + codegen), Go 1.22+, Go `text/template`, `github.com/stretchr/testify` for assertions.
+
+**Worktree:** `.claude/worktrees/adr-026-phase1-impl/` on branch `agent-3/feat/adr-026-phase1` (off `origin/main` which contains the merged spec).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `proto/experimentation/common/v1/metric.proto` | Modify | Add 3 enum values, oneof, 4 messages, 1 enum |
+| `services/metrics/internal/spark/templates/filtered_mean.sql.tmpl` | Create | Render FILTERED_MEAN metrics to Spark SQL |
+| `services/metrics/internal/spark/templates/composite.sql.tmpl` | Create | Render COMPOSITE metrics — read operand values, pivot, apply operator |
+| `services/metrics/internal/spark/templates/windowed_count.sql.tmpl` | Create | Render WINDOWED_COUNT metrics with time-window predicate |
+| `services/metrics/internal/spark/renderer.go` | Modify | TemplateParams extension, OperandParam, `last` helper, 3 Render methods, 3 RenderForType arms |
+| `services/metrics/internal/spark/renderer_test.go` | Modify | Tests for the 3 new Render methods + RenderForType extension |
+| `services/metrics/testdata/golden/filtered_mean_*.sql` | Create | 3 golden files (simple / multi-clause / value-column-filter) |
+| `services/metrics/testdata/golden/composite_*.sql` | Create | 6 golden files (5 operators + WEIGHTED_SUM non-uniform) |
+| `services/metrics/testdata/golden/windowed_count_*.sql` | Create | 4 golden files (with-filter / no-filter / 1h / 168h) |
+
+Total: 1 modified proto, 3 new templates, 1 modified renderer, 1 modified test file, 13 new goldens.
+
+---
+
+## Task 1: Proto schema additions
+
+**Files:**
+- Modify: `proto/experimentation/common/v1/metric.proto`
+
+The proto edit is atomic — three enum values, the oneof, and the new messages all land in one commit since they reference each other. After the edit, regenerate bindings and verify nothing else compiles broken.
+
+- [ ] **Step 1.1: Add three new `MetricType` enum values**
+
+Append the new values to the existing `MetricType` enum (after `METRIC_TYPE_CUSTOM = 6;`):
+
+```proto
+enum MetricType {
+  // ... existing 0..6 unchanged ...
+  // Mean of `value_column` over rows matching a Spark SQL filter (ADR-026 Phase 1).
+  METRIC_TYPE_FILTERED_MEAN  = 7;
+  // Composition of other metrics via arithmetic operator (ADR-026 Phase 1).
+  METRIC_TYPE_COMPOSITE      = 8;
+  // Count of an event type within a time window after first exposure (ADR-026 Phase 1).
+  METRIC_TYPE_WINDOWED_COUNT = 9;
+}
+```
+
+- [ ] **Step 1.2: Add the `oneof type_config` and per-type config messages**
+
+Add to the end of `MetricDefinition` (after field 16):
+
+```proto
+message MetricDefinition {
+  // ... existing 1..16 unchanged ...
+
+  // Per-type config for new types (ADR-026 Phase 1). Existing types continue
+  // to use their flat sibling fields; a future ADR may consolidate them here.
+  oneof type_config {
+    FilteredMeanConfig   filtered_mean   = 17;
+    CompositeConfig      composite       = 18;
+    WindowedCountConfig  windowed_count  = 19;
+  }
+}
+```
+
+Add the three new config messages and operator enum at the end of the file:
+
+```proto
+// FilteredMeanConfig — config for METRIC_TYPE_FILTERED_MEAN. The metric is the
+// AVG of `value_column` over rows whose `event_type` matches
+// MetricDefinition.source_event_type AND that pass `filter_sql`.
+message FilteredMeanConfig {
+  // Spark SQL fragment AND'd into the scan WHERE clause.
+  // Validated in M5 (#433): column allowlist + parse check.
+  // Example: "platform = 'mobile' AND duration_ms > 5000"
+  string filter_sql = 1;
+
+  // Column from source_event_type to AVG over.
+  // Example: "duration_ms"
+  string value_column = 2;
+}
+
+// CompositeConfig — config for METRIC_TYPE_COMPOSITE. The metric is computed
+// from per-user values of other (already-computed) metrics via the operator.
+message CompositeConfig {
+  // Operands referenced by metric_id. Cycle detection lives in M5 (#433).
+  repeated CompositeOperand operands = 1;
+  CompositeOperator         operator = 2;
+}
+
+message CompositeOperand {
+  string metric_id = 1;
+  // Coefficient. Required for WEIGHTED_SUM (must be > 0); ignored for other operators.
+  // Note: proto3 has no custom default mechanism for scalar fields — `double`
+  // unset deserialises to 0.0, not 1.0. WEIGHTED_SUM operands must therefore
+  // set `weight` explicitly; M5 (#433) and the renderer reject `weight <= 0`
+  // when operator = WEIGHTED_SUM.
+  double weight = 2;
+}
+
+enum CompositeOperator {
+  COMPOSITE_OPERATOR_UNSPECIFIED  = 0;
+  COMPOSITE_OPERATOR_ADD          = 1;
+  COMPOSITE_OPERATOR_SUBTRACT     = 2;
+  COMPOSITE_OPERATOR_MULTIPLY     = 3;
+  COMPOSITE_OPERATOR_DIVIDE       = 4;
+  COMPOSITE_OPERATOR_WEIGHTED_SUM = 5;
+}
+
+// WindowedCountConfig — config for METRIC_TYPE_WINDOWED_COUNT. The metric is
+// COUNT of events of `event_type` whose `event_timestamp` falls within
+// [exposure_ts, exposure_ts + window_hours) for each exposed user.
+message WindowedCountConfig {
+  // Event type to count. Validated against the event catalog in M5 (#433).
+  string event_type = 1;
+
+  // Optional Spark SQL fragment AND'd into the scan WHERE clause.
+  string filter_sql = 2;
+
+  // Time window relative to the user's first exposure (hours).
+  int32 window_hours = 3;
+}
+```
+
+- [ ] **Step 1.3: Run `buf lint`**
+
+Run: `buf lint proto/`
+Expected: no output (clean exit code 0).
+
+- [ ] **Step 1.4: Run `buf breaking`**
+
+Run: `buf breaking proto/ --against .git#branch=main`
+Expected: clean. Only additions; no field renumbering, no removed fields.
+
+- [ ] **Step 1.5: Regenerate bindings**
+
+Run: `just proto-gen` (or whatever the project convention is — check `justfile` for the canonical command).
+Expected: `gen/go/common/v1/metric.pb.go` (and Rust bindings) updated; no errors.
+
+- [ ] **Step 1.6: Verify workspace still compiles**
+
+Run: `cargo check --workspace`
+Expected: clean.
+
+Run: `go build ./services/metrics/...`
+Expected: clean.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add proto/experimentation/common/v1/metric.proto gen/
+git commit -m "feat(proto): ADR-026 Phase 1 — add FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT types
+
+Adds three new structured MetricType values via a hybrid oneof on
+MetricDefinition (Option C from spec). Existing types untouched.
+
+- METRIC_TYPE_FILTERED_MEAN (7) — AVG over filtered scan
+- METRIC_TYPE_COMPOSITE (8) — arithmetic on other metrics
+- METRIC_TYPE_WINDOWED_COUNT (9) — count within time window
+- New messages: FilteredMeanConfig, CompositeConfig, CompositeOperand,
+  WindowedCountConfig
+- New enum: CompositeOperator (5 operators + UNSPECIFIED)
+- New oneof type_config { ... } at fields 17-19 on MetricDefinition
+
+Wire-compatible: only additions, buf breaking passes.
+
+Refs #432"
+```
+
+---
+
+## Task 2: Renderer scaffolding
+
+**Files:**
+- Modify: `services/metrics/internal/spark/renderer.go`
+
+Add the new TemplateParams fields, the OperandParam type, the `last` template helper, and stub `Render*` methods. This task does NOT add the templates themselves nor the `RenderForType` arms — those land in subsequent tasks. After this task, `go build` is clean and tests still pass (no new tests yet).
+
+- [ ] **Step 2.1: Add `OperandParam` struct and extend `TemplateParams`**
+
+In `services/metrics/internal/spark/renderer.go`, after the existing `TemplateParams` struct definition, append the new fields and add `OperandParam`:
+
+```go
+type TemplateParams struct {
+    // ... existing fields unchanged ...
+
+    // ADR-026 Phase 1 — FILTERED_MEAN
+    FilterSQL   string // Spark SQL fragment AND'd into the scan WHERE clause
+    ValueColumn string // bare identifier (M5-validated against allowlist) — column to AVG
+
+    // ADR-026 Phase 1 — COMPOSITE
+    Operands []OperandParam
+    Operator string // uppercase: ADD, SUBTRACT, MULTIPLY, DIVIDE, WEIGHTED_SUM
+
+    // ADR-026 Phase 1 — WINDOWED_COUNT
+    EventType   string // counted event type (named distinctly from SourceEventType)
+    WindowHours int32  // time window after first exposure
+}
+
+// OperandParam represents one operand of a COMPOSITE metric.
+// Weight is meaningful only for WEIGHTED_SUM; ignored otherwise.
+type OperandParam struct {
+    MetricID string
+    Weight   float64
+}
+```
+
+Note: `FilterSQL` is shared between FILTERED_MEAN and WINDOWED_COUNT. They use the same field on TemplateParams to avoid duplication.
+
+- [ ] **Step 2.2: Register the `last` template helper**
+
+In the renderer constructor (the function that calls `template.New(...).ParseFS(...)`), register the `last` FuncMap helper before parsing:
+
+```go
+funcMap := template.FuncMap{
+    "last": func(i int, slice []OperandParam) bool {
+        return i == len(slice)-1
+    },
+}
+tmpl, err := template.New("spark").Funcs(funcMap).ParseFS(templateFS, "templates/*.sql.tmpl")
+```
+
+If a `FuncMap` is already registered (for other helpers), add `last` to the existing map rather than creating a new one.
+
+- [ ] **Step 2.3: Add stub `Render*` methods**
+
+Add three new methods after the existing `RenderRatio` etc.:
+
+```go
+func (r *SQLRenderer) RenderFilteredMean(p TemplateParams) (string, error) {
+    return r.Render("filtered_mean.sql.tmpl", p)
+}
+
+func (r *SQLRenderer) RenderComposite(p TemplateParams) (string, error) {
+    return r.Render("composite.sql.tmpl", p)
+}
+
+func (r *SQLRenderer) RenderWindowedCount(p TemplateParams) (string, error) {
+    return r.Render("windowed_count.sql.tmpl", p)
+}
+```
+
+These stubs reference template files that don't exist yet — that's fine, the failure surfaces at runtime (Task 3+), not build time. The methods exist so the test files compile.
+
+- [ ] **Step 2.4: Verify the workspace compiles**
+
+Run: `go build ./services/metrics/...`
+Expected: clean.
+
+Run: `go vet ./services/metrics/...`
+Expected: clean.
+
+- [ ] **Step 2.5: Run existing tests to confirm no regression**
+
+Run: `go test ./services/metrics/internal/spark/...`
+Expected: all existing tests still pass; no new tests yet.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add services/metrics/internal/spark/renderer.go
+git commit -m "feat(metrics): ADR-026 Phase 1 — TemplateParams + OperandParam + Render method skeletons
+
+Extends renderer infrastructure for FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT:
+- TemplateParams gains FilterSQL, ValueColumn, Operands, Operator, EventType, WindowHours
+- New OperandParam{MetricID, Weight} struct for COMPOSITE
+- 'last' template helper registered on FuncMap (used by composite trailing-comma logic)
+- RenderFilteredMean, RenderComposite, RenderWindowedCount stubs
+
+Templates don't exist yet — added in subsequent commits per type. RenderForType
+dispatch arms also deferred. This task ships only the surface area.
+
+Refs #432"
+```
+
+---
+
+## Task 3: `filtered_mean` template + golden tests
+
+**Files:**
+- Create: `services/metrics/internal/spark/templates/filtered_mean.sql.tmpl`
+- Create: `services/metrics/testdata/golden/filtered_mean_simple_expected.sql`
+- Create: `services/metrics/testdata/golden/filtered_mean_multi_clause_expected.sql`
+- Create: `services/metrics/testdata/golden/filtered_mean_value_column_filter_expected.sql`
+- Modify: `services/metrics/internal/spark/renderer_test.go`
+
+Three golden scenarios. We RED-GREEN the simple case first, then add the other two as additional fixture rows. Strict TDD: write the golden by hand (the SQL we *want*), write the test, watch it fail, write the template, watch it pass.
+
+- [ ] **Step 3.1: Write the simple golden file by hand**
+
+Create `services/metrics/testdata/golden/filtered_mean_simple_expected.sql` with the exact SQL we want for fixture `{ExperimentID: "exp-001", MetricID: "mobile_avg_watch_time", SourceEventType: "heartbeat", ValueColumn: "duration_ms", FilterSQL: "platform = 'mobile'", ComputationDate: "2024-01-15"}`:
+
+```sql
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.duration_ms AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'heartbeat'
+      AND (platform = 'mobile')
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'mobile_avg_watch_time' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;
+```
+
+- [ ] **Step 3.2: Add the test**
+
+In `services/metrics/internal/spark/renderer_test.go`, add after `TestRenderRatioDeltaMethod`:
+
+```go
+func TestRenderFilteredMean(t *testing.T) {
+    r, err := NewSQLRenderer()
+    require.NoError(t, err)
+    p := testParams
+    p.MetricID = "mobile_avg_watch_time"
+    p.SourceEventType = "heartbeat"
+    p.ValueColumn = "duration_ms"
+    p.FilterSQL = "platform = 'mobile'"
+    sql, err := r.RenderFilteredMean(p)
+    require.NoError(t, err)
+    assert.Equal(t, readGolden(t, "filtered_mean_simple_expected.sql"), sql)
+}
+```
+
+- [ ] **Step 3.3: Run the test — expect FAIL**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderFilteredMean -v`
+Expected: FAIL with error like `template: filtered_mean.sql.tmpl: not defined` (because the template file doesn't exist).
+
+- [ ] **Step 3.4: Create the template**
+
+Create `services/metrics/internal/spark/templates/filtered_mean.sql.tmpl`:
+
+```
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.{{.ValueColumn}} AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND ({{.FilterSQL}})
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;
+```
+
+- [ ] **Step 3.5: Run the test — expect PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderFilteredMean -v`
+Expected: PASS. If the assertion fails on whitespace, iterate the template (most commonly leading/trailing newlines) until output matches the golden byte-for-byte.
+
+- [ ] **Step 3.6: Add multi-clause-filter golden**
+
+Create `services/metrics/testdata/golden/filtered_mean_multi_clause_expected.sql` with the SQL for fixture `{... FilterSQL: "platform = 'mobile' AND duration_ms > 5000"}`:
+
+```sql
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.duration_ms AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'heartbeat'
+      AND (platform = 'mobile' AND duration_ms > 5000)
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'mobile_long_watch_avg' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;
+```
+
+- [ ] **Step 3.7: Add the multi-clause test case**
+
+Extend the existing test or add a sibling. Convert `TestRenderFilteredMean` into a table-driven test:
+
+```go
+func TestRenderFilteredMean(t *testing.T) {
+    cases := []struct {
+        name        string
+        metricID    string
+        valueColumn string
+        filterSQL   string
+        golden      string
+    }{
+        {"simple", "mobile_avg_watch_time", "duration_ms", "platform = 'mobile'", "filtered_mean_simple_expected.sql"},
+        {"multi_clause", "mobile_long_watch_avg", "duration_ms", "platform = 'mobile' AND duration_ms > 5000", "filtered_mean_multi_clause_expected.sql"},
+    }
+    r, err := NewSQLRenderer()
+    require.NoError(t, err)
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            p := testParams
+            p.MetricID = tc.metricID
+            p.SourceEventType = "heartbeat"
+            p.ValueColumn = tc.valueColumn
+            p.FilterSQL = tc.filterSQL
+            sql, err := r.RenderFilteredMean(p)
+            require.NoError(t, err)
+            assert.Equal(t, readGolden(t, tc.golden), sql)
+        })
+    }
+}
+```
+
+- [ ] **Step 3.8: Run — expect both PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderFilteredMean -v`
+Expected: both subtests PASS.
+
+- [ ] **Step 3.9: Add value-column-filter golden**
+
+Create `services/metrics/testdata/golden/filtered_mean_value_column_filter_expected.sql`. Fixture: `{MetricID: "long_watches_only_avg", ValueColumn: "duration_ms", FilterSQL: "duration_ms > 1000"}`:
+
+```sql
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.duration_ms AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'heartbeat'
+      AND (duration_ms > 1000)
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'long_watches_only_avg' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;
+```
+
+Add a third case to the table:
+```go
+{"value_column_filter", "long_watches_only_avg", "duration_ms", "duration_ms > 1000", "filtered_mean_value_column_filter_expected.sql"},
+```
+
+- [ ] **Step 3.10: Run all three — expect PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderFilteredMean -v`
+Expected: all 3 subtests PASS.
+
+- [ ] **Step 3.11: Commit**
+
+```bash
+git add services/metrics/internal/spark/templates/filtered_mean.sql.tmpl \
+        services/metrics/testdata/golden/filtered_mean_*.sql \
+        services/metrics/internal/spark/renderer_test.go
+git commit -m "feat(metrics): ADR-026 Phase 1 — filtered_mean.sql.tmpl + 3 golden tests
+
+Implements FILTERED_MEAN: AVG of value_column over events that pass
+filter_sql. Custom CTEs (does not reuse exposure_join because that
+template hardcodes the value column).
+
+Goldens cover: simple single-predicate filter, multi-clause AND filter,
+filter referencing the value column itself.
+
+Refs #432"
+```
+
+---
+
+## Task 4: `composite` template + golden tests
+
+**Files:**
+- Create: `services/metrics/internal/spark/templates/composite.sql.tmpl`
+- Create: 6 goldens under `services/metrics/testdata/golden/composite_*.sql`
+- Modify: `services/metrics/internal/spark/renderer_test.go`
+
+Six scenarios — one per operator (5) + WEIGHTED_SUM with non-uniform weights. We TDD the ADD case first, then add the others as additional fixture rows.
+
+Common fixture across all 6: `{ExperimentID: "exp-001", MetricID: "composite_metric", ComputationDate: "2024-01-15"}`. Per-case differences: `Operator` and `Operands` (2 operands per case).
+
+- [ ] **Step 4.1: Write the ADD golden**
+
+Create `services/metrics/testdata/golden/composite_add_expected.sql`. Fixture: `{Operands: [{MetricID: "m1", Weight: 1.0}, {MetricID: "m2", Weight: 1.0}], Operator: "ADD"}`:
+
+```sql
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    (m0 + m1) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;
+```
+
+- [ ] **Step 4.2: Add the ADD test**
+
+In `renderer_test.go`, add a new table-driven test:
+
+```go
+func TestRenderComposite(t *testing.T) {
+    twoOperands := []OperandParam{
+        {MetricID: "m1", Weight: 1.0},
+        {MetricID: "m2", Weight: 1.0},
+    }
+    cases := []struct {
+        name     string
+        operator string
+        operands []OperandParam
+        golden   string
+    }{
+        {"add", "ADD", twoOperands, "composite_add_expected.sql"},
+    }
+    r, err := NewSQLRenderer()
+    require.NoError(t, err)
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            p := testParams
+            p.MetricID = "composite_metric"
+            p.Operands = tc.operands
+            p.Operator = tc.operator
+            sql, err := r.RenderComposite(p)
+            require.NoError(t, err)
+            assert.Equal(t, readGolden(t, tc.golden), sql)
+        })
+    }
+}
+```
+
+- [ ] **Step 4.3: Run — expect FAIL**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderComposite -v`
+Expected: FAIL — `template: composite.sql.tmpl: not defined`.
+
+- [ ] **Step 4.4: Create the template**
+
+Create `services/metrics/internal/spark/templates/composite.sql.tmpl`. The `last` helper suppresses the trailing comma in the pivot SELECT:
+
+```
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = '{{.ExperimentID}}'
+      AND computation_date = CAST('{{.ComputationDate}}' AS DATE)
+      AND metric_id IN ({{ range $i, $op := .Operands }}{{if $i}}, {{end}}'{{$op.MetricID}}'{{end}})
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        {{ range $i, $op := .Operands -}}
+        MAX(CASE WHEN metric_id = '{{$op.MetricID}}' THEN metric_value END) AS m{{$i}}{{ if not (last $i $.Operands) }},{{ end }}
+        {{ end }}
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    user_id,
+    variant_id,
+    '{{.MetricID}}' AS metric_id,
+    {{- if eq .Operator "ADD" }}
+    ({{ range $i, $op := .Operands }}{{if $i}} + {{end}}m{{$i}}{{end}})
+    {{- else if eq .Operator "SUBTRACT" }}
+    ({{ range $i, $op := .Operands }}{{if $i}} - {{end}}m{{$i}}{{end}})
+    {{- else if eq .Operator "MULTIPLY" }}
+    ({{ range $i, $op := .Operands }}{{if $i}} * {{end}}m{{$i}}{{end}})
+    {{- else if eq .Operator "DIVIDE" }}
+    ({{ range $i, $op := .Operands }}{{if $i}} / NULLIF(m{{$i}}, 0){{else}}m{{$i}}{{end}}{{end}})
+    {{- else if eq .Operator "WEIGHTED_SUM" }}
+    ({{ range $i, $op := .Operands }}{{if $i}} + {{end}}({{$op.Weight}} * m{{$i}}){{end}})
+    {{- end }} AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;
+```
+
+- [ ] **Step 4.5: Run — expect ADD case to PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderComposite -v`
+Expected: PASS for `add` subtest. If whitespace doesn't match, iterate the template (the `{{-` and `-}}` trim markers control whitespace; adjust per Go template rules).
+
+- [ ] **Step 4.6: Write the SUBTRACT, MULTIPLY, DIVIDE, WEIGHTED_SUM (uniform), WEIGHTED_SUM (non-uniform) goldens**
+
+For each, the structure matches the ADD golden but the `metric_value` expression differs. Operands `{m1: 1.0, m2: 1.0}` for the first four; `{m1: 0.7, m2: 0.3}` for the non-uniform WEIGHTED_SUM.
+
+`composite_subtract_expected.sql` — same as ADD but `(m0 - m1)`.
+`composite_multiply_expected.sql` — `(m0 * m1)`.
+`composite_divide_expected.sql` — `(m0 / NULLIF(m1, 0))`.
+`composite_weighted_sum_uniform_expected.sql` — `((1 * m0) + (1 * m1))`.
+`composite_weighted_sum_nonuniform_expected.sql` — `((0.7 * m0) + (0.3 * m1))`.
+
+Note: Go's `text/template` renders `1.0` as `1` when written via `{{$op.Weight}}` — so a uniform `1.0` becomes `1` in the rendered SQL. Verify by running the test; if the actual output uses a different float format (e.g., `1` vs `1.0`), update the goldens to match the actual renderer behaviour rather than hand-guessed format.
+
+- [ ] **Step 4.7: Add the five new test cases to the table**
+
+Extend the `cases` slice in `TestRenderComposite`:
+
+```go
+nonUniformOperands := []OperandParam{
+    {MetricID: "m1", Weight: 0.7},
+    {MetricID: "m2", Weight: 0.3},
+}
+cases := []struct {...}{
+    {"add", "ADD", twoOperands, "composite_add_expected.sql"},
+    {"subtract", "SUBTRACT", twoOperands, "composite_subtract_expected.sql"},
+    {"multiply", "MULTIPLY", twoOperands, "composite_multiply_expected.sql"},
+    {"divide", "DIVIDE", twoOperands, "composite_divide_expected.sql"},
+    {"weighted_sum_uniform", "WEIGHTED_SUM", twoOperands, "composite_weighted_sum_uniform_expected.sql"},
+    {"weighted_sum_nonuniform", "WEIGHTED_SUM", nonUniformOperands, "composite_weighted_sum_nonuniform_expected.sql"},
+}
+```
+
+- [ ] **Step 4.8: Run all six — expect PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderComposite -v`
+Expected: all 6 subtests PASS.
+
+- [ ] **Step 4.9: Commit**
+
+```bash
+git add services/metrics/internal/spark/templates/composite.sql.tmpl \
+        services/metrics/testdata/golden/composite_*.sql \
+        services/metrics/internal/spark/renderer_test.go
+git commit -m "feat(metrics): ADR-026 Phase 1 — composite.sql.tmpl + 6 golden tests
+
+Implements COMPOSITE: arithmetic on per-user values of other metrics.
+Reads from delta.metric_summaries (operand metrics must be computed
+first; scheduler dependency tracked in #475).
+
+Goldens cover all 5 operators: ADD, SUBTRACT, MULTIPLY, DIVIDE
+(with NULLIF guard), WEIGHTED_SUM uniform (weight=1.0), WEIGHTED_SUM
+non-uniform (0.7 / 0.3).
+
+Refs #432"
+```
+
+---
+
+## Task 5: `windowed_count` template + golden tests
+
+**Files:**
+- Create: `services/metrics/internal/spark/templates/windowed_count.sql.tmpl`
+- Create: 4 goldens under `services/metrics/testdata/golden/windowed_count_*.sql`
+- Modify: `services/metrics/internal/spark/renderer_test.go`
+
+Four scenarios: with-filter / no-filter / 1h-window / 168h-window. Common fixture: `{ExperimentID: "exp-001", ComputationDate: "2024-01-15"}`.
+
+- [ ] **Step 5.1: Verify schema assumption**
+
+The template uses `eu.exposure_ts` and `me.event_timestamp`. Confirm `delta.exposures` has `exposure_timestamp` and `delta.metric_events` has `event_timestamp`.
+
+Run: `grep -rn 'exposure_timestamp\|event_timestamp' delta/ services/metrics/ 2>/dev/null | head -10`
+
+If the column names differ (e.g., `event_time`, `exposed_at`), update the template fixtures and goldens accordingly. If they don't exist at all, this task is blocked — file a sub-issue and pause #432 until the schema is reconciled.
+
+- [ ] **Step 5.2: Write the with-filter golden**
+
+Create `services/metrics/testdata/golden/windowed_count_with_filter_expected.sql`. Fixture: `{MetricID: "movie_starts_24h", EventType: "stream_start", FilterSQL: "content_type = 'movie'", WindowHours: 24}`:
+
+```sql
+WITH exposed_users AS (
+    SELECT user_id, variant_id,
+           MIN(exposure_timestamp) AS exposure_ts,
+           MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+windowed_events AS (
+    SELECT eu.user_id, eu.variant_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'stream_start'
+      AND me.event_timestamp >= eu.exposure_ts
+      AND me.event_timestamp <  eu.exposure_ts + INTERVAL 24 HOURS
+      AND (content_type = 'movie')
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'movie_starts_24h' AS metric_id,
+    CAST(COUNT(we.user_id) AS DOUBLE) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN windowed_events we ON eu.user_id = we.user_id AND eu.variant_id = we.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;
+```
+
+- [ ] **Step 5.3: Add the with-filter test**
+
+In `renderer_test.go`:
+
+```go
+func TestRenderWindowedCount(t *testing.T) {
+    cases := []struct {
+        name        string
+        metricID    string
+        eventType   string
+        filterSQL   string
+        windowHours int32
+        golden      string
+    }{
+        {"with_filter", "movie_starts_24h", "stream_start", "content_type = 'movie'", 24, "windowed_count_with_filter_expected.sql"},
+    }
+    r, err := NewSQLRenderer()
+    require.NoError(t, err)
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            p := testParams
+            p.MetricID = tc.metricID
+            p.EventType = tc.eventType
+            p.FilterSQL = tc.filterSQL
+            p.WindowHours = tc.windowHours
+            sql, err := r.RenderWindowedCount(p)
+            require.NoError(t, err)
+            assert.Equal(t, readGolden(t, tc.golden), sql)
+        })
+    }
+}
+```
+
+- [ ] **Step 5.4: Run — expect FAIL**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderWindowedCount -v`
+Expected: FAIL — template missing.
+
+- [ ] **Step 5.5: Create the template**
+
+Create `services/metrics/internal/spark/templates/windowed_count.sql.tmpl`:
+
+```
+WITH exposed_users AS (
+    SELECT user_id, variant_id,
+           MIN(exposure_timestamp) AS exposure_ts,
+           MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+windowed_events AS (
+    SELECT eu.user_id, eu.variant_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.EventType}}'
+      AND me.event_timestamp >= eu.exposure_ts
+      AND me.event_timestamp <  eu.exposure_ts + INTERVAL {{.WindowHours}} HOURS
+      {{ if .FilterSQL }}AND ({{.FilterSQL}}){{ end }}
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CAST(COUNT(we.user_id) AS DOUBLE) AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN windowed_events we ON eu.user_id = we.user_id AND eu.variant_id = we.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;
+```
+
+- [ ] **Step 5.6: Run — expect PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderWindowedCount -v`
+Expected: PASS for `with_filter`. Iterate template if whitespace differs.
+
+- [ ] **Step 5.7: Add no-filter, 1h, 168h goldens**
+
+`windowed_count_no_filter_expected.sql` — same structure as with-filter golden but `FilterSQL=""`. The template's `{{ if .FilterSQL }}AND (...){{ end }}` block disappears (and so does any extra whitespace around it — verify with the actual rendered output).
+
+`windowed_count_1h_expected.sql` — `WindowHours=1`, no filter. `INTERVAL 1 HOURS` instead of `INTERVAL 24 HOURS`.
+
+`windowed_count_168h_expected.sql` — `WindowHours=168`, no filter. `INTERVAL 168 HOURS`.
+
+- [ ] **Step 5.8: Add 3 new test cases to the table**
+
+```go
+{"no_filter", "all_starts_24h", "stream_start", "", 24, "windowed_count_no_filter_expected.sql"},
+{"1h", "starts_1h", "stream_start", "", 1, "windowed_count_1h_expected.sql"},
+{"168h", "starts_7d", "stream_start", "", 168, "windowed_count_168h_expected.sql"},
+```
+
+- [ ] **Step 5.9: Run all 4 — expect PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderWindowedCount -v`
+Expected: all 4 subtests PASS.
+
+- [ ] **Step 5.10: Commit**
+
+```bash
+git add services/metrics/internal/spark/templates/windowed_count.sql.tmpl \
+        services/metrics/testdata/golden/windowed_count_*.sql \
+        services/metrics/internal/spark/renderer_test.go
+git commit -m "feat(metrics): ADR-026 Phase 1 — windowed_count.sql.tmpl + 4 golden tests
+
+Implements WINDOWED_COUNT: count of an event_type within
+[exposure_ts, exposure_ts + window_hours) per exposed user. Custom CTEs
+because the existing exposure_join template doesn't expose timestamps.
+
+LEFT JOIN preserves zero-count users (matches count.sql.tmpl pattern).
+Half-open interval matches industry convention.
+
+Goldens: with-filter, no-filter, 1h window, 168h (7-day) window.
+
+Refs #432"
+```
+
+---
+
+## Task 6: `RenderForType` dispatch arms with validation
+
+**Files:**
+- Modify: `services/metrics/internal/spark/renderer.go` (the `RenderForType` switch)
+- Modify: `services/metrics/internal/spark/renderer_test.go` (extend `TestRenderForType` + add validation tests)
+
+This task wires the new types into `RenderForType` with the validation surface from §4 of the spec: positive allow-list for COMPOSITE operator, per-operand `metric_id` non-empty check, WEIGHTED_SUM `weight > 0` guard.
+
+- [ ] **Step 6.1: Write the validation tests first (RED)**
+
+Add a new test that exercises each rejection case the spec promises:
+
+```go
+func TestRenderForType_NewTypes_Validation(t *testing.T) {
+    r, err := NewSQLRenderer()
+    require.NoError(t, err)
+
+    cases := []struct {
+        name      string
+        metricType string
+        params    func(p *TemplateParams)
+        wantErrSubstring string
+    }{
+        {
+            "filtered_mean_empty_filter",
+            "FILTERED_MEAN",
+            func(p *TemplateParams) { p.ValueColumn = "duration_ms"; p.SourceEventType = "heartbeat" },
+            "non-empty filter_sql",
+        },
+        {
+            "filtered_mean_empty_value_column",
+            "FILTERED_MEAN",
+            func(p *TemplateParams) { p.FilterSQL = "1=1"; p.SourceEventType = "heartbeat" },
+            "non-empty value_column",
+        },
+        {
+            "composite_no_operands",
+            "COMPOSITE",
+            func(p *TemplateParams) { p.Operator = "ADD" },
+            "at least one operand",
+        },
+        {
+            "composite_unknown_operator",
+            "COMPOSITE",
+            func(p *TemplateParams) {
+                p.Operands = []OperandParam{{MetricID: "m1", Weight: 1}}
+                p.Operator = "POWER"
+            },
+            "unrecognized operator",
+        },
+        {
+            "composite_unspecified_operator",
+            "COMPOSITE",
+            func(p *TemplateParams) {
+                p.Operands = []OperandParam{{MetricID: "m1", Weight: 1}}
+                p.Operator = "UNSPECIFIED"
+            },
+            "unrecognized operator",
+        },
+        {
+            "composite_empty_metric_id",
+            "COMPOSITE",
+            func(p *TemplateParams) {
+                p.Operands = []OperandParam{{MetricID: "", Weight: 1}}
+                p.Operator = "ADD"
+            },
+            "non-empty metric_id",
+        },
+        {
+            "composite_weighted_sum_zero_weight",
+            "COMPOSITE",
+            func(p *TemplateParams) {
+                p.Operands = []OperandParam{{MetricID: "m1", Weight: 0}}
+                p.Operator = "WEIGHTED_SUM"
+            },
+            "weight > 0",
+        },
+        {
+            "composite_weighted_sum_negative_weight",
+            "COMPOSITE",
+            func(p *TemplateParams) {
+                p.Operands = []OperandParam{{MetricID: "m1", Weight: -1}}
+                p.Operator = "WEIGHTED_SUM"
+            },
+            "weight > 0",
+        },
+        {
+            "windowed_count_empty_event_type",
+            "WINDOWED_COUNT",
+            func(p *TemplateParams) { p.WindowHours = 24 },
+            "non-empty event_type",
+        },
+        {
+            "windowed_count_zero_window",
+            "WINDOWED_COUNT",
+            func(p *TemplateParams) { p.EventType = "stream_start"; p.WindowHours = 0 },
+            "window_hours > 0",
+        },
+    }
+
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            p := testParams
+            p.MetricID = "test_metric"
+            tc.params(&p)
+            _, err := r.RenderForType(tc.metricType, p)
+            require.Error(t, err)
+            assert.Contains(t, err.Error(), tc.wantErrSubstring)
+        })
+    }
+}
+```
+
+- [ ] **Step 6.2: Run — expect FAIL on every case**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderForType_NewTypes_Validation -v`
+Expected: every subtest FAILs because `RenderForType` falls through to the default arm (returns "unsupported metric type") rather than the type-specific errors.
+
+- [ ] **Step 6.3: Add the three dispatch arms**
+
+In `services/metrics/internal/spark/renderer.go`, find `RenderForType` and add three arms before the `default`:
+
+```go
+case "FILTERED_MEAN":
+    if p.FilterSQL == "" {
+        return "", fmt.Errorf("spark: FILTERED_MEAN metric %q requires non-empty filter_sql", p.MetricID)
+    }
+    if p.ValueColumn == "" {
+        return "", fmt.Errorf("spark: FILTERED_MEAN metric %q requires non-empty value_column", p.MetricID)
+    }
+    return r.RenderFilteredMean(p)
+
+case "COMPOSITE":
+    if len(p.Operands) == 0 {
+        return "", fmt.Errorf("spark: COMPOSITE metric %q requires at least one operand", p.MetricID)
+    }
+    // Allow-list, not deny-list: composite.sql.tmpl handles exactly these five
+    // operators. A new proto enum value without a matching template branch must
+    // fail loudly here, not produce malformed SQL.
+    switch p.Operator {
+    case "ADD", "SUBTRACT", "MULTIPLY", "DIVIDE", "WEIGHTED_SUM":
+        // ok
+    default:
+        return "", fmt.Errorf("spark: COMPOSITE metric %q has unrecognized operator %q (supported: ADD, SUBTRACT, MULTIPLY, DIVIDE, WEIGHTED_SUM)", p.MetricID, p.Operator)
+    }
+    for i, op := range p.Operands {
+        if op.MetricID == "" {
+            return "", fmt.Errorf("spark: COMPOSITE metric %q operand[%d] requires non-empty metric_id", p.MetricID, i)
+        }
+        if p.Operator == "WEIGHTED_SUM" && op.Weight <= 0 {
+            // proto3 doubles default to 0.0; "unset" and "explicit zero" are
+            // indistinguishable. Force callers to be explicit so we never
+            // silently multiply an operand by 0 in the rendered SQL.
+            return "", fmt.Errorf("spark: COMPOSITE metric %q operand[%d] (%s) requires weight > 0 for WEIGHTED_SUM", p.MetricID, i, op.MetricID)
+        }
+    }
+    return r.RenderComposite(p)
+
+case "WINDOWED_COUNT":
+    if p.EventType == "" {
+        return "", fmt.Errorf("spark: WINDOWED_COUNT metric %q requires non-empty event_type", p.MetricID)
+    }
+    if p.WindowHours <= 0 {
+        return "", fmt.Errorf("spark: WINDOWED_COUNT metric %q requires window_hours > 0", p.MetricID)
+    }
+    return r.RenderWindowedCount(p)
+```
+
+- [ ] **Step 6.4: Update the `default` arm error message**
+
+Find the `default:` arm and update its `Errorf` call to include the new types:
+
+```go
+default:
+    return "", fmt.Errorf("spark: unsupported metric type %q (supported: MEAN, PROPORTION, COUNT, RATIO, PERCENTILE, CUSTOM, FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT)", metricType)
+```
+
+- [ ] **Step 6.5: Run — expect validation tests PASS**
+
+Run: `go test ./services/metrics/internal/spark/ -run TestRenderForType_NewTypes_Validation -v`
+Expected: all 11 subtests PASS.
+
+- [ ] **Step 6.6: Extend the existing `TestRenderForType` happy-path table**
+
+Add three rows to the existing `TestRenderForType` table-driven test (around line 84 of `renderer_test.go`). The wantErr column distinguishes valid vs invalid types:
+
+```go
+for _, tc := range []struct{ mt string; wantErr bool }{
+    {"MEAN", false}, {"PROPORTION", false}, {"COUNT", false}, {"RATIO", false},
+    {"mean", false}, {"ratio", false}, {"CUSTOM", true}, {"INVALID", true},
+    // ADR-026 Phase 1
+    {"FILTERED_MEAN", false}, {"COMPOSITE", false}, {"WINDOWED_COUNT", false},
+} {
+    ...
+}
+```
+
+The test fixture (`p`) needs the new fields populated for the happy path. Add these to the `p` setup just before the loop:
+
+```go
+p.FilterSQL = "1=1"
+p.ValueColumn = "value"
+p.Operands = []OperandParam{{MetricID: "m1", Weight: 1.0}}
+p.Operator = "ADD"
+p.EventType = "stream_start"
+p.WindowHours = 24
+```
+
+- [ ] **Step 6.7: Run the full renderer test suite — expect PASS**
+
+Run: `go test ./services/metrics/internal/spark/... -v`
+Expected: every test passes — the 3 new render tests (filtered_mean × 3, composite × 6, windowed_count × 4), the new validation test (× 11 subtests), the extended TestRenderForType, and every pre-existing test.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add services/metrics/internal/spark/renderer.go \
+        services/metrics/internal/spark/renderer_test.go
+git commit -m "feat(metrics): ADR-026 Phase 1 — RenderForType dispatch + validation
+
+Adds RenderForType arms for FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT.
+Validation surface per spec §4:
+
+- FILTERED_MEAN: filter_sql + value_column non-empty
+- COMPOSITE: positive allow-list of operators (ADD/SUBTRACT/MULTIPLY/
+  DIVIDE/WEIGHTED_SUM); per-operand metric_id non-empty;
+  WEIGHTED_SUM requires every operand weight > 0
+- WINDOWED_COUNT: event_type non-empty, window_hours > 0
+
+11-case validation test covers every rejection branch. Existing
+TestRenderForType extended with the three new types in the happy-path
+table.
+
+Refs #432"
+```
+
+---
+
+## Task 7: Workspace verification + final commit
+
+**Files:** none modified directly; this task is a final smoke check.
+
+- [ ] **Step 7.1: Run the entire workspace test suite**
+
+Run: `go test ./...`
+Expected: every Go package passes.
+
+Run: `cargo test --workspace`
+Expected: every Rust crate passes (the proto changes regenerated bindings, so this also exercises proto consumers).
+
+- [ ] **Step 7.2: Re-run proto checks**
+
+Run: `buf lint proto/`
+Expected: clean.
+
+Run: `buf breaking proto/ --against .git#branch=main`
+Expected: clean.
+
+- [ ] **Step 7.3: Confirm no untracked clutter**
+
+Run: `git status`
+Expected: clean working tree (no stray temp files, no `.beads/`, no editor backups).
+
+- [ ] **Step 7.4: Push branch**
+
+Run: `git push -u origin agent-3/feat/adr-026-phase1`
+Expected: branch pushed; GitHub returns the PR-creation URL.
+
+- [ ] **Step 7.5: Open the PR**
+
+Run:
+
+```bash
+gh pr create --base main --head agent-3/feat/adr-026-phase1 \
+  --title "feat(metrics): ADR-026 Phase 1 — FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT" \
+  --body "$(cat <<'EOF'
+Implements [issue #432](https://github.com/wunderkennd/kaizen-experimentation/issues/432) per the design spec at `docs/superpowers/specs/2026-05-04-adr-026-phase1-design.md` (merged in #473).
+
+## What's in this PR
+
+- **Proto schema**: 3 new MetricType enum values + oneof type_config with FilteredMeanConfig, CompositeConfig, WindowedCountConfig + CompositeOperator enum + CompositeOperand. Wire-compatible with all existing serialized MetricDefinitions.
+- **M3 SQL templates**: filtered_mean.sql.tmpl, composite.sql.tmpl, windowed_count.sql.tmpl. Custom CTEs where the existing exposure_join template doesn't fit.
+- **Renderer plumbing**: TemplateParams extended with 6 new fields + OperandParam struct, last template helper, RenderFilteredMean/Composite/WindowedCount methods, three new RenderForType arms with positive-allow-list operator validation, per-operand metric_id checks, and WEIGHTED_SUM weight > 0 guards.
+- **Golden tests**: 13 new goldens (3 filtered_mean + 6 composite + 4 windowed_count) + 11-case validation test.
+
+## Out of scope
+
+- M5 semantic validation (column allowlist, parse check, COMPOSITE cycle detection, event-catalog lookup) — issue #433
+- M6 UI for the new types — issue #434
+- M3 scheduler topological-order enforcement for COMPOSITE operand dependencies — issue #475
+- M4a coordination on COMPOSITE assignment_probability semantics — flagged for downstream review
+
+## Test plan
+
+- [x] go test ./services/metrics/... — all pass
+- [x] cargo test --workspace — all pass
+- [x] buf lint proto/ — clean
+- [x] buf breaking proto/ --against .git#branch=main — clean
+- [ ] CI on this PR — full suite
+
+Closes #432
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 7.6: Final commit (if any tooling-driven changes were left uncommitted)**
+
+If `gen/` or other tooling-driven artifacts have uncommitted updates, commit them:
+
+```bash
+git status
+# If anything's modified or untracked beyond expected:
+git add <files>
+git commit -m "chore: regenerate bindings"
+git push
+```
+
+If status is clean, this step is a no-op.
+
+---
+
+## Self-Review Checklist
+
+Run after writing the plan:
+
+**1. Spec coverage:**
+- [x] Three new MetricType enum values → Task 1
+- [x] FilteredMeanConfig, CompositeConfig, WindowedCountConfig messages → Task 1
+- [x] CompositeOperator enum, CompositeOperand message → Task 1
+- [x] oneof type_config on MetricDefinition → Task 1
+- [x] filtered_mean.sql.tmpl → Task 3
+- [x] composite.sql.tmpl → Task 4
+- [x] windowed_count.sql.tmpl → Task 5
+- [x] Renderer dispatch + validation → Tasks 2, 6
+- [x] Golden-file tests for each template (3+6+4=13) → Tasks 3, 4, 5
+- [x] buf lint + buf breaking → Tasks 1, 7
+- [x] WEIGHTED_SUM weight > 0 invariant → Task 6
+- [x] COMPOSITE operator allow-list → Task 6
+
+**2. Placeholder scan:** No "TBD", "TODO", "implement later", or vague directives. Each step has actual code or commands.
+
+**3. Type consistency:** `OperandParam` is defined once in Task 2 and referenced consistently in Tasks 4 and 6. `TemplateParams` field names (`FilterSQL`, `ValueColumn`, `Operands`, `Operator`, `EventType`, `WindowHours`) match across the plan. `MetricID` (uppercase D) used everywhere.
+
+**4. Out-of-band concerns:** Schema verification step in Task 5.1 catches the `exposure_timestamp` / `event_timestamp` column-existence assumption before the template lands. If those columns don't exist, the task documents the blocking action.
+
+---
+
+## Execution Choice
+
+Two options for execution:
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review the diff between tasks, fast iteration. Each task is self-contained enough to hand to a subagent with just the task heading + all sub-steps.
+
+2. **Inline Execution** — Run all 7 tasks in one session via `superpowers:executing-plans`, with checkpoints between tasks for review.

--- a/proto/experimentation/common/v1/metric.proto
+++ b/proto/experimentation/common/v1/metric.proto
@@ -44,6 +44,12 @@ enum MetricType {
   METRIC_TYPE_PERCENTILE = 5;
   // Custom SQL-defined metric. M3 executes the custom_sql field.
   METRIC_TYPE_CUSTOM = 6;
+  // Mean of value_column over rows matching a Spark SQL filter (ADR-026 Phase 1).
+  METRIC_TYPE_FILTERED_MEAN  = 7;
+  // Composition of other metrics via arithmetic operator (ADR-026 Phase 1).
+  METRIC_TYPE_COMPOSITE      = 8;
+  // Count of an event type within a time window after first exposure (ADR-026 Phase 1).
+  METRIC_TYPE_WINDOWED_COUNT = 9;
 }
 
 // MetricDefinition is the specification for a metric computed by M3.
@@ -81,4 +87,67 @@ message MetricDefinition {
   MetricStakeholder stakeholder = 15;
   // Unit of observation for this metric. Drives M3 computation pipeline selection.
   MetricAggregationLevel aggregation_level = 16;
+
+  // Per-type config for new types (ADR-026 Phase 1). Existing types continue
+  // to use their flat sibling fields; a future ADR may consolidate them here.
+  oneof type_config {
+    FilteredMeanConfig   filtered_mean   = 17;
+    CompositeConfig      composite       = 18;
+    WindowedCountConfig  windowed_count  = 19;
+  }
+}
+
+// FilteredMeanConfig — config for METRIC_TYPE_FILTERED_MEAN. The metric is the
+// AVG of value_column over rows whose event_type matches
+// MetricDefinition.source_event_type AND that pass filter_sql.
+message FilteredMeanConfig {
+  // Spark SQL fragment AND'd into the scan WHERE clause.
+  // Validated in M5 (#433): column allowlist + parse check.
+  // Example: "platform = 'mobile' AND duration_ms > 5000"
+  string filter_sql = 1;
+
+  // Column from source_event_type to AVG over.
+  // Example: "duration_ms"
+  string value_column = 2;
+}
+
+// CompositeConfig — config for METRIC_TYPE_COMPOSITE. The metric is computed
+// from per-user values of other (already-computed) metrics via the operator.
+message CompositeConfig {
+  // Operands referenced by metric_id. Cycle detection lives in M5 (#433).
+  repeated CompositeOperand operands = 1;
+  CompositeOperator         operator = 2;
+}
+
+message CompositeOperand {
+  string metric_id = 1;
+  // Coefficient. Required for WEIGHTED_SUM (must be > 0); ignored for other operators.
+  // Note: proto3 has no custom default mechanism for scalar fields — `double`
+  // unset deserialises to 0.0, not 1.0. WEIGHTED_SUM operands must therefore
+  // set `weight` explicitly; M5 (#433) and the renderer reject `weight <= 0`
+  // when operator = WEIGHTED_SUM.
+  double weight = 2;
+}
+
+enum CompositeOperator {
+  COMPOSITE_OPERATOR_UNSPECIFIED  = 0;
+  COMPOSITE_OPERATOR_ADD          = 1;
+  COMPOSITE_OPERATOR_SUBTRACT     = 2;
+  COMPOSITE_OPERATOR_MULTIPLY     = 3;
+  COMPOSITE_OPERATOR_DIVIDE       = 4;
+  COMPOSITE_OPERATOR_WEIGHTED_SUM = 5;
+}
+
+// WindowedCountConfig — config for METRIC_TYPE_WINDOWED_COUNT. The metric is
+// COUNT of events of event_type whose event_timestamp falls within
+// [exposure_ts, exposure_ts + window_hours) for each exposed user.
+message WindowedCountConfig {
+  // Event type to count. Validated against the event catalog in M5 (#433).
+  string event_type = 1;
+
+  // Optional Spark SQL fragment AND'd into the scan WHERE clause.
+  string filter_sql = 2;
+
+  // Time window relative to the user's first exposure (hours).
+  int32 window_hours = 3;
 }

--- a/proto/experimentation/common/v1/metric.proto
+++ b/proto/experimentation/common/v1/metric.proto
@@ -45,9 +45,9 @@ enum MetricType {
   // Custom SQL-defined metric. M3 executes the custom_sql field.
   METRIC_TYPE_CUSTOM = 6;
   // Mean of value_column over rows matching a Spark SQL filter (ADR-026 Phase 1).
-  METRIC_TYPE_FILTERED_MEAN  = 7;
+  METRIC_TYPE_FILTERED_MEAN = 7;
   // Composition of other metrics via arithmetic operator (ADR-026 Phase 1).
-  METRIC_TYPE_COMPOSITE      = 8;
+  METRIC_TYPE_COMPOSITE = 8;
   // Count of an event type within a time window after first exposure (ADR-026 Phase 1).
   METRIC_TYPE_WINDOWED_COUNT = 9;
 }
@@ -91,9 +91,9 @@ message MetricDefinition {
   // Per-type config for new types (ADR-026 Phase 1). Existing types continue
   // to use their flat sibling fields; a future ADR may consolidate them here.
   oneof type_config {
-    FilteredMeanConfig   filtered_mean   = 17;
-    CompositeConfig      composite       = 18;
-    WindowedCountConfig  windowed_count  = 19;
+    FilteredMeanConfig filtered_mean = 17;
+    CompositeConfig composite = 18;
+    WindowedCountConfig windowed_count = 19;
   }
 }
 
@@ -107,16 +107,24 @@ message FilteredMeanConfig {
   string filter_sql = 1;
 
   // Column from source_event_type to AVG over.
+  // Must be a numeric column in the source_event_type schema. Validated in M5 (#433).
   // Example: "duration_ms"
   string value_column = 2;
 }
 
 // CompositeConfig — config for METRIC_TYPE_COMPOSITE. The metric is computed
 // from per-user values of other (already-computed) metrics via the operator.
+//
+// Operand arity rules (enforced by M5 #433):
+//   ADD, MULTIPLY, WEIGHTED_SUM:    >= 2 operands, evaluated left-to-right
+//   SUBTRACT, DIVIDE:               exactly 2 operands (operands[0] op operands[1])
+//   UNSPECIFIED:                    invalid
+// Cycle detection over metric_id references also lives in M5.
 message CompositeConfig {
   // Operands referenced by metric_id. Cycle detection lives in M5 (#433).
   repeated CompositeOperand operands = 1;
-  CompositeOperator         operator = 2;
+  // Arithmetic operator applied to operands. See operand arity rules above.
+  CompositeOperator operator = 2;
 }
 
 message CompositeOperand {
@@ -130,11 +138,12 @@ message CompositeOperand {
 }
 
 enum CompositeOperator {
-  COMPOSITE_OPERATOR_UNSPECIFIED  = 0;
-  COMPOSITE_OPERATOR_ADD          = 1;
-  COMPOSITE_OPERATOR_SUBTRACT     = 2;
-  COMPOSITE_OPERATOR_MULTIPLY     = 3;
-  COMPOSITE_OPERATOR_DIVIDE       = 4;
+  COMPOSITE_OPERATOR_UNSPECIFIED = 0;
+  COMPOSITE_OPERATOR_ADD = 1;
+  COMPOSITE_OPERATOR_SUBTRACT = 2;
+  COMPOSITE_OPERATOR_MULTIPLY = 3;
+  COMPOSITE_OPERATOR_DIVIDE = 4;
+  // Linear combination: sum(operand_i * weight_i). Use ADD when all weights are 1.0.
   COMPOSITE_OPERATOR_WEIGHTED_SUM = 5;
 }
 
@@ -146,8 +155,10 @@ message WindowedCountConfig {
   string event_type = 1;
 
   // Optional Spark SQL fragment AND'd into the scan WHERE clause.
+  // Validated in M5 (#433): column allowlist + parse check.
   string filter_sql = 2;
 
   // Time window relative to the user's first exposure (hours).
+  // Must be > 0; M5 (#433) rejects window_hours <= 0.
   int32 window_hours = 3;
 }

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -193,7 +193,52 @@ func (r *SQLRenderer) RenderForType(metricType string, p TemplateParams) (string
 			return "", fmt.Errorf("spark: CUSTOM metric %q: %w", p.MetricID, err)
 		}
 		return r.RenderCustom(p)
+
+	case "FILTERED_MEAN":
+		if p.FilterSQL == "" {
+			return "", fmt.Errorf("spark: FILTERED_MEAN metric %q requires non-empty filter_sql", p.MetricID)
+		}
+		if p.ValueColumn == "" {
+			return "", fmt.Errorf("spark: FILTERED_MEAN metric %q requires non-empty value_column", p.MetricID)
+		}
+		return r.RenderFilteredMean(p)
+
+	case "COMPOSITE":
+		if len(p.Operands) == 0 {
+			return "", fmt.Errorf("spark: COMPOSITE metric %q requires at least one operand", p.MetricID)
+		}
+		// Allow-list, not deny-list: composite.sql.tmpl handles exactly these five
+		// operators. A new proto enum value without a matching template branch must
+		// fail loudly here, not produce malformed SQL.
+		switch p.Operator {
+		case "ADD", "SUBTRACT", "MULTIPLY", "DIVIDE", "WEIGHTED_SUM":
+			// ok
+		default:
+			return "", fmt.Errorf("spark: COMPOSITE metric %q has unrecognized operator %q (supported: ADD, SUBTRACT, MULTIPLY, DIVIDE, WEIGHTED_SUM)", p.MetricID, p.Operator)
+		}
+		for i, op := range p.Operands {
+			if op.MetricID == "" {
+				return "", fmt.Errorf("spark: COMPOSITE metric %q operand[%d] requires non-empty metric_id", p.MetricID, i)
+			}
+			if p.Operator == "WEIGHTED_SUM" && op.Weight <= 0 {
+				// proto3 doubles default to 0.0; "unset" and "explicit zero" are
+				// indistinguishable. Force callers to be explicit so we never
+				// silently multiply an operand by 0 in the rendered SQL.
+				return "", fmt.Errorf("spark: COMPOSITE metric %q operand[%d] (%s) requires weight > 0 for WEIGHTED_SUM", p.MetricID, i, op.MetricID)
+			}
+		}
+		return r.RenderComposite(p)
+
+	case "WINDOWED_COUNT":
+		if p.EventType == "" {
+			return "", fmt.Errorf("spark: WINDOWED_COUNT metric %q requires non-empty event_type", p.MetricID)
+		}
+		if p.WindowHours <= 0 {
+			return "", fmt.Errorf("spark: WINDOWED_COUNT metric %q requires window_hours > 0", p.MetricID)
+		}
+		return r.RenderWindowedCount(p)
+
 	default:
-		return "", fmt.Errorf("spark: unsupported metric type %q (supported: MEAN, PROPORTION, COUNT, RATIO, PERCENTILE, CUSTOM)", metricType)
+		return "", fmt.Errorf("spark: unsupported metric type %q (supported: MEAN, PROPORTION, COUNT, RATIO, PERCENTILE, CUSTOM, FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT)", metricType)
 	}
 }

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -155,8 +155,8 @@ func (r *SQLRenderer) RenderFeedbackLoopContamination(p TemplateParams) (string,
 	return r.Render("feedback_loop_contamination.sql.tmpl", p)
 }
 
-// ADR-026 Phase 1 — new metric type renderers.
-// Templates are added in subsequent commits; these stubs wire the surface area.
+// ADR-026 Phase 1 (#432). filtered_mean (Task 3) and composite (Task 4)
+// templates land alongside this file; windowed_count.sql.tmpl ships in Task 5.
 
 func (r *SQLRenderer) RenderFilteredMean(p TemplateParams) (string, error) {
 	return r.Render("filtered_mean.sql.tmpl", p)

--- a/services/metrics/internal/spark/renderer.go
+++ b/services/metrics/internal/spark/renderer.go
@@ -53,6 +53,25 @@ type TemplateParams struct {
 	MLRATELookbackDays      int      // days of pre-experiment data for feature computation
 	MLRATEModelURI          string   // MLflow model URI prefix; fold models at {uri}/fold_{k}
 	MLRATEFoldID            int      // current fold ID for per-fold prediction (1-indexed)
+
+	// ADR-026 Phase 1 — FILTERED_MEAN
+	FilterSQL   string // Spark SQL fragment AND'd into the scan WHERE clause
+	ValueColumn string // bare identifier (M5-validated against allowlist) — column to AVG
+
+	// ADR-026 Phase 1 — COMPOSITE
+	Operands []OperandParam
+	Operator string // uppercase: ADD, SUBTRACT, MULTIPLY, DIVIDE, WEIGHTED_SUM
+
+	// ADR-026 Phase 1 — WINDOWED_COUNT
+	EventType   string // counted event type (named distinctly from SourceEventType)
+	WindowHours int32  // time window after first exposure
+}
+
+// OperandParam represents one operand of a COMPOSITE metric.
+// Weight is meaningful only for WEIGHTED_SUM; ignored otherwise.
+type OperandParam struct {
+	MetricID string
+	Weight   float64
 }
 
 type SQLRenderer struct {
@@ -60,7 +79,14 @@ type SQLRenderer struct {
 }
 
 func NewSQLRenderer() (*SQLRenderer, error) {
-	tmpl, err := template.ParseFS(templateFS, "templates/*.sql.tmpl")
+	funcMap := template.FuncMap{
+		// last reports whether index i is the last element of slice. Used by
+		// composite.sql.tmpl to suppress the trailing comma in the pivot SELECT.
+		"last": func(i int, slice []OperandParam) bool {
+			return i == len(slice)-1
+		},
+	}
+	tmpl, err := template.New("spark").Funcs(funcMap).ParseFS(templateFS, "templates/*.sql.tmpl")
 	if err != nil {
 		return nil, fmt.Errorf("spark: parse templates: %w", err)
 	}
@@ -127,6 +153,21 @@ func (r *SQLRenderer) RenderMLRATECrossFitPredict(p TemplateParams) (string, err
 // Results go to delta.feedback_loop_contamination; consumed by M4a FeedbackLoopDetector.
 func (r *SQLRenderer) RenderFeedbackLoopContamination(p TemplateParams) (string, error) {
 	return r.Render("feedback_loop_contamination.sql.tmpl", p)
+}
+
+// ADR-026 Phase 1 — new metric type renderers.
+// Templates are added in subsequent commits; these stubs wire the surface area.
+
+func (r *SQLRenderer) RenderFilteredMean(p TemplateParams) (string, error) {
+	return r.Render("filtered_mean.sql.tmpl", p)
+}
+
+func (r *SQLRenderer) RenderComposite(p TemplateParams) (string, error) {
+	return r.Render("composite.sql.tmpl", p)
+}
+
+func (r *SQLRenderer) RenderWindowedCount(p TemplateParams) (string, error) {
+	return r.Render("windowed_count.sql.tmpl", p)
 }
 
 func (r *SQLRenderer) RenderForType(metricType string, p TemplateParams) (string, error) {

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -419,6 +419,11 @@ func TestRenderComposite(t *testing.T) {
 		{MetricID: "m1", Weight: 0.7},
 		{MetricID: "m2", Weight: 0.3},
 	}
+	threeOperands := []OperandParam{
+		{MetricID: "m1", Weight: 0.5},
+		{MetricID: "m2", Weight: 0.3},
+		{MetricID: "m3", Weight: 0.2},
+	}
 	cases := []struct {
 		name     string
 		operator string
@@ -431,6 +436,7 @@ func TestRenderComposite(t *testing.T) {
 		{"divide", "DIVIDE", twoOperands, "composite_divide_expected.sql"},
 		{"weighted_sum_uniform", "WEIGHTED_SUM", twoOperands, "composite_weighted_sum_uniform_expected.sql"},
 		{"weighted_sum_nonuniform", "WEIGHTED_SUM", nonUniformOperands, "composite_weighted_sum_nonuniform_expected.sql"},
+		{"weighted_sum_three_operands", "WEIGHTED_SUM", threeOperands, "composite_weighted_sum_three_operands_expected.sql"},
 	}
 	r, err := NewSQLRenderer()
 	require.NoError(t, err)

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -408,6 +408,45 @@ func TestRenderFilteredMean(t *testing.T) {
 	}
 }
 
+// ADR-026 Phase 1: COMPOSITE template.
+
+func TestRenderComposite(t *testing.T) {
+	twoOperands := []OperandParam{
+		{MetricID: "m1", Weight: 1.0},
+		{MetricID: "m2", Weight: 1.0},
+	}
+	nonUniformOperands := []OperandParam{
+		{MetricID: "m1", Weight: 0.7},
+		{MetricID: "m2", Weight: 0.3},
+	}
+	cases := []struct {
+		name     string
+		operator string
+		operands []OperandParam
+		golden   string
+	}{
+		{"add", "ADD", twoOperands, "composite_add_expected.sql"},
+		{"subtract", "SUBTRACT", twoOperands, "composite_subtract_expected.sql"},
+		{"multiply", "MULTIPLY", twoOperands, "composite_multiply_expected.sql"},
+		{"divide", "DIVIDE", twoOperands, "composite_divide_expected.sql"},
+		{"weighted_sum_uniform", "WEIGHTED_SUM", twoOperands, "composite_weighted_sum_uniform_expected.sql"},
+		{"weighted_sum_nonuniform", "WEIGHTED_SUM", nonUniformOperands, "composite_weighted_sum_nonuniform_expected.sql"},
+	}
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testParams
+			p.MetricID = "composite_metric"
+			p.Operands = tc.operands
+			p.Operator = tc.operator
+			sql, err := r.RenderComposite(p)
+			require.NoError(t, err)
+			assert.Equal(t, readGolden(t, tc.golden), sql)
+		})
+	}
+}
+
 // ADR-015 Phase 2: MLRATE cross-fitting templates.
 
 func TestRenderMLRATEFeatures(t *testing.T) {

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -89,9 +89,17 @@ func TestRenderForType(t *testing.T) {
 	p.SourceEventType = "test_event"
 	p.NumeratorEventType = "num_event"
 	p.DenominatorEventType = "denom_event"
+	// ADR-026 Phase 1 fixture
+	p.FilterSQL = "1=1"
+	p.ValueColumn = "value"
+	p.Operands = []OperandParam{{MetricID: "m1", Weight: 1.0}}
+	p.Operator = "ADD"
+	p.EventType = "stream_start"
+	p.WindowHours = 24
 	for _, tc := range []struct{ mt string; wantErr bool }{
 		{"MEAN", false}, {"PROPORTION", false}, {"COUNT", false}, {"RATIO", false},
 		{"mean", false}, {"ratio", false}, {"CUSTOM", true}, {"INVALID", true},
+		{"FILTERED_MEAN", false}, {"COMPOSITE", false}, {"WINDOWED_COUNT", false},
 	} {
 		t.Run(tc.mt, func(t *testing.T) {
 			_, err := r.RenderForType(tc.mt, p)
@@ -481,6 +489,105 @@ func TestRenderWindowedCount(t *testing.T) {
 			sql, err := r.RenderWindowedCount(p)
 			require.NoError(t, err)
 			assert.Equal(t, readGolden(t, tc.golden), sql)
+		})
+	}
+}
+
+func TestRenderForType_NewTypes_Validation(t *testing.T) {
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+
+	cases := []struct {
+		name             string
+		metricType       string
+		params           func(p *TemplateParams)
+		wantErrSubstring string
+	}{
+		{
+			"filtered_mean_empty_filter",
+			"FILTERED_MEAN",
+			func(p *TemplateParams) { p.ValueColumn = "duration_ms"; p.SourceEventType = "heartbeat" },
+			"non-empty filter_sql",
+		},
+		{
+			"filtered_mean_empty_value_column",
+			"FILTERED_MEAN",
+			func(p *TemplateParams) { p.FilterSQL = "1=1"; p.SourceEventType = "heartbeat" },
+			"non-empty value_column",
+		},
+		{
+			"composite_no_operands",
+			"COMPOSITE",
+			func(p *TemplateParams) { p.Operator = "ADD" },
+			"at least one operand",
+		},
+		{
+			"composite_unknown_operator",
+			"COMPOSITE",
+			func(p *TemplateParams) {
+				p.Operands = []OperandParam{{MetricID: "m1", Weight: 1}}
+				p.Operator = "POWER"
+			},
+			"unrecognized operator",
+		},
+		{
+			"composite_unspecified_operator",
+			"COMPOSITE",
+			func(p *TemplateParams) {
+				p.Operands = []OperandParam{{MetricID: "m1", Weight: 1}}
+				p.Operator = "UNSPECIFIED"
+			},
+			"unrecognized operator",
+		},
+		{
+			"composite_empty_metric_id",
+			"COMPOSITE",
+			func(p *TemplateParams) {
+				p.Operands = []OperandParam{{MetricID: "", Weight: 1}}
+				p.Operator = "ADD"
+			},
+			"non-empty metric_id",
+		},
+		{
+			"composite_weighted_sum_zero_weight",
+			"COMPOSITE",
+			func(p *TemplateParams) {
+				p.Operands = []OperandParam{{MetricID: "m1", Weight: 0}}
+				p.Operator = "WEIGHTED_SUM"
+			},
+			"weight > 0",
+		},
+		{
+			"composite_weighted_sum_negative_weight",
+			"COMPOSITE",
+			func(p *TemplateParams) {
+				p.Operands = []OperandParam{{MetricID: "m1", Weight: -1}}
+				p.Operator = "WEIGHTED_SUM"
+			},
+			"weight > 0",
+		},
+		{
+			"windowed_count_empty_event_type",
+			"WINDOWED_COUNT",
+			func(p *TemplateParams) { p.WindowHours = 24 },
+			"non-empty event_type",
+		},
+		{
+			"windowed_count_zero_window",
+			"WINDOWED_COUNT",
+			func(p *TemplateParams) { p.EventType = "stream_start"; p.WindowHours = 0 },
+			"window_hours > 0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testParams
+			p.MetricID = "test_metric"
+			tc.params(&p)
+			_, err := r.RenderForType(tc.metricType, p)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrSubstring)
 		})
 	}
 }

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -378,6 +378,36 @@ func TestRenderQoEEngagementCorrelation_ContainsKeyFields(t *testing.T) {
 	assert.Contains(t, sql, "STDDEV_SAMP")
 }
 
+// ADR-026 Phase 1: FILTERED_MEAN template.
+
+func TestRenderFilteredMean(t *testing.T) {
+	cases := []struct {
+		name        string
+		metricID    string
+		valueColumn string
+		filterSQL   string
+		golden      string
+	}{
+		{"simple", "mobile_avg_watch_time", "duration_ms", "platform = 'mobile'", "filtered_mean_simple_expected.sql"},
+		{"multi_clause", "mobile_long_watch_avg", "duration_ms", "platform = 'mobile' AND duration_ms > 5000", "filtered_mean_multi_clause_expected.sql"},
+		{"value_column_filter", "long_watches_only_avg", "duration_ms", "duration_ms > 1000", "filtered_mean_value_column_filter_expected.sql"},
+	}
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testParams
+			p.MetricID = tc.metricID
+			p.SourceEventType = "heartbeat"
+			p.ValueColumn = tc.valueColumn
+			p.FilterSQL = tc.filterSQL
+			sql, err := r.RenderFilteredMean(p)
+			require.NoError(t, err)
+			assert.Equal(t, readGolden(t, tc.golden), sql)
+		})
+	}
+}
+
 // ADR-015 Phase 2: MLRATE cross-fitting templates.
 
 func TestRenderMLRATEFeatures(t *testing.T) {

--- a/services/metrics/internal/spark/renderer_test.go
+++ b/services/metrics/internal/spark/renderer_test.go
@@ -453,6 +453,38 @@ func TestRenderComposite(t *testing.T) {
 	}
 }
 
+// ADR-026 Phase 1: WINDOWED_COUNT template.
+
+func TestRenderWindowedCount(t *testing.T) {
+	cases := []struct {
+		name        string
+		metricID    string
+		eventType   string
+		filterSQL   string
+		windowHours int32
+		golden      string
+	}{
+		{"with_filter", "movie_starts_24h", "stream_start", "content_type = 'movie'", 24, "windowed_count_with_filter_expected.sql"},
+		{"no_filter", "all_starts_24h", "stream_start", "", 24, "windowed_count_no_filter_expected.sql"},
+		{"1h", "starts_1h", "stream_start", "", 1, "windowed_count_1h_expected.sql"},
+		{"168h", "starts_7d", "stream_start", "", 168, "windowed_count_168h_expected.sql"},
+	}
+	r, err := NewSQLRenderer()
+	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testParams
+			p.MetricID = tc.metricID
+			p.EventType = tc.eventType
+			p.FilterSQL = tc.filterSQL
+			p.WindowHours = tc.windowHours
+			sql, err := r.RenderWindowedCount(p)
+			require.NoError(t, err)
+			assert.Equal(t, readGolden(t, tc.golden), sql)
+		})
+	}
+}
+
 // ADR-015 Phase 2: MLRATE cross-fitting templates.
 
 func TestRenderMLRATEFeatures(t *testing.T) {

--- a/services/metrics/internal/spark/templates/composite.sql.tmpl
+++ b/services/metrics/internal/spark/templates/composite.sql.tmpl
@@ -1,0 +1,36 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = '{{.ExperimentID}}'
+      AND computation_date = CAST('{{.ComputationDate}}' AS DATE)
+      AND metric_id IN ({{range $i, $op := .Operands}}{{if $i}}, {{end}}'{{$op.MetricID}}'{{end}})
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        {{- range $i, $op := .Operands}}
+        MAX(CASE WHEN metric_id = '{{$op.MetricID}}' THEN metric_value END) AS m{{$i}}{{if not (last $i $.Operands)}},{{end}}
+        {{- end}}
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    user_id,
+    variant_id,
+    '{{.MetricID}}' AS metric_id,
+    {{- if eq .Operator "ADD"}}
+    ({{range $i, $op := .Operands}}{{if $i}} + {{end}}m{{$i}}{{end}}) AS metric_value,
+    {{- else if eq .Operator "SUBTRACT"}}
+    ({{range $i, $op := .Operands}}{{if $i}} - {{end}}m{{$i}}{{end}}) AS metric_value,
+    {{- else if eq .Operator "MULTIPLY"}}
+    ({{range $i, $op := .Operands}}{{if $i}} * {{end}}m{{$i}}{{end}}) AS metric_value,
+    {{- else if eq .Operator "DIVIDE"}}
+    ({{range $i, $op := .Operands}}{{if $i}} / NULLIF(m{{$i}}, 0){{else}}m{{$i}}{{end}}{{end}}) AS metric_value,
+    {{- else if eq .Operator "WEIGHTED_SUM"}}
+    ({{range $i, $op := .Operands}}{{if $i}} + {{end}}({{$op.Weight}} * m{{$i}}){{end}}) AS metric_value,
+    {{- end}}
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/internal/spark/templates/filtered_mean.sql.tmpl
+++ b/services/metrics/internal/spark/templates/filtered_mean.sql.tmpl
@@ -1,0 +1,24 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.{{.ValueColumn}} AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.SourceEventType}}'
+      AND ({{.FilterSQL}})
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/internal/spark/templates/windowed_count.sql.tmpl
+++ b/services/metrics/internal/spark/templates/windowed_count.sql.tmpl
@@ -1,0 +1,30 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id,
+           MIN(event_timestamp) AS exposure_ts,
+           MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = '{{.ExperimentID}}'
+    GROUP BY user_id, variant_id
+),
+windowed_events AS (
+    SELECT eu.user_id, eu.variant_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = '{{.EventType}}'
+      AND me.event_timestamp >= eu.exposure_ts
+      AND me.event_timestamp <  eu.exposure_ts + INTERVAL {{.WindowHours}} HOURS
+      {{- if .FilterSQL }}
+      AND ({{.FilterSQL}})
+      {{- end }}
+)
+SELECT
+    '{{.ExperimentID}}' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    '{{.MetricID}}' AS metric_id,
+    CAST(COUNT(we.user_id) AS DOUBLE) AS metric_value,
+    CAST('{{.ComputationDate}}' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN windowed_events we ON eu.user_id = we.user_id AND eu.variant_id = we.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/testdata/golden/composite_add_expected.sql
+++ b/services/metrics/testdata/golden/composite_add_expected.sql
@@ -1,0 +1,25 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    (m0 + m1) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/testdata/golden/composite_divide_expected.sql
+++ b/services/metrics/testdata/golden/composite_divide_expected.sql
@@ -1,0 +1,25 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    (m0 / NULLIF(m1, 0)) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/testdata/golden/composite_multiply_expected.sql
+++ b/services/metrics/testdata/golden/composite_multiply_expected.sql
@@ -1,0 +1,25 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    (m0 * m1) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/testdata/golden/composite_subtract_expected.sql
+++ b/services/metrics/testdata/golden/composite_subtract_expected.sql
@@ -1,0 +1,25 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    (m0 - m1) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/testdata/golden/composite_weighted_sum_nonuniform_expected.sql
+++ b/services/metrics/testdata/golden/composite_weighted_sum_nonuniform_expected.sql
@@ -1,0 +1,25 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    ((0.7 * m0) + (0.3 * m1)) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/testdata/golden/composite_weighted_sum_three_operands_expected.sql
+++ b/services/metrics/testdata/golden/composite_weighted_sum_three_operands_expected.sql
@@ -1,0 +1,26 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2', 'm3')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1,
+        MAX(CASE WHEN metric_id = 'm3' THEN metric_value END) AS m2
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    ((0.5 * m0) + (0.3 * m1) + (0.2 * m2)) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/testdata/golden/composite_weighted_sum_uniform_expected.sql
+++ b/services/metrics/testdata/golden/composite_weighted_sum_uniform_expected.sql
@@ -1,0 +1,25 @@
+WITH operand_rows AS (
+    SELECT user_id, variant_id, metric_id, metric_value
+    FROM delta.metric_summaries
+    WHERE experiment_id = 'exp-001'
+      AND computation_date = CAST('2024-01-15' AS DATE)
+      AND metric_id IN ('m1', 'm2')
+),
+pivoted AS (
+    SELECT
+        user_id,
+        variant_id,
+        MAX(CASE WHEN metric_id = 'm1' THEN metric_value END) AS m0,
+        MAX(CASE WHEN metric_id = 'm2' THEN metric_value END) AS m1
+    FROM operand_rows
+    GROUP BY user_id, variant_id
+)
+SELECT
+    'exp-001' AS experiment_id,
+    user_id,
+    variant_id,
+    'composite_metric' AS metric_id,
+    ((1 * m0) + (1 * m1)) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    1.0 AS assignment_probability
+FROM pivoted;

--- a/services/metrics/testdata/golden/filtered_mean_multi_clause_expected.sql
+++ b/services/metrics/testdata/golden/filtered_mean_multi_clause_expected.sql
@@ -1,0 +1,24 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.duration_ms AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'heartbeat'
+      AND (platform = 'mobile' AND duration_ms > 5000)
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'mobile_long_watch_avg' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/testdata/golden/filtered_mean_simple_expected.sql
+++ b/services/metrics/testdata/golden/filtered_mean_simple_expected.sql
@@ -1,0 +1,24 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.duration_ms AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'heartbeat'
+      AND (platform = 'mobile')
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'mobile_avg_watch_time' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/testdata/golden/filtered_mean_value_column_filter_expected.sql
+++ b/services/metrics/testdata/golden/filtered_mean_value_column_filter_expected.sql
@@ -1,0 +1,24 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id, MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+filtered_data AS (
+    SELECT me.user_id, eu.variant_id, me.duration_ms AS value
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'heartbeat'
+      AND (duration_ms > 1000)
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'long_watches_only_avg' AS metric_id,
+    AVG(fd.value) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN filtered_data fd ON eu.user_id = fd.user_id AND eu.variant_id = fd.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/testdata/golden/windowed_count_168h_expected.sql
+++ b/services/metrics/testdata/golden/windowed_count_168h_expected.sql
@@ -1,0 +1,27 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id,
+           MIN(event_timestamp) AS exposure_ts,
+           MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+windowed_events AS (
+    SELECT eu.user_id, eu.variant_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'stream_start'
+      AND me.event_timestamp >= eu.exposure_ts
+      AND me.event_timestamp <  eu.exposure_ts + INTERVAL 168 HOURS
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'starts_7d' AS metric_id,
+    CAST(COUNT(we.user_id) AS DOUBLE) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN windowed_events we ON eu.user_id = we.user_id AND eu.variant_id = we.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/testdata/golden/windowed_count_1h_expected.sql
+++ b/services/metrics/testdata/golden/windowed_count_1h_expected.sql
@@ -1,0 +1,27 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id,
+           MIN(event_timestamp) AS exposure_ts,
+           MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+windowed_events AS (
+    SELECT eu.user_id, eu.variant_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'stream_start'
+      AND me.event_timestamp >= eu.exposure_ts
+      AND me.event_timestamp <  eu.exposure_ts + INTERVAL 1 HOURS
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'starts_1h' AS metric_id,
+    CAST(COUNT(we.user_id) AS DOUBLE) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN windowed_events we ON eu.user_id = we.user_id AND eu.variant_id = we.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/testdata/golden/windowed_count_no_filter_expected.sql
+++ b/services/metrics/testdata/golden/windowed_count_no_filter_expected.sql
@@ -1,0 +1,27 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id,
+           MIN(event_timestamp) AS exposure_ts,
+           MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+windowed_events AS (
+    SELECT eu.user_id, eu.variant_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'stream_start'
+      AND me.event_timestamp >= eu.exposure_ts
+      AND me.event_timestamp <  eu.exposure_ts + INTERVAL 24 HOURS
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'all_starts_24h' AS metric_id,
+    CAST(COUNT(we.user_id) AS DOUBLE) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN windowed_events we ON eu.user_id = we.user_id AND eu.variant_id = we.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;

--- a/services/metrics/testdata/golden/windowed_count_with_filter_expected.sql
+++ b/services/metrics/testdata/golden/windowed_count_with_filter_expected.sql
@@ -1,0 +1,28 @@
+WITH exposed_users AS (
+    SELECT user_id, variant_id,
+           MIN(event_timestamp) AS exposure_ts,
+           MIN(assignment_probability) AS assignment_probability
+    FROM delta.exposures
+    WHERE experiment_id = 'exp-001'
+    GROUP BY user_id, variant_id
+),
+windowed_events AS (
+    SELECT eu.user_id, eu.variant_id
+    FROM delta.metric_events me
+    INNER JOIN exposed_users eu ON me.user_id = eu.user_id
+    WHERE me.event_type = 'stream_start'
+      AND me.event_timestamp >= eu.exposure_ts
+      AND me.event_timestamp <  eu.exposure_ts + INTERVAL 24 HOURS
+      AND (content_type = 'movie')
+)
+SELECT
+    'exp-001' AS experiment_id,
+    eu.user_id,
+    eu.variant_id,
+    'movie_starts_24h' AS metric_id,
+    CAST(COUNT(we.user_id) AS DOUBLE) AS metric_value,
+    CAST('2024-01-15' AS DATE) AS computation_date,
+    eu.assignment_probability
+FROM exposed_users eu
+LEFT JOIN windowed_events we ON eu.user_id = we.user_id AND eu.variant_id = we.variant_id
+GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;


### PR DESCRIPTION
Implements [issue #432](https://github.com/wunderkennd/kaizen-experimentation/issues/432) per the design spec at `docs/superpowers/specs/2026-05-04-adr-026-phase1-design.md` (merged in #473).

Plan: `docs/superpowers/plans/2026-05-05-adr-026-phase1.md` (in this branch).

## What's in this PR

- **Proto schema** — 3 new `MetricType` enum values (`FILTERED_MEAN`, `COMPOSITE`, `WINDOWED_COUNT`); new `oneof type_config` on `MetricDefinition` with `FilteredMeanConfig`, `CompositeConfig`, `WindowedCountConfig`; `CompositeOperator` enum with 5 operators; `CompositeOperand` with the proto3-default-zero gotcha documented inline. Wire-compatible — additions only, all existing serialized metrics deserialize unchanged.
- **M3 SQL templates** — `filtered_mean.sql.tmpl`, `composite.sql.tmpl`, `windowed_count.sql.tmpl`. Custom CTEs where the existing `exposure_join` template doesn't fit.
- **Renderer plumbing** — `TemplateParams` extended with 6 new fields + `OperandParam` struct, `last` template helper for trailing-comma suppression, `RenderFilteredMean` / `RenderComposite` / `RenderWindowedCount` methods, three new `RenderForType` arms with positive-allow-list operator validation, per-operand `metric_id` checks, and WEIGHTED_SUM `weight > 0` guards.
- **Golden tests** — 14 new goldens (3 filtered_mean + 7 composite + 4 windowed_count) plus a 10-case `TestRenderForType_NewTypes_Validation` covering every rejection branch. Existing `TestRenderForType` extended with the three new types in the happy-path table.

## ⚠️ Production-readiness gap surfaced in final review

**The renderer is plumbed, but the M3 production caller is not.** `services/metrics/internal/config/loader.go` (`MetricConfig`) and `services/metrics/internal/jobs/standard.go` (the entry point that builds `TemplateParams`) pre-date ADR-026 Phase 1 and have no fields for the new types. A real-world FILTERED_MEAN / COMPOSITE / WINDOWED_COUNT metric arriving from M5 → M3 today would:

1. Hit `RenderForType` with empty new-type fields.
2. Be rejected by the renderer's validation arms.
3. Be downgraded to `slog.Warn("skipping unsupported metric type", ...)` by `standard.go`.
4. Produce no `metric_summaries` row.

**This PR is correctly scoped to issue #432** (proto + templates + renderer + goldens — that's the issue's acceptance criteria). The wiring gap is tracked in the new follow-up **issue #504** (P1, agent-3, sprint-5.6). On-call engineers seeing the WARN log should pick up #504.

## Schema correction surfaced during implementation

The spec referenced `delta.exposures.exposure_timestamp` for the WINDOWED_COUNT anchor. Schema verification found the actual column is `delta.exposures.event_timestamp` (`/delta/delta_lake_tables.sql:25`). Template and goldens use the actual column name. The spec PR #473 should be updated retroactively (or tracked as a follow-up).

## Out of scope (tracked separately)

- **M3 MetricConfig wiring — #504 (NEW, P1)**
- M5 semantic validation (column allowlist, parse check, COMPOSITE cycle detection, event-catalog lookup) — issue #433
- M6 UI for the new types — issue #434
- M3 scheduler topological-order enforcement for COMPOSITE operand dependencies — issue #475
- M4a coordination on COMPOSITE `assignment_probability` semantics (currently hard-coded to 1.0) — flagged for review
- Future migration of existing flat type-config fields into the same `oneof` — issue #476

## Test plan

- [x] `go test ./...` — all packages green (pre-existing services/management setup failures unrelated)
- [x] `cargo test --workspace` — all crates green (one pre-existing `bandit_contextual_features_forwarded` flake unrelated to this work)
- [x] `buf lint proto/` — clean
- [x] `buf breaking proto/ --against .git#branch=main` — only pre-existing `analysis_service.proto` import error (unrelated)
- [x] `go vet ./services/metrics/...` — clean
- [ ] CI on this PR — full matrix

## Final review feedback rolled into this PR description

- Operator string case-sensitivity: COMPOSITE switch matches uppercase exactly. Spec says callers pass uppercase. Could add `strings.ToUpper(p.Operator)` for forgiveness but risks masking contract violations.
- WindowHours upper-bound: enforced at M5 (#433); current renderer only checks `> 0`.
- One additional doc-comment on `windowed_count.sql.tmpl` explaining `MIN(event_timestamp) AS exposure_ts` (column-aliasing breadcrumb for future readers) — happy to fold in if reviewers want it inline.
- `assignment_probability = 1.0` for COMPOSITE is hard-coded in the template; M4a coordination flagged separately.

## Closes

Closes #432