### PR TITLE
feat(infra): GCP network module — VPC, firewall, Service Directory, VPC connector

### DIFF
--- a/infra/Pulumi.gcp-dev.yaml
+++ b/infra/Pulumi.gcp-dev.yaml
@@ -1,0 +1,28 @@
+config:
+  gcp:project: kaizen-experimentation-dev
+  gcp:region: us-central1
+  kaizen-experimentation:environment: dev
+  kaizen-experimentation:cloudProvider: gcp
+  kaizen-experimentation:projectName: kaizen-experimentation
+  kaizen-experimentation:domain: example.com
+  kaizen-experimentation:vpcCidr: "10.0.0.0/16"
+  kaizen-experimentation:gcpPublicSubnetCidr: "10.0.0.0/20"
+  kaizen-experimentation:gcpPrivateSubnetCidr: "10.0.16.0/20"
+  kaizen-experimentation:gcpVpcConnectorCidr: "10.8.0.0/28"
+  kaizen-experimentation:gcpVpcConnectorMachineType: e2-micro
+  # Downstream stages (storage, database, cache, secrets, compute, cicd)
+  # are wired through subsequent issues #480-#486. The values below are
+  # placeholders so LoadConfig() does not panic on Require() — they will
+  # be revisited as each downstream GCP module lands.
+  kaizen-experimentation:rdsInstanceClass: db-custom-2-7680
+  kaizen-experimentation:rdsMultiAz: "false"
+  kaizen-experimentation:mskBrokerCount: "2"
+  kaizen-experimentation:mskInstanceType: redpanda.t3.small
+  kaizen-experimentation:redisNodeType: BASIC_M1
+  kaizen-experimentation:m4bInstanceType: n2-standard-4
+  kaizen-experimentation:natGatewayCount: "1"
+  kaizen-experimentation:wafEnabled: "false"
+  kaizen-experimentation:fargateMinTasks: "1"
+  kaizen-experimentation:cloudwatchRetentionDays: "7"
+  kafka:saslUsername: kaizen-redpanda-user
+  kafka:saslPassword: CHANGE_ME_VIA_PULUMI_CONFIG_SET_SECRET

--- a/infra/Pulumi.gcp-dev.yaml
+++ b/infra/Pulumi.gcp-dev.yaml
@@ -23,7 +23,7 @@ config:
   # GCP network subnet CIDR ranges (read by pkg/gcp/network).
   kaizen-experimentation:gcpPublicSubnetCidr: "10.0.0.0/20"
   kaizen-experimentation:gcpPrivateSubnetCidr: "10.0.16.0/20"
-  kaizen-experimentation:gcpVpcConnectorCidr: "10.8.0.0/28"
+  kaizen-experimentation:gcpVpcConnectorCidr: "10.0.32.0/28"
   kaizen-experimentation:gcpVpcConnectorMachineType: e2-micro
 
   # The remaining values are required by config.LoadConfig() because LoadConfig

--- a/infra/go.mod
+++ b/infra/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.17.0 // indirect
+	github.com/pulumi/pulumi-gcp/sdk/v8 v8.41.1
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect

--- a/infra/go.sum
+++ b/infra/go.sum
@@ -187,6 +187,8 @@ github.com/pulumi/pulumi-aws/sdk/v6 v6.83.2 h1:KrV04/k8+PRfkX/90pLm/jug6tfc9YeQH
 github.com/pulumi/pulumi-aws/sdk/v6 v6.83.2/go.mod h1:520DDoW2zBYVWwwAT8qt/9VhNoBcDIslDljzE8/O080=
 github.com/pulumi/pulumi-command/sdk v1.2.1 h1:mAziZ91a/9U+5IjZH5Skcar80OSmpBSYljeQNRblTWQ=
 github.com/pulumi/pulumi-command/sdk v1.2.1/go.mod h1:hQxv9DXg6bFjcd9BEiNdMImQ/V1rnC9D115q5VXYNps=
+github.com/pulumi/pulumi-gcp/sdk/v8 v8.41.1 h1:w6OnO3d4j5yVf2vpm8OzXFC/xHOEGqt+9FjWCUBCq6U=
+github.com/pulumi/pulumi-gcp/sdk/v8 v8.41.1/go.mod h1:UyZyv7hz4knpFx6/Sh+SkZe6hT6sJHtDvw9A0TbvEsk=
 github.com/pulumi/pulumi-kafka/sdk/v3 v3.12.3 h1:M1jPYXKr7qMm1MlKRY9I4K19WnbW9oD08puFG42Uhrw=
 github.com/pulumi/pulumi-kafka/sdk/v3 v3.12.3/go.mod h1:SCwRmNwNVMfoZuy3UFkz7VMGhLZd0zHcWSRcDqvu5F4=
 github.com/pulumi/pulumi/sdk/v3 v3.229.0 h1:jsAw5lXiHN22YQeo4bZHZBAG/DUlEnzsFWg5MuHnTSs=

--- a/infra/main.go
+++ b/infra/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kaizen-experimentation/infra/pkg/aws"
 	"github.com/kaizen-experimentation/infra/pkg/aws/loadbalancer"
 	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/gcp"
 	"github.com/kaizen-experimentation/infra/pkg/types"
 )
 
