### PR TITLE
feat(infra): swap Confluent Schema Registry for Redpanda in docker-compose

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,10 @@
 # Lightweight infrastructure for CI integration tests.
 # No persistent volumes — everything is ephemeral.
+#
+# Streaming: Redpanda (Kafka API + built-in Schema Registry).
+# Replaces the prior single-node Confluent KRaft Kafka image as of Phase 2 of
+# the multi-cloud migration (docs/superpowers/specs/2026-04-20-multi-cloud-gcp-aws-design.md).
+# Tests bind to localhost:9092 the same way they did against Confluent Kafka.
 
 services:
   postgres:
@@ -18,23 +23,30 @@ services:
       timeout: 2s
       retries: 10
 
-  kafka:
-    image: confluentinc/cp-kafka:7.7.0
-    ports: ["9092:9092"]
-    environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      CLUSTER_ID: "Y2ktdGVzdC1rYWZrYS0wMD"
-    user: "0:0"
-    tmpfs: /var/lib/kafka/data
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.5
+    container_name: redpanda-test
+    command:
+      - redpanda
+      - start
+      - --smp=1
+      - --memory=1G
+      - --reserve-memory=0M
+      - --mode=dev-container
+      - --default-log-level=info
+      - --kafka-addr=internal://0.0.0.0:29092,external://0.0.0.0:9092
+      - --advertise-kafka-addr=internal://redpanda:29092,external://localhost:9092
+      - --schema-registry-addr=internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr=redpanda:33145
+      - --advertise-rpc-addr=redpanda:33145
+    ports:
+      - "9092:9092"     # Kafka API
+      - "8081:8081"     # Schema Registry (built-in)
+      - "9644:9644"     # Admin API
+    tmpfs: /var/lib/redpanda/data
     healthcheck:
-      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:9092"]
-      interval: 5s
+      test: ["CMD-SHELL", "rpk cluster health --brokers=localhost:9092 | grep -E 'Healthy:[[:space:]]+true'"]
+      interval: 2s
       timeout: 3s
-      retries: 10
+      retries: 30
+      start_period: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 ##############################################################################
 # Local Development Infrastructure
 # Usage:
-#   docker-compose up -d                 # Start all infra
-#   docker-compose up -d postgres kafka  # Start specific services
-#   docker-compose down -v               # Stop and remove volumes
+#   docker-compose up -d                    # Start all infra
+#   docker-compose up -d postgres redpanda  # Start specific services
+#   docker-compose down -v                  # Stop and remove volumes
+#
+# Streaming: Redpanda (Kafka API + built-in Schema Registry).
+# Replaces Confluent Kafka + Zookeeper + Schema Registry as of Phase 2 of the
+# multi-cloud migration (docs/superpowers/specs/2026-04-20-multi-cloud-gcp-aws-design.md).
+# See docs/guides/streaming-integration.md for compatibility notes.
 ##############################################################################
 
 services:
@@ -23,60 +28,65 @@ services:
       timeout: 3s
       retries: 5
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.7.0
-    ports: ["2181:2181"]
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  kafka:
-    image: confluentinc/cp-kafka:7.7.0
-    ports: ["9092:9092", "29092:29092"]
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,HOST://localhost:9092
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
-      KAFKA_NUM_PARTITIONS: 4
-      KAFKA_DEFAULT_REPLICATION_FACTOR: 1
-    depends_on:
-      zookeeper: { condition: service_started }
+  # Redpanda: Kafka API on :9092 (external) and :29092 (internal),
+  # built-in Schema Registry on :8081, Pandaproxy on :8082, Admin API on :9644.
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.5
+    container_name: redpanda
+    command:
+      - redpanda
+      - start
+      - --smp=1
+      - --memory=1G
+      - --reserve-memory=0M
+      - --mode=dev-container
+      - --default-log-level=info
+      - --kafka-addr=internal://0.0.0.0:29092,external://0.0.0.0:9092
+      - --advertise-kafka-addr=internal://redpanda:29092,external://localhost:9092
+      - --pandaproxy-addr=internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr=internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr=internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr=redpanda:33145
+      - --advertise-rpc-addr=redpanda:33145
+    ports:
+      - "9092:9092"     # Kafka API (host)
+      - "29092:29092"   # Kafka API (in-network alias kept for parity with prior kafka:29092)
+      - "8081:8081"     # Schema Registry (Confluent-compatible HTTP API)
+      - "18081:18081"   # Schema Registry (host alias, unused by services)
+      - "8082:8082"     # Pandaproxy (Kafka REST proxy, optional)
+      - "18082:18082"   # Pandaproxy (host alias)
+      - "9644:9644"     # Admin API (rpk, monitoring)
+    volumes:
+      - redpanda_data:/var/lib/redpanda/data
     healthcheck:
