### PR TITLE
🎨 Palette: Standardize navigation and interaction feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -72,3 +72,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-06-25 - Defensive Permission Gating
 **Learning:** Components rendering role-based information (like 'Insufficient Permissions' alerts) should wrap access to `user.role` or `ROLE_LABELS` in a conditional check (e.g., `{user && ...}`) to avoid runtime errors before the `AuthUser` object is fully loaded from context. Similarly, ensure data objects like `flag` are present before accessing their properties in breadcrumbs or titles within error states.
 **Action:** Always use optional chaining or conditional rendering when accessing `user` or asynchronous data objects in permission-gated UI blocks.
+
+## 2026-06-28 - Platform Navigation and Interaction Consistency
+**Learning:** Standardizing secondary navigation (breadcrumbs) and interaction patterns (disabled buttons vs. hiding) across all primary sections significantly reduces user disorientation and cognitive load. Providing explicit feedback on restricted actions (e.g., tooltips on disabled buttons) is more helpful than removing elements, as it clarifies permission boundaries without changing the UI layout.
+**Action:** Ensure all primary list and detail pages include breadcrumbs starting from the platform root. Use disabled states with role-requirement tooltips for permission-gated actions instead of hiding them.

--- a/ui/src/__tests__/metric-browser.test.tsx
+++ b/ui/src/__tests__/metric-browser.test.tsx
@@ -5,6 +5,7 @@ import { server } from '@/__mocks__/server';
 import { describe, it, expect, vi } from 'vitest';
 import MetricBrowserPage from '@/app/metrics/page';
 import { ToastProvider } from '@/lib/toast-context';
+import { AuthProvider } from '@/lib/auth-context';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
 