@@ -34,6 +35,8 @@ func Deploy(ctx *pulumi.Context) error {
 	switch cfg.CloudProvider {
 	case "aws":
 		netOut, err = aws.NewNetwork(ctx, cfg)
+	case "gcp":
+		netOut, err = gcp.NewNetwork(ctx, cfg)
 	default:
 		return unsupportedCloud(cfg.CloudProvider)
 	}

--- a/infra/network_topology_test.go
+++ b/infra/network_topology_test.go
@@ -1,0 +1,213 @@
+// Parameterized topology tests for the network slice of Deploy(). Run the
+// network stage with mocks for both cloudProvider: aws and cloudProvider:
+// gcp, and assert that the resulting types.NetworkOutputs has matching
+// field shapes across providers. Subsequent issues (#480-#486) extend
+// coverage to the remaining stages.
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	awsfacade "github.com/kaizen-experimentation/infra/pkg/aws"
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	gcpfacade "github.com/kaizen-experimentation/infra/pkg/gcp"
+	"github.com/kaizen-experimentation/infra/pkg/types"
+)
+
+// gcpTopologyMocks captures GCP resource registrations for the topology
+// test. Keeps GCP-specific output shapes — self-links and resource names —
+// alongside the AWS mocks already defined in fullstack_test.go.
+type gcpTopologyMocks struct {
+	mu        sync.Mutex
+	resources []fsResource
+}
+
+func (m *gcpTopologyMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	m.resources = append(m.resources, fsResource{
+		TypeToken: args.TypeToken,
+		Name:      args.Name,
+		Inputs:    args.Inputs,
+	})
+	m.mu.Unlock()
+
+	id := args.Name + "_id"
+	outputs := resource.PropertyMap{}
+	for k, v := range args.Inputs {
+		outputs[k] = v
+	}
+
+	switch args.TypeToken {
+	case "gcp:compute/network:Network":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/networks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/subnetwork:Subnetwork":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/subnetworks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/router:Router":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/routers/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/routerNat:RouterNat":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/firewall:Firewall":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/firewalls/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:servicedirectory/namespace:Namespace":
+		outputs["name"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/namespaces/" + args.Name)
+	case "gcp:vpcaccess/connector:Connector":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/connectors/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	}
+
+	return id, outputs, nil
+}
+
+func (m *gcpTopologyMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+// TestNetworkTopologyParameterized runs the network stage for both
+// providers and asserts the NetworkOutputs shape contract. AWS already has
+// a comprehensive fullstack test; this case re-runs only the network slice
+// to keep the AWS↔GCP comparison apples-to-apples.
+func TestNetworkTopologyParameterized(t *testing.T) {
+	cases := []struct {
+		name               string
+		runner             func(t *testing.T) types.NetworkOutputs
+		expectAwsResources bool
+		expectGcpResources bool
+	}{
+		{
+			name: "aws",
+			runner: func(t *testing.T) types.NetworkOutputs {
+				mocks := &fullstackMocks{}
+				var captured types.NetworkOutputs
+				err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+					cfg := kconfig.LoadConfig(ctx)
+					out, err := awsfacade.NewNetwork(ctx, cfg)
+					if err != nil {
+						return err
+					}
+					captured = out
+					return nil
+				}, pulumi.WithMocks("kaizen", "dev", mocks),
+					configWithProvider("aws"))
+				if err != nil {
+					t.Fatalf("aws NewNetwork failed: %v", err)
+				}
+				if got := mocks.count("aws:ec2/vpc:Vpc"); got != 1 {
+					t.Errorf("aws: expected 1 VPC, got %d", got)
+				}
+				if got := mocks.count("aws:ec2/securityGroup:SecurityGroup"); got < 6 {
+					t.Errorf("aws: expected at least 6 SecurityGroups, got %d", got)
+				}
+				return captured
+			},
+			expectAwsResources: true,
+		},
+		{
+			name: "gcp",
+			runner: func(t *testing.T) types.NetworkOutputs {
+				mocks := &gcpTopologyMocks{}
+				var captured types.NetworkOutputs
+				err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+					cfg := kconfig.LoadConfig(ctx)
+					out, err := gcpfacade.NewNetwork(ctx, cfg)
+					if err != nil {
+						return err
+					}
+					captured = out
+					return nil
+				}, pulumi.WithMocks("kaizen", "dev", mocks),
+					configWithProvider("gcp"))
+				if err != nil {
+					t.Fatalf("gcp NewNetwork failed: %v", err)
+				}
+				if got := countByType(mocks.resources, "gcp:compute/network:Network"); got != 1 {
+					t.Errorf("gcp: expected 1 Network, got %d", got)
+				}
+				if got := countByType(mocks.resources, "gcp:compute/firewall:Firewall"); got != 6 {
+					t.Errorf("gcp: expected 6 Firewall rules, got %d", got)
+				}
+				if got := countByType(mocks.resources, "gcp:servicedirectory/namespace:Namespace"); got != 1 {
+					t.Errorf("gcp: expected 1 Service Directory Namespace, got %d", got)
+				}
+				if got := countByType(mocks.resources, "gcp:vpcaccess/connector:Connector"); got != 1 {
+					t.Errorf("gcp: expected 1 VPC Connector, got %d", got)
+				}
+				return captured
+			},
+			expectGcpResources: true,
+		},
+	}
+
+	// Required keys mirror the AWS security-groups module exactly. The
+	// outputs.go doc comment lists "ecs", "alb", "rds", "msk", "redis",
+	// "schema-registry" but the actual AWS implementation returns "m4b" in
+	// place of "schema-registry"; this test reflects the implementation.
+	requiredKeys := []string{"alb", "ecs", "rds", "msk", "redis", "m4b"}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tc.runner(t)
+			for _, k := range requiredKeys {
+				if _, ok := out.SecurityGroupIds[k]; !ok {
+					t.Errorf("provider %s: missing required SecurityGroupIds key %q", tc.name, k)
+				}
+			}
+		})
+	}
+}
+
+func countByType(records []fsResource, typeToken string) int {
+	n := 0
+	for _, r := range records {
+		if r.TypeToken == typeToken {
+			n++
+		}
+	}
+	return n
+}
+
+// configWithProvider returns the complete Pulumi stack config required by
+// LoadConfig + the network modules, with cloudProvider set to the requested
+// value. The helper mirrors fullstackConfig() exactly so LoadConfig's
+// Require() calls don't panic on missing downstream fields.
+func configWithProvider(provider string) pulumi.RunOption {
+	return func(info *pulumi.RunInfo) {
+		info.Config = map[string]string{
+			"aws:region":                                     "us-east-1",
+			"gcp:project":                                    "kaizen-test",
+			"gcp:region":                                     "us-central1",
+			"kaizen:vpcCidr":                                 "10.0.0.0/16",
+			"kaizen:natGatewayCount":                         "1",
+			"kaizen-experimentation:environment":             "dev",
+			"kaizen-experimentation:vpcCidr":                 "10.0.0.0/16",
+			"kaizen-experimentation:rdsInstanceClass":        "db.t3.medium",
+			"kaizen-experimentation:rdsMultiAz":              "false",
+			"kaizen-experimentation:mskBrokerCount":          "3",
+			"kaizen-experimentation:mskInstanceType":         "kafka.m5.large",
+			"kaizen-experimentation:redisNodeType":           "cache.t3.medium",
+			"kaizen-experimentation:m4bInstanceType":         "c5.xlarge",
+			"kaizen-experimentation:natGatewayCount":         "1",
+			"kaizen-experimentation:wafEnabled":              "false",
+			"kaizen-experimentation:fargateMinTasks":         "1",
+			"kaizen-experimentation:cloudwatchRetentionDays": "7",
+			"kaizen-experimentation:domain":                  "example.com",
+			"kaizen-experimentation:projectName":             "kaizen-experimentation",
+			"kaizen-experimentation:cloudProvider":           provider,
+			"kafka:saslUsername":                             "kaizen-msk-user",
+			"kafka:saslPassword":                             "test-password",
+		}
+	}
+}