-      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "localhost:29092"]
-      interval: 10s
+      test: ["CMD-SHELL", "rpk cluster health --brokers=localhost:9092 | grep -E 'Healthy:[[:space:]]+true'"]
+      interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 20
+      start_period: 20s
 
-  kafka-init:
-    image: confluentinc/cp-kafka:7.7.0
+  # Topic seeding. Kept as a separate service so the broker stays generic
+  # and topic config is reviewable in one place. Mirrors the Confluent
+  # `kafka-init` step that this compose file used to run.
+  redpanda-init:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.3.5
     depends_on:
-      kafka: { condition: service_healthy }
+      redpanda: { condition: service_healthy }
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        echo 'Creating Kafka topics...'
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic exposures         --partitions 4 --replication-factor 1
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic metric_events     --partitions 8 --replication-factor 1
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic reward_events     --partitions 4 --replication-factor 1
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic qoe_events        --partitions 4 --replication-factor 1
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic guardrail_alerts            --partitions 2 --replication-factor 1
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic model_retraining_events    --partitions 8 --replication-factor 1
-        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic model_training_requests    --partitions 2 --replication-factor 1
+        set -e
+        echo 'Creating Redpanda topics...'
+        BROKERS=redpanda:29092
+        rpk topic create exposures               --partitions 4 --replicas 1 --brokers $$BROKERS || true
+        rpk topic create metric_events           --partitions 8 --replicas 1 --brokers $$BROKERS || true
+        rpk topic create reward_events           --partitions 4 --replicas 1 --brokers $$BROKERS || true
+        rpk topic create qoe_events              --partitions 4 --replicas 1 --brokers $$BROKERS || true
+        rpk topic create guardrail_alerts        --partitions 2 --replicas 1 --brokers $$BROKERS || true
+        rpk topic create model_retraining_events --partitions 8 --replicas 1 --brokers $$BROKERS || true
+        rpk topic create model_training_requests --partitions 2 --replicas 1 --brokers $$BROKERS || true
         echo 'Done.'
-
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.7.0
-    ports: ["8081:8081"]
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:29092
-      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
-    depends_on:
-      kafka: { condition: service_healthy }
+        rpk topic list --brokers $$BROKERS
 
   redis:
     image: redis:7-alpine
@@ -87,15 +97,19 @@ services:
       timeout: 3s
       retries: 5
 
+  # Redpanda Console — successor to the previous `kafka-ui` setup.
+  # Talks to the broker over the internal listener and to the built-in
+  # Schema Registry over its internal HTTP endpoint.
   kafka-ui:
     image: docker.redpanda.com/redpandadata/console:latest
     ports: ["8080:8080"]
     environment:
-      KAFKA_BROKERS: kafka:29092
+      KAFKA_BROKERS: redpanda:29092
       KAFKA_SCHEMAREGISTRY_ENABLED: "true"
-      KAFKA_SCHEMAREGISTRY_URLS: http://schema-registry:8081
+      KAFKA_SCHEMAREGISTRY_URLS: http://redpanda:8081
     depends_on:
-      kafka: { condition: service_healthy }
+      redpanda: { condition: service_healthy }
 
 volumes:
   postgres_data:
+  redpanda_data:

