### PR TITLE
Phase 1: GCP secrets module (Secret Manager) (Closes #481)

### DIFF
--- a/infra/go.mod
+++ b/infra/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.83.2
 	github.com/pulumi/pulumi-command/sdk v1.2.1
+	github.com/pulumi/pulumi-gcp/sdk/v8 v8.41.1
 	github.com/pulumi/pulumi-kafka/sdk/v3 v3.12.3
 	github.com/pulumi/pulumi/sdk/v3 v3.229.0
 )

--- a/infra/go.sum
+++ b/infra/go.sum
@@ -187,6 +187,8 @@ github.com/pulumi/pulumi-aws/sdk/v6 v6.83.2 h1:KrV04/k8+PRfkX/90pLm/jug6tfc9YeQH
 github.com/pulumi/pulumi-aws/sdk/v6 v6.83.2/go.mod h1:520DDoW2zBYVWwwAT8qt/9VhNoBcDIslDljzE8/O080=
 github.com/pulumi/pulumi-command/sdk v1.2.1 h1:mAziZ91a/9U+5IjZH5Skcar80OSmpBSYljeQNRblTWQ=
 github.com/pulumi/pulumi-command/sdk v1.2.1/go.mod h1:hQxv9DXg6bFjcd9BEiNdMImQ/V1rnC9D115q5VXYNps=
+github.com/pulumi/pulumi-gcp/sdk/v8 v8.41.1 h1:w6OnO3d4j5yVf2vpm8OzXFC/xHOEGqt+9FjWCUBCq6U=
+github.com/pulumi/pulumi-gcp/sdk/v8 v8.41.1/go.mod h1:UyZyv7hz4knpFx6/Sh+SkZe6hT6sJHtDvw9A0TbvEsk=
 github.com/pulumi/pulumi-kafka/sdk/v3 v3.12.3 h1:M1jPYXKr7qMm1MlKRY9I4K19WnbW9oD08puFG42Uhrw=
 github.com/pulumi/pulumi-kafka/sdk/v3 v3.12.3/go.mod h1:SCwRmNwNVMfoZuy3UFkz7VMGhLZd0zHcWSRcDqvu5F4=
 github.com/pulumi/pulumi/sdk/v3 v3.229.0 h1:jsAw5lXiHN22YQeo4bZHZBAG/DUlEnzsFWg5MuHnTSs=

