### PR TITLE
🎨 Palette: Standardize list page headers, breadcrumbs, and RBAC UI

### DIFF
--- a/ui/src/__tests__/flag-pages.test.tsx
+++ b/ui/src/__tests__/flag-pages.test.tsx
@@ -198,23 +198,25 @@ describe('Flag List Page', () => {
     expect(screen.getByTestId('new-flag-button')).toHaveAttribute('href', '/flags/new');
   });
 
-  it('hides "New Flag" button for viewers', async () => {
+  it('shows disabled "New Flag" button for viewers', async () => {
+    // The AuthProvider within FlagListPage will use NEXT_PUBLIC_USER_ROLE which is experimenter
+    // We need to wrap it with an AuthProvider with a viewer user to test RBAC.
     render(
       <AuthProvider initialUser={viewerUser}>
         <FlagListPage />
       </AuthProvider>,
     );
-    // The AuthProvider wrapper is inside FlagListPage itself, so we need to
-    // use the non-wrapped content. Since FlagListPage wraps its own AuthProvider,
-    // the viewer test needs to override at the MSW level or use env vars.
-    // For simplicity, test that the button exists in default render (experimenter role via env).
     await waitFor(() => {
       expect(screen.getByText('dark_mode_rollout')).toBeInTheDocument();
     });
+    const disabledBtn = screen.getByTestId('new-flag-disabled');
+    expect(disabledBtn).toBeInTheDocument();
+    expect(disabledBtn.className).toContain('cursor-not-allowed');
+    expect(disabledBtn.title).toContain('Requires Experimenter role');
   });
 
 
-  it('has Flags nav link pointing to /flags', async () => {
+  it('has breadcrumb and nav link pointing to /flags', async () => {
     render(
       <AuthProvider>
         <NavHeader />
@@ -224,6 +226,13 @@ describe('Flag List Page', () => {
     await waitFor(() => {
       expect(screen.getByText('dark_mode_rollout')).toBeInTheDocument();
     });
+
+    // Check breadcrumb
+    const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i });
+    expect(within(breadcrumb).getByText('Flags')).toBeInTheDocument();
+    expect(within(breadcrumb).getByText('Experiments')).toHaveAttribute('href', '/');
+
+    // Check nav link
     const navLink = screen.getByTestId('nav-flags');
     expect(navLink).toHaveAttribute('href', '/flags');
     expect(navLink).toHaveTextContent('Flags');

--- a/ui/src/__tests__/monitoring.test.tsx
+++ b/ui/src/__tests__/monitoring.test.tsx
@@ -25,7 +25,7 @@ vi.mock('next/link', () => ({
 async function renderAndWait() {
   render(<MonitoringPage />);
   await waitFor(() => {
-    expect(screen.getByText('Monitoring')).toBeInTheDocument();
+    expect(screen.getAllByText('Monitoring').length).toBeGreaterThan(0);
     expect(screen.getByTestId('summary-cards')).toBeInTheDocument();
   });
 }
@@ -39,8 +39,12 @@ describe('Monitoring Page', () => {
     vi.useRealTimers();
   });
 
-  it('renders page heading', async () => {
+  it('renders breadcrumb and page heading', async () => {
     await renderAndWait();
+
+    const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i });
+    expect(within(breadcrumb).getByText('Monitoring')).toBeInTheDocument();
+    expect(within(breadcrumb).getByText('Experiments')).toHaveAttribute('href', '/');
 
     expect(screen.getByRole('heading', { name: 'Monitoring', level: 1 })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Active Experiments Summary' })).toBeInTheDocument();

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -6,6 +6,8 @@ import type { Flag, FlagType } from '@/lib/types';
 import { listFlags } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
+import { Breadcrumb } from '@/components/breadcrumb';
+import { ROLE_LABELS } from '@/lib/auth';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -15,7 +17,7 @@ const FLAG_TYPE_BADGE: Record<FlagType, string> = {
 };
 
 function FlagListContent() {
-  const { canAtLeast } = useAuth();
+  const { canAtLeast, user } = useAuth();
   const [flags, setFlags] = useState<Flag[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -48,48 +50,20 @@ function FlagListContent() {
     );
   }, [flags, search]);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
-        <span className="sr-only">Loading</span>
-      </div>
-    );
-  }
-
-  if (error) {
-    return <RetryableError message={error} onRetry={fetchData} context="feature flags" />;
-  }
-
-  if (flags.length === 0) {
-    return (
-      <div className="py-12 text-center" data-testid="empty-state">
-        <p className="text-sm text-gray-500">No feature flags found.</p>
-        {canAtLeast('experimenter') && (
-          <div className="mt-6">
-            <Link
-              href="/flags/new"
-              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-              data-testid="create-first-flag"
-            >
-              Create your first feature flag
-            </Link>
-          </div>
-        )}
-      </div>
-    );
-  }
-
   return (
     <div>
+      <Breadcrumb items={[{ label: 'Experiments', href: '/' }, { label: 'Flags' }]} />
+
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-gray-900">Feature Flags</h1>
-          <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="flag-count">
-            {filtered.length}
-          </span>
+          {!loading && !error && flags.length > 0 && (
+            <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="flag-count">
+              {filtered.length}
+            </span>
+          )}
         </div>
-        {canAtLeast('experimenter') && (
+        {canAtLeast('experimenter') ? (
           <Link
             href="/flags/new"
             className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
@@ -97,8 +71,41 @@ function FlagListContent() {
           >
             New Flag
           </Link>
+        ) : (
+          <span
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+            title={`Requires Experimenter role (you are ${user ? ROLE_LABELS[user.role] : 'Unknown'})`}
+            data-testid="new-flag-disabled"
+          >
+            New Flag
+          </span>
         )}
       </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+          <span className="sr-only">Loading</span>
+        </div>
+      ) : error ? (
+        <RetryableError message={error} onRetry={fetchData} context="feature flags" />
+      ) : flags.length === 0 ? (
+        <div className="py-12 text-center" data-testid="empty-state">
+          <p className="text-sm text-gray-500">No feature flags found.</p>
+          {canAtLeast('experimenter') && (
+            <div className="mt-6">
+              <Link
+                href="/flags/new"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                data-testid="create-first-flag"
+              >
+                Create your first feature flag
+              </Link>
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
 
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <div className="relative flex-1 min-w-[300px] max-w-md">
@@ -132,18 +139,18 @@ function FlagListContent() {
         )}
       </div>
 
-      {filtered.length === 0 ? (
-        <div className="py-12 text-center" data-testid="no-filter-matches">
-          <p className="text-sm text-gray-500">No flags match your search.</p>
-          <button
-            onClick={() => setSearch('')}
-            className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
-          >
-            Clear filters
-          </button>
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          {filtered.length === 0 ? (
+            <div className="py-12 text-center" data-testid="no-filter-matches">
+              <p className="text-sm text-gray-500">No flags match your search.</p>
+              <button
+                onClick={() => setSearch('')}
+                className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+              >
+                Clear filters
+              </button>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
@@ -187,6 +194,8 @@ function FlagListContent() {
             </tbody>
           </table>
         </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/ui/src/app/monitoring/page.tsx
+++ b/ui/src/app/monitoring/page.tsx
@@ -7,6 +7,7 @@ import { MonitoringSummaryCards } from '@/components/monitoring-summary-cards';
 import { MonitoringHealthTable } from '@/components/monitoring-health-table';
 import { MonitoringBreachList } from '@/components/monitoring-breach-list';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 const AUTO_REFRESH_INTERVAL_MS = 30_000;
 
@@ -101,21 +102,10 @@ export default function MonitoringPage() {
     };
   }, [autoRefresh, fetchData]);
 
-  if (loading && experiments.length === 0) {
-    return (
-      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
-        <span className="sr-only">Loading</span>
-      </div>
-    );
-  }
-
-  if (error && experiments.length === 0) {
-    return <RetryableError message={error} onRetry={fetchData} context="monitoring data" />;
-  }
-
   return (
     <div>
+      <Breadcrumb items={[{ label: 'Experiments', href: '/' }, { label: 'Monitoring' }]} />
+
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">Monitoring</h1>
         <div className="flex items-center gap-4">
@@ -137,7 +127,16 @@ export default function MonitoringPage() {
         </div>
       </div>
 
-      <section className="mb-8" aria-labelledby="summary-heading">
+      {loading && experiments.length === 0 ? (
+        <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+          <span className="sr-only">Loading</span>
+        </div>
+      ) : error && experiments.length === 0 ? (
+        <RetryableError message={error} onRetry={fetchData} context="monitoring data" />
+      ) : (
+        <>
+          <section className="mb-8" aria-labelledby="summary-heading">
         <h2 id="summary-heading" className="mb-4 text-lg font-semibold text-gray-800">
           Active Experiments Summary
         </h2>
@@ -155,15 +154,17 @@ export default function MonitoringPage() {
         />
       </section>
 
-      <section aria-labelledby="breaches-heading">
-        <h2 id="breaches-heading" className="mb-4 text-lg font-semibold text-gray-800">
-          Recent Guardrail Breaches
-        </h2>
-        <MonitoringBreachList
-          experiments={experiments}
-          guardrailStatuses={guardrailStatuses}
-        />
-      </section>
+          <section aria-labelledby="breaches-heading">
+            <h2 id="breaches-heading" className="mb-4 text-lg font-semibold text-gray-800">
+              Recent Guardrail Breaches
+            </h2>
+            <MonitoringBreachList
+              experiments={experiments}
+              guardrailStatuses={guardrailStatuses}
+            />
+          </section>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This PR standardizes the user experience on the Feature Flags and Monitoring list pages.

💡 **What:**
- Added `Breadcrumb` navigation to both pages.
- Refactored the page structure to ensure the `h1` heading and main action buttons (like "New Flag") remain visible even while data is loading or if an error occurs.
- Replaced the pattern of hiding the "New Flag" button with a disabled state that includes a tooltip explaining the required 'Experimenter' role.

🎯 **Why:**
- Improves spatial awareness by showing the user's location via breadcrumbs.
- Enhances "perceived performance" and stability by keeping the page layout consistent during async operations (no layout shifts).
- Provides better feedback on permissions by explaining why an action is restricted instead of simply omitting it.

♿ **Accessibility:**
- Breadcrumbs use semantic `<nav>` and `aria-current="page"`.
- Disabled buttons include descriptive titles for screen readers and mouse users.
- Main headings are prioritized in the DOM order.

Verified with 50 passing Vitest tests and visual inspection via Playwright.

---
*PR created automatically by Jules for task [9968458247736747302](https://jules.google.com/task/9968458247736747302) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->