### PR TITLE
🎨 Palette: Standardize breadcrumbs on Experiments and Comparison pages

### DIFF
--- a/ui/src/app/compare/page.tsx
+++ b/ui/src/app/compare/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import type { Experiment, AnalysisResult } from '@/lib/types';
 import { listExperiments, getAnalysisResult } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { ExperimentSelector } from '@/components/experiment-selector';
 import { ComparisonTable } from '@/components/comparison-table';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Dynamic import for chart — recharts only loads when needed
 const ComparisonChart = dynamic(
@@ -97,11 +97,7 @@ export default function ComparePage() {
   if (error) {
     return (
       <div>
-        <nav className="mb-4 text-sm text-gray-500">
-          <Link href="/" className="hover:text-indigo-600">Experiments</Link>
-          <span className="mx-2">/</span>
-          <span className="text-gray-900">Compare</span>
-        </nav>
+        <Breadcrumb items={[{ label: 'Experiments', href: '/' }, { label: 'Compare' }]} />
         <RetryableError message={error} onRetry={fetchExperiments} context="experiments" />
       </div>
     );
@@ -109,12 +105,7 @@ export default function ComparePage() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav className="mb-4 text-sm text-gray-500">
-        <Link href="/" className="hover:text-indigo-600">Experiments</Link>
-        <span className="mx-2">/</span>
-        <span className="text-gray-900">Compare</span>
-      </nav>
+      <Breadcrumb items={[{ label: 'Experiments', href: '/' }, { label: 'Compare' }]} />
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Experiment Comparison</h1>
 

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -10,6 +10,7 @@ import { useExperimentFilters, type SortField } from '@/lib/use-experiment-filte
 import { useAuth } from '@/lib/auth-context';
 import { ROLE_LABELS } from '@/lib/auth';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 function SortableHeader({
   label,
@@ -88,6 +89,7 @@ export default function ExperimentListPage() {
   if (experiments.length === 0) {
     return (
       <div>
+        <Breadcrumb items={[{ label: 'Experiments' }]} />
         <h1 className="mb-6 text-2xl font-bold text-gray-900">Experiments</h1>
         <div className="py-12 text-center" data-testid="empty-state">
           <p className="text-sm text-gray-500">No experiments yet.</p>
@@ -111,6 +113,8 @@ export default function ExperimentListPage() {
 
   return (
     <div>
+      <Breadcrumb items={[{ label: 'Experiments' }]} />
+
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">Experiments</h1>
         {canCreate ? (

--- a/ui/src/app/portfolio/provider-health/page.tsx
+++ b/ui/src/app/portfolio/provider-health/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { getProviderHealth } from '@/lib/api';
 import type { ProviderHealthResult, ProviderHealthSeries } from '@/lib/types';
 import { RetryableError } from '@/components/retryable-error';
+import { Breadcrumb } from '@/components/breadcrumb';
 
 // Code-split: chart bundle loaded only when page is rendered
 const CatalogCoverageChart = dynamic(
@@ -97,12 +98,11 @@ export default function ProviderHealthPage() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-2 text-sm text-gray-500">
-        <Link href="/portfolio" className="hover:text-gray-700">Portfolio</Link>
-        <span aria-hidden="true">/</span>
-        <span className="text-gray-900 font-medium">Provider Health</span>
-      </nav>
+      <Breadcrumb items={[
+        { label: 'Experiments', href: '/' },
+        { label: 'Portfolio', href: '/portfolio' },
+        { label: 'Provider Health' },
+      ]} />
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>


### PR DESCRIPTION
This PR standardizes the breadcrumb navigation across the Experiments list, Experiment Comparison, and Provider Health pages. By replacing manual breadcrumb implementations with the reusable `Breadcrumb` component, we ensure visual consistency, accessibility (aria-labels), and maintainable navigation paths across the platform.

💡 What:
- Updated `ui/src/app/page.tsx` to include a top-level breadcrumb.
- Refactored `ui/src/app/compare/page.tsx` and `ui/src/app/portfolio/provider-health/page.tsx` to use the `Breadcrumb` component instead of manual HTML/CSS.
- Standardized the navigation root to always start with "Experiments".

🎯 Why:
Users previously experienced inconsistent breadcrumb styling and missing navigation context on primary list and dashboard pages. Standardizing these elements improves spatial awareness and provides a predictable return path to the main experiments list.

♿ Accessibility:
- Preserves `aria-label="Breadcrumb"` on the navigation container.
- Uses `aria-current="page"` for the active/last breadcrumb item.
- Hides separators from screen readers using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [3077727952460436816](https://jules.google.com/task/3077727952460436816) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->