### PR TITLE
fix(metrics): gate post-processing branches on isLegacyStyle (#511)

### DIFF
--- a/docs/superpowers/plans/2026-05-07-issue-511-post-processing-type-gates.md
+++ b/docs/superpowers/plans/2026-05-07-issue-511-post-processing-type-gates.md
@@ -1,0 +1,610 @@
+# Issue #511 Post-Processing Type-Gates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the four post-processing branches in `services/metrics/internal/jobs/standard.go` (CUPED, MLRATE, session-level, lifecycle) behind an `isLegacyStyle` predicate so ADR-026 Phase 1 metric types (FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT) cleanly skip post-processing instead of silently producing wrong SQL.
+
+**Architecture:** A small file-private helper `isLegacyStyle(string) bool` returns true for the 6 legacy types; each of the 4 post-processing branches wraps its existing body in a nested if/else that emits a single-line `slog.Info` skip message for non-legacy types. See spec at `docs/superpowers/specs/2026-05-07-issue-511-post-processing-type-gates.md`.
+
+**Tech Stack:** Go 1.22+, `log/slog`, existing `strings` import already in `standard.go`. `github.com/stretchr/testify` for assertions.
+
+**Worktree:** `.claude/worktrees/issue-511-post-processing-gates/` on branch `agent-3/fix/issue-511-post-processing-type-gates` (off `origin/main`). Spec committed as `3f52f9a`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `services/metrics/internal/jobs/standard.go` | Modify | Add `isLegacyStyle` helper + wrap 4 post-processing branches in type-gates |
+| `services/metrics/internal/jobs/standard_test.go` | Modify | Add `TestIsLegacyStyle` direct unit test + extend `TestStandardJob_Run_ADR026Phase1_NewTypes` with skip-verification subtests |
+| `services/metrics/internal/config/testdata/seed_adr026_phase1.json` | Modify | Enable `session_level: true` + `lifecycle_stratification_enabled: true` on experiment; add `cuped_covariate_metric_id` to one new-type metric; add a legacy MEAN metric to verify post-processing still runs for legacy types |
+
+Total expected diff: ~25 lines impl + ~50 lines test + ~15 lines fixture.
+
+---
+
+## Task 1: Add `isLegacyStyle` helper with TDD
+
+**Files:**
+- Modify: `services/metrics/internal/jobs/standard.go`
+- Modify: `services/metrics/internal/jobs/standard_test.go`
+
+TDD: write the failing test first (compile error), then add the helper.
+
+- [ ] **Step 1.1: Write the failing test**
+
+Append to `services/metrics/internal/jobs/standard_test.go`:
+
+```go
+func TestIsLegacyStyle(t *testing.T) {
+	t.Run("legacy types return true", func(t *testing.T) {
+		legacy := []string{
+			"MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM",
+			"mean", "proportion", "count", "ratio", "percentile", "custom",
+			"Custom", "Ratio",
+		}
+		for _, mt := range legacy {
+			assert.True(t, isLegacyStyle(mt), "%q should be legacy", mt)
+		}
+	})
+
+	t.Run("ADR-026 Phase 1 types return false", func(t *testing.T) {
+		nonLegacy := []string{
+			"FILTERED_MEAN", "COMPOSITE", "WINDOWED_COUNT",
+			"filtered_mean", "composite", "windowed_count",
+		}
+		for _, mt := range nonLegacy {
+			assert.False(t, isLegacyStyle(mt), "%q should not be legacy", mt)
+		}
+	})
+
+	t.Run("unknown types return false", func(t *testing.T) {
+		unknown := []string{"", " ", "UNKNOWN_TYPE", "FOO_BAR"}
+		for _, mt := range unknown {
+			assert.False(t, isLegacyStyle(mt), "%q should not be legacy", mt)
+		}
+	})
+}
+```
+
+The file's existing imports already include `testing`, `assert`, `require`. No new imports needed.
+
+- [ ] **Step 1.2: Run the test — expect compile error**
+
+Run: `go test ./services/metrics/internal/jobs/ -run TestIsLegacyStyle -v`
+Expected: COMPILE FAIL with `undefined: isLegacyStyle`.
+
+- [ ] **Step 1.3: Add the helper to `standard.go`**
+
+In `services/metrics/internal/jobs/standard.go`, append the helper near the bottom of the file (next to the existing `toSparkOperands` helper, after the `Run` function):
+
+```go
+// isLegacyStyle reports whether a MetricType uses the legacy MEAN-style
+// column convention (me.value, me.event_type = '{{.SourceEventType}}')
+// that the post-processing templates (cuped_covariate, session_level_mean,
+// lifecycle_mean, mlrate_*) assume.
+//
+// ADR-026 Phase 1 types (FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT) use
+// different column conventions and must skip post-processing until those
+// templates grow per-type variants (issue #511 option b).
+func isLegacyStyle(metricType string) bool {
+	switch strings.ToUpper(metricType) {
+	case "MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM":
+		return true
+	}
+	return false
+}
+```
+
+The `strings` package is already imported in `standard.go`; no new imports needed.
+
+- [ ] **Step 1.4: Run the test — expect PASS**
+
+Run: `go test ./services/metrics/internal/jobs/ -run TestIsLegacyStyle -v`
+Expected: 3 subtests PASS (`legacy types return true`, `ADR-026 Phase 1 types return false`, `unknown types return false`).
+
+- [ ] **Step 1.5: Run the existing jobs suite — expect PASS**
+
+Run: `go test ./services/metrics/internal/jobs/...`
+Expected: every existing test still passes (the helper is a new isolated function with no callers yet).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add services/metrics/internal/jobs/standard.go services/metrics/internal/jobs/standard_test.go
+git commit -m "feat(metrics): isLegacyStyle helper for ADR-026 Phase 1 type-gating
+
+Adds a file-private predicate that returns true for the 6 legacy
+MetricType values (MEAN, PROPORTION, COUNT, RATIO, PERCENTILE, CUSTOM)
+and false for ADR-026 Phase 1 types and unknowns.
+
+Will be used in the next commit to gate the four post-processing
+branches in standard.go's Run loop. The helper is case-insensitive
+to match the case-normalization the renderer's RenderForType already
+applies.
+
+Refs #511"
+```
+
+---
+
+## Task 2: Apply type-gates to the four post-processing branches
+
+**Files:**
+- Modify: `services/metrics/internal/jobs/standard.go`
+
+Wire the helper into the four post-processing branches in `Run`. Each gate wraps the existing branch body in a nested if/else; the skip path emits a one-line `slog.Info` and falls through (no `continue` — branches are independent).
+
+No new tests in this task — Task 3's e2e fixture exercises the gates end-to-end.
+
+- [ ] **Step 2.1: Gate the CUPED covariate branch**
+
+In `services/metrics/internal/jobs/standard.go`, find the CUPED block in `Run` (currently around lines 162-206 — locate by `if m.CupedCovariateMetricID != "" && exp.StartedAt != "" {`). Wrap its existing body in a nested if/else:
+
+```go
+		// If metric has a CUPED covariate configured and experiment has a start date,
+		// compute the pre-experiment covariate value for variance reduction.
+		if m.CupedCovariateMetricID != "" && exp.StartedAt != "" {
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping CUPED covariate: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				covMetric, err := j.config.GetMetric(m.CupedCovariateMetricID)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: resolve CUPED covariate metric %s for %s: %w",
+						m.CupedCovariateMetricID, m.MetricID, err)
+				}
+
+				cupedParams := params
+				cupedParams.CupedEnabled = true
+				cupedParams.CupedCovariateEventType = covMetric.SourceEventType
+				cupedParams.ExperimentStartDate = exp.StartedAt
+				cupedParams.CupedLookbackDays = defaultCupedLookbackDays
+
+				cupedSQL, err := j.renderer.RenderCupedCovariate(cupedParams)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: render CUPED covariate for %s: %w", m.MetricID, err)
+				}
+
+				cupedResult, err := j.executor.ExecuteAndWrite(ctx, cupedSQL, "delta.metric_summaries")
+				if err != nil {
+					return nil, fmt.Errorf("jobs: execute CUPED covariate for %s: %w", m.MetricID, err)
+				}
+				m3metrics.SparkQueryDuration.WithLabelValues("cuped_covariate").Observe(cupedResult.Duration.Seconds())
+				m3metrics.SparkQueryRows.WithLabelValues("cuped_covariate").Observe(float64(cupedResult.RowCount))
+
+				if err := j.queryLog.Log(ctx, querylog.Entry{
+					ExperimentID: experimentID,
+					MetricID:     m.MetricID,
+					SQLText:      cupedSQL,
+					RowCount:     cupedResult.RowCount,
+					DurationMs:   cupedResult.Duration.Milliseconds(),
+					JobType:      "cuped_covariate",
+				}); err != nil {
+					return nil, fmt.Errorf("jobs: log CUPED covariate query for %s: %w", m.MetricID, err)
+				}
+
+				slog.Info("computed CUPED covariate",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"covariate_metric_id", m.CupedCovariateMetricID,
+					"rows", cupedResult.RowCount,
+				)
+			}
+		}
+```
+
+- [ ] **Step 2.2: Gate the MLRATE cross-fit branch**
+
+Find the MLRATE block (around lines 208-223 — locate by `if exp.MLRATEEnabled && len(m.MLRATEFeatureEventTypes) > 0 && m.MLRATEModelURI != "" && exp.StartedAt != "" {`). Wrap:
+
+```go
+		// MLRATE cross-fitting: if experiment has MLRATE enabled and metric has
+		// feature config, generate K-fold cross-fitted predictions as AVLM covariates.
+		if exp.MLRATEEnabled && len(m.MLRATEFeatureEventTypes) > 0 && m.MLRATEModelURI != "" && exp.StartedAt != "" {
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping MLRATE cross-fit: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				mlrateJob := NewMLRATEJob(j.renderer, j.executor, j.queryLog)
+				mlrateResult, err := mlrateJob.Run(ctx, exp, &m, computationDate)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: MLRATE cross-fit for %s: %w", m.MetricID, err)
+				}
+
+				slog.Info("computed MLRATE cross-fitted predictions",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"folds", mlrateResult.Folds,
+					"users_scored", mlrateResult.UsersScored,
+				)
+			}
+		}
+```
+
+- [ ] **Step 2.3: Gate the session-level branch**
+
+Find the session-level block (around lines 226-258 — locate by `if exp.SessionLevel && !m.IsQoEMetric {`). Wrap:
+
+```go
+		// Session-level aggregation: if enabled, also compute per-session metrics.
+		if exp.SessionLevel && !m.IsQoEMetric {
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping session-level metric: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				slParams := params
+				slParams.SessionLevel = true
+
+				slSQL, err := j.renderer.RenderSessionLevelMean(slParams)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: render session-level metric for %s: %w", m.MetricID, err)
+				}
+
+				slResult, err := j.executor.ExecuteAndWrite(ctx, slSQL, "delta.metric_summaries")
+				if err != nil {
+					return nil, fmt.Errorf("jobs: execute session-level metric for %s: %w", m.MetricID, err)
+				}
+				m3metrics.SparkQueryDuration.WithLabelValues("session_level_metric").Observe(slResult.Duration.Seconds())
+				m3metrics.SparkQueryRows.WithLabelValues("session_level_metric").Observe(float64(slResult.RowCount))
+
+				if err := j.queryLog.Log(ctx, querylog.Entry{
+					ExperimentID: experimentID,
+					MetricID:     m.MetricID,
+					SQLText:      slSQL,
+					RowCount:     slResult.RowCount,
+					DurationMs:   slResult.Duration.Milliseconds(),
+					JobType:      "session_level_metric",
+				}); err != nil {
+					return nil, fmt.Errorf("jobs: log session-level metric query for %s: %w", m.MetricID, err)
+				}
+
+				slog.Info("computed session-level metric",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"rows", slResult.RowCount,
+				)
+			}
+		}
+```
+
+- [ ] **Step 2.4: Gate the lifecycle branch**
+
+Find the lifecycle block (around lines 261-293 — locate by `if exp.LifecycleStratificationEnabled && !m.IsQoEMetric {`). Wrap:
+
+```go
+		// Lifecycle segmentation: if enabled, also compute per-lifecycle-segment metrics.
+		if exp.LifecycleStratificationEnabled && !m.IsQoEMetric {
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping lifecycle metric: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				lcParams := params
+				lcParams.LifecycleEnabled = true
+
+				lcSQL, err := j.renderer.RenderLifecycleMean(lcParams)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: render lifecycle metric for %s: %w", m.MetricID, err)
+				}
+
+				lcResult, err := j.executor.ExecuteAndWrite(ctx, lcSQL, "delta.metric_summaries")
+				if err != nil {
+					return nil, fmt.Errorf("jobs: execute lifecycle metric for %s: %w", m.MetricID, err)
+				}
+				m3metrics.SparkQueryDuration.WithLabelValues("lifecycle_metric").Observe(lcResult.Duration.Seconds())
+				m3metrics.SparkQueryRows.WithLabelValues("lifecycle_metric").Observe(float64(lcResult.RowCount))
+
+				if err := j.queryLog.Log(ctx, querylog.Entry{
+					ExperimentID: experimentID,
+					MetricID:     m.MetricID,
+					SQLText:      lcSQL,
+					RowCount:     lcResult.RowCount,
+					DurationMs:   lcResult.Duration.Milliseconds(),
+					JobType:      "lifecycle_metric",
+				}); err != nil {
+					return nil, fmt.Errorf("jobs: log lifecycle metric query for %s: %w", m.MetricID, err)
+				}
+
+				slog.Info("computed lifecycle metric",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"rows", lcResult.RowCount,
+				)
+			}
+		}
+```
+
+- [ ] **Step 2.5: Verify build**
+
+Run: `go build ./services/metrics/...`
+Expected: clean.
+
+- [ ] **Step 2.6: Run all jobs tests — expect PASS**
+
+Run: `go test ./services/metrics/internal/jobs/...`
+Expected: every existing test passes. Existing tests use only legacy types, so the gates are no-ops for them.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add services/metrics/internal/jobs/standard.go
+git commit -m "fix(metrics): gate post-processing branches on isLegacyStyle
+
+Wraps the four post-processing branches in standard.go's Run loop
+(CUPED, MLRATE, session-level, lifecycle) in nested if/else with an
+isLegacyStyle gate. Non-legacy types (FILTERED_MEAN, COMPOSITE,
+WINDOWED_COUNT) emit a single-line slog.Info skip message and fall
+through to the next branch.
+
+Skip behavior is fall-through (no continue) so independent branches
+don't suppress each other — skipping CUPED for a non-legacy type
+should not also suppress session-level for that metric (though both
+will skip if both are enabled, by the same gate).
+
+Existing legacy-type metrics are unaffected — the gate is a no-op
+for them.
+
+Refs #511"
+```
+
+---
+
+## Task 3: Extend e2e test with skip-verification
+
+**Files:**
+- Modify: `services/metrics/internal/config/testdata/seed_adr026_phase1.json`
+- Modify: `services/metrics/internal/jobs/standard_test.go`
+
+Augment the existing fixture to enable session-level and lifecycle on the experiment, attach a CUPED covariate to one new-type metric, and add a legacy MEAN metric to prove post-processing still runs for legacy types in the same run.
+
+- [ ] **Step 3.1: Modify the seed fixture**
+
+Replace `services/metrics/internal/config/testdata/seed_adr026_phase1.json` with the following (additions: `session_level: true`, `lifecycle_stratification_enabled: true` on the experiment; `cuped_covariate_metric_id` on `mobile_avg_watch_time`; new `secondary_metric_ids` includes `legacy_watch_time`; new fifth metric `legacy_watch_time` of type MEAN):
+
+```json
+{
+  "experiments": [
+    {
+      "experiment_id": "e0000000-0000-0000-0000-0000000adr26",
+      "name": "adr026_phase1_smoke",
+      "type": "STANDARD",
+      "state": "RUNNING",
+      "started_at": "2026-05-01",
+      "primary_metric_id": "mobile_avg_watch_time",
+      "secondary_metric_ids": ["composite_engagement", "stream_starts_24h", "legacy_watch_time"],
+      "session_level": true,
+      "lifecycle_stratification_enabled": true,
+      "variants": [
+        {"variant_id": "control", "name": "Control", "traffic_fraction": 0.5, "is_control": true},
+        {"variant_id": "treatment", "name": "Treatment", "traffic_fraction": 0.5, "is_control": false}
+      ]
+    }
+  ],
+  "metrics": [
+    {
+      "metric_id": "mobile_avg_watch_time",
+      "name": "Mobile avg watch time",
+      "type": "FILTERED_MEAN",
+      "source_event_type": "heartbeat",
+      "filter_sql": "platform = 'mobile'",
+      "value_column": "duration_ms",
+      "cuped_covariate_metric_id": "legacy_watch_time"
+    },
+    {
+      "metric_id": "composite_engagement",
+      "name": "Composite engagement",
+      "type": "COMPOSITE",
+      "source_event_type": "n/a",
+      "operator": "WEIGHTED_SUM",
+      "operands": [
+        {"metric_id": "watch_time_minutes", "weight": 0.7},
+        {"metric_id": "stream_start_rate", "weight": 0.3}
+      ]
+    },
+    {
+      "metric_id": "stream_starts_24h",
+      "name": "Stream starts within 24h of exposure",
+      "type": "WINDOWED_COUNT",
+      "source_event_type": "n/a",
+      "event_type": "stream_start",
+      "window_hours": 24
+    },
+    {
+      "metric_id": "legacy_watch_time",
+      "name": "Legacy watch time (MEAN)",
+      "type": "MEAN",
+      "source_event_type": "heartbeat"
+    }
+  ]
+}
+```
+
+- [ ] **Step 3.2: Update the existing test's `MetricsComputed` assertion**
+
+In `services/metrics/internal/jobs/standard_test.go`, find `TestStandardJob_Run_ADR026Phase1_NewTypes`. The previous test asserted `MetricsComputed == 3`; now it must assert `MetricsComputed == 4` (the 3 new-type + 1 legacy). Update that assertion:
+
+```go
+	assert.Equal(t, 4, result.MetricsComputed,
+		"all 4 metrics (3 new-type + 1 legacy) should compute primary SQL successfully")
+```
+
+- [ ] **Step 3.3: Add new subtests asserting gate behavior**
+
+Append two new subtests to `TestStandardJob_Run_ADR026Phase1_NewTypes`, after the existing `windowed_count SQL` subtest:
+
+```go
+	// Build a set lookup of post-processing JobType values per metric_id from the query log.
+	postProcessJobTypes := map[string]bool{
+		"session_level_metric": true,
+		"lifecycle_metric":     true,
+		"cuped_covariate":      true,
+	}
+	postProcByMetric := make(map[string][]string) // metric_id -> []JobType
+	for _, e := range entries {
+		if postProcessJobTypes[e.JobType] {
+			postProcByMetric[e.MetricID] = append(postProcByMetric[e.MetricID], e.JobType)
+		}
+	}
+
+	t.Run("new types skip legacy post-processing", func(t *testing.T) {
+		newTypeIDs := []string{"mobile_avg_watch_time", "composite_engagement", "stream_starts_24h"}
+		for _, id := range newTypeIDs {
+			assert.Empty(t, postProcByMetric[id],
+				"%s (new ADR-026 Phase 1 type) should NOT emit any session-level / lifecycle / cuped_covariate SQL", id)
+		}
+	})
+
+	t.Run("legacy types still run post-processing", func(t *testing.T) {
+		got := postProcByMetric["legacy_watch_time"]
+		assert.Contains(t, got, "session_level_metric",
+			"legacy MEAN metric should produce session_level_metric SQL when session_level is enabled")
+		assert.Contains(t, got, "lifecycle_metric",
+			"legacy MEAN metric should produce lifecycle_metric SQL when lifecycle_stratification is enabled")
+		// Note: legacy_watch_time has no cuped_covariate_metric_id, so no cuped_covariate entry expected.
+	})
+```
+
+- [ ] **Step 3.4: Run the test — expect PASS**
+
+Run: `go test ./services/metrics/internal/jobs/ -run TestStandardJob_Run_ADR026Phase1_NewTypes -v`
+Expected: outer test + 5 subtests PASS (the 3 existing primary-SQL subtests + 2 new gate-behavior subtests).
+
+If the new subtests fail:
+- If `new types skip legacy post-processing` fails because `postProcByMetric` has entries for new-type IDs, the gate isn't firing for that metric — check the slog output for the skip message. Most likely cause: `isLegacyStyle` returns true unexpectedly, or the gate wraps the wrong block.
+- If `legacy types still run post-processing` fails, the legacy MEAN metric is being incorrectly gated. Verify `isLegacyStyle("MEAN") == true` (Task 1's unit test).
+
+- [ ] **Step 3.5: Run the full jobs suite — expect PASS**
+
+Run: `go test ./services/metrics/internal/jobs/...`
+Expected: every test passes. Existing tests using `seed_config.json` are unaffected (they don't use the new fixture).
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add services/metrics/internal/config/testdata/seed_adr026_phase1.json services/metrics/internal/jobs/standard_test.go
+git commit -m "test(metrics): verify ADR-026 type-gates skip post-processing for new types
+
+Extends seed_adr026_phase1.json with session_level + lifecycle_stratification
+enabled on the experiment, a CUPED covariate on the FILTERED_MEAN metric,
+and a fifth legacy MEAN metric (legacy_watch_time) to prove the gate
+still runs post-processing for legacy types.
+
+Two new subtests in TestStandardJob_Run_ADR026Phase1_NewTypes:
+- 'new types skip legacy post-processing' — asserts ZERO post-processing
+  JobType entries (session_level_metric, lifecycle_metric, cuped_covariate)
+  for any of the 3 new-type metric_ids.
+- 'legacy types still run post-processing' — asserts the legacy MEAN
+  metric DOES emit session_level_metric and lifecycle_metric entries.
+
+Updated MetricsComputed assertion from 3 to 4 (3 new-type + 1 legacy).
+
+Refs #511"
+```
+
+---
+
+## Task 4: Workspace verification + PR open
+
+**Files:** none modified directly; this task is the final smoke + PR.
+
+- [ ] **Step 4.1: Run the full Go test suite**
+
+Run: `go test ./...`
+Expected: every Go package passes. Pre-existing failures in `services/management` (gen/go/experimentation/management/v1 setup-failed pattern from prior PRs) are acceptable; verify by checking they reproduce on `origin/main` if uncertain.
+
+- [ ] **Step 4.2: Run `go vet`**
+
+Run: `go vet ./...`
+Expected: clean.
+
+- [ ] **Step 4.3: Confirm git status is clean**
+
+Run: `git status`
+Expected: clean working tree (or only `.beads/`/`.superpowers/` runtime cruft).
+
+- [ ] **Step 4.4: Push branch**
+
+Run: `git push -u origin agent-3/fix/issue-511-post-processing-type-gates`
+Expected: branch pushed; GitHub returns the PR-creation URL.
+
+- [ ] **Step 4.5: Open the PR**
+
+```bash
+gh pr create --base main --head agent-3/fix/issue-511-post-processing-type-gates \
+  --title "fix(metrics): gate post-processing branches on isLegacyStyle (#511)" \
+  --body "$(cat <<'PRBODY'
+Closes [#511](https://github.com/wunderkennd/kaizen-experimentation/issues/511) (option a — type-gate). Option b (per-type post-processing templates) remains open for a future ADR.
+
+Spec: \`docs/superpowers/specs/2026-05-07-issue-511-post-processing-type-gates.md\`
+Plan: \`docs/superpowers/plans/2026-05-07-issue-511-post-processing-type-gates.md\`
+
+## What changed
+
+- **`isLegacyStyle` helper** in `services/metrics/internal/jobs/standard.go`: case-insensitive switch returning true for the 6 legacy MetricType values (MEAN, PROPORTION, COUNT, RATIO, PERCENTILE, CUSTOM), false for everything else.
+- **Four post-processing gates** in `Run`: CUPED covariate, MLRATE cross-fit, session-level, lifecycle. Each branch wraps its existing body in a nested if/else; the skip path emits a single-line \`slog.Info\` and falls through (no \`continue\`).
+- **Test fixture extension** in \`services/metrics/internal/config/testdata/seed_adr026_phase1.json\`: enables \`session_level: true\` and \`lifecycle_stratification_enabled: true\` on the experiment, attaches a \`cuped_covariate_metric_id\` to one new-type metric, and adds a fifth legacy MEAN metric to prove post-processing still runs for legacy types.
+- **Two new subtests** in \`TestStandardJob_Run_ADR026Phase1_NewTypes\`: verify new-type metrics skip post-processing AND legacy metrics still run it.
+- **Direct unit test** \`TestIsLegacyStyle\` covering legacy / non-legacy / unknown / case-insensitive paths (also exercises MLRATE coverage indirectly since the helper is shared across all 4 branches).
+
+## Verification
+
+- [x] \`go test ./services/metrics/...\` — all green
+- [x] \`go test ./...\` — all green (pre-existing services/management setup-failed errors unrelated)
+- [x] \`go vet ./...\` — clean
+- [ ] CI on this PR — full matrix
+
+## Closes the loop on PR #510
+
+The latent bug surfaced in PR #510's final review (#510's review comments) is fixed: any combination of new-type metric + (\`session_level: true\` | \`lifecycle_stratification_enabled: true\` | \`cuped_covariate_metric_id\` | MLRATE config) now skips post-processing cleanly with a discoverable log message instead of producing silently-wrong (or empty) SQL.
+
+## Out of scope
+
+- Per-type post-processing templates (option b) — future ADR.
+- M5 validation of legal feature combinations — issue #433.
+- Loader refactor — issue #506.
+
+Refs #432 (Phase 1 renderer), #504 / #510 (M3 wiring).
+PRBODY
+)"
+```
+
+- [ ] **Step 4.6: Capture the PR URL in the report**
+
+Note the PR number returned by \`gh pr create\` for the final report.
+
+---
+
+## Self-Review Checklist
+
+**1. Spec coverage:**
+- [x] §1 `isLegacyStyle` helper (file-private, case-insensitive switch over 6 legacy types) → Task 1
+- [x] §2 four post-processing gates with branch-specific skip messages → Task 2
+- [x] §3 testing: extended fixture with experiment flags + CUPED covariate + legacy MEAN → Task 3
+- [x] §3 direct unit test for `isLegacyStyle` → Task 1
+- [x] §3 e2e subtests asserting new types skip + legacy types run → Task 3
+- [x] §2 design choice: `slog.Info` not `slog.Warn`, fall-through not `continue` → Task 2's gate code
+
+**2. Placeholder scan:** No "TBD", "TODO", "implement later", or vague directives. Each step has actual code or commands.
+
+**3. Type consistency:** `isLegacyStyle` is defined once (Task 1) with signature `func(string) bool`, called identically from 4 sites (Task 2). The fixture's `cuped_covariate_metric_id: "legacy_watch_time"` references the legacy metric defined in the same fixture. Test assertions reference the right `MetricID` values (`mobile_avg_watch_time`, `composite_engagement`, `stream_starts_24h`, `legacy_watch_time`) and the right `JobType` values (`session_level_metric`, `lifecycle_metric`, `cuped_covariate`).
+
+---
+
+## Execution Choice
+
+Two options:
+
+1. **Subagent-Driven (recommended)** — Same workflow as PR #497 / PR #510: fresh subagent per task with two-stage review (spec compliance + code quality). Each of the 4 tasks runs to a clean commit before the next.
+
+2. **Inline Execution** — Run all 4 tasks in this session via `superpowers:executing-plans` with checkpoints between tasks.
+
+Subagent-driven is recommended for consistency with prior work on this feature stream.

--- a/docs/superpowers/specs/2026-05-07-issue-511-post-processing-type-gates.md
+++ b/docs/superpowers/specs/2026-05-07-issue-511-post-processing-type-gates.md
@@ -1,0 +1,164 @@
+# Issue #511 — Post-Processing Branch Type-Gates
+
+- **Date:** 2026-05-07
+- **Status:** Approved
+- **Author:** Kenneth Sylvain + Claude Code
+- **Implements:** [Issue #511](https://github.com/wunderkennd/kaizen-experimentation/issues/511) (option a — type-gate; option b deferred to future ADR)
+- **Builds on:** [PR #510](https://github.com/wunderkennd/kaizen-experimentation/pull/510) (issue #504, M3 MetricConfig wiring)
+
+## Context
+
+PR #510 wired ADR-026 Phase 1 metric types (`FILTERED_MEAN`, `COMPOSITE`, `WINDOWED_COUNT`) end-to-end through `services/metrics/internal/jobs/standard.go`. **Side effect:** these types are now reachable from the four post-processing branches in `Run`:
+
+1. **CUPED covariate** (lines ~162–206) — fires when `m.CupedCovariateMetricID != "" && exp.StartedAt != ""`.
+2. **MLRATE cross-fit** (lines ~208–223) — fires when `exp.MLRATEEnabled && len(m.MLRATEFeatureEventTypes) > 0 && m.MLRATEModelURI != ""`.
+3. **Session-level** (lines ~226–258) — fires when `exp.SessionLevel && !m.IsQoEMetric`.
+4. **Lifecycle** (lines ~261–293) — fires when `exp.LifecycleStratificationEnabled && !m.IsQoEMetric`.
+
+All four branches reuse `params` and call SQL templates that **assume the legacy MEAN-style column convention** — `me.value` for the metric value and `me.event_type = '{{.SourceEventType}}'` for the row filter. The new types break this assumption:
+
+| Type | Mismatch |
+| --- | --- |
+| `FILTERED_MEAN` | uses `me.{{.ValueColumn}}`, not `me.value` — column may not exist |
+| `COMPOSITE` | reads from `delta.metric_summaries`, not `delta.metric_events` — `me.event_type = 'n/a'` matches zero rows |
+| `WINDOWED_COUNT` | counts rows, doesn't average values — `AVG()` against COUNT semantics is meaningless |
+
+**Today's risk is bounded** — no current seed file or staging environment combines `session_level: true` / `lifecycle_stratification_enabled: true` / `cuped_covariate_metric_id` / `mlrate_feature_event_types` with a new-type metric. But the moment one is, production data is silently wrong.
+
+## Decision
+
+**Adopt option (a) from issue #511: type-gate the four post-processing branches with an `isLegacyStyle` predicate, emit a single-line `slog.Info` skip message for non-legacy types, and continue the loop.**
+
+### Rationale
+
+Option (b) — proper per-type post-processing — is the right long-term shape but requires designing 12 new SQL templates (3 new types × 4 branches) plus the M5 validation that determines which combinations are legal. That's an ADR-scale exercise; gating buys time at the cost of one helper function and four if/else wraps.
+
+The type-gate has the right failure mode: a real-world misconfiguration (someone enables `session_level: true` on an experiment whose secondary metric is COMPOSITE) emits a clear `slog.Info` instead of producing silently-wrong rows. On-call engineers can grep for the skip message and route the request to whoever owns option (b).
+
+## Architecture
+
+### 1. `isLegacyStyle` helper
+
+Add to `services/metrics/internal/jobs/standard.go` near the existing `toSparkOperands` helper (file-private, lowercase first letter):
+
+```go
+// isLegacyStyle reports whether a MetricType uses the legacy MEAN-style
+// column convention (me.value, me.event_type = '{{.SourceEventType}}')
+// that the post-processing templates (cuped_covariate, session_level_mean,
+// lifecycle_mean, mlrate_*) assume.
+//
+// ADR-026 Phase 1 types (FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT) use
+// different column conventions and must skip post-processing until those
+// templates grow per-type variants (issue #511 option b).
+func isLegacyStyle(metricType string) bool {
+    switch strings.ToUpper(metricType) {
+    case "MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM":
+        return true
+    }
+    return false
+}
+```
+
+### 2. Four post-processing gates
+
+For each of the four branches, wrap the existing body in a nested if/else. Skip path emits a one-line `slog.Info` and falls through (no `continue` — other branches still get a chance):
+
+```go
+// Pattern applied to all 4 branches:
+if <existing-trigger-condition> {
+    if !isLegacyStyle(m.Type) {
+        slog.Info("skipping <branch-name>: legacy column convention not supported for this metric type",
+            "metric_id", m.MetricID,
+            "type", m.Type,
+        )
+    } else {
+        // existing branch body unchanged
+    }
+}
+```
+
+Branch-specific skip messages:
+
+| Branch | Skip message |
+| --- | --- |
+| CUPED covariate | `"skipping CUPED covariate: legacy column convention not supported for this metric type"` |
+| MLRATE cross-fit | `"skipping MLRATE cross-fit: legacy column convention not supported for this metric type"` |
+| Session-level | `"skipping session-level metric: legacy column convention not supported for this metric type"` |
+| Lifecycle | `"skipping lifecycle metric: legacy column convention not supported for this metric type"` |
+
+### Design choices
+
+| Choice | Decision | Why |
+| --- | --- | --- |
+| Helper location | Package-level unexported function in `standard.go` | Testable in isolation; matches `toSparkOperands` placement |
+| Helper input type | `string` (not a typed enum) | Matches the existing `MetricConfig.Type` field shape and the renderer's `RenderForType(metricType string, ...)` signature |
+| Case sensitivity | `strings.ToUpper` | Matches the renderer's existing case-normalization pattern |
+| Skip behavior | `slog.Info` + fall through (NOT `continue`) | Each branch is independent — skipping CUPED shouldn't suppress session-level. Falling through preserves that |
+| Skip log level | `Info` (not `Warn` or `Error`) | This is expected behavior, not degraded behavior — the metric's primary SQL still ran. Reserving `Warn` for the existing `RenderForType` failure path keeps log-level signal meaningful |
+| MLRATE inclusion | Yes | Same column-convention mismatch; same fix shape. Avoids a future #511.5 |
+| QoE branch | Already gated by `!m.IsQoEMetric` — leave unchanged | QoE is a separate template family with its own column conventions; not in #511's scope |
+
+### 3. Testing
+
+Modify `services/metrics/internal/config/testdata/seed_adr026_phase1.json`:
+
+- Enable `session_level: true` on the experiment.
+- Enable `lifecycle_stratification_enabled: true` on the experiment.
+- Add `cuped_covariate_metric_id: "watch_time_minutes"` to one of the new-type metrics (the gate fires before we look up the covariate, so referencing a non-existent metric is fine — but using a real legacy one keeps the fixture consistent).
+- Add a fifth metric to the experiment: a legacy `MEAN` metric named `watch_time_minutes` with the standard MEAN config. This proves post-processing still runs for legacy types in the same experiment.
+- Reference the legacy metric from `secondary_metric_ids` so it's actually computed.
+
+The MLRATE branch requires several extra fields (`mlrate_enabled`, `mlrate_feature_event_types`, `mlrate_model_uri`). To keep the fixture compact, MLRATE coverage is verified by **direct unit test** of `isLegacyStyle` rather than by the e2e fixture. The end-to-end fixture covers CUPED, session-level, and lifecycle.
+
+Extend `TestStandardJob_Run_ADR026Phase1_NewTypes` in `services/metrics/internal/jobs/standard_test.go`:
+
+- New subtest **`new types skip legacy post-processing`**: filter `qlWriter.AllEntries()` for new-type metric IDs (`mobile_avg_watch_time`, `composite_engagement`, `stream_starts_24h`); assert ZERO entries with `JobType` ∈ `{session_level_metric, lifecycle_metric, cuped_covariate}`.
+- New subtest **`legacy types still run post-processing`**: filter for the legacy `watch_time_minutes` metric ID; assert it produces entries with the post-processing `JobType` values (proves the gate doesn't break legacy behavior).
+- The existing 3 subtests (filtered_mean / composite / windowed_count primary SQL) continue to assert the new types produce their main `daily_metric` SQL — proving the gate doesn't break primary computation.
+
+Add a **direct unit test for `isLegacyStyle`** in `standard_test.go`:
+
+```go
+func TestIsLegacyStyle(t *testing.T) {
+    legacy := []string{"MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM",
+        "mean", "ratio", "Custom"} // case-insensitive
+    nonLegacy := []string{"FILTERED_MEAN", "COMPOSITE", "WINDOWED_COUNT",
+        "filtered_mean", "", "UNKNOWN_TYPE"}
+    for _, t_ := range legacy {
+        assert.True(t, isLegacyStyle(t_), "%q should be legacy", t_)
+    }
+    for _, t_ := range nonLegacy {
+        assert.False(t, isLegacyStyle(t_), "%q should not be legacy", t_)
+    }
+}
+```
+
+This exercises MLRATE coverage indirectly (via the helper) and locks down case-insensitivity.
+
+## Out of scope
+
+| Concern | Tracked elsewhere |
+| --- | --- |
+| Per-type post-processing (option b — proper SQL templates) | #511 (this issue's option b — defer to future ADR) |
+| M5 validation of legal feature combinations (e.g. "can a COMPOSITE have a CUPED covariate?") | #433 |
+| Loader refactor to consume proto MetricDefinition | #506 |
+| Future Option B proto migration | #476 |
+
+## Decisions log
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Option a vs b | a (gate) | b is ADR-scale; a is small fast-follow that closes the production-risk gap |
+| Include MLRATE in gate set | Yes | Same column-convention mismatch as the other 3 branches; same fix shape |
+| Helper return type | `bool` | Matches Go-idiomatic `is*` predicate pattern |
+| Skip log level | `Info` | Expected behavior, not degraded — primary SQL still runs |
+| Skip behavior | Fall through (no `continue`) | Branches are independent |
+| MLRATE e2e coverage | Direct unit test of `isLegacyStyle` | Keeps fixture compact; full e2e MLRATE setup requires too many extra fields |
+
+## References
+
+- Issue #511 — primary deliverable
+- PR #510 / Issue #504 — the wiring that made these branches reachable for new types
+- `services/metrics/internal/jobs/standard.go` — the four post-processing branches
+- `services/metrics/internal/config/testdata/seed_adr026_phase1.json` — fixture from PR #510 to extend
+- `services/metrics/internal/jobs/standard_test.go` — test file with `TestStandardJob_Run_ADR026Phase1_NewTypes` to extend

--- a/services/metrics/internal/config/testdata/seed_adr026_phase1.json
+++ b/services/metrics/internal/config/testdata/seed_adr026_phase1.json
@@ -7,7 +7,9 @@
       "state": "RUNNING",
       "started_at": "2026-05-01",
       "primary_metric_id": "mobile_avg_watch_time",
-      "secondary_metric_ids": ["composite_engagement", "stream_starts_24h"],
+      "secondary_metric_ids": ["composite_engagement", "stream_starts_24h", "legacy_watch_time"],
+      "session_level": true,
+      "lifecycle_stratification_enabled": true,
       "variants": [
         {"variant_id": "control", "name": "Control", "traffic_fraction": 0.5, "is_control": true},
         {"variant_id": "treatment", "name": "Treatment", "traffic_fraction": 0.5, "is_control": false}
@@ -21,7 +23,8 @@
       "type": "FILTERED_MEAN",
       "source_event_type": "heartbeat",
       "filter_sql": "platform = 'mobile'",
-      "value_column": "duration_ms"
+      "value_column": "duration_ms",
+      "cuped_covariate_metric_id": "legacy_watch_time"
     },
     {
       "metric_id": "composite_engagement",
@@ -41,6 +44,12 @@
       "source_event_type": "n/a",
       "event_type": "stream_start",
       "window_hours": 24
+    },
+    {
+      "metric_id": "legacy_watch_time",
+      "name": "Legacy watch time (MEAN)",
+      "type": "MEAN",
+      "source_event_type": "heartbeat"
     }
   ]
 }

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -162,134 +162,162 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 		// If metric has a CUPED covariate configured and experiment has a start date,
 		// compute the pre-experiment covariate value for variance reduction.
 		if m.CupedCovariateMetricID != "" && exp.StartedAt != "" {
-			covMetric, err := j.config.GetMetric(m.CupedCovariateMetricID)
-			if err != nil {
-				return nil, fmt.Errorf("jobs: resolve CUPED covariate metric %s for %s: %w",
-					m.CupedCovariateMetricID, m.MetricID, err)
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping CUPED covariate: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				covMetric, err := j.config.GetMetric(m.CupedCovariateMetricID)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: resolve CUPED covariate metric %s for %s: %w",
+						m.CupedCovariateMetricID, m.MetricID, err)
+				}
+
+				cupedParams := params
+				cupedParams.CupedEnabled = true
+				cupedParams.CupedCovariateEventType = covMetric.SourceEventType
+				cupedParams.ExperimentStartDate = exp.StartedAt
+				cupedParams.CupedLookbackDays = defaultCupedLookbackDays
+
+				cupedSQL, err := j.renderer.RenderCupedCovariate(cupedParams)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: render CUPED covariate for %s: %w", m.MetricID, err)
+				}
+
+				cupedResult, err := j.executor.ExecuteAndWrite(ctx, cupedSQL, "delta.metric_summaries")
+				if err != nil {
+					return nil, fmt.Errorf("jobs: execute CUPED covariate for %s: %w", m.MetricID, err)
+				}
+				m3metrics.SparkQueryDuration.WithLabelValues("cuped_covariate").Observe(cupedResult.Duration.Seconds())
+				m3metrics.SparkQueryRows.WithLabelValues("cuped_covariate").Observe(float64(cupedResult.RowCount))
+
+				if err := j.queryLog.Log(ctx, querylog.Entry{
+					ExperimentID: experimentID,
+					MetricID:     m.MetricID,
+					SQLText:      cupedSQL,
+					RowCount:     cupedResult.RowCount,
+					DurationMs:   cupedResult.Duration.Milliseconds(),
+					JobType:      "cuped_covariate",
+				}); err != nil {
+					return nil, fmt.Errorf("jobs: log CUPED covariate query for %s: %w", m.MetricID, err)
+				}
+
+				slog.Info("computed CUPED covariate",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"covariate_metric_id", m.CupedCovariateMetricID,
+					"rows", cupedResult.RowCount,
+				)
 			}
-
-			cupedParams := params
-			cupedParams.CupedEnabled = true
-			cupedParams.CupedCovariateEventType = covMetric.SourceEventType
-			cupedParams.ExperimentStartDate = exp.StartedAt
-			cupedParams.CupedLookbackDays = defaultCupedLookbackDays
-
-			cupedSQL, err := j.renderer.RenderCupedCovariate(cupedParams)
-			if err != nil {
-				return nil, fmt.Errorf("jobs: render CUPED covariate for %s: %w", m.MetricID, err)
-			}
-
-			cupedResult, err := j.executor.ExecuteAndWrite(ctx, cupedSQL, "delta.metric_summaries")
-			if err != nil {
-				return nil, fmt.Errorf("jobs: execute CUPED covariate for %s: %w", m.MetricID, err)
-			}
-			m3metrics.SparkQueryDuration.WithLabelValues("cuped_covariate").Observe(cupedResult.Duration.Seconds())
-			m3metrics.SparkQueryRows.WithLabelValues("cuped_covariate").Observe(float64(cupedResult.RowCount))
-
-			if err := j.queryLog.Log(ctx, querylog.Entry{
-				ExperimentID: experimentID,
-				MetricID:     m.MetricID,
-				SQLText:      cupedSQL,
-				RowCount:     cupedResult.RowCount,
-				DurationMs:   cupedResult.Duration.Milliseconds(),
-				JobType:      "cuped_covariate",
-			}); err != nil {
-				return nil, fmt.Errorf("jobs: log CUPED covariate query for %s: %w", m.MetricID, err)
-			}
-
-			slog.Info("computed CUPED covariate",
-				"experiment_id", experimentID,
-				"metric_id", m.MetricID,
-				"covariate_metric_id", m.CupedCovariateMetricID,
-				"rows", cupedResult.RowCount,
-			)
 		}
 
 		// MLRATE cross-fitting: if experiment has MLRATE enabled and metric has
 		// feature config, generate K-fold cross-fitted predictions as AVLM covariates.
 		if exp.MLRATEEnabled && len(m.MLRATEFeatureEventTypes) > 0 && m.MLRATEModelURI != "" && exp.StartedAt != "" {
-			mlrateJob := NewMLRATEJob(j.renderer, j.executor, j.queryLog)
-			mlrateResult, err := mlrateJob.Run(ctx, exp, &m, computationDate)
-			if err != nil {
-				return nil, fmt.Errorf("jobs: MLRATE cross-fit for %s: %w", m.MetricID, err)
-			}
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping MLRATE cross-fit: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				mlrateJob := NewMLRATEJob(j.renderer, j.executor, j.queryLog)
+				mlrateResult, err := mlrateJob.Run(ctx, exp, &m, computationDate)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: MLRATE cross-fit for %s: %w", m.MetricID, err)
+				}
 
-			slog.Info("computed MLRATE cross-fitted predictions",
-				"experiment_id", experimentID,
-				"metric_id", m.MetricID,
-				"folds", mlrateResult.Folds,
-				"users_scored", mlrateResult.UsersScored,
-			)
+				slog.Info("computed MLRATE cross-fitted predictions",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"folds", mlrateResult.Folds,
+					"users_scored", mlrateResult.UsersScored,
+				)
+			}
 		}
 
 		// Session-level aggregation: if enabled, also compute per-session metrics.
 		if exp.SessionLevel && !m.IsQoEMetric {
-			slParams := params
-			slParams.SessionLevel = true
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping session-level metric: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				slParams := params
+				slParams.SessionLevel = true
 
-			slSQL, err := j.renderer.RenderSessionLevelMean(slParams)
-			if err != nil {
-				return nil, fmt.Errorf("jobs: render session-level metric for %s: %w", m.MetricID, err)
+				slSQL, err := j.renderer.RenderSessionLevelMean(slParams)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: render session-level metric for %s: %w", m.MetricID, err)
+				}
+
+				slResult, err := j.executor.ExecuteAndWrite(ctx, slSQL, "delta.metric_summaries")
+				if err != nil {
+					return nil, fmt.Errorf("jobs: execute session-level metric for %s: %w", m.MetricID, err)
+				}
+				m3metrics.SparkQueryDuration.WithLabelValues("session_level_metric").Observe(slResult.Duration.Seconds())
+				m3metrics.SparkQueryRows.WithLabelValues("session_level_metric").Observe(float64(slResult.RowCount))
+
+				if err := j.queryLog.Log(ctx, querylog.Entry{
+					ExperimentID: experimentID,
+					MetricID:     m.MetricID,
+					SQLText:      slSQL,
+					RowCount:     slResult.RowCount,
+					DurationMs:   slResult.Duration.Milliseconds(),
+					JobType:      "session_level_metric",
+				}); err != nil {
+					return nil, fmt.Errorf("jobs: log session-level metric query for %s: %w", m.MetricID, err)
+				}
+
+				slog.Info("computed session-level metric",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"rows", slResult.RowCount,
+				)
 			}
-
-			slResult, err := j.executor.ExecuteAndWrite(ctx, slSQL, "delta.metric_summaries")
-			if err != nil {
-				return nil, fmt.Errorf("jobs: execute session-level metric for %s: %w", m.MetricID, err)
-			}
-			m3metrics.SparkQueryDuration.WithLabelValues("session_level_metric").Observe(slResult.Duration.Seconds())
-			m3metrics.SparkQueryRows.WithLabelValues("session_level_metric").Observe(float64(slResult.RowCount))
-
-			if err := j.queryLog.Log(ctx, querylog.Entry{
-				ExperimentID: experimentID,
-				MetricID:     m.MetricID,
-				SQLText:      slSQL,
-				RowCount:     slResult.RowCount,
-				DurationMs:   slResult.Duration.Milliseconds(),
-				JobType:      "session_level_metric",
-			}); err != nil {
-				return nil, fmt.Errorf("jobs: log session-level metric query for %s: %w", m.MetricID, err)
-			}
-
-			slog.Info("computed session-level metric",
-				"experiment_id", experimentID,
-				"metric_id", m.MetricID,
-				"rows", slResult.RowCount,
-			)
 		}
 
 		// Lifecycle segmentation: if enabled, also compute per-lifecycle-segment metrics.
 		if exp.LifecycleStratificationEnabled && !m.IsQoEMetric {
-			lcParams := params
-			lcParams.LifecycleEnabled = true
+			if !isLegacyStyle(m.Type) {
+				slog.Info("skipping lifecycle metric: legacy column convention not supported for this metric type",
+					"metric_id", m.MetricID,
+					"type", m.Type,
+				)
+			} else {
+				lcParams := params
+				lcParams.LifecycleEnabled = true
 
-			lcSQL, err := j.renderer.RenderLifecycleMean(lcParams)
-			if err != nil {
-				return nil, fmt.Errorf("jobs: render lifecycle metric for %s: %w", m.MetricID, err)
+				lcSQL, err := j.renderer.RenderLifecycleMean(lcParams)
+				if err != nil {
+					return nil, fmt.Errorf("jobs: render lifecycle metric for %s: %w", m.MetricID, err)
+				}
+
+				lcResult, err := j.executor.ExecuteAndWrite(ctx, lcSQL, "delta.metric_summaries")
+				if err != nil {
+					return nil, fmt.Errorf("jobs: execute lifecycle metric for %s: %w", m.MetricID, err)
+				}
+				m3metrics.SparkQueryDuration.WithLabelValues("lifecycle_metric").Observe(lcResult.Duration.Seconds())
+				m3metrics.SparkQueryRows.WithLabelValues("lifecycle_metric").Observe(float64(lcResult.RowCount))
+
+				if err := j.queryLog.Log(ctx, querylog.Entry{
+					ExperimentID: experimentID,
+					MetricID:     m.MetricID,
+					SQLText:      lcSQL,
+					RowCount:     lcResult.RowCount,
+					DurationMs:   lcResult.Duration.Milliseconds(),
+					JobType:      "lifecycle_metric",
+				}); err != nil {
+					return nil, fmt.Errorf("jobs: log lifecycle metric query for %s: %w", m.MetricID, err)
+				}
+
+				slog.Info("computed lifecycle metric",
+					"experiment_id", experimentID,
+					"metric_id", m.MetricID,
+					"rows", lcResult.RowCount,
+				)
 			}
-
-			lcResult, err := j.executor.ExecuteAndWrite(ctx, lcSQL, "delta.metric_summaries")
-			if err != nil {
-				return nil, fmt.Errorf("jobs: execute lifecycle metric for %s: %w", m.MetricID, err)
-			}
-			m3metrics.SparkQueryDuration.WithLabelValues("lifecycle_metric").Observe(lcResult.Duration.Seconds())
-			m3metrics.SparkQueryRows.WithLabelValues("lifecycle_metric").Observe(float64(lcResult.RowCount))
-
-			if err := j.queryLog.Log(ctx, querylog.Entry{
-				ExperimentID: experimentID,
-				MetricID:     m.MetricID,
-				SQLText:      lcSQL,
-				RowCount:     lcResult.RowCount,
-				DurationMs:   lcResult.Duration.Milliseconds(),
-				JobType:      "lifecycle_metric",
-			}); err != nil {
-				return nil, fmt.Errorf("jobs: log lifecycle metric query for %s: %w", m.MetricID, err)
-			}
-
-			slog.Info("computed lifecycle metric",
-				"experiment_id", experimentID,
-				"metric_id", m.MetricID,
-				"rows", lcResult.RowCount,
-			)
 		}
 
 		slog.Info("computed metric",

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -403,6 +403,22 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 	}, nil
 }
 
+// isLegacyStyle reports whether a MetricType uses the legacy MEAN-style
+// column convention (me.value, me.event_type = '{{.SourceEventType}}')
+// that the post-processing templates (cuped_covariate, session_level_mean,
+// lifecycle_mean, mlrate_*) assume.
+//
+// ADR-026 Phase 1 types (FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT) use
+// different column conventions and must skip post-processing until those
+// templates grow per-type variants (issue #511 option b).
+func isLegacyStyle(metricType string) bool {
+	switch strings.ToUpper(metricType) {
+	case "MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM":
+		return true
+	}
+	return false
+}
+
 // toSparkOperands converts config-layer OperandConfig values to the
 // spark.OperandParam shape consumed by the renderer's composite template.
 // Returns nil for an empty/nil input (matches Go's zero-value convention).

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -475,8 +475,8 @@ func TestStandardJob_Run_ADR026Phase1_NewTypes(t *testing.T) {
 	ctx := context.Background()
 	result, err := job.Run(ctx, "e0000000-0000-0000-0000-0000000adr26")
 	require.NoError(t, err)
-	assert.Equal(t, 3, result.MetricsComputed,
-		"all 3 new-type metrics should compute successfully (no slog.Warn skip)")
+	assert.Equal(t, 4, result.MetricsComputed,
+		"all 4 metrics (3 new-type + 1 legacy) should compute primary SQL successfully")
 
 	calls := executor.GetCalls()
 	require.GreaterOrEqual(t, len(calls), 3, "executor should receive >= 3 SQL calls (one per metric, plus any post-processing)")
@@ -522,5 +522,35 @@ func TestStandardJob_Run_ADR026Phase1_NewTypes(t *testing.T) {
 			"WINDOWED_COUNT SQL must inline the configured window_hours")
 		assert.Contains(t, sql, "me.event_type = 'stream_start'",
 			"WINDOWED_COUNT SQL must inline the configured event_type")
+	})
+
+	// Build a set lookup of post-processing JobType values per metric_id from the query log.
+	postProcessJobTypes := map[string]bool{
+		"session_level_metric": true,
+		"lifecycle_metric":     true,
+		"cuped_covariate":      true,
+	}
+	postProcByMetric := make(map[string][]string) // metric_id -> []JobType
+	for _, e := range entries {
+		if postProcessJobTypes[e.JobType] {
+			postProcByMetric[e.MetricID] = append(postProcByMetric[e.MetricID], e.JobType)
+		}
+	}
+
+	t.Run("new types skip legacy post-processing", func(t *testing.T) {
+		newTypeIDs := []string{"mobile_avg_watch_time", "composite_engagement", "stream_starts_24h"}
+		for _, id := range newTypeIDs {
+			assert.Empty(t, postProcByMetric[id],
+				"%s (new ADR-026 Phase 1 type) should NOT emit any session-level / lifecycle / cuped_covariate SQL", id)
+		}
+	})
+
+	t.Run("legacy types still run post-processing", func(t *testing.T) {
+		got := postProcByMetric["legacy_watch_time"]
+		assert.Contains(t, got, "session_level_metric",
+			"legacy MEAN metric should produce session_level_metric SQL when session_level is enabled")
+		assert.Contains(t, got, "lifecycle_metric",
+			"legacy MEAN metric should produce lifecycle_metric SQL when lifecycle_stratification is enabled")
+		// Note: legacy_watch_time has no cuped_covariate_metric_id, so no cuped_covariate entry expected.
 	})
 }

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -431,6 +431,36 @@ func TestStandardJob_Run_AllExperimentsWithExposureJoin(t *testing.T) {
 	}
 }
 
+func TestIsLegacyStyle(t *testing.T) {
+	t.Run("legacy types return true", func(t *testing.T) {
+		legacy := []string{
+			"MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM",
+			"mean", "proportion", "count", "ratio", "percentile", "custom",
+			"Custom", "Ratio",
+		}
+		for _, mt := range legacy {
+			assert.True(t, isLegacyStyle(mt), "%q should be legacy", mt)
+		}
+	})
+
+	t.Run("ADR-026 Phase 1 types return false", func(t *testing.T) {
+		nonLegacy := []string{
+			"FILTERED_MEAN", "COMPOSITE", "WINDOWED_COUNT",
+			"filtered_mean", "composite", "windowed_count",
+		}
+		for _, mt := range nonLegacy {
+			assert.False(t, isLegacyStyle(mt), "%q should not be legacy", mt)
+		}
+	})
+
+	t.Run("unknown types return false", func(t *testing.T) {
+		unknown := []string{"", " ", "UNKNOWN_TYPE", "FOO_BAR"}
+		for _, mt := range unknown {
+			assert.False(t, isLegacyStyle(mt), "%q should not be legacy", mt)
+		}
+	})
+}
+
 func TestStandardJob_Run_ADR026Phase1_NewTypes(t *testing.T) {
 	cfgStore, err := config.LoadFromFile("../config/testdata/seed_adr026_phase1.json")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Gates the four post-processing branches in `services/metrics/internal/jobs/standard.go` (CUPED covariate, MLRATE cross-fit, session-level, lifecycle) on a new file-private `isLegacyStyle` predicate so ADR-026 Phase 1 metric types (FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT) skip post-processing cleanly with a single-line `slog.Info` instead of producing silently-wrong SQL against the legacy `me.value` / `me.event_type` column convention.

This is option (a) from issue #511. Option (b) — proper per-type post-processing SQL templates — is deferred to a future ADR (would require 12 new templates × M5 validation of legal feature combinations).

## Changes

- **New helper** `isLegacyStyle(metricType string) bool` in `standard.go` — case-insensitive check against {MEAN, PROPORTION, COUNT, RATIO, PERCENTILE, CUSTOM}
- **Four post-processing branches gated** with the same nested if/else pattern; each emits its own branch-specific skip message and falls through (no `continue` — each branch stays independent)
- **Direct unit test** `TestIsLegacyStyle` covers legacy/new/unknown types and case-insensitivity (also exercises MLRATE coverage, since the fixture intentionally doesn't pull in the full MLRATE field set)
- **Fixture extension** in `seed_adr026_phase1.json` enables `session_level: true`, `lifecycle_stratification_enabled: true`, attaches `cuped_covariate_metric_id: "legacy_watch_time"` to `mobile_avg_watch_time`, and adds a fifth legacy MEAN metric so we can verify both gate paths in the same experiment
- **Two new e2e subtests** in `TestStandardJob_Run_ADR026Phase1_NewTypes` — `new types skip legacy post-processing` (asserts no entries with post-processing JobTypes for new-type metric IDs) and `legacy types still run post-processing` (asserts the legacy MEAN metric still produces session-level + lifecycle entries)

## Test Plan

- [x] `go test ./services/metrics/...` — all metrics package tests pass
- [x] `go vet ./services/metrics/...` — clean
- [x] `TestIsLegacyStyle` passes (case-insensitivity, new-type rejection)
- [x] `TestStandardJob_Run_ADR026Phase1_NewTypes/new types skip legacy post-processing` passes (zero post-processing entries for `mobile_avg_watch_time`, `composite_engagement`, `stream_starts_24h`)
- [x] `TestStandardJob_Run_ADR026Phase1_NewTypes/legacy types still run post-processing` passes (`legacy_watch_time` produces both `session_level_metric` and `lifecycle_metric` entries — proves the gate doesn't break legacy)
- [x] Existing `TestStandardJob_Run_ADR026Phase1_NewTypes` subtests (filtered_mean / composite / windowed_count primary SQL) still pass — proves the gate doesn't break primary computation

## Out of scope

| Concern | Tracked elsewhere |
| --- | --- |
| Per-type post-processing (option b — proper SQL templates) | Future ADR (deferred from #511) |
| M5 validation of legal feature combinations | #433 |
| Loader refactor to consume proto MetricDefinition | #506 |
| Future Option B proto migration | #476 |

Closes #511
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->