--- a/infra/pkg/gcp/gcp.go
+++ b/infra/pkg/gcp/gcp.go
@@ -1,0 +1,75 @@
+// Package gcp is the GCP-side facade for Deploy(). Each function here
+// composes one or more module-internal constructors (in pkg/gcp/<module>/)
+// and returns one of the shared output structs from pkg/types/.
+//
+// This is the GCP analogue of pkg/aws/aws.go — the Deploy() switch picks
+// one or the other based on cfg.CloudProvider; both must return identical
+// types.*Outputs shapes so subsequent stages compose without branching.
+//
+// Phase 1 implements only NewNetwork. Other stages (storage, database,
+// cache, secrets, compute, cicd) follow in subsequent issues.
+package gcp
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/gcp/network"
+	"github.com/kaizen-experimentation/infra/pkg/types"
+)
+
+// ─── Stage 1: Network ───────────────────────────────────────────────────────
+
+// NewNetwork creates the GCP networking foundation: a custom VPC with public
+// and private regional subnets, Cloud Router + Cloud NAT for egress, six
+// firewall rules whose target tags match the AWS security-group keys, a
+// Service Directory namespace for service discovery, and a Serverless VPC
+// Access connector so Cloud Run services can reach private resources.
+//
+// Returns types.NetworkOutputs with provider-specific zero values for the
+// AWS-only fields PrivateRouteTableIds and S3VpcEndpointId — GCP networks
+// route implicitly and have no S3 gateway endpoint analogue. Documented in
+// pkg/types/outputs.go.
+func NewNetwork(ctx *pulumi.Context, _ *kconfig.Config) (types.NetworkOutputs, error) {
+	vpcOut, err := network.NewVpc(ctx)
+	if err != nil {
+		return types.NetworkOutputs{}, err
+	}
+
+	fwRes, err := network.NewFirewallRules(ctx, &network.FirewallArgs{
+		NetworkId: vpcOut.NetworkId,
+	})
+	if err != nil {
+		return types.NetworkOutputs{}, err
+	}
+
+	sdOut, err := network.NewServiceDirectory(ctx, &network.ServiceDirectoryArgs{
+		Region: vpcOut.Region,
+	})
+	if err != nil {
+		return types.NetworkOutputs{}, err
+	}
+	ctx.Export("serviceDirectoryNamespaceId", sdOut.NamespaceId)
+	ctx.Export("serviceDirectoryNamespaceName", sdOut.NamespaceName)
+
+	connOut, err := network.NewVpcConnector(ctx, &network.VpcConnectorArgs{
+		NetworkName: vpcOut.NetworkName,
+		Region:      vpcOut.Region,
+	})
+	if err != nil {
+		return types.NetworkOutputs{}, err
+	}
+	ctx.Export("vpcConnectorId", connOut.ConnectorId)
+	ctx.Export("vpcConnectorSelfLink", connOut.ConnectorSelfLink)
+
+	return types.NetworkOutputs{
+		VpcId:              vpcOut.NetworkId,
+		PublicSubnetIds:    vpcOut.PublicSubnetIds,
+		PrivateSubnetIds:   vpcOut.PrivateSubnetIds,
+		SecurityGroupIds:   fwRes.Rules,
+		ServiceDiscoveryId: sdOut.NamespaceId,
+		// Zero-valued on GCP per types.NetworkOutputs documentation:
+		// PrivateRouteTableIds — GCP routes implicitly via subnet definitions.
+		// S3VpcEndpointId — no S3 gateway endpoint analogue on GCP.
+	}, nil
+}

--- a/infra/pkg/gcp/gcp.go
+++ b/infra/pkg/gcp/gcp.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
-	"github.com/kaizen-experimentation/infra/pkg/gcp/cicd"
 	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/gcp/cicd"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/network"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/storage"
 	"github.com/kaizen-experimentation/infra/pkg/types"

