### PR TITLE
🎨 Palette: Monitoring Page Breadcrumbs & Persistent Layout

### DIFF
--- a/ui/src/__tests__/monitoring.test.tsx
+++ b/ui/src/__tests__/monitoring.test.tsx
@@ -25,7 +25,7 @@ vi.mock('next/link', () => ({
 async function renderAndWait() {
   render(<MonitoringPage />);
   await waitFor(() => {
-    expect(screen.getByText('Monitoring')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Monitoring', level: 1 })).toBeInTheDocument();
     expect(screen.getByTestId('summary-cards')).toBeInTheDocument();
   });
 }

--- a/ui/src/app/monitoring/page.tsx
+++ b/ui/src/app/monitoring/page.tsx
@@ -7,6 +7,7 @@ import { MonitoringSummaryCards } from '@/components/monitoring-summary-cards';
 import { MonitoringHealthTable } from '@/components/monitoring-health-table';
 import { MonitoringBreachList } from '@/components/monitoring-breach-list';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const AUTO_REFRESH_INTERVAL_MS = 30_000;
 
@@ -101,21 +102,60 @@ export default function MonitoringPage() {
     };
   }, [autoRefresh, fetchData]);
 
-  if (loading && experiments.length === 0) {
-    return (
-      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
-        <span className="sr-only">Loading</span>
-      </div>
-    );
-  }
+  const renderContent = () => {
+    if (loading && experiments.length === 0) {
+      return (
+        <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+          <span className="sr-only">Loading</span>
+        </div>
+      );
+    }
 
-  if (error && experiments.length === 0) {
-    return <RetryableError message={error} onRetry={fetchData} context="monitoring data" />;
-  }
+    if (error && experiments.length === 0) {
+      return <RetryableError message={error} onRetry={fetchData} context="monitoring data" />;
+    }
+
+    return (
+      <>
+        <section className="mb-8" aria-labelledby="summary-heading">
+          <h2 id="summary-heading" className="mb-4 text-lg font-semibold text-gray-800">
+            Active Experiments Summary
+          </h2>
+          <MonitoringSummaryCards experiments={experiments} />
+        </section>
+
+        <section className="mb-8" aria-labelledby="health-heading">
+          <h2 id="health-heading" className="mb-4 text-lg font-semibold text-gray-800">
+            Running Experiments Health
+          </h2>
+          <MonitoringHealthTable
+            experiments={experiments}
+            analysisResults={analysisResults}
+            guardrailStatuses={guardrailStatuses}
+          />
+        </section>
+
+        <section aria-labelledby="breaches-heading">
+          <h2 id="breaches-heading" className="mb-4 text-lg font-semibold text-gray-800">
+            Recent Guardrail Breaches
+          </h2>
+          <MonitoringBreachList
+            experiments={experiments}
+            guardrailStatuses={guardrailStatuses}
+          />
+        </section>
+      </>
+    );
+  };
 
   return (
     <div>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Monitoring' },
+      ]} />
+
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">Monitoring</h1>
         <div className="flex items-center gap-4">
@@ -137,33 +177,7 @@ export default function MonitoringPage() {
         </div>
       </div>
 
-      <section className="mb-8" aria-labelledby="summary-heading">
-        <h2 id="summary-heading" className="mb-4 text-lg font-semibold text-gray-800">
-          Active Experiments Summary
-        </h2>
-        <MonitoringSummaryCards experiments={experiments} />
-      </section>
-
-      <section className="mb-8" aria-labelledby="health-heading">
-        <h2 id="health-heading" className="mb-4 text-lg font-semibold text-gray-800">
-          Running Experiments Health
-        </h2>
-        <MonitoringHealthTable
-          experiments={experiments}
-          analysisResults={analysisResults}
-          guardrailStatuses={guardrailStatuses}
-        />
-      </section>
-
-      <section aria-labelledby="breaches-heading">
-        <h2 id="breaches-heading" className="mb-4 text-lg font-semibold text-gray-800">
-          Recent Guardrail Breaches
-        </h2>
-        <MonitoringBreachList
-          experiments={experiments}
-          guardrailStatuses={guardrailStatuses}
-        />
-      </section>
+      {renderContent()}
     </div>
   );
 }


### PR DESCRIPTION
I have implemented a micro-UX improvement on the Monitoring page:

1.  **Added Breadcrumbs**: Users now see a clear navigation path (`Experiments / Monitoring`) at the top of the page, matching the pattern used in other sections of the app.
2.  **Persistent Layout**: Refactored the page structure so that the breadcrumbs and the "Monitoring" page heading are rendered *before* the loading or error states. This ensures that users always know where they are, even if the data takes a moment to load or if a network error occurs.
3.  **Test Stability**: Updated the associated Vitest tests to use specific ARIA role queries (`getByRole('heading', { level: 1 })`) for the page title, preventing failures caused by the breadcrumb also containing the word "Monitoring".

This change brings the Monitoring page into alignment with the platform's standardized list-page pattern, improving consistency and accessibility.

---
*PR created automatically by Jules for task [12188020930582855528](https://jules.google.com/task/12188020930582855528) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->