--- a/docs/guides/streaming-integration.md
+++ b/docs/guides/streaming-integration.md
@@ -1,0 +1,180 @@
+# Streaming Integration Guide
+
+**Audience:** developers writing Kafka producer/consumer code or schema-aware
+clients against the local dev stack and CI test infrastructure.
+
+**Status:** Phase 2 of the multi-cloud migration — Redpanda has replaced the
+Confluent CP stack in `docker-compose.yml` and `docker-compose.test.yml`. All
+existing Rust and Go Kafka clients continue to work without code changes.
+See `docs/superpowers/specs/2026-04-20-multi-cloud-gcp-aws-design.md` for the
+full design context.
+
+## What changed
+
+| Concern | Before (Confluent CP 7.7.0) | After (Redpanda v24.3.5) |
+| --- | --- | --- |
+| Containers | `confluentinc/cp-zookeeper` + `confluentinc/cp-kafka` + `confluentinc/cp-schema-registry` + a `kafka-init` job | Single `redpanda` container + a small `redpanda-init` topic-seeding job |
+| Process model | JVM (Kafka, Zookeeper, SR) | Single C++ process |
+| Kafka API port (host) | `localhost:9092` | `localhost:9092` (unchanged) |
+| Kafka API port (in-network) | `kafka:29092` | `redpanda:29092` |
+| Schema Registry port | `localhost:8081` | `localhost:8081` (unchanged) |
+| Schema Registry storage | `_schemas` topic on Kafka | Internal Raft group (managed by Redpanda) |
+| Admin tooling | `kafka-topics`, `kafka-console-consumer` | `rpk topic`, `rpk cluster`, `rpk registry` |
+| Default replication factor | 1 (dev) | 1 (`dev-container` mode) |
+| Health check | `kafka-broker-api-versions` | `rpk cluster health` |
+| UI | `kafka-ui` (Redpanda Console) → `kafka:29092` + `http://schema-registry:8081` | Same image, repointed at `redpanda:29092` + `http://redpanda:8081` |
+
+The Kafka wire protocol, Schema Registry HTTP API contract, port numbers, and
+container DNS surface stay the same from the application's perspective.
+Redpanda is wire-compatible with Kafka 3.x and ships a Confluent-compatible
+Schema Registry. Tests that connected to `localhost:9092` and `localhost:8081`
+continue to do so without edits.
+
+## How to use
+
+### Bring up the stack
+
+```bash
+docker compose up -d                  # starts redpanda, redpanda-init, postgres, redis, kafka-ui
+just infra                            # justfile shortcut (--wait gates on health)
+```
+
+The `redpanda-init` service runs `rpk topic create` for the seven topics the
+platform expects (`exposures`, `metric_events`, `reward_events`, `qoe_events`,
+`guardrail_alerts`, `model_retraining_events`, `model_training_requests`),
+exits, and stays exited. This mirrors the previous `kafka-init` Confluent job.
+
+### Inspect topics and consumer groups
+
+Inside the broker container (preferred):
+
+```bash
+docker exec -it redpanda rpk topic list --brokers=localhost:9092
+docker exec -it redpanda rpk topic describe metric_events --brokers=localhost:9092
+docker exec -it redpanda rpk group list --brokers=localhost:9092
+docker exec -it redpanda rpk topic consume reward_events --brokers=localhost:9092 -o end
+```
+
+From the host, with `rpk` installed (`brew install redpanda-data/tap/redpanda`):
+
+```bash
+rpk topic list -X brokers=localhost:9092
+rpk registry subject list -X registry.hosts=localhost:8081
+```
+
+`rpk` is the only CLI you should reach for. `kafka-topics`/`kafka-console-*`
+are not present on the Redpanda image; if you have a habit of typing them,
+update muscle memory now.
+
+### Schema Registry
+
+The HTTP API is served by the broker itself on `:8081`. There is no separate
+container, and there is no `_schemas` Kafka topic — the registry stores
+schemas in its own Raft group. From the application's perspective this is
+invisible; clients hit the same endpoints they used against Confluent.
+
+```bash
+curl -s http://localhost:8081/subjects
+curl -s http://localhost:8081/schemas/types
+curl -s http://localhost:8081/config
+```
+
+#### Compatibility caveats
+
+The Confluent and Redpanda implementations are intentionally interchangeable
+for the endpoints typical clients use, but a few edges differ. None of them
+are exercised by the current Rust/Go test suite — this section exists so
+future schema-validation work doesn't get surprised.
+
+| Surface | Confluent CP 7.x | Redpanda v24.3 | Impact on this repo |
+| --- | --- | --- | --- |
+| Subject CRUD (`/subjects`, `/subjects/{n}/versions`) | ✓ | ✓ | None — wire-compatible |
+| Schema lookup (`/schemas/ids/{id}`, `/schemas/types`) | ✓ | ✓ | None |
+| Compatibility checks (`/compatibility/...`) | ✓ | ✓ | None |
+| `/config` (global + per-subject) | ✓ | ✓ | None — `BACKWARD` is the default in both |
+| `/mode` (global + per-subject) | ✓ | ✓ | None |
+| `/exporters` (Schema Linking) | ✓ | ✗ — not implemented | Out of scope for Kaizen; we don't replicate schemas across clusters in dev/test |
+| `_schemas` topic config tweaks (e.g. `kafkastore.topic`) | Required env wiring on the SR container | N/A — Redpanda stores schemas internally | Drop any `SCHEMA_REGISTRY_KAFKASTORE_*` env vars when porting tooling |
+| JSON Schema draft support | drafts 4, 6, 7 | drafts 4, 6, 7, 2019-09, 2020-12 | Strictly additive |
+| Protobuf normalization | Confluent canonical form | Same | Identical — no diff for our `.proto`-derived schemas |
+| Per-subject naming strategy headers | Required when not `TopicNameStrategy` | Same | None — we use `TopicNameStrategy` everywhere |
+
+If you add a Schema Registry-aware client and need to talk to the registry
+from inside a container, the URL is `http://redpanda:8081` (not
+`http://schema-registry:8081`).
+
+### Kafka client configuration
+
+No change. Existing producer/consumer config keeps working:
+
+```rust
+// Rust — rdkafka
+ClientConfig::new()
+    .set("bootstrap.servers", "localhost:9092")
+    .set("group.id", "metric-consumer")
+```
+
+```go
+// Go — segmentio/kafka-go
+kafka.NewReader(kafka.ReaderConfig{
+    Brokers: []string{"localhost:9092"},
+    Topic:   "guardrail_alerts",
+    GroupID: "m5-consumer",
+})
+```
+
+Inside the docker network, use `redpanda:29092` instead of `localhost:9092`
+(replacing the previous `kafka:29092`). For services started via Pulumi/IaC
+this is wired automatically through the `BootstrapBrokers` output.
+
+## CI and local test workflow
+
+`docker-compose.test.yml` boots the same Redpanda image with `tmpfs`-backed
+storage and no `kafka-ui`. Tests gated by `#[ignore]` (Rust) and
+`//go:build integration` (Go) connect to `localhost:9092` exactly as before.
+
+```bash
+docker compose -f docker-compose.test.yml up -d --wait
+
+# Rust — runs the live-Kafka tests
+cargo test -p experimentation-pipeline -- --ignored
+cargo test -p experimentation-ingest   -- --ignored
+
+# Go — runs the integration-tagged tests
+go test -tags=integration ./services/metrics/...
+```
+
+### Why "no application code changes" matters
+
+Phase 2 is the wire-compatibility gate. A successful run of the integration
+suites against Redpanda — with no edits to `crates/`, `services/`, or
+`sdks/` — is the prerequisite for any cloud-side Redpanda deployment
+(`infra/pkg/streaming/redpanda.go`, Phase 5+ work). If a test ever needs a
+code edit to pass against Redpanda, that's a bug in either the swap or the
+client config; surface it before the cloud migration consumes it.
+
+## Migration checklist for new tooling
+
+When you add new code that touches Kafka or the Schema Registry:
+
+- [ ] Talk to brokers via `localhost:9092` from the host or `redpanda:29092`
+      from inside docker. Don't hardcode `kafka:29092`.
+- [ ] Talk to the registry via `localhost:8081` / `redpanda:8081`. Don't
+      hardcode `schema-registry:8081`.
+- [ ] If you need a topic that doesn't exist yet, add it to the
+      `redpanda-init` service in **both** compose files in the same PR.
+- [ ] If you start using a Schema Registry endpoint not listed in the
+      compatibility table above, run `curl http://localhost:8081/<endpoint>`
+      against both Confluent and Redpanda first and update this guide.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-04-20-multi-cloud-gcp-aws-design.md`
+  (Phase 2 + Testing Strategy → Streaming integration test)
+- Redpanda Schema Registry docs:
+  https://docs.redpanda.com/current/manage/schema-reg/schema-reg-overview/
+- Redpanda `rpk` reference:
+  https://docs.redpanda.com/current/reference/rpk/
+- ADR-026 (custom metrics) and ADR-027 (TOST equivalence) — both are likely
+  consumers of the Schema Registry; link this guide from their design docs
+  when they reach implementation.

--- a/justfile
+++ b/justfile
@@ -627,8 +627,8 @@ status:
         || echo "    (not reachable)"
     @echo ""
     @echo "  Kafka topics:"
-    @docker exec -it $$({{ docker }} ps -q --filter name=kafka 2>/dev/null | head -1) \
-        kafka-topics --bootstrap-server localhost:29092 --list 2>/dev/null \
+    @docker exec -i $$({{ docker }} ps -q --filter name=redpanda 2>/dev/null | head -1) \
+        rpk topic list --brokers=localhost:9092 2>/dev/null \
         || echo "    (not reachable)"
 
 # Watch Rust workspace for changes and re-run tests


### PR DESCRIPTION
## Summary

Phase 2 of the multi-cloud GCP/AWS migration (Redpanda wire-compatibility gate before any cloud deployment). Replaces `confluentinc/cp-zookeeper` + `confluentinc/cp-kafka` + `confluentinc/cp-schema-registry` + the `kafka-init` topic-seeding job with **one** Redpanda v24.3.5 container that serves the Kafka API on `:9092`/`:29092` and a Confluent-compatible Schema Registry on `:8081`. A small `redpanda-init` companion creates the seven platform topics via `rpk topic create`.

- `docker-compose.yml` — local dev stack
- `docker-compose.test.yml` — CI integration tests (tmpfs-backed, no UI)
- `justfile` — `status` recipe updated from `kafka-topics` to `rpk topic list`
- `docs/guides/streaming-integration.md` — new guide covering port/CLI cheat sheet and Confluent vs Redpanda Schema Registry compatibility caveats

**Zero application code changes.** No `crates/`, `services/`, or `sdks/` files are touched. Rust crates connect to `localhost:9092` exactly as before; Schema Registry endpoints are wire-compatible.

Closes #478

## Why a single container

Redpanda's Schema Registry is built into the broker process — there is no separate JVM, no `_schemas` Kafka topic (Redpanda stores schemas in an internal Raft group), and no Zookeeper. This collapses 4 containers into 1+1 (broker + topic-seeder), drops the JVM warmup, and gives us the same image we'll deploy to Redpanda Cloud later.

## Compatibility caveats

Documented in `docs/guides/streaming-integration.md`. None affect the current test suite. Highlights:

- ✅ `/subjects`, `/schemas/ids/{id}`, `/config`, `/mode`, `/compatibility/...` — wire-identical
- ✅ Protobuf canonical form, `TopicNameStrategy` — identical
- ✅ JSON Schema drafts — Redpanda is a strict superset (adds 2019-09 + 2020-12)
- ❌ `/exporters` (Schema Linking) — not implemented in Redpanda, but Kaizen doesn't replicate schemas across clusters
- ⚠️ `SCHEMA_REGISTRY_KAFKASTORE_*` env vars — N/A; drop them when porting tooling

## Test plan

Verified locally on this PR's branch:

- [x] `docker compose -f docker-compose.yml config --quiet` — compose file is valid
- [x] `docker compose -f docker-compose.test.yml config --quiet` — CI compose is valid
- [x] `cargo check -p experimentation-pipeline -p experimentation-ingest` — clean build, no app code changes
- [x] `cargo test -p experimentation-pipeline -p experimentation-ingest --no-run` — all integration tests compile
- [x] `cargo test -p experimentation-pipeline -p experimentation-ingest --tests` — non-ignored tests pass (17 passed, 7 ignored as expected — those are the live-Kafka tests gated on `#[ignore]`)
- [x] `go vet ./services/metrics/...` and `go vet -tags=integration ./services/metrics/internal/alerts/...` — clean
- [x] `go test ./services/metrics/internal/alerts/...` — non-integration tests pass