--- a/infra/pkg/gcp/secrets/secrets.go
+++ b/infra/pkg/gcp/secrets/secrets.go
@@ -1,0 +1,259 @@
+// Package secrets provisions GCP Secret Manager secrets for all Kaizen
+// service credentials: database (PG), Kafka/Redpanda (SASL), Redis (AUTH),
+// and OAuth2 client credentials. Secret payloads are JSON-serialized so
+// the same wire shape works on AWS Secrets Manager and GCP Secret Manager.
+//
+// This module mirrors the public API of pkg/aws/secrets so that the
+// per-cloud aggregator (pkg/gcp/gcp.go, added in a follow-up integration PR)
+// can call NewSecrets identically on either provider.
+//
+// IAM bindings that grant compute service accounts read access to these
+// secrets are intentionally NOT created here — on AWS they live in
+// pkg/aws/compute/services.go (and pkg/aws/compute/migration.go), so we
+// preserve that boundary for parity. Wiring will land alongside the GCP
+// compute module (issue #486).
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/secretmanager"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/kaizen-experimentation/infra/pkg/config"
+)
+
+// SecretsOutputs exposes the resource-name paths of all provisioned secrets
+// in their `projects/{project}/secrets/{secret_id}` form. Callers that need
+// a `versions/latest` accessor should use the *Ref fields, which already
+// append that suffix.
+type SecretsOutputs struct {
+	// DatabaseSecretName is the bare path: projects/<P>/secrets/<S>
+	DatabaseSecretName pulumi.StringOutput
+	KafkaSecretName    pulumi.StringOutput
+	RedisSecretName    pulumi.StringOutput
+	AuthSecretName     pulumi.StringOutput
+
+	// DatabaseSecretRef is the version-qualified path:
+	// projects/<P>/secrets/<S>/versions/latest. This is the form Cloud Run
+	// expects when wiring secrets via env-var references and what AWS
+	// compute consumers see as the cross-cloud SecretRef.
+	DatabaseSecretRef pulumi.StringOutput
+	KafkaSecretRef    pulumi.StringOutput
+	RedisSecretRef    pulumi.StringOutput
+	AuthSecretRef     pulumi.StringOutput
+}
+
+// DatabaseSecret holds the JSON-serializable structure for the Cloud SQL
+// connection secret. The shape matches pkg/aws/secrets.DatabaseSecret so
+// service code is identical on both clouds.
+type DatabaseSecret struct {
+	Engine   string `json:"engine"`
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Dbname   string `json:"dbname"`
+}
+
+// KafkaSecret holds SASL/SCRAM credentials and bootstrap servers. Used
+// against MSK on AWS and against Redpanda on GCP — same shape, same field
+// names. Service code reads either transparently.
+type KafkaSecret struct {
+	SaslUsername     string `json:"sasl_username"`
+	SaslPassword     string `json:"sasl_password"`
+	SaslMechanism    string `json:"sasl_mechanism"`
+	BootstrapBrokers string `json:"bootstrap_brokers"`
+}
+
+// RedisSecret holds the AUTH token and endpoint for Memorystore Redis.
+type RedisSecret struct {
+	AuthToken string `json:"auth_token"`
+	Endpoint  string `json:"endpoint"`
+	Port      int    `json:"port"`
+}
+
+// AuthSecret holds OAuth2 client credentials for the platform auth layer.
+type AuthSecret struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	TokenURL     string `json:"token_url"`
+	Issuer       string `json:"issuer"`
+}
+
+// SecretsInputs holds resource outputs from upstream Phase 1 modules
+// (database, cache, streaming). These flow lazily through Pulumi outputs
+// so the secrets module can be constructed before its dependencies have
+// resolved their endpoints.
+type SecretsInputs struct {
+	// CloudSqlEndpoint is the Cloud SQL PostgreSQL primary endpoint
+	// (host or host:port format).
+	CloudSqlEndpoint pulumi.StringOutput
+	// KafkaBootstrapBrokers is the comma-separated SASL bootstrap broker
+	// list. On GCP this typically points at Redpanda; on AWS it points at
+	// MSK. The shared SecretsInputs name avoids cloud-specific field names.
+	KafkaBootstrapBrokers pulumi.StringOutput
+	// RedisEndpoint is the Memorystore primary endpoint address.
+	RedisEndpoint pulumi.StringOutput
+}
+
+// NewSecrets creates all four Secret Manager secrets (database, kafka,
+// redis, auth) with automatic Google-managed replication. Resource
+// endpoints from SecretsInputs feed the JSON payloads.
+//
+// Naming: the GCP SecretId must match [A-Za-z0-9_-]+, so we use
+// cfg.ResourceName(...) (which produces `kaizen-<env>-<component>`) rather
+// than cfg.SecretPath which embeds slashes for AWS-style hierarchical
+// secrets.
+func NewSecrets(ctx *pulumi.Context, cfg *config.Config, inputs *SecretsInputs) (*SecretsOutputs, error) {
+	if inputs == nil {
+		return nil, fmt.Errorf("gcp/secrets: SecretsInputs must not be nil")
+	}
+
+	dbSecret, err := newSecretContainer(ctx, cfg, "database")
+	if err != nil {
+		return nil, err
+	}
+	dbPayload := inputs.CloudSqlEndpoint.ApplyT(func(endpoint string) (string, error) {
+		return marshalJSON(DatabaseSecret{
+			Engine:   "postgres",
+			Host:     endpoint,
+			Port:     5432,
+			Username: "kaizen_admin",
+			Password: "CHANGE_ME",
+			Dbname:   "kaizen",
+		})
+	}).(pulumi.StringOutput)
+	if err := newSecretVersion(ctx, cfg, "database", dbSecret, dbPayload); err != nil {
+		return nil, err
+	}
+
+	kafkaSecret, err := newSecretContainer(ctx, cfg, "kafka")
+	if err != nil {
+		return nil, err
+	}
+	kafkaPayload := inputs.KafkaBootstrapBrokers.ApplyT(func(brokers string) (string, error) {
+		return marshalJSON(KafkaSecret{
+			SaslUsername:     "kaizen-kafka-user",
+			SaslPassword:     "CHANGE_ME",
+			SaslMechanism:    "SCRAM-SHA-512",
+			BootstrapBrokers: brokers,
+		})
+	}).(pulumi.StringOutput)
+	if err := newSecretVersion(ctx, cfg, "kafka", kafkaSecret, kafkaPayload); err != nil {
+		return nil, err
+	}
+
+	redisSecret, err := newSecretContainer(ctx, cfg, "redis")
+	if err != nil {
+		return nil, err
+	}
+	redisPayload := inputs.RedisEndpoint.ApplyT(func(endpoint string) (string, error) {
+		return marshalJSON(RedisSecret{
+			AuthToken: "CHANGE_ME",
+			Endpoint:  endpoint,
+			Port:      6379,
+		})
+	}).(pulumi.StringOutput)
+	if err := newSecretVersion(ctx, cfg, "redis", redisSecret, redisPayload); err != nil {
+		return nil, err
+	}
+
+	authSecret, err := newSecretContainer(ctx, cfg, "auth")
+	if err != nil {
+		return nil, err
+	}
+	authJSON, err := marshalJSON(AuthSecret{
+		ClientID:     "kaizen-platform",
+		ClientSecret: "CHANGE_ME",
+		TokenURL:     "https://auth.example.com/oauth2/token",
+		Issuer:       "https://auth.example.com",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := newSecretVersion(ctx, cfg, "auth", authSecret, pulumi.String(authJSON).ToStringOutput()); err != nil {
+		return nil, err
+	}
+
+	return &SecretsOutputs{
+		DatabaseSecretName: dbSecret.Name,
+		KafkaSecretName:    kafkaSecret.Name,
+		RedisSecretName:    redisSecret.Name,
+		AuthSecretName:     authSecret.Name,
+		DatabaseSecretRef:  versionLatestRef(dbSecret.Name),
+		KafkaSecretRef:     versionLatestRef(kafkaSecret.Name),
+		RedisSecretRef:     versionLatestRef(redisSecret.Name),
+		AuthSecretRef:      versionLatestRef(authSecret.Name),
+	}, nil
+}
+
+// newSecretContainer creates a Secret Manager secret with automatic
+// Google-managed replication. The version is added separately so the
+// caller can wire payloads from upstream pulumi.Outputs.
+func newSecretContainer(ctx *pulumi.Context, cfg *config.Config, component string) (*secretmanager.Secret, error) {
+	resourceName := cfg.ResourceName("secret-" + component)
+	secret, err := secretmanager.NewSecret(ctx, resourceName, &secretmanager.SecretArgs{
+		SecretId: pulumi.String(SecretID(cfg, component)),
+		Replication: &secretmanager.SecretReplicationArgs{
+			Auto: &secretmanager.SecretReplicationAutoArgs{},
+		},
+		Labels: pulumi.StringMap{
+			"project":     pulumi.String(cfg.Project),
+			"environment": pulumi.String(string(cfg.Env)),
+			"managed_by":  pulumi.String("pulumi"),
+			"component":   pulumi.String(component),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create %s secret: %w", component, err)
+	}
+	return secret, nil
+}
+
+// newSecretVersion attaches a payload version to an existing secret.
+func newSecretVersion(
+	ctx *pulumi.Context,
+	cfg *config.Config,
+	component string,
+	secret *secretmanager.Secret,
+	payload pulumi.StringOutput,
+) error {
+	resourceName := cfg.ResourceName("secret-" + component) + "-version"
+	_, err := secretmanager.NewSecretVersion(ctx, resourceName, &secretmanager.SecretVersionArgs{
+		Secret:     secret.Name,
+		SecretData: payload,
+	})
+	if err != nil {
+		return fmt.Errorf("create %s secret version: %w", component, err)
+	}
+	return nil
+}
+
+// SecretID derives the GCP SecretId for a given component. GCP requires
+// SecretId to match [A-Za-z0-9_-]+, so we format as
+// `kaizen-<env>-<component>` (which is what cfg.ResourceName already
+// returns — exposed here as a pure function so tests don't need a Pulumi
+// context).
+func SecretID(cfg *config.Config, component string) string {
+	return fmt.Sprintf("kaizen-%s-%s", cfg.Env, component)
+}
+
+// versionLatestRef appends "/versions/latest" to a secret resource-name
+// output so callers get the form Cloud Run / GCE expects when wiring
+// secrets via env-var references.
+func versionLatestRef(name pulumi.StringOutput) pulumi.StringOutput {
+	return pulumi.Sprintf("%s/versions/latest", name)
+}
+
+// marshalJSON is a tiny helper that wraps json.Marshal with a typed error
+// so ApplyT callbacks can return the marshalled string + error tuple
+// directly.
+func marshalJSON(v interface{}) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("marshal secret payload: %w", err)
+	}
+	return string(b), nil
+}

--- a/infra/pkg/gcp/secrets/secrets_test.go
+++ b/infra/pkg/gcp/secrets/secrets_test.go
@@ -1,0 +1,422 @@
+package secrets
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/kaizen-experimentation/infra/pkg/config"
+)
+
+// ---------------------------------------------------------------------------
+// Pure-function tests — no Pulumi context required
+// ---------------------------------------------------------------------------
+
+func TestSecretID(t *testing.T) {
+	tests := []struct {
+		env       config.Environment
+		component string
+		want      string
+	}{
+		{config.EnvDev, "database", "kaizen-dev-database"},
+		{config.EnvStaging, "kafka", "kaizen-staging-kafka"},
+		{config.EnvProd, "redis", "kaizen-prod-redis"},
+		{config.EnvDev, "auth", "kaizen-dev-auth"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.env)+"/"+tt.component, func(t *testing.T) {
+			cfg := &config.Config{Env: tt.env}
+			got := SecretID(cfg, tt.component)
+			if got != tt.want {
+				t.Errorf("SecretID(%s, %s) = %q, want %q", tt.env, tt.component, got, tt.want)
+			}
+		})
+	}
+}
+
+// SecretID must satisfy GCP's [A-Za-z0-9_-]+ rule. Slashes from cfg.SecretPath()
+// would be invalid — this guards against future regressions if someone swaps
+// the helper.
+func TestSecretIDIsGCPCompatible(t *testing.T) {
+	cfg := &config.Config{Env: config.EnvDev}
+	for _, component := range []string{"database", "kafka", "redis", "auth"} {
+		id := SecretID(cfg, component)
+		for _, r := range id {
+			ok := (r >= 'a' && r <= 'z') ||
+				(r >= 'A' && r <= 'Z') ||
+				(r >= '0' && r <= '9') ||
+				r == '-' || r == '_'
+			if !ok {
+				t.Errorf("SecretID(%q) = %q contains invalid GCP SecretId char %q", component, id, r)
+			}
+		}
+		if len(id) > 255 {
+			t.Errorf("SecretID(%q) = %q exceeds 255 char GCP limit", component, id)
+		}
+	}
+}
+
+func TestDatabaseSecretJSONShape(t *testing.T) {
+	v := DatabaseSecret{
+		Engine:   "postgres",
+		Host:     "10.0.0.1",
+		Port:     5432,
+		Username: "u",
+		Password: "p",
+		Dbname:   "d",
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Wire shape must match pkg/aws/secrets.DatabaseSecret. Service code
+	// reads identical JSON on both clouds.
+	wantFields := []string{
+		`"engine":"postgres"`,
+		`"host":"10.0.0.1"`,
+		`"port":5432`,
+		`"username":"u"`,
+		`"password":"p"`,
+		`"dbname":"d"`,
+	}
+	got := string(b)
+	for _, f := range wantFields {
+		if !strings.Contains(got, f) {
+			t.Errorf("DatabaseSecret JSON missing field %s; got %s", f, got)
+		}
+	}
+}
+
+func TestKafkaSecretJSONShape(t *testing.T) {
+	v := KafkaSecret{
+		SaslUsername:     "u",
+		SaslPassword:     "p",
+		SaslMechanism:    "SCRAM-SHA-512",
+		BootstrapBrokers: "broker:9092",
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, f := range []string{
+		`"sasl_username":"u"`,
+		`"sasl_password":"p"`,
+		`"sasl_mechanism":"SCRAM-SHA-512"`,
+		`"bootstrap_brokers":"broker:9092"`,
+	} {
+		if !strings.Contains(got, f) {
+			t.Errorf("KafkaSecret JSON missing field %s; got %s", f, got)
+		}
+	}
+}
+
+func TestRedisSecretJSONShape(t *testing.T) {
+	v := RedisSecret{AuthToken: "t", Endpoint: "host", Port: 6379}
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, f := range []string{
+		`"auth_token":"t"`,
+		`"endpoint":"host"`,
+		`"port":6379`,
+	} {
+		if !strings.Contains(got, f) {
+			t.Errorf("RedisSecret JSON missing field %s; got %s", f, got)
+		}
+	}
+}
+
+func TestMarshalJSONWrapsError(t *testing.T) {
+	// json.Marshal cannot encode a channel; verify the error is wrapped.
+	_, err := marshalJSON(make(chan int))
+	if err == nil {
+		t.Fatal("marshalJSON(chan) returned nil error; want non-nil")
+	}
+	if !strings.Contains(err.Error(), "marshal secret payload") {
+		t.Errorf("error %q does not contain wrapping prefix", err.Error())
+	}
+}
+
+func TestAuthSecretJSONShape(t *testing.T) {
+	v := AuthSecret{
+		ClientID:     "id",
+		ClientSecret: "secret",
+		TokenURL:     "https://t",
+		Issuer:       "https://i",
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, f := range []string{
+		`"client_id":"id"`,
+		`"client_secret":"secret"`,
+		`"token_url":"https://t"`,
+		`"issuer":"https://i"`,
+	} {
+		if !strings.Contains(got, f) {
+			t.Errorf("AuthSecret JSON missing field %s; got %s", f, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pulumi mock tests — verify resource creation, naming, replication policy
+// ---------------------------------------------------------------------------
+
+type trackedResource struct {
+	TypeToken string
+	Name      string
+	Inputs    resource.PropertyMap
+}
+
+type secretsMocks struct {
+	mu        sync.Mutex
+	resources []trackedResource
+}
+
+func (m *secretsMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	m.resources = append(m.resources, trackedResource{
+		TypeToken: args.TypeToken,
+		Name:      args.Name,
+		Inputs:    args.Inputs,
+	})
+	m.mu.Unlock()
+
+	id := args.Name + "_id"
+	outputs := resource.PropertyMap{}
+	for k, v := range args.Inputs {
+		outputs[k] = v
+	}
+
+	// Type-specific output enrichment so downstream `secret.Name` references
+	// resolve to a realistic-looking GCP path.
+	if args.TypeToken == "gcp:secretmanager/secret:Secret" {
+		secretID := args.Name
+		if v, ok := args.Inputs["secretId"]; ok && v.HasValue() {
+			secretID = v.StringValue()
+		}
+		outputs["name"] = resource.NewStringProperty("projects/test-project/secrets/" + secretID)
+		outputs["project"] = resource.NewStringProperty("test-project")
+	}
+	return id, outputs, nil
+}
+
+func (m *secretsMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func (m *secretsMocks) findByType(token string) []trackedResource {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]trackedResource, 0)
+	for _, r := range m.resources {
+		if r.TypeToken == token {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestNewSecretsCreatesAllFourSecrets(t *testing.T) {
+	mocks := &secretsMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &config.Config{
+			Project: "kaizen",
+			Env:     config.EnvDev,
+		}
+		_, err := NewSecrets(ctx, cfg, &SecretsInputs{
+			CloudSqlEndpoint:      pulumi.String("10.0.0.1:5432").ToStringOutput(),
+			KafkaBootstrapBrokers: pulumi.String("redpanda:9092").ToStringOutput(),
+			RedisEndpoint:         pulumi.String("10.0.0.2").ToStringOutput(),
+		})
+		return err
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("Pulumi program failed: %v", err)
+	}
+
+	secretResources := mocks.findByType("gcp:secretmanager/secret:Secret")
+	if len(secretResources) != 4 {
+		t.Fatalf("expected 4 secrets, got %d", len(secretResources))
+	}
+
+	found := make(map[string]bool)
+	for _, s := range secretResources {
+		v, ok := s.Inputs["secretId"]
+		if !ok || !v.HasValue() {
+			t.Errorf("secret %q missing secretId input", s.Name)
+			continue
+		}
+		found[v.StringValue()] = true
+	}
+	for _, want := range []string{
+		"kaizen-dev-database",
+		"kaizen-dev-kafka",
+		"kaizen-dev-redis",
+		"kaizen-dev-auth",
+	} {
+		if !found[want] {
+			t.Errorf("missing secret with secretId=%q", want)
+		}
+	}
+
+	// All 4 must also have a SecretVersion attached.
+	versions := mocks.findByType("gcp:secretmanager/secretVersion:SecretVersion")
+	if len(versions) != 4 {
+		t.Fatalf("expected 4 secret versions, got %d", len(versions))
+	}
+}
+
+func TestNewSecretsUsesAutomaticReplication(t *testing.T) {
+	mocks := &secretsMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &config.Config{Project: "kaizen", Env: config.EnvProd}
+		_, err := NewSecrets(ctx, cfg, &SecretsInputs{
+			CloudSqlEndpoint:      pulumi.String("h:5432").ToStringOutput(),
+			KafkaBootstrapBrokers: pulumi.String("b:9092").ToStringOutput(),
+			RedisEndpoint:         pulumi.String("r").ToStringOutput(),
+		})
+		return err
+	}, pulumi.WithMocks("kaizen", "prod", mocks))
+	if err != nil {
+		t.Fatalf("Pulumi program failed: %v", err)
+	}
+
+	for _, s := range mocks.findByType("gcp:secretmanager/secret:Secret") {
+		repl, ok := s.Inputs["replication"]
+		if !ok || !repl.HasValue() {
+			t.Errorf("secret %q missing replication policy", s.Name)
+			continue
+		}
+		// Replication is an object; its "auto" key must be present (even if empty
+		// — that's how Pulumi serializes the empty-message Auto config).
+		if !repl.IsObject() {
+			t.Errorf("secret %q replication not an object", s.Name)
+			continue
+		}
+		obj := repl.ObjectValue()
+		if _, hasAuto := obj["auto"]; !hasAuto {
+			t.Errorf("secret %q replication missing 'auto' key (got keys: %v)", s.Name, keys(obj))
+		}
+	}
+}
+
+func TestNewSecretsAppliesEnvironmentLabels(t *testing.T) {
+	mocks := &secretsMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &config.Config{Project: "kaizen", Env: config.EnvStaging}
+		_, err := NewSecrets(ctx, cfg, &SecretsInputs{
+			CloudSqlEndpoint:      pulumi.String("h").ToStringOutput(),
+			KafkaBootstrapBrokers: pulumi.String("b").ToStringOutput(),
+			RedisEndpoint:         pulumi.String("r").ToStringOutput(),
+		})
+		return err
+	}, pulumi.WithMocks("kaizen", "staging", mocks))
+	if err != nil {
+		t.Fatalf("Pulumi program failed: %v", err)
+	}
+
+	for _, s := range mocks.findByType("gcp:secretmanager/secret:Secret") {
+		labels, ok := s.Inputs["labels"]
+		if !ok || !labels.HasValue() {
+			t.Errorf("secret %q missing labels", s.Name)
+			continue
+		}
+		obj := labels.ObjectValue()
+		if v, ok := obj["environment"]; !ok || v.StringValue() != "staging" {
+			t.Errorf("secret %q environment label = %v, want staging", s.Name, v)
+		}
+		if v, ok := obj["managed_by"]; !ok || v.StringValue() != "pulumi" {
+			t.Errorf("secret %q managed_by label = %v, want pulumi", s.Name, v)
+		}
+		if _, ok := obj["component"]; !ok {
+			t.Errorf("secret %q missing component label", s.Name)
+		}
+	}
+}
+
+func TestNewSecretsRefsHaveVersionsLatest(t *testing.T) {
+	mocks := &secretsMocks{}
+	var (
+		dbRef, kafkaRef, redisRef, authRef string
+	)
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &config.Config{Project: "kaizen", Env: config.EnvDev}
+		out, err := NewSecrets(ctx, cfg, &SecretsInputs{
+			CloudSqlEndpoint:      pulumi.String("h").ToStringOutput(),
+			KafkaBootstrapBrokers: pulumi.String("b").ToStringOutput(),
+			RedisEndpoint:         pulumi.String("r").ToStringOutput(),
+		})
+		if err != nil {
+			return err
+		}
+
+		// Drain refs into local strings using ApplyT; pulumi.RunErr blocks until
+		// all outputs resolve, so the values are populated by the time RunErr
+		// returns.
+		var wg sync.WaitGroup
+		wg.Add(4)
+		out.DatabaseSecretRef.ApplyT(func(s string) string { dbRef = s; wg.Done(); return s })
+		out.KafkaSecretRef.ApplyT(func(s string) string { kafkaRef = s; wg.Done(); return s })
+		out.RedisSecretRef.ApplyT(func(s string) string { redisRef = s; wg.Done(); return s })
+		out.AuthSecretRef.ApplyT(func(s string) string { authRef = s; wg.Done(); return s })
+		wg.Wait()
+		return nil
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("Pulumi program failed: %v", err)
+	}
+
+	for name, ref := range map[string]string{
+		"database": dbRef,
+		"kafka":    kafkaRef,
+		"redis":    redisRef,
+		"auth":     authRef,
+	} {
+		if !strings.HasSuffix(ref, "/versions/latest") {
+			t.Errorf("%s ref %q does not end in /versions/latest", name, ref)
+		}
+		if !strings.HasPrefix(ref, "projects/") {
+			t.Errorf("%s ref %q does not start with projects/", name, ref)
+		}
+		if !strings.Contains(ref, "/secrets/kaizen-dev-"+name) {
+			t.Errorf("%s ref %q missing /secrets/kaizen-dev-%s segment", name, ref, name)
+		}
+	}
+}
+
+func TestNewSecretsRejectsNilInputs(t *testing.T) {
+	mocks := &secretsMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &config.Config{Project: "kaizen", Env: config.EnvDev}
+		_, err := NewSecrets(ctx, cfg, nil)
+		if err == nil {
+			t.Errorf("NewSecrets(nil inputs) returned nil error; want non-nil")
+		}
+		return nil
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("Pulumi program failed: %v", err)
+	}
+}
+
+// keys returns the keys of a PropertyMap as a sorted-ish slice (for error
+// messages — order doesn't matter for assertions).
+func keys(m resource.PropertyMap) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, string(k))
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

GCP Secret Manager port of `pkg/aws/secrets`. Provisions four secrets (`database`, `kafka`, `redis`, `auth`) with Google-managed automatic replication and exposes `versions/latest` references in the `projects/<P>/secrets/<S>/versions/latest` form Cloud Run consumes.

Closes #481. Builds on Phase 0 (#509).

## What's in this PR

| File | Purpose |
|---|---|
| `infra/pkg/gcp/secrets/secrets.go` | `NewSecrets(ctx, cfg, *SecretsInputs) (*SecretsOutputs, error)` — mirrors the AWS API surface |
| `infra/pkg/gcp/secrets/secrets_test.go` | 12 unit + mock-based tests (77.1 % coverage; 100 % on pure logic) |
| `infra/go.mod`, `infra/go.sum` | Adds `github.com/pulumi/pulumi-gcp/sdk/v8 v8.41.1` |

## Design notes

**Layout — subpackage, not flat file.** The design doc sketches `pkg/gcp/secrets.go` (one file in `package gcp`), but Phase 0 cemented the subpackage pattern (`pkg/aws/secrets/secrets.go` in `package secrets`). I'm following Phase 0 so three Phase 1 workers (network/storage/secrets) can land in parallel without conflicting on a shared `pkg/gcp/` package declaration. Resulting path: `infra/pkg/gcp/secrets/secrets.go`.

**JSON wire shape parity.** `DatabaseSecret`, `KafkaSecret`, `RedisSecret`, `AuthSecret` use the exact same struct tags as `pkg/aws/secrets`, so service code that reads either provider's secret JSON is identical.

**SecretId format.** GCP requires `[A-Za-z0-9_-]+`; `cfg.SecretPath()` returns slash-separated `kaizen/dev/database` (valid for AWS, invalid for GCP). I use `cfg.ResourceName("secret-<component>")` style → `kaizen-dev-database`. Pure helper `SecretID(cfg, component)` exposed for testing without Pulumi context.

**Replication = Automatic.** No CMEK, no user-managed multi-region — keeps Phase 1 simple. Easy to add a `EncryptionKey *config` knob later.

**`versions/latest` ref construction.** Built lazily via `pulumi.Sprintf("%s/versions/latest", secret.Name)` so the value flows correctly through Pulumi's DAG (regular `fmt.Sprintf` would silently emit an unresolved-output string).

## Out of scope (intentional)

These are noted here so they aren't lost — they're not in this PR per the AWS pattern boundary:

1. **IAM bindings for compute service accounts.** On AWS, the secret-read IAM policy lives in `pkg/aws/compute/services.go:816` — not the secrets module. Mirroring that boundary, GCP compute will create the `secretmanager.SecretIamMember` bindings when the GCP compute SA exists. Belongs in #486.
2. **Aggregator (`pkg/gcp/gcp.go`) and `Deploy()` switch wiring.** Three Phase 1 workers (clever-otter=network, nice-wolf=storage, me=secrets) are landing modules in parallel. The aggregator should land as a single integration PR after all three modules merge — same approach Phase 0 took with `pkg/aws/aws.go`.
3. **Cross-provider topology test** ("every secret referenced in compute module inputs has a creator"). Needs both providers' compute modules to exist; will land alongside the topology-test refactor in Phase 1.

## Test plan

- [x] `cd infra && go build ./...` clean
- [x] `cd infra && go vet ./pkg/gcp/...` clean
- [x] `cd infra && go test -race -count=1 ./pkg/... ./test/...` — full infra suite green
- [x] `go test -cover ./pkg/gcp/secrets/...` — 77.1 % (100 % on pure logic; remaining ~23 % is pulumi-gcp resource-creation error wrapping which can't be triggered without a fail-on-demand mock)
- [x] Pulumi mock tests verify: 4 `Secret` resources created, each with `Replication.Auto`, environment labels, GCP-compatible `secretId`, 4 `SecretVersion`s attached, refs ending in `/versions/latest`
- [ ] (HITL) `pulumi preview --stack gcp-dev` for the secrets slice — needs aggregator wiring (out of scope)

## References

- Issue: #481
- Spec: `docs/superpowers/specs/2026-04-20-multi-cloud-gcp-aws-design.md` (Phase 1 + Testing Strategy)
- Mirrors: `infra/pkg/aws/secrets/secrets.go`
- Phase 0 base: #509
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->