### PR TITLE
docs(spec): erratum — exposure_timestamp → event_timestamp in ADR-026 Phase 1

### DIFF
--- a/docs/superpowers/specs/2026-05-04-adr-026-phase1-design.md
+++ b/docs/superpowers/specs/2026-05-04-adr-026-phase1-design.md
@@ -1,11 +1,15 @@
 # ADR-026 Phase 1 — Design Spec
 
-- **Date:** 2026-05-04
-- **Status:** Approved
+- **Date:** 2026-05-04 (errata 2026-05-06)
+- **Status:** Approved (with erratum)
 - **Author:** Kenneth Sylvain + Claude Code
 - **Implements:** [Issue #432](https://github.com/wunderkennd/kaizen-experimentation/issues/432) (proto + M3 templates + renderer)
 - **Downstream consumers:** [#433](https://github.com/wunderkennd/kaizen-experimentation/issues/433) (M5 validation), [#434](https://github.com/wunderkennd/kaizen-experimentation/issues/434) (M6 UI)
 - **Parent ADR:** [ADR-026 Phase 1](../../adrs/026-custom-metrics-layer.md)
+
+## Erratum (2026-05-06)
+
+The original draft of this spec referenced a non-existent column `delta.exposures.exposure_timestamp` in the `windowed_count.sql.tmpl` template literal and supporting prose. The actual schema column is `event_timestamp` (`delta/delta_lake_tables.sql:14-29`; the table is even partitioned on this column). All affected lines have been corrected to `event_timestamp` to match reality. The implementation in PR #497 was correct against the schema; this erratum aligns the spec with what shipped. No design decisions changed — only the column name in the worked SQL example.
 
 ## Context
 
@@ -219,12 +223,12 @@ This is real additional scope outside #432's "proto + templates + golden files" 
 
 #### `windowed_count.sql.tmpl`
 
-Custom CTEs because it needs `event_timestamp` and `exposure_timestamp`, which the existing `exposure_join` template doesn't expose:
+Custom CTEs because it needs `event_timestamp` from both `delta.exposures` (anchor) and `delta.metric_events` (counted-event time), which the existing `exposure_join` template doesn't expose:
 
 ```sql
 WITH exposed_users AS (
     SELECT user_id, variant_id,
-           MIN(exposure_timestamp) AS exposure_ts,
+           MIN(event_timestamp) AS exposure_ts,
            MIN(assignment_probability) AS assignment_probability
     FROM delta.exposures
     WHERE experiment_id = '{{.ExperimentID}}'
@@ -253,8 +257,8 @@ GROUP BY eu.user_id, eu.variant_id, eu.assignment_probability;
 ```
 
 - Half-open interval `[exposure_ts, exposure_ts + window)` matches industry convention.
-- `MIN(exposure_timestamp)` anchors to the user's first exposure (a user can be exposed multiple times; first wins).
-- Schema dependency: assumes `delta.exposures` has an `exposure_timestamp` column. Implementation must verify against the actual Delta Lake schema before the template ships.
+- `MIN(event_timestamp)` anchors to the user's first exposure (a user can be exposed multiple times; first wins). The alias `exposure_ts` makes the semantic role clear locally even though the underlying column is `event_timestamp`.
+- Schema confirmed (post-implementation): `delta.exposures.event_timestamp` exists per `delta/delta_lake_tables.sql:25` (column the table is also partitioned on). The implementation in PR #497 uses this column verbatim.
 
 ### 3. Renderer plumbing
 


### PR DESCRIPTION
Erratum on the [ADR-026 Phase 1 design spec](docs/superpowers/specs/2026-05-04-adr-026-phase1-design.md) (merged in #473).

## What was wrong

The spec's worked SQL example for \`windowed_count.sql.tmpl\` referenced a non-existent column \`delta.exposures.exposure_timestamp\`. The actual schema column is \`event_timestamp\` per \`delta/delta_lake_tables.sql:14-29\` (the table is partitioned on this column, which is conclusive evidence).

## How it was caught

Plan Step 5.1 of the implementation plan (\`docs/superpowers/plans/2026-05-05-adr-026-phase1.md\`) explicitly required schema verification before writing the template:

> Run from the worktree root: \`grep -rn 'exposure_timestamp\\|event_timestamp\\|exposed_at\\|occurred_at' delta/ services/metrics/\` ...

The implementer ran this and discovered the spec error before any code shipped. PR #497 (closes #432) used the correct column name throughout. The verification gate worked exactly as designed.

## Why a follow-up reviewer flagged it

After PR #497 merged, an automated reviewer noted the discrepancy between the spec's example and the shipped template, and recommended changing the template to match the spec. This was the right instinct (always verify when the spec and the code disagree) but the spec was the wrong document — the schema was the source of truth and the implementation matched it.

This PR aligns the spec with reality so future readers don't trip on the same discrepancy.

## Changes (10 insertions, 6 deletions in one file)

- Top metadata: status now reads \"Approved (with erratum)\" with errata date 2026-05-06.
- New \`## Erratum (2026-05-06)\` section right after the metadata block summarizing what was wrong and what was corrected.
- §2 worked SQL example: \`MIN(exposure_timestamp) AS exposure_ts,\` → \`MIN(event_timestamp) AS exposure_ts,\`.
- §2 prose intro to the SQL block: rewrote the \"needs event_timestamp and exposure_timestamp\" line to clarify that both come from \`event_timestamp\` columns on different tables (\`delta.exposures\` and \`delta.metric_events\`).
- §2 schema-dependency bullet: rewrote from \"assumes ... must verify\" to \"schema confirmed (post-implementation)\" with the \`delta/delta_lake_tables.sql:25\` citation.

No design decisions changed.

## Test plan

- [x] \`grep -n exposure_timestamp <spec-file>\` returns only the erratum's quoted occurrence (the value being corrected).
- [x] Diff reviewed — only the spec markdown file modified.
- [ ] CI on this PR — markdown-only, no build / proto / test impact expected.

## Refs

- Issue #432 — closed by PR #497 (the implementation that surfaced this typo)
- PR #473 — the original spec PR that introduced the typo
- PR #497 — the implementation, correctly used \`event_timestamp\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->