--- a/infra/pkg/gcp/network/firewall.go
+++ b/infra/pkg/gcp/network/firewall.go
@@ -1,0 +1,199 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/compute"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// FirewallArgs holds the inputs for creating the GCP firewall rules.
+type FirewallArgs struct {
+	NetworkId pulumi.IDOutput
+}
+
+// FirewallResult holds the created firewall rule resource IDs keyed by role.
+// Keys mirror the AWS module exactly: "alb", "ecs", "rds", "msk", "redis",
+// "m4b". The values are GCP firewall rule IDs (the rule name) — the
+// NetworkOutputs contract documents this provider-specific interpretation.
+type FirewallResult struct {
+	Rules map[string]pulumi.IDOutput
+}
+
+// Network tags that GCP resources opt into to receive a firewall rule's
+// inbound traffic. Keys here match the AWS security-group keys exactly so
+// downstream modules can use the same names regardless of provider.
+const (
+	tagAlb   = "kaizen-alb"
+	tagEcs   = "kaizen-ecs"
+	tagRds   = "kaizen-rds"
+	tagMsk   = "kaizen-msk"
+	tagRedis = "kaizen-redis"
+	tagM4b   = "kaizen-m4b"
+)
+
+// NewFirewallRules creates 6 firewall rules whose target tags match the
+// security-group key names exposed by the AWS module. GCP firewall rules
+// are network-wide; resources opt into a rule by adding the matching network
+// tag (or service account, for Cloud Run via the VPC connector).
+//
+// Traffic flow mirrors the AWS module:
+//
+//	Internet ─443→ [tag:kaizen-alb]
+//	[tag:kaizen-alb] ─tcp→ [tag:kaizen-ecs / kaizen-m4b]
+//	[tag:kaizen-ecs / kaizen-m4b] ─5432→ [tag:kaizen-rds]
+//	[tag:kaizen-ecs / kaizen-m4b] ─9092/9094/9096→ [tag:kaizen-msk]
+//	[tag:kaizen-ecs / kaizen-m4b] ─6379→ [tag:kaizen-redis]
+//	[tag:kaizen-ecs] ↔ [tag:kaizen-m4b]   (cross-compute gRPC)
+func NewFirewallRules(ctx *pulumi.Context, args *FirewallArgs) (*FirewallResult, error) {
+	netRef := args.NetworkId.ToStringOutput()
+
+	// ── ALB equivalent: ingress 443 from the internet ─────────────────
+	albFw, err := compute.NewFirewall(ctx, "kaizen-fw-alb", &compute.FirewallArgs{
+		Name:        pulumi.String("kaizen-fw-alb"),
+		Network:     netRef,
+		Direction:   pulumi.String("INGRESS"),
+		Description: pulumi.String("ALB equivalent — public HTTPS ingress"),
+		SourceRanges: pulumi.StringArray{
+			pulumi.String("0.0.0.0/0"),
+		},
+		TargetTags: pulumi.StringArray{pulumi.String(tagAlb)},
+		Allows: compute.FirewallAllowArray{
+			&compute.FirewallAllowArgs{
+				Protocol: pulumi.String("tcp"),
+				Ports:    pulumi.StringArray{pulumi.String("443")},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("alb firewall: %w", err)
+	}
+
+	// ── ECS equivalent: from ALB / self / M4b on all TCP ──────────────
+	// Mirrors the AWS ecs-sg ingress (alb, self, m4b) — GCP firewall rules
+	// support multiple sourceTags so all three sources collapse into one
+	// rule rather than the three separate AWS rules.
+	ecsFw, err := compute.NewFirewall(ctx, "kaizen-fw-ecs", &compute.FirewallArgs{
+		Name:        pulumi.String("kaizen-fw-ecs"),
+		Network:     netRef,
+		Direction:   pulumi.String("INGRESS"),
+		Description: pulumi.String("ECS/Cloud Run equivalent — inter-service gRPC"),
+		SourceTags: pulumi.StringArray{
+			pulumi.String(tagAlb),
+			pulumi.String(tagEcs),
+			pulumi.String(tagM4b),
+		},
+		TargetTags: pulumi.StringArray{pulumi.String(tagEcs)},
+		Allows: compute.FirewallAllowArray{
+			&compute.FirewallAllowArgs{
+				Protocol: pulumi.String("tcp"),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ecs firewall: %w", err)
+	}
+
+	// ── RDS equivalent: PostgreSQL 5432 from ECS/M4b ──────────────────
+	rdsFw, err := compute.NewFirewall(ctx, "kaizen-fw-rds", &compute.FirewallArgs{
+		Name:        pulumi.String("kaizen-fw-rds"),
+		Network:     netRef,
+		Direction:   pulumi.String("INGRESS"),
+		Description: pulumi.String("Cloud SQL equivalent — PostgreSQL from ECS/M4b only"),
+		SourceTags: pulumi.StringArray{
+			pulumi.String(tagEcs),
+			pulumi.String(tagM4b),
+		},
+		TargetTags: pulumi.StringArray{pulumi.String(tagRds)},
+		Allows: compute.FirewallAllowArray{
+			&compute.FirewallAllowArgs{
+				Protocol: pulumi.String("tcp"),
+				Ports:    pulumi.StringArray{pulumi.String("5432")},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rds firewall: %w", err)
+	}
+
+	// ── MSK equivalent: Kafka 9092/9094/9096 from ECS/M4b ─────────────
+	mskFw, err := compute.NewFirewall(ctx, "kaizen-fw-msk", &compute.FirewallArgs{
+		Name:        pulumi.String("kaizen-fw-msk"),
+		Network:     netRef,
+		Direction:   pulumi.String("INGRESS"),
+		Description: pulumi.String("Kafka equivalent — plaintext/TLS/SASL_SSL from ECS/M4b only"),
+		SourceTags: pulumi.StringArray{
+			pulumi.String(tagEcs),
+			pulumi.String(tagM4b),
+		},
+		TargetTags: pulumi.StringArray{pulumi.String(tagMsk)},
+		Allows: compute.FirewallAllowArray{
+			&compute.FirewallAllowArgs{
+				Protocol: pulumi.String("tcp"),
+				Ports: pulumi.StringArray{
+					pulumi.String("9092"),
+					pulumi.String("9094"),
+					pulumi.String("9096"),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("msk firewall: %w", err)
+	}
+
+	// ── Redis equivalent: 6379 from ECS/M4b ───────────────────────────
+	redisFw, err := compute.NewFirewall(ctx, "kaizen-fw-redis", &compute.FirewallArgs{
+		Name:        pulumi.String("kaizen-fw-redis"),
+		Network:     netRef,
+		Direction:   pulumi.String("INGRESS"),
+		Description: pulumi.String("Memorystore Redis equivalent — 6379 from ECS/M4b only"),
+		SourceTags: pulumi.StringArray{
+			pulumi.String(tagEcs),
+			pulumi.String(tagM4b),
+		},
+		TargetTags: pulumi.StringArray{pulumi.String(tagRedis)},
+		Allows: compute.FirewallAllowArray{
+			&compute.FirewallAllowArgs{
+				Protocol: pulumi.String("tcp"),
+				Ports:    pulumi.StringArray{pulumi.String("6379")},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("redis firewall: %w", err)
+	}
+
+	// ── M4b: same surface as ECS (alb / self / ecs) ───────────────────
+	m4bFw, err := compute.NewFirewall(ctx, "kaizen-fw-m4b", &compute.FirewallArgs{
+		Name:        pulumi.String("kaizen-fw-m4b"),
+		Network:     netRef,
+		Direction:   pulumi.String("INGRESS"),
+		Description: pulumi.String("M4b Policy service — mirrors ECS rule surface"),
+		SourceTags: pulumi.StringArray{
+			pulumi.String(tagAlb),
+			pulumi.String(tagEcs),
+			pulumi.String(tagM4b),
+		},
+		TargetTags: pulumi.StringArray{pulumi.String(tagM4b)},
+		Allows: compute.FirewallAllowArray{
+			&compute.FirewallAllowArgs{
+				Protocol: pulumi.String("tcp"),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("m4b firewall: %w", err)
+	}
+
+	return &FirewallResult{
+		Rules: map[string]pulumi.IDOutput{
+			"alb":   albFw.ID(),
+			"ecs":   ecsFw.ID(),
+			"rds":   rdsFw.ID(),
+			"msk":   mskFw.ID(),
+			"redis": redisFw.ID(),
+			"m4b":   m4bFw.ID(),
+		},
+	}, nil
+}

--- a/infra/pkg/gcp/network/network_test.go
+++ b/infra/pkg/gcp/network/network_test.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"net"
 	"sync"
 	"testing"
 
@@ -201,5 +202,19 @@ func TestVpcConnectorCidrIsValidSlash28(t *testing.T) {
 	// validation belongs at the Pulumi/GCP level.
 	if got := cidr[len(cidr)-3:]; got != "/28" {
 		t.Errorf("expected /28 CIDR, got %q", cidr)
+	}
+
+	// Connector CIDR must sit inside the VPC supernet (10.0.0.0/16) so VPC
+	// peering / Cloud Interconnect advertising the supernet still reaches it.
+	connectorIp, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("connector CIDR %q is not valid: %v", cidr, err)
+	}
+	_, supernet, err := net.ParseCIDR("10.0.0.0/16")
+	if err != nil {
+		t.Fatalf("parse VPC supernet: %v", err)
+	}
+	if !supernet.Contains(connectorIp) {
+		t.Errorf("connector CIDR %q is outside the VPC supernet %s", cidr, supernet)
 	}
 }

--- a/infra/pkg/gcp/network/network_test.go
+++ b/infra/pkg/gcp/network/network_test.go
@@ -1,0 +1,205 @@
+// Package network unit tests — exercise the GCP network module against
+// pulumi.MockResourceMonitor and assert the shape and count of registered
+// resources. Mirrors the AWS network module test approach.
+package network
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// gcpNetworkMocks captures GCP resource registrations and returns reasonable
+// mock outputs (self-links, IDs, names) so downstream apply chains resolve.
+type gcpNetworkMocks struct {
+	mu        sync.Mutex
+	resources []resourceRecord
+}
+
+type resourceRecord struct {
+	TypeToken string
+	Name      string
+	Inputs    resource.PropertyMap
+}
+
+func (m *gcpNetworkMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	m.resources = append(m.resources, resourceRecord{
+		TypeToken: args.TypeToken,
+		Name:      args.Name,
+		Inputs:    args.Inputs,
+	})
+	m.mu.Unlock()
+
+	id := args.Name + "_id"
+	outputs := resource.PropertyMap{}
+	for k, v := range args.Inputs {
+		outputs[k] = v
+	}
+
+	switch args.TypeToken {
+	case "gcp:compute/network:Network":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/networks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/subnetwork:Subnetwork":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/subnetworks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/router:Router":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/routers/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/routerNat:RouterNat":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/firewall:Firewall":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/firewalls/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:servicedirectory/namespace:Namespace":
+		outputs["name"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/namespaces/" + args.Name)
+	case "gcp:vpcaccess/connector:Connector":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/connectors/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	}
+
+	return id, outputs, nil
+}
+
+func (m *gcpNetworkMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func (m *gcpNetworkMocks) byType(typeToken string) []resourceRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []resourceRecord
+	for _, r := range m.resources {
+		if r.TypeToken == typeToken {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestVpcCreatesExpectedResources runs NewVpc and asserts the basic shape:
+// one network, two subnets, one router, one NAT.
+func TestVpcCreatesExpectedResources(t *testing.T) {
+	mocks := &gcpNetworkMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := NewVpc(ctx)
+		return err
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("NewVpc failed: %v", err)
+	}
+
+	if got := len(mocks.byType("gcp:compute/network:Network")); got != 1 {
+		t.Errorf("expected 1 Network, got %d", got)
+	}
+	if got := len(mocks.byType("gcp:compute/subnetwork:Subnetwork")); got != 2 {
+		t.Errorf("expected 2 Subnetworks (public+private), got %d", got)
+	}
+	if got := len(mocks.byType("gcp:compute/router:Router")); got != 1 {
+		t.Errorf("expected 1 Router, got %d", got)
+	}
+	if got := len(mocks.byType("gcp:compute/routerNat:RouterNat")); got != 1 {
+		t.Errorf("expected 1 RouterNat, got %d", got)
+	}
+}
+
+// TestFirewallRulesMatchAwsKeys is the parity gate — every key the AWS
+// security_groups.go module exposes ("alb", "ecs", "rds", "msk", "redis",
+// "m4b") must also be exposed by the GCP firewall module so downstream
+// stages compose without branching.
+func TestFirewallRulesMatchAwsKeys(t *testing.T) {
+	mocks := &gcpNetworkMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		vpc, err := NewVpc(ctx)
+		if err != nil {
+			return err
+		}
+		fw, err := NewFirewallRules(ctx, &FirewallArgs{NetworkId: vpc.NetworkId})
+		if err != nil {
+			return err
+		}
+
+		expectedKeys := []string{"alb", "ecs", "rds", "msk", "redis", "m4b"}
+		for _, k := range expectedKeys {
+			if _, ok := fw.Rules[k]; !ok {
+				t.Errorf("firewall key %q missing from result", k)
+			}
+		}
+		if got := len(fw.Rules); got != len(expectedKeys) {
+			t.Errorf("expected %d firewall rules, got %d", len(expectedKeys), got)
+		}
+		return nil
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("RunErr failed: %v", err)
+	}
+
+	if got := len(mocks.byType("gcp:compute/firewall:Firewall")); got != 6 {
+		t.Errorf("expected 6 Firewall resources, got %d", got)
+	}
+}
+
+// TestServiceDirectoryNamespaceIsRegional verifies the Service Directory
+// namespace is created with a Location parameter (regional resource), the
+// GCP analogue of AWS Cloud Map's VPC-scoped private DNS namespace.
+func TestServiceDirectoryNamespaceIsRegional(t *testing.T) {
+	mocks := &gcpNetworkMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := NewServiceDirectory(ctx, &ServiceDirectoryArgs{
+			Region: pulumi.String("us-central1").ToStringOutput(),
+		})
+		return err
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("NewServiceDirectory failed: %v", err)
+	}
+
+	namespaces := mocks.byType("gcp:servicedirectory/namespace:Namespace")
+	if len(namespaces) != 1 {
+		t.Fatalf("expected 1 Namespace, got %d", len(namespaces))
+	}
+	if _, ok := namespaces[0].Inputs["location"]; !ok {
+		t.Errorf("Namespace input missing required 'location' field")
+	}
+}
+
+// TestVpcConnectorCidrIsValidSlash28 ensures the Serverless VPC Access
+// connector receives a /28 CIDR — required by GCP, the connector subnet
+// must be exactly /28.
+func TestVpcConnectorCidrIsValidSlash28(t *testing.T) {
+	mocks := &gcpNetworkMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		_, err := NewVpcConnector(ctx, &VpcConnectorArgs{
+			NetworkName: pulumi.String("kaizen-vpc").ToStringOutput(),
+			Region:      pulumi.String("us-central1").ToStringOutput(),
+		})
+		return err
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("NewVpcConnector failed: %v", err)
+	}
+
+	connectors := mocks.byType("gcp:vpcaccess/connector:Connector")
+	if len(connectors) != 1 {
+		t.Fatalf("expected 1 Connector, got %d", len(connectors))
+	}
+	cidrProp, ok := connectors[0].Inputs["ipCidrRange"]
+	if !ok {
+		t.Fatal("connector missing ipCidrRange input")
+	}
+	cidr := cidrProp.StringValue()
+	// /28 mask is 8 chars + suffix "/28" — cheap structural check; format
+	// validation belongs at the Pulumi/GCP level.
+	if got := cidr[len(cidr)-3:]; got != "/28" {
+		t.Errorf("expected /28 CIDR, got %q", cidr)
+	}
+}

--- a/infra/pkg/gcp/network/service_directory.go
+++ b/infra/pkg/gcp/network/service_directory.go
@@ -1,0 +1,48 @@
+package network
+
+import (
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/servicedirectory"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// ServiceDirectoryArgs holds the inputs for creating the Service Directory
+// namespace.
+type ServiceDirectoryArgs struct {
+	// Region is the GCP region the namespace lives in. Service Directory
+	// namespaces are regional, unlike AWS Cloud Map which is VPC-scoped.
+	Region pulumi.StringOutput
+}
+
+// ServiceDirectoryOutputs holds the namespace identifier returned to
+// callers. Mirrors the shape of ServiceDiscoveryOutputs in the AWS module
+// so the top-level facade can map both into types.NetworkOutputs uniformly.
+type ServiceDirectoryOutputs struct {
+	// NamespaceId is the Pulumi-managed ID of the namespace, used by Cloud
+	// Run services and the AWS-side downstream consumer that types this
+	// field as pulumi.IDOutput.
+	NamespaceId pulumi.IDOutput
+	// NamespaceName is the fully-qualified Service Directory resource name
+	// (projects/<P>/locations/<R>/namespaces/<N>) used by service
+	// registrations and IAM bindings.
+	NamespaceName pulumi.StringOutput
+}
+
+// NewServiceDirectory creates the Service Directory namespace that backs
+// internal service discovery for Kaizen on GCP. This is the GCP equivalent
+// of the AWS Cloud Map private DNS namespace; Cloud Run services register
+// here and resolve each other via Service Directory's HTTP API or via the
+// auto-published private DNS zone.
+func NewServiceDirectory(ctx *pulumi.Context, args *ServiceDirectoryArgs, opts ...pulumi.ResourceOption) (*ServiceDirectoryOutputs, error) {
+	ns, err := servicedirectory.NewNamespace(ctx, "kaizen-local", &servicedirectory.NamespaceArgs{
+		NamespaceId: pulumi.String("kaizen-local"),
+		Location:    args.Region,
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceDirectoryOutputs{
+		NamespaceId:   ns.ID(),
+		NamespaceName: ns.Name,
+	}, nil
+}

--- a/infra/pkg/gcp/network/vpc.go
+++ b/infra/pkg/gcp/network/vpc.go
@@ -1,0 +1,159 @@
+// Package network provisions the Kaizen GCP networking foundation: a custom
+// VPC, public and private regional subnetworks, a Cloud Router, and a Cloud
+// NAT gateway for private-subnet egress. GCP subnets are regional and span
+// every zone in the region, so a single private subnet plays the role of the
+// three AZ-pinned private subnets on AWS.
+package network
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/compute"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+// VpcOutputs exposes the GCP VPC resources that downstream modules consume.
+// Field shapes mirror the AWS VpcOutputs so callers can compose without
+// branching, but the underlying values use GCP self-links and regional IDs.
+type VpcOutputs struct {
+	// NetworkId is the GCP network self-link (returned by .ID() on
+	// compute.Network — Pulumi returns the resource's self-link as the ID).
+	NetworkId pulumi.IDOutput
+
+	// NetworkName is the bare network name, used by firewall rules and the
+	// Serverless VPC Access connector that need a name reference instead of a
+	// self-link.
+	NetworkName pulumi.StringOutput
+
+	// PublicSubnetIds is a single-element array holding the public regional
+	// subnet's self-link. Returned as an array so the shared NetworkOutputs
+	// shape (PublicSubnetIds pulumi.StringArrayOutput) is satisfied without a
+	// special case.
+	PublicSubnetIds pulumi.StringArrayOutput
+
+	// PrivateSubnetIds is a single-element array holding the private regional
+	// subnet's self-link.
+	PrivateSubnetIds pulumi.StringArrayOutput
+
+	// PrivateSubnetName is the bare name of the private subnet. The
+	// Serverless VPC Access connector references its host subnet by name.
+	PrivateSubnetName pulumi.StringOutput
+
+	// Region is the configured GCP region. Downstream modules (Cloud SQL,
+	// Memorystore, VPC connector) need this and the network module is the
+	// canonical place it is read once.
+	Region pulumi.StringOutput
+}
+
+// NewVpc creates the core GCP networking foundation: a custom-mode VPC,
+// public and private regional subnetworks, a Cloud Router, and a Cloud NAT
+// gateway. Mirrors infra/pkg/aws/network/vpc.go in shape but uses GCP's
+// regional subnet model.
+func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
+	cfg := config.New(ctx, "kaizen")
+	gcpCfg := config.New(ctx, "gcp")
+
+	region := gcpCfg.Get("region")
+	if region == "" {
+		region = "us-central1"
+	}
+
+	publicCidr := cfg.Get("gcpPublicSubnetCidr")
+	if publicCidr == "" {
+		publicCidr = "10.0.0.0/20"
+	}
+	privateCidr := cfg.Get("gcpPrivateSubnetCidr")
+	if privateCidr == "" {
+		privateCidr = "10.0.16.0/20"
+	}
+
+	// ── VPC (custom-mode network — no auto-created subnets) ────────────
+	network, err := compute.NewNetwork(ctx, "kaizen-vpc", &compute.NetworkArgs{
+		Name:                  pulumi.String("kaizen-vpc"),
+		AutoCreateSubnetworks: pulumi.Bool(false),
+		RoutingMode:           pulumi.String("REGIONAL"),
+		Description:           pulumi.String("Kaizen experimentation VPC (custom mode)"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create VPC: %w", err)
+	}
+
+	// ── Public regional subnet ─────────────────────────────────────────
+	// Holds external load balancer NEGs and any internet-facing GCE.
+	publicSubnet, err := compute.NewSubnetwork(ctx, "kaizen-public", &compute.SubnetworkArgs{
+		Name:                  pulumi.String("kaizen-public"),
+		Network:               network.ID(),
+		IpCidrRange:           pulumi.String(publicCidr),
+		Region:                pulumi.String(region),
+		PrivateIpGoogleAccess: pulumi.Bool(true),
+		Description:           pulumi.String("Public regional subnet for ingress and NAT"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create public subnet: %w", err)
+	}
+
+	// ── Private regional subnet ────────────────────────────────────────
+	// Holds Cloud SQL (via private services access), Memorystore, GCE M4b,
+	// and Cloud Run egress via the Serverless VPC Access connector.
+	privateSubnet, err := compute.NewSubnetwork(ctx, "kaizen-private", &compute.SubnetworkArgs{
+		Name:                  pulumi.String("kaizen-private"),
+		Network:               network.ID(),
+		IpCidrRange:           pulumi.String(privateCidr),
+		Region:                pulumi.String(region),
+		PrivateIpGoogleAccess: pulumi.Bool(true),
+		Description:           pulumi.String("Private regional subnet for stateful workloads"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create private subnet: %w", err)
+	}
+
+	// ── Cloud Router + Cloud NAT (egress for private subnet) ───────────
+	// GCP equivalent of the AWS NAT gateway; one Cloud NAT services every
+	// zone in the region so a single resource replaces the AWS NAT-per-AZ
+	// fleet.
+	router, err := compute.NewRouter(ctx, "kaizen-router", &compute.RouterArgs{
+		Name:        pulumi.String("kaizen-router"),
+		Network:     network.ID(),
+		Region:      pulumi.String(region),
+		Description: pulumi.String("Cloud Router for NAT egress and dynamic routing"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create Cloud Router: %w", err)
+	}
+
+	if _, err = compute.NewRouterNat(ctx, "kaizen-nat", &compute.RouterNatArgs{
+		Name:                          pulumi.String("kaizen-nat"),
+		Router:                        router.Name,
+		Region:                        pulumi.String(region),
+		NatIpAllocateOption:           pulumi.String("AUTO_ONLY"),
+		SourceSubnetworkIpRangesToNat: pulumi.String("LIST_OF_SUBNETWORKS"),
+		Subnetworks: compute.RouterNatSubnetworkArray{
+			&compute.RouterNatSubnetworkArgs{
+				Name: privateSubnet.ID(),
+				SourceIpRangesToNats: pulumi.StringArray{
+					pulumi.String("ALL_IP_RANGES"),
+				},
+			},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("create Cloud NAT: %w", err)
+	}
+
+	// ── Pulumi stack exports ───────────────────────────────────────────
+	pubIds := pulumi.StringArray{publicSubnet.ID().ToStringOutput()}.ToStringArrayOutput()
+	privIds := pulumi.StringArray{privateSubnet.ID().ToStringOutput()}.ToStringArrayOutput()
+	ctx.Export("gcpNetworkId", network.ID())
+	ctx.Export("gcpPublicSubnetIds", pubIds)
+	ctx.Export("gcpPrivateSubnetIds", privIds)
+	ctx.Export("gcpRegion", pulumi.String(region))
+
+	return &VpcOutputs{
+		NetworkId:         network.ID(),
+		NetworkName:       network.Name,
+		PublicSubnetIds:   pubIds,
+		PrivateSubnetIds:  privIds,
+		PrivateSubnetName: privateSubnet.Name,
+		Region:            pulumi.String(region).ToStringOutput(),
+	}, nil
+}

--- a/infra/pkg/gcp/network/vpc.go
+++ b/infra/pkg/gcp/network/vpc.go
@@ -51,7 +51,7 @@ type VpcOutputs struct {
 // gateway. Mirrors infra/pkg/aws/network/vpc.go in shape but uses GCP's
 // regional subnet model.
 func NewVpc(ctx *pulumi.Context) (*VpcOutputs, error) {
-	cfg := config.New(ctx, "kaizen")
+	cfg := config.New(ctx, "kaizen-experimentation")
 	gcpCfg := config.New(ctx, "gcp")
 
 	region := gcpCfg.Get("region")

--- a/infra/pkg/gcp/network/vpc_connector.go
+++ b/infra/pkg/gcp/network/vpc_connector.go
@@ -28,7 +28,7 @@ type VpcConnectorOutputs struct {
 // kaizen-rds / kaizen-redis / kaizen-msk just as ECS Fargate ENIs do on
 // the AWS side.
 func NewVpcConnector(ctx *pulumi.Context, args *VpcConnectorArgs, opts ...pulumi.ResourceOption) (*VpcConnectorOutputs, error) {
-	cfg := config.New(ctx, "kaizen")
+	cfg := config.New(ctx, "kaizen-experimentation")
 
 	cidr := cfg.Get("gcpVpcConnectorCidr")
 	if cidr == "" {

--- a/infra/pkg/gcp/network/vpc_connector.go
+++ b/infra/pkg/gcp/network/vpc_connector.go
@@ -32,10 +32,11 @@ func NewVpcConnector(ctx *pulumi.Context, args *VpcConnectorArgs, opts ...pulumi
 
 	cidr := cfg.Get("gcpVpcConnectorCidr")
 	if cidr == "" {
-		// Default /28 inside the VPC supernet. Must not overlap with any
-		// other subnet; placed deliberately above the private subnet (10.0.16.0/20)
-		// and well below any reserved private services access ranges (10.x.x.x/16).
-		cidr = "10.8.0.0/28"
+		// Default /28 inside the VPC supernet (10.0.0.0/16). Must not overlap
+		// with any other subnet; placed immediately after the private subnet
+		// (10.0.16.0/20 ends at 10.0.31.255) so VPC peering / Cloud Interconnect
+		// advertising 10.0.0.0/16 still reaches the connector.
+		cidr = "10.0.32.0/28"
 	}
 
 	machineType := cfg.Get("gcpVpcConnectorMachineType")

--- a/infra/pkg/gcp/network/vpc_connector.go
+++ b/infra/pkg/gcp/network/vpc_connector.go
@@ -1,0 +1,66 @@
+package network
+
+import (
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/vpcaccess"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+// VpcConnectorArgs holds the inputs for creating the Serverless VPC Access
+// connector that lets Cloud Run reach private VPC resources (Cloud SQL,
+// Memorystore, GCE M4b, Redpanda).
+type VpcConnectorArgs struct {
+	NetworkName pulumi.StringOutput
+	Region      pulumi.StringOutput
+}
+
+// VpcConnectorOutputs exposes the connector's self-link so Cloud Run service
+// templates can reference it via vpc_access.connector.
+type VpcConnectorOutputs struct {
+	ConnectorId       pulumi.IDOutput
+	ConnectorSelfLink pulumi.StringOutput
+}
+
+// NewVpcConnector provisions the Serverless VPC Access connector. The
+// connector occupies its own /28 IP range that is implicitly trusted by
+// firewall rules whose sourceTag includes the matching workload role —
+// Cloud Run egress from the connector reaches private resources tagged
+// kaizen-rds / kaizen-redis / kaizen-msk just as ECS Fargate ENIs do on
+// the AWS side.
+func NewVpcConnector(ctx *pulumi.Context, args *VpcConnectorArgs, opts ...pulumi.ResourceOption) (*VpcConnectorOutputs, error) {
+	cfg := config.New(ctx, "kaizen")
+
+	cidr := cfg.Get("gcpVpcConnectorCidr")
+	if cidr == "" {
+		// Default /28 inside the VPC supernet. Must not overlap with any
+		// other subnet; placed deliberately above the private subnet (10.0.16.0/20)
+		// and well below any reserved private services access ranges (10.x.x.x/16).
+		cidr = "10.8.0.0/28"
+	}
+
+	machineType := cfg.Get("gcpVpcConnectorMachineType")
+	if machineType == "" {
+		// e2-micro is the cheapest connector instance type. Cloud Run autoscales
+		// its connector pool between minInstances and maxInstances regardless,
+		// so the per-instance type only affects per-throughput cost.
+		machineType = "e2-micro"
+	}
+
+	conn, err := vpcaccess.NewConnector(ctx, "kaizen-vpc-connector", &vpcaccess.ConnectorArgs{
+		Name:         pulumi.String("kaizen-vpc-connector"),
+		Region:       args.Region,
+		Network:      args.NetworkName,
+		IpCidrRange:  pulumi.String(cidr),
+		MachineType:  pulumi.String(machineType),
+		MinInstances: pulumi.Int(2),
+		MaxInstances: pulumi.Int(10),
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VpcConnectorOutputs{
+		ConnectorId:       conn.ID(),
+		ConnectorSelfLink: conn.SelfLink,
+	}, nil
+}


### PR DESCRIPTION
## Summary

Phase 1 of the multi-cloud foundation: GCP network provider-module that returns `types.NetworkOutputs`, composing into `Deploy()` via switch-dispatch without touching the AWS path.

Closes #479. Unblocks downstream Phase 1 issues (#480-#486 — storage/database/cache/secrets/compute/cicd on GCP).

**Resources provisioned (`pkg/gcp/network/`):**
- Custom-mode VPC + regional public/private subnetworks
- Cloud Router + Cloud NAT for private-subnet egress
- 6 firewall rules whose target tags match the AWS security-group keys (`alb`/`ecs`/`rds`/`msk`/`redis`/`m4b`)
- Service Directory namespace `kaizen-local` (Cloud Map analogue)
- Serverless VPC Access connector for Cloud Run → VPC traffic

**Wiring:**
- `pkg/gcp/gcp.go` — facade `NewNetwork(ctx, cfg) (types.NetworkOutputs, error)` mirroring `pkg/aws/aws.go`
- `main.go` — added `case "gcp":` arm to the network stage switch
- `Pulumi.gcp-dev.yaml` — stack config for the GCP dev environment

## Design notes worth review

1. **Regional subnets, not zonal.** GCP subnets span every zone in a region, so I provisioned 1 public + 1 private regional subnet rather than 3-per-zone. `NetworkOutputs.PublicSubnetIds`/`PrivateSubnetIds` come back as 1-element `pulumi.StringArrayOutput` values. The `outputs.go` doc comment was authored with AWS's zonal model in mind — updating it is out of scope here, but worth flagging for a follow-up.

2. **Firewall rules collapse.** The AWS module emits ~30 `SecurityGroupRule` resources for inter-tier traffic; GCP firewall rules accept multiple `sourceTags`, so the equivalent posture is 6 rules total. Same security stance, fewer resources.

3. **Schema-registry vs m4b key.** `outputs.go` doc-comment lists `"schema-registry"` as a SG key, but the actual AWS `security_groups.go` returns `"m4b"`. The GCP module mirrors the implementation (`m4b`). Worth a follow-up to reconcile the docstring.

4. **AWS-only fields zero-valued.** `PrivateRouteTableIds` and `S3VpcEndpointId` come back as zero-value Pulumi outputs on GCP — already documented in `outputs.go`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/gcp/...` clean
- [x] `gofmt` clean
- [x] Unit tests in `pkg/gcp/network/network_test.go` (4 tests):
  - `TestVpcCreatesExpectedResources` — 1 Network, 2 Subnetworks, 1 Router, 1 NAT
  - `TestFirewallRulesMatchAwsKeys` — 6 firewall rules with keys `{alb, ecs, rds, msk, redis, m4b}`
  - `TestServiceDirectoryNamespaceIsRegional` — namespace creation with `Location` field
  - `TestVpcConnectorCidrIsValidSlash28` — connector CIDR ends in `/28`
- [x] Parameterized topology test in `network_topology_test.go`:
  - `TestNetworkTopologyParameterized/aws` — passes
  - `TestNetworkTopologyParameterized/gcp` — passes
  - Both providers expose the same `SecurityGroupIds` key set
- [ ] `pulumi preview --stack gcp-dev` — Pulumi CLI not available in this worker. The topology test (which uses `pulumi.MockResourceMonitor` end-to-end) is the in-CI proxy; it passes for both providers. Manual `pulumi preview` verification recommended on a workstation with the CLI installed before merge.

## Pre-existing issue (not this PR)

`TestFullStackDeploy` in `infra/fullstack_test.go` panics in `pkg/aws/storage/s3.go:310` (`applyVpcEndpointPolicy`) with `interface {} is pulumi.ID, not string`. **This reproduces on `main` and is unrelated to this PR.** Worth a separate ticket — happy to file if not already tracked.

## Follow-ups (not in scope)

- Update `types.NetworkOutputs` doc comments to acknowledge GCP's regional subnet model
- Reconcile `schema-registry` vs `m4b` docstring discrepancy in `outputs.go`
- Continue Phase 1 with `pkg/gcp/{storage,database,cache,secrets,compute,cicd}.go` (#480-#486)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->