**Not verified on this worker** (Docker daemon was unavailable — colima had a stale disk lock and I didn't want to forcibly reset the user's local VM state). Reviewer or CI should run:

- [ ] `docker compose up -d --wait` brings up the stack and the broker becomes healthy
- [ ] `docker exec redpanda rpk topic list --brokers=localhost:9092` shows all seven seeded topics
- [ ] `cargo test -p experimentation-pipeline -- --ignored` — the 7+ live Kafka roundtrip tests
- [ ] `cargo test -p experimentation-ingest -- --ignored`
- [ ] `go test -tags=integration ./services/metrics/...` — `m3m5_guardrail_contract_test.go`, `publisher_integration_test.go`
- [ ] `curl http://localhost:8081/subjects` returns `[]` (empty Schema Registry on a fresh stack)
- [ ] Redpanda Console at `http://localhost:8080` connects to broker + registry

## References

- Spec: `docs/superpowers/specs/2026-04-20-multi-cloud-gcp-aws-design.md` (Phase 2, Testing Strategy → Streaming integration test)
- Guide added: `docs/guides/streaming-integration.md`
- Out of scope (per spec): `infra/pkg/streaming/redpanda.go` (Pulumi cloud resource) — covered by a separate Phase 5+ PR

## Notes for the reviewer / continuation

- If you'd rather not pin to `v24.3.5`, swap to `:latest` — but pinning makes CI reproducible and matches what we'll target for the cloud rollout.
- `docker-compose.yml` keeps the `29092:29092` host port mapping for parity with anything that previously bound to `kafka:29092` from outside the docker network. We could drop it; nothing in this repo needs it from the host. Left in to minimize surprise.
- The compatibility table in the guide should be revisited when ADR-026 (custom metrics) or ADR-027 (TOST) start using the Schema Registry directly — those are likely the first real consumers of the registry HTTP API in this repo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->