@@ -25,9 +26,11 @@ vi.mock('next/link', () => ({
 
 async function renderAndWait() {
   render(
-    <ToastProvider>
-      <MetricBrowserPage />
-    </ToastProvider>
+    <AuthProvider>
+      <ToastProvider>
+        <MetricBrowserPage />
+      </ToastProvider>
+    </AuthProvider>
   );
   await waitFor(() => {
     expect(screen.getByText('Stream Start Rate')).toBeInTheDocument();
@@ -57,9 +60,11 @@ describe('Metric Browser Page', () => {
 
   it('shows loading spinner initially', () => {
     render(
-      <ToastProvider>
-        <MetricBrowserPage />
-      </ToastProvider>
+      <AuthProvider>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
     );
     expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
@@ -72,9 +77,11 @@ describe('Metric Browser Page', () => {
     );
 
     render(
-      <ToastProvider>
-        <MetricBrowserPage />
-      </ToastProvider>
+      <AuthProvider>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
     );
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
@@ -98,9 +105,11 @@ describe('Metric Browser Page', () => {
     );
 
     render(
-      <ToastProvider>
-        <MetricBrowserPage />
-      </ToastProvider>
+      <AuthProvider>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
     );
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();

--- a/ui/src/__tests__/monitoring.test.tsx
+++ b/ui/src/__tests__/monitoring.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from 'msw';
 import { server } from '@/__mocks__/server';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import MonitoringPage from '@/app/monitoring/page';
+import { AuthProvider } from '@/lib/auth-context';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
 const ANALYSIS_SVC = '*/experimentation.analysis.v1.AnalysisService';
@@ -23,9 +24,13 @@ vi.mock('next/link', () => ({
 }));
 
 async function renderAndWait() {
-  render(<MonitoringPage />);
+  render(
+    <AuthProvider>
+      <MonitoringPage />
+    </AuthProvider>,
+  );
   await waitFor(() => {
-    expect(screen.getByText('Monitoring')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Monitoring', level: 1 })).toBeInTheDocument();
     expect(screen.getByTestId('summary-cards')).toBeInTheDocument();
   });
 }
@@ -43,6 +48,7 @@ describe('Monitoring Page', () => {
     await renderAndWait();
 
     expect(screen.getByRole('heading', { name: 'Monitoring', level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('Experiments')).toBeInTheDocument(); // Breadcrumb
     expect(screen.getByRole('heading', { name: 'Active Experiments Summary' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Running Experiments Health' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Recent Guardrail Breaches' })).toBeInTheDocument();
@@ -167,7 +173,11 @@ describe('Monitoring Page', () => {
       }),
     );
 
-    render(<MonitoringPage />);
+    render(
+      <AuthProvider>
+        <MonitoringPage />
+      </AuthProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('no-running-experiments')).toBeInTheDocument();
     });
@@ -221,7 +231,11 @@ describe('Monitoring Page', () => {
       }),
     );
 
-    render(<MonitoringPage />);
+    render(
+      <AuthProvider>
+        <MonitoringPage />
+      </AuthProvider>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('days-running-test-days')).toBeInTheDocument();
     });

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -77,7 +77,11 @@ function FlagDetailContent() {
 
   return (
     <div>
-      <Breadcrumb items={[{ label: 'Flags', href: '/flags' }, { label: flag.name }]} />
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Flags', href: '/flags' },
+        { label: flag.name },
+      ]} />
 
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-bold text-gray-900" data-testid="flag-name">{flag.name}</h1>

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -6,6 +6,8 @@ import type { Flag, FlagType } from '@/lib/types';
 import { listFlags } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
+import { ROLE_LABELS } from '@/lib/auth';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -15,7 +17,7 @@ const FLAG_TYPE_BADGE: Record<FlagType, string> = {
 };
 
 function FlagListContent() {
-  const { canAtLeast } = useAuth();
+  const { canAtLeast, user } = useAuth();
   const [flags, setFlags] = useState<Flag[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -61,35 +63,25 @@ function FlagListContent() {
     return <RetryableError message={error} onRetry={fetchData} context="feature flags" />;
   }
 
-  if (flags.length === 0) {
-    return (
-      <div className="py-12 text-center" data-testid="empty-state">
-        <p className="text-sm text-gray-500">No feature flags found.</p>
-        {canAtLeast('experimenter') && (
-          <div className="mt-6">
-            <Link
-              href="/flags/new"
-              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-              data-testid="create-first-flag"
-            >
-              Create your first feature flag
-            </Link>
-          </div>
-        )}
-      </div>
-    );
-  }
+  const isEmpty = flags.length === 0;
 
   return (
     <div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Flags' },
+      ]} />
+
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-gray-900">Feature Flags</h1>
-          <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="flag-count">
-            {filtered.length}
-          </span>
+          {!isEmpty && (
+            <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="flag-count">
+              {filtered.length}
+            </span>
+          )}
         </div>
-        {canAtLeast('experimenter') && (
+        {canAtLeast('experimenter') ? (
           <Link
             href="/flags/new"
             className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
@@ -97,8 +89,34 @@ function FlagListContent() {
           >
             New Flag
           </Link>
+        ) : (
+          <span
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+            title={`Requires Experimenter role (you are ${user ? ROLE_LABELS[user.role] : 'Unknown'})`}
+            data-testid="new-flag-disabled"
+          >
+            New Flag
+          </span>
         )}
       </div>
+
+      {isEmpty ? (
+        <div className="py-12 text-center" data-testid="empty-state">
+          <p className="text-sm text-gray-500">No feature flags found.</p>
+          {canAtLeast('experimenter') && (
+            <div className="mt-6">
+              <Link
+                href="/flags/new"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                data-testid="create-first-flag"
+              >
+                Create your first feature flag
+              </Link>
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
 
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <div className="relative flex-1 min-w-[300px] max-w-md">
@@ -132,61 +150,63 @@ function FlagListContent() {
         )}
       </div>
 
-      {filtered.length === 0 ? (
-        <div className="py-12 text-center" data-testid="no-filter-matches">
-          <p className="text-sm text-gray-500">No flags match your search.</p>
-          <button
-            onClick={() => setSearch('')}
-            className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
-          >
-            Clear filters
-          </button>
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Default</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Enabled</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Rollout %</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Variants</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {filtered.map((f) => (
-                <tr key={f.flagId} className="hover:bg-gray-50" data-testid={`flag-row-${f.flagId}`}>
-                  <td className="px-4 py-3">
-                    <Link href={`/flags/${f.flagId}`} className="font-medium text-indigo-600 hover:text-indigo-800">
-                      {f.name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${FLAG_TYPE_BADGE[f.type] || 'bg-gray-100 text-gray-800'}`}>
-                      {f.type}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600">
-                    <code className="text-xs">{f.defaultValue}</code>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${f.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
-                      {f.enabled ? 'On' : 'Off'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600">
-                    {(f.rolloutPercentage * 100).toFixed(0)}%
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600">
-                    {f.variants.length}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+          {filtered.length === 0 ? (
+            <div className="py-12 text-center" data-testid="no-filter-matches">
+              <p className="text-sm text-gray-500">No flags match your search.</p>
+              <button
+                onClick={() => setSearch('')}
+                className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+              >
+                Clear filters
+              </button>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Default</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Enabled</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Rollout %</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Variants</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {filtered.map((f) => (
+                    <tr key={f.flagId} className="hover:bg-gray-50" data-testid={`flag-row-${f.flagId}`}>
+                      <td className="px-4 py-3">
+                        <Link href={`/flags/${f.flagId}`} className="font-medium text-indigo-600 hover:text-indigo-800">
+                          {f.name}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${FLAG_TYPE_BADGE[f.type] || 'bg-gray-100 text-gray-800'}`}>
+                          {f.type}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">
+                        <code className="text-xs">{f.defaultValue}</code>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${f.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
+                          {f.enabled ? 'On' : 'Off'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">
+                        {(f.rolloutPercentage * 100).toFixed(0)}%
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">
+                        {f.variants.length}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -247,13 +247,7 @@ function MetricBrowserContent() {
     return <RetryableError message={error} onRetry={fetchData} context="metric definitions" />;
   }
 
-  if (metrics.length === 0) {
-    return (
-      <div className="py-12 text-center" data-testid="empty-state">
-        <p className="text-sm text-gray-500">No metric definitions found.</p>
-      </div>
-    );
-  }
+  const isEmpty = metrics.length === 0;
 
   return (
     <div>
@@ -264,10 +258,19 @@ function MetricBrowserContent() {
 
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-bold text-gray-900">Metric Definitions</h1>
-        <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="metric-count">
-          {filtered.length}
-        </span>
+        {!isEmpty && (
+          <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="metric-count">
+            {filtered.length}
+          </span>
+        )}
       </div>
+
+      {isEmpty ? (
+        <div className="py-12 text-center" data-testid="empty-state">
+          <p className="text-sm text-gray-500">No metric definitions found.</p>
+        </div>
+      ) : (
+        <>
 
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <div className="relative flex-1 min-w-[300px] max-w-md">
@@ -313,37 +316,39 @@ function MetricBrowserContent() {
         )}
       </div>
 
-      {filtered.length === 0 ? (
-        <div className="py-12 text-center" data-testid="no-filter-matches">
-          <p className="text-sm text-gray-500">No metrics match your filters.</p>
-          <button
-            onClick={clearFilters}
-            className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
-            data-testid="clear-filters-empty"
-          >
-            Clear filters
-          </button>
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Metric ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Source Event</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Direction</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Flags</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {filtered.map((m) => (
-                <MetricRow key={m.metricId} metric={m} />
-              ))}
-            </tbody>
-          </table>
-        </div>
+        {filtered.length === 0 ? (
+          <div className="py-12 text-center" data-testid="no-filter-matches">
+            <p className="text-sm text-gray-500">No metrics match your filters.</p>
+            <button
+              onClick={clearFilters}
+              className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+              data-testid="clear-filters-empty"
+            >
+              Clear filters
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Metric ID</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Source Event</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Direction</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Flags</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {filtered.map((m) => (
+                  <MetricRow key={m.metricId} metric={m} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        </>
       )}
     </div>
   );

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -6,6 +6,7 @@ import type { MetricDefinition, MetricType } from '@/lib/types';
 import { listMetricDefinitions } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { CopyButton } from '@/components/copy-button';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const SqlHighlighter = dynamic(
   () => import('@/components/sql-highlighter').then((m) => ({ default: m.SqlHighlighter })),
@@ -256,6 +257,11 @@ function MetricBrowserContent() {
 
   return (
     <div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Metrics' },
+      ]} />
+
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-bold text-gray-900">Metric Definitions</h1>
         <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="metric-count">

--- a/ui/src/app/monitoring/page.tsx
+++ b/ui/src/app/monitoring/page.tsx
@@ -7,6 +7,7 @@ import { MonitoringSummaryCards } from '@/components/monitoring-summary-cards';
 import { MonitoringHealthTable } from '@/components/monitoring-health-table';
 import { MonitoringBreachList } from '@/components/monitoring-breach-list';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const AUTO_REFRESH_INTERVAL_MS = 30_000;
 
@@ -116,6 +117,11 @@ export default function MonitoringPage() {
 
   return (
     <div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Monitoring' },
+      ]} />
+
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">Monitoring</h1>
         <div className="flex items-center gap-4">

--- a/ui/src/app/portfolio/page.tsx
+++ b/ui/src/app/portfolio/page.tsx
@@ -7,6 +7,7 @@ import { getPortfolioAllocation, getPortfolioMetrics, getParetoFrontier } from '
 import type { PortfolioAllocationResult, PortfolioMetricsResult, ParetoFrontierResult } from '@/lib/types';
 import { ExperimentPortfolioTable } from '@/components/experiment-portfolio-table';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Code-split: chart bundles loaded only when page renders
 const BudgetAllocationChart = dynamic(
@@ -120,10 +121,10 @@ export default function PortfolioDashboard() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <span className="text-gray-900 font-medium">Portfolio</span>
-      </nav>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Portfolio' },
+      ]} />
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>


### PR DESCRIPTION
💡 What: This PR standardizes secondary navigation (breadcrumbs) across all primary list pages and implements a more transparent interaction pattern for permission-restricted actions.

🎯 Why: 
- Users were experiencing disorientation when navigating between the Experiments root and other primary sections (Flags, Metrics, etc.). Standardized breadcrumbs provide clear spatial awareness and consistent return paths.
- Hiding the "New Flag" button for viewers was causing confusion about where creation actions were located. Replacing this with a disabled button and informative tooltip clarifies role-based restrictions without layout shifts.
- Refined empty states ensure that navigation and headers are always available for orientation, even before data is populated.

♿ Accessibility:
- Added semantic breadcrumb navigation to multiple pages.
- Used native `title` tooltips to explain disabled button states.
- Maintained consistent heading hierarchy across empty/populated states.

📸 Before/After:
- Feature Flags page now has "Experiments / Flags" breadcrumb.
- "New Flag" button now visible but disabled for viewers with "Requires Experimenter role" tooltip.
- Metrics, Monitoring, and Portfolio pages now include "Experiments / [Section]" breadcrumbs.

---
*PR created automatically by Jules for task [448726132587634511](https://jules.google.com/task/448726132587634511) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->