### PR TITLE
Phase 1: GCP Cloud Run service template + Workload Identity + Service Directory (Closes #486)

### DIFF
--- a/infra/main.go
+++ b/infra/main.go
@@ -99,12 +99,14 @@ func Deploy(ctx *pulumi.Context) error {
 	}
 
 	// =====================================================================
-	// GCP early return — Phase 1 storage + cache + database + cicd + M4b compute slice
+	// GCP early return — Phase 1 storage + cache + database + cicd + M4b + Cloud Run compute slice
 	// =====================================================================
-	// Stage 4 (streaming + secrets), Stage 5 stateless compute, and Stage 6
-	// (edge) are AWS-only today. GCP arms for those stages land in subsequent
-	// Phase 1 PRs. Until they do, we run every GCP stage that's already wired
-	// (network, storage, cache, database above; cicd + M4b compute below) and
+	// Stage 4 (streaming + secrets), Stage 5 per-service stateless Cloud Run
+	// deploys, and Stage 6 (edge) are AWS-only today. GCP arms for those
+	// stages land in subsequent Phase 1 PRs. Until they do, we run every GCP
+	// stage that's already wired (network, storage, cache, database above;
+	// cicd + compute below — the latter covering both M4b stateful (issue
+	// #487) and the Cloud Run service factory + canary (issue #486)) and
 	// return cleanly so `pulumi preview --stack gcp-dev` succeeds.
 	// Each subsequent Phase 1 PR moves this early-return marker further down
 	// Deploy() and removes it entirely once all stages are wired.
@@ -116,10 +118,11 @@ func Deploy(ctx *pulumi.Context) error {
 		if url, ok := cicdOut.RepositoryURLs["assignment"]; ok {
 			ctx.Export("cicdAssignmentRepositoryUrl", url)
 		}
-		// M4b stateful compute slice — issue #487. Cloud Run services for
-		// the eight stateless modules land in #486; when they do, this
-		// NewCompute call grows to wire them in too and the early-return
-		// marker moves below the edge stage.
+		// gcp.NewCompute provisions both the stateful M4b slice (issue #487)
+		// and the Cloud Run service factory + canary (issue #486). Per-service
+		// stateless Cloud Run deploys (M1, M2, ..., M7) land in follow-up
+		// issues #488..#495; when they do, this NewCompute call grows to wire
+		// them in too and the early-return marker moves below the edge stage.
 		gcpComputeOut, err := gcp.NewCompute(ctx, cfg, netOut)
 		if err != nil {
 			return err
@@ -127,6 +130,9 @@ func Deploy(ctx *pulumi.Context) error {
 		ctx.Export("m4bAsgName", gcpComputeOut.M4bAsgName)
 		ctx.Export("m4bInstanceId", gcpComputeOut.M4bInstanceId)
 		ctx.Export("m4bEndpointAddress", gcpComputeOut.M4bEndpoint)
+		for name, url := range gcpComputeOut.ServiceEndpoints {
+			ctx.Export("cloudRunUrl_"+name, url)
+		}
 		ctx.Export("dataBucket", storageOut.DataBucketName)
 		ctx.Export("cacheEndpoint", cacheOut.Endpoint)
 		ctx.Export("databaseEndpoint", dbOut.Endpoint)

--- a/infra/pkg/gcp/compute/compute.go
+++ b/infra/pkg/gcp/compute/compute.go
@@ -564,7 +564,7 @@ func saAccountID(env, name string) (string, error) {
 // enforce the same upper bound on `name` so the resource name never
 // overflows the 63-char Cloud Run limit even with "staging" as env.
 func isValidServiceName(s string) bool {
-	if len(s) == 0 || len(s) > 49 {
+	if len(s) == 0 || len(s) > 48 {
 		return false
 	}
 	first := s[0]

--- a/infra/pkg/gcp/compute/compute.go
+++ b/infra/pkg/gcp/compute/compute.go
@@ -581,7 +581,9 @@ func isValidServiceName(s string) bool {
 			return false
 		}
 	}
-	return true
+	last := s[len(s)-1]
+	return last != '-'
+}
 }
 
 // slug rewrites IAM role strings (e.g. "roles/cloudsql.client") into a

--- a/infra/pkg/gcp/compute/compute.go
+++ b/infra/pkg/gcp/compute/compute.go
@@ -466,7 +466,7 @@ func validateInputs(cfg *config.Config, inputs *Inputs, name string, opts *Optio
 		return fmt.Errorf("compute.NewCloudRunService: name must not be empty")
 	}
 	if !isValidServiceName(name) {
-		return fmt.Errorf("compute.NewCloudRunService: name %q must match [a-z][a-z0-9-]* and be 1..49 chars", name)
+		return fmt.Errorf("compute.NewCloudRunService: name %q must match [a-z][a-z0-9-]*[a-z0-9] and be 1..48 chars", name)
 	}
 	if opts == nil {
 		return fmt.Errorf("compute.NewCloudRunService: opts must not be nil")
@@ -559,10 +559,9 @@ func saAccountID(env, name string) (string, error) {
 }
 
 // isValidServiceName accepts only DNS-label-compatible service names (which
-// is also the SD service-id constraint). Cloud Run resource names extend
-// to 49 chars in practice once the kaizen-<env>- prefix is added; we
-// enforce the same upper bound on `name` so the resource name never
-// overflows the 63-char Cloud Run limit even with "staging" as env.
+// is also the SD service-id constraint). The Cloud Run resource name is
+// formatted as kaizen-<env>-<name>; with env="staging" (15-char prefix)
+// the name must be at most 48 chars so the total never exceeds 63.
 func isValidServiceName(s string) bool {
 	if len(s) == 0 || len(s) > 48 {
 		return false
@@ -583,7 +582,6 @@ func isValidServiceName(s string) bool {
 	}
 	last := s[len(s)-1]
 	return last != '-'
-}
 }
 
 // slug rewrites IAM role strings (e.g. "roles/cloudsql.client") into a

--- a/infra/pkg/gcp/compute/compute.go
+++ b/infra/pkg/gcp/compute/compute.go
@@ -1,0 +1,628 @@
+// Package compute is the GCP compute factory. It exposes a single
+// per-service helper, NewCloudRunService, that mirrors the AWS ECS Fargate
+// task-def factory (pkg/aws/compute/services.go::newFargateService) so the
+// GCP and AWS provider arms expose the same operational shape:
+//
+//	1. A dedicated runtime identity (Workload Identity service account here,
+//	   ECS task role on AWS).
+//	2. Consistent VPC wiring (Serverless VPC Access connector here, awsvpc
+//	   network mode + private-subnet ENIs on AWS).
+//	3. Service discovery registration (Service Directory endpoint here,
+//	   Cloud Map service on AWS).
+//	4. Secret injection from the cloud-native secret store
+//	   (Secret Manager here, Secrets Manager on AWS).
+//	5. Bucket / project IAM bindings driven by per-service options.
+//
+// Out of scope for this PR (issue #486):
+//   - Per-Kaizen-service deploys (M1, M2, ..., M7) — issues #10..#17.
+//   - GCE M4b stateful service — separate issue under the same sprint.
+//
+// Topology test guarantees (per spec gap mitigation #2): every Cloud Run
+// service registered through this helper has a corresponding Workload
+// Identity service account, IAM bindings for every secret/bucket/project
+// role declared in opts, and a Service Directory endpoint registration.
+package compute
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/cloudrunv2"
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/projects"
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/secretmanager"
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/serviceaccount"
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/servicedirectory"
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/storage"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/kaizen-experimentation/infra/pkg/config"
+)
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+// Inputs holds the cross-stage values every Cloud Run service in the same
+// stack consumes identically: project, region, environment, the Serverless
+// VPC Access connector, and the Service Directory namespace.
+//
+// One Inputs value is constructed per Pulumi stack (in pkg/gcp/gcp.go's
+// NewCompute aggregator) and reused across every NewCloudRunService call.
+type Inputs struct {
+	// Project is the GCP project ID hosting all compute resources.
+	// Maps to cfg.GCPProjectID.
+	Project string
+
+	// Region is the GCP region for Cloud Run + the SD namespace, e.g.
+	// "us-central1". Cloud Run is regional; the helper uses this verbatim.
+	Region string
+
+	// VpcConnectorSelfLink is the connector resource consumed by every
+	// Cloud Run service's template.vpcAccess.connector. Sourced from
+	// types.NetworkOutputs.VpcConnectorSelfLink, populated by the network
+	// stage in pkg/gcp/network/vpc_connector.go.
+	VpcConnectorSelfLink pulumi.StringOutput
+
+	// ServiceDirectoryNamespaceID identifies the namespace each service
+	// registers under as an SD service + endpoint. Sourced from
+	// types.NetworkOutputs.ServiceDiscoveryId, populated by the network
+	// stage in pkg/gcp/network/service_directory.go.
+	ServiceDirectoryNamespaceID pulumi.StringOutput
+}
+
+// EnvVar models a single literal environment variable for a Cloud Run
+// container. Use SecretEnv (below) for env vars whose value comes from
+// Secret Manager.
+type EnvVar struct {
+	// Name is the env var name. Required, must be a C identifier.
+	Name string
+	// Value is a literal string, late-bound via pulumi.StringInput so
+	// callers can thread Pulumi outputs (endpoints, bucket names, etc.).
+	Value pulumi.StringInput
+}
+
+// SecretEnv binds an env var name to a Secret Manager secret version. The
+// helper auto-creates the SecretIamMember binding granting the service's
+// runtime SA roles/secretmanager.secretAccessor on the secret resource.
+//
+// SecretID is the local secret ID (e.g. "kaizen-dev-database") within the
+// stack's project — NOT the version-qualified path. Cloud Run's
+// secretKeyRef wants the bare secret ID (or a fully-qualified
+// projects/<P>/secrets/<S> path for cross-project references). The helper
+// passes Version through verbatim; "latest" is the conventional default.
+type SecretEnv struct {
+	// EnvName is the env var the container reads (required).
+	EnvName string
+	// SecretID is the local Secret Manager secret ID (required).
+	SecretID pulumi.StringInput
+	// Version is the secret version to mount; "latest" is recommended for
+	// rotation. Empty defaults to "latest".
+	Version string
+}
+
+// Options configures a single Cloud Run service. Passed to NewCloudRunService
+// per service. Fields not set get safe defaults documented inline.
+type Options struct {
+	// Image is the container image URL (e.g.
+	// "us-central1-docker.pkg.dev/<P>/kaizen/m1-assignment:latest" pulled
+	// from CICDOutputs.RepositoryURLs). Required.
+	Image pulumi.StringInput
+
+	// ContainerPort is the port the container listens on (env $PORT). 0
+	// defaults to 8080 — Cloud Run's documented default.
+	ContainerPort int
+
+	// MinInstances controls cold-start behavior. Defaults to 0; M1 and M7
+	// override to 1 to hold the p99 < 5ms SLA per the multi-cloud spec
+	// (Compute Model → Cold starts).
+	MinInstances int
+
+	// MaxInstances caps autoscaling. 0 defers to the Cloud Run default
+	// (calculated from project quota; typically 100).
+	MaxInstances int
+
+	// EnvVars are static environment variables threaded into the container.
+	EnvVars []EnvVar
+
+	// Secrets are env vars whose value comes from Secret Manager. The
+	// helper creates one SecretIamMember binding per entry granting the
+	// runtime SA roles/secretmanager.secretAccessor.
+	Secrets []SecretEnv
+
+	// Buckets lists Cloud Storage bucket names the runtime SA needs
+	// roles/storage.objectAdmin on. Pass StorageOutputs.DataBucketName /
+	// MlflowBucketName / LogsBucketName as needed. Empty by default.
+	Buckets []pulumi.StringInput
+
+	// ProjectRoles lists project-level roles the runtime SA needs, e.g.
+	// "roles/cloudsql.client" for Cloud SQL access, "roles/redis.editor"
+	// for Memorystore, "roles/cloudtrace.agent" for Cloud Trace.
+	ProjectRoles []string
+
+	// ServiceID overrides the Service Directory service ID. Defaults to
+	// `name`. Constraint: 1-63 chars, [a-z][a-z0-9-]*.
+	ServiceID string
+
+	// AllowPublicInvoke, if true, grants roles/run.invoker to allUsers,
+	// making the service public. Defaults false (Cloud Run gates on IAM
+	// when ingress allows external callers; M6 UI behind a load balancer
+	// is the typical case where this would be true).
+	AllowPublicInvoke bool
+}
+
+// CloudRunService is the per-service output bundle returned to callers
+// (typically the GCP NewCompute aggregator). Tests inspect these fields
+// directly to verify shape; production callers thread URL into
+// ComputeOutputs.ServiceEndpoints.
+type CloudRunService struct {
+	// Name is the logical service name passed to NewCloudRunService
+	// (e.g. "m1-assignment"). Convenience for callers building maps.
+	Name string
+
+	// Service is the Cloud Run resource. Pass it to
+	// pulumi.DependsOn(...) when wiring downstream resources.
+	Service *cloudrunv2.Service
+
+	// URL is the Cloud Run service URL (https://<svc>-<hash>-<region>.a.run.app).
+	// This is what callers stuff into ComputeOutputs.ServiceEndpoints[name].
+	URL pulumi.StringOutput
+
+	// ServiceAccount is the per-service Workload Identity SA resource.
+	ServiceAccount *serviceaccount.Account
+
+	// ServiceAccountEmail is the SA email the WI binding sets on the
+	// Cloud Run revision template.
+	ServiceAccountEmail pulumi.StringOutput
+
+	// ServiceAccountMember is the IAM principal form ("serviceAccount:<email>").
+	// Tests use this to verify role bindings reference the right principal.
+	ServiceAccountMember pulumi.StringOutput
+
+	// SDService is the Service Directory parent of the endpoint. Created
+	// once per Cloud Run service so endpoints can co-exist (e.g., per-region).
+	SDService *servicedirectory.Service
+
+	// SDEndpoint is the Service Directory endpoint resource registered
+	// under SDService. Tests assert on its presence per acceptance
+	// criterion 3.
+	SDEndpoint *servicedirectory.Endpoint
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+// NewCloudRunService provisions one Cloud Run service plus everything
+// needed for it to function safely:
+//
+//	1. A dedicated Workload Identity service account.
+//	2. roles/secretmanager.secretAccessor on each opts.Secrets entry.
+//	3. roles/storage.objectAdmin on each opts.Buckets entry.
+//	4. Each opts.ProjectRoles role bound at the project level to the SA.
+//	5. The Cloud Run service itself, with the SA on the revision template,
+//	   the VPC connector wired, env vars + secret env vars set, and
+//	   min/max instances configured.
+//	6. A Service Directory service + endpoint that resolves to the Cloud
+//	   Run URL so other services can discover it via the namespace from
+//	   inputs.ServiceDirectoryNamespaceID.
+//
+// Returns the bundle in CloudRunService. The caller composes URL into
+// types.ComputeOutputs.ServiceEndpoints.
+func NewCloudRunService(
+	ctx *pulumi.Context,
+	cfg *config.Config,
+	inputs *Inputs,
+	name string,
+	opts *Options,
+	resourceOpts ...pulumi.ResourceOption,
+) (*CloudRunService, error) {
+	if err := validateInputs(cfg, inputs, name, opts); err != nil {
+		return nil, err
+	}
+
+	// Apply defaults in a copy so the caller's struct is not mutated.
+	o := normalizeOptions(*opts, name)
+
+	// ── Runtime service account ────────────────────────────────────────
+	saAccountID, err := saAccountID(cfg.Environment, name)
+	if err != nil {
+		return nil, err
+	}
+
+	sa, err := serviceaccount.NewAccount(
+		ctx,
+		fmt.Sprintf("kaizen-%s-%s-sa", cfg.Environment, name),
+		&serviceaccount.AccountArgs{
+			Project:     pulumi.String(cfg.GCPProjectID),
+			AccountId:   pulumi.String(saAccountID),
+			DisplayName: pulumi.Sprintf("Kaizen %s %s runtime", cfg.Environment, name),
+			Description: pulumi.String("Workload Identity SA for Kaizen Cloud Run service " + name),
+		},
+		resourceOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create service account for %s: %w", name, err)
+	}
+	saMember := sa.Email.ApplyT(func(email string) string {
+		return "serviceAccount:" + email
+	}).(pulumi.StringOutput)
+
+	// ── IAM: project-level roles ───────────────────────────────────────
+	for _, role := range sortedUnique(o.ProjectRoles) {
+		_, err := projects.NewIAMMember(
+			ctx,
+			fmt.Sprintf("kaizen-%s-%s-role-%s", cfg.Environment, name, slug(role)),
+			&projects.IAMMemberArgs{
+				Project: pulumi.String(cfg.GCPProjectID),
+				Role:    pulumi.String(role),
+				Member:  saMember,
+			},
+			resourceOpts...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("bind project role %s to %s SA: %w", role, name, err)
+		}
+	}
+
+	// ── IAM: per-secret accessor bindings ──────────────────────────────
+	for i, sec := range o.Secrets {
+		_, err := secretmanager.NewSecretIamMember(
+			ctx,
+			fmt.Sprintf("kaizen-%s-%s-secret-%d", cfg.Environment, name, i),
+			&secretmanager.SecretIamMemberArgs{
+				Project:  pulumi.String(cfg.GCPProjectID),
+				SecretId: sec.SecretID,
+				Role:     pulumi.String("roles/secretmanager.secretAccessor"),
+				Member:   saMember,
+			},
+			resourceOpts...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("bind secret accessor for %s/%s: %w", name, sec.EnvName, err)
+		}
+	}
+
+	// ── IAM: per-bucket object admin bindings ──────────────────────────
+	for i, bucket := range o.Buckets {
+		_, err := storage.NewBucketIAMMember(
+			ctx,
+			fmt.Sprintf("kaizen-%s-%s-bucket-%d", cfg.Environment, name, i),
+			&storage.BucketIAMMemberArgs{
+				Bucket: bucket,
+				Role:   pulumi.String("roles/storage.objectAdmin"),
+				Member: saMember,
+			},
+			resourceOpts...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("bind bucket %d for %s: %w", i, name, err)
+		}
+	}
+
+	// ── Cloud Run service ──────────────────────────────────────────────
+	envs := buildContainerEnvs(o.EnvVars, o.Secrets)
+
+	scaling := &cloudrunv2.ServiceTemplateScalingArgs{
+		MinInstanceCount: pulumi.Int(o.MinInstances),
+	}
+	if o.MaxInstances > 0 {
+		scaling.MaxInstanceCount = pulumi.Int(o.MaxInstances)
+	}
+
+	svc, err := cloudrunv2.NewService(
+		ctx,
+		fmt.Sprintf("kaizen-%s-%s-run", cfg.Environment, name),
+		&cloudrunv2.ServiceArgs{
+			Name:     pulumi.String(fmt.Sprintf("kaizen-%s-%s", cfg.Environment, name)),
+			Project:  pulumi.String(cfg.GCPProjectID),
+			Location: pulumi.String(cfg.GCPRegion),
+			// INGRESS_TRAFFIC_INTERNAL_AND_CLOUD_LOAD_BALANCING is the
+			// safer default — service-to-service traffic stays on the
+			// VPC; only the load balancer (Phase 3) can reach it
+			// publicly. Mirrors AWS ECS services living on private
+			// subnets with the ALB in front.
+			Ingress: pulumi.String("INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"),
+			Labels: pulumi.StringMap{
+				"project":     pulumi.String("kaizen"),
+				"environment": pulumi.String(cfg.Environment),
+				"service":     pulumi.String(name),
+				"managed_by":  pulumi.String("pulumi"),
+			},
+			Template: &cloudrunv2.ServiceTemplateArgs{
+				ServiceAccount: sa.Email,
+				Scaling:        scaling,
+				VpcAccess: &cloudrunv2.ServiceTemplateVpcAccessArgs{
+					Connector: inputs.VpcConnectorSelfLink,
+					// PRIVATE_RANGES_ONLY routes only RFC-1918 traffic
+					// through the connector, keeping public egress (e.g.
+					// to Artifact Registry image pulls) on the
+					// platform-default path. ALL_TRAFFIC would force
+					// every request through the connector and hit its
+					// throughput limit.
+					Egress: pulumi.String("PRIVATE_RANGES_ONLY"),
+				},
+				Containers: cloudrunv2.ServiceTemplateContainerArray{
+					&cloudrunv2.ServiceTemplateContainerArgs{
+						Image: o.Image,
+						Ports: &cloudrunv2.ServiceTemplateContainerPortsArgs{
+							ContainerPort: pulumi.Int(o.ContainerPort),
+						},
+						Envs: envs,
+					},
+				},
+			},
+		},
+		resourceOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create Cloud Run service %s: %w", name, err)
+	}
+
+	// Optional public-invoke binding (M6 UI behind a load balancer).
+	if o.AllowPublicInvoke {
+		_, err := cloudrunv2.NewServiceIamMember(
+			ctx,
+			fmt.Sprintf("kaizen-%s-%s-public", cfg.Environment, name),
+			&cloudrunv2.ServiceIamMemberArgs{
+				Project:  pulumi.String(cfg.GCPProjectID),
+				Location: pulumi.String(cfg.GCPRegion),
+				Name:     svc.Name,
+				Role:     pulumi.String("roles/run.invoker"),
+				Member:   pulumi.String("allUsers"),
+			},
+			resourceOpts...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("public invoke binding for %s: %w", name, err)
+		}
+	}
+
+	// ── Service Directory: service + endpoint ──────────────────────────
+	// The SD service sits below the namespace. The endpoint sits below
+	// the service and carries the resolvable URL. Other Cloud Run
+	// services discover this via Service Directory's HTTP API or, when
+	// enabled, the auto-published private DNS zone.
+	sdSvc, err := servicedirectory.NewService(
+		ctx,
+		fmt.Sprintf("kaizen-%s-%s-sd-svc", cfg.Environment, name),
+		&servicedirectory.ServiceArgs{
+			Namespace: inputs.ServiceDirectoryNamespaceID,
+			ServiceId: pulumi.String(o.ServiceID),
+			Metadata: pulumi.StringMap{
+				"environment": pulumi.String(cfg.Environment),
+				"managed_by":  pulumi.String("pulumi"),
+			},
+		},
+		resourceOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create SD service for %s: %w", name, err)
+	}
+
+	// Cloud Run URLs are HTTPS; SD endpoints store host/port. We strip
+	// the scheme and default to 443 so callers can resolve a routable
+	// host:port pair from the namespace.
+	sdEndpoint, err := servicedirectory.NewEndpoint(
+		ctx,
+		fmt.Sprintf("kaizen-%s-%s-sd-ep", cfg.Environment, name),
+		&servicedirectory.EndpointArgs{
+			Service:    sdSvc.ID(),
+			EndpointId: pulumi.String("primary"),
+			Address:    svc.Uri.ApplyT(stripScheme).(pulumi.StringOutput),
+			Port:       pulumi.Int(443),
+			Metadata: pulumi.StringMap{
+				"protocol":    pulumi.String("https"),
+				"backend":     pulumi.String("cloud-run"),
+				"environment": pulumi.String(cfg.Environment),
+			},
+		},
+		resourceOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create SD endpoint for %s: %w", name, err)
+	}
+
+	return &CloudRunService{
+		Name:                 name,
+		Service:              svc,
+		URL:                  svc.Uri,
+		ServiceAccount:       sa,
+		ServiceAccountEmail:  sa.Email,
+		ServiceAccountMember: saMember,
+		SDService:            sdSvc,
+		SDEndpoint:           sdEndpoint,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// validateInputs is a single-spot check that catches misconfiguration at
+// program-build time rather than apply time (where Pulumi would surface a
+// less-actionable Cloud Run / IAM API error).
+func validateInputs(cfg *config.Config, inputs *Inputs, name string, opts *Options) error {
+	if cfg == nil {
+		return fmt.Errorf("compute.NewCloudRunService: cfg must not be nil")
+	}
+	if cfg.GCPProjectID == "" {
+		// Required to scope project-level IAM bindings and Cloud Run
+		// resource args. The GCP facade enforces presence at the
+		// stage boundary (gcp.NewCICD already does this), so a missing
+		// value here means the helper was called outside a GCP stack.
+		return fmt.Errorf("compute.NewCloudRunService: cfg.GCPProjectID must not be empty")
+	}
+	if cfg.Environment == "" {
+		return fmt.Errorf("compute.NewCloudRunService: cfg.Environment must not be empty")
+	}
+	if cfg.GCPRegion == "" {
+		return fmt.Errorf("compute.NewCloudRunService: cfg.GCPRegion must not be empty (set kaizen-experimentation:gcpRegion)")
+	}
+	if inputs == nil {
+		return fmt.Errorf("compute.NewCloudRunService: inputs must not be nil")
+	}
+	if name == "" {
+		return fmt.Errorf("compute.NewCloudRunService: name must not be empty")
+	}
+	if !isValidServiceName(name) {
+		return fmt.Errorf("compute.NewCloudRunService: name %q must match [a-z][a-z0-9-]* and be 1..49 chars", name)
+	}
+	if opts == nil {
+		return fmt.Errorf("compute.NewCloudRunService: opts must not be nil")
+	}
+	if opts.Image == nil {
+		return fmt.Errorf("compute.NewCloudRunService: opts.Image is required for service %s", name)
+	}
+	if opts.MinInstances < 0 {
+		return fmt.Errorf("compute.NewCloudRunService: opts.MinInstances must be >= 0 (got %d)", opts.MinInstances)
+	}
+	if opts.MaxInstances < 0 {
+		return fmt.Errorf("compute.NewCloudRunService: opts.MaxInstances must be >= 0 (got %d)", opts.MaxInstances)
+	}
+	if opts.MaxInstances > 0 && opts.MaxInstances < opts.MinInstances {
+		return fmt.Errorf("compute.NewCloudRunService: opts.MaxInstances (%d) must be >= MinInstances (%d)",
+			opts.MaxInstances, opts.MinInstances)
+	}
+	for _, sec := range opts.Secrets {
+		if sec.EnvName == "" || sec.SecretID == nil {
+			return fmt.Errorf("compute.NewCloudRunService: each opts.Secrets entry needs EnvName + SecretID (service %s)", name)
+		}
+	}
+	for _, env := range opts.EnvVars {
+		if env.Name == "" || env.Value == nil {
+			return fmt.Errorf("compute.NewCloudRunService: each opts.EnvVars entry needs Name + Value (service %s)", name)
+		}
+	}
+	return nil
+}
+
+// normalizeOptions returns a copy of opts with defaults applied. Defaults:
+//   - ContainerPort: 8080 (Cloud Run platform default).
+//   - ServiceID: name (matches the Cloud Run service name).
+func normalizeOptions(opts Options, name string) Options {
+	if opts.ContainerPort == 0 {
+		opts.ContainerPort = 8080
+	}
+	if opts.ServiceID == "" {
+		opts.ServiceID = name
+	}
+	return opts
+}
+
+// buildContainerEnvs assembles the env array consumed by the Cloud Run
+// container. Literal env vars come first; secret-backed env vars are
+// appended via valueSource.secretKeyRef so Cloud Run mounts them at start.
+func buildContainerEnvs(literals []EnvVar, secrets []SecretEnv) cloudrunv2.ServiceTemplateContainerEnvArray {
+	envs := cloudrunv2.ServiceTemplateContainerEnvArray{}
+	for _, e := range literals {
+		envs = append(envs, &cloudrunv2.ServiceTemplateContainerEnvArgs{
+			Name:  pulumi.String(e.Name),
+			Value: e.Value,
+		})
+	}
+	for _, s := range secrets {
+		version := s.Version
+		if version == "" {
+			version = "latest"
+		}
+		envs = append(envs, &cloudrunv2.ServiceTemplateContainerEnvArgs{
+			Name: pulumi.String(s.EnvName),
+			ValueSource: &cloudrunv2.ServiceTemplateContainerEnvValueSourceArgs{
+				SecretKeyRef: &cloudrunv2.ServiceTemplateContainerEnvValueSourceSecretKeyRefArgs{
+					Secret:  s.SecretID,
+					Version: pulumi.String(version),
+				},
+			},
+		})
+	}
+	return envs
+}
+
+// saAccountID returns the GCP service account local ID for a service.
+// Format: <env>-<name>-run, e.g. "dev-m1-assignment-run". Caps at 30 chars
+// per GCP's accountId constraint ([a-z][a-z0-9-]{4,28}[a-z0-9]).
+//
+// The error path catches names that would overflow once env is prepended,
+// so the misconfiguration is visible at program-build time rather than as
+// an opaque Cloud IAM 400 at apply.
+func saAccountID(env, name string) (string, error) {
+	id := fmt.Sprintf("%s-%s-run", env, name)
+	if len(id) < 6 {
+		return "", fmt.Errorf("compute: derived service account id %q is shorter than the 6-char GCP minimum", id)
+	}
+	if len(id) > 30 {
+		return "", fmt.Errorf("compute: derived service account id %q is %d chars, exceeds the 30-char GCP maximum (env=%q, name=%q)",
+			id, len(id), env, name)
+	}
+	return id, nil
+}
+
+// isValidServiceName accepts only DNS-label-compatible service names (which
+// is also the SD service-id constraint). Cloud Run resource names extend
+// to 49 chars in practice once the kaizen-<env>- prefix is added; we
+// enforce the same upper bound on `name` so the resource name never
+// overflows the 63-char Cloud Run limit even with "staging" as env.
+func isValidServiceName(s string) bool {
+	if len(s) == 0 || len(s) > 49 {
+		return false
+	}
+	first := s[0]
+	if first < 'a' || first > 'z' {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9':
+		case c == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// slug rewrites IAM role strings (e.g. "roles/cloudsql.client") into a
+// Pulumi-resource-name-safe suffix ("cloudsql-client"). Used to keep
+// per-binding resource names stable and readable.
+func slug(s string) string {
+	r := strings.NewReplacer("/", "-", ".", "-", "_", "-")
+	out := strings.ToLower(r.Replace(s))
+	// Strip any leading "roles-" prefix from the standard role slug so the
+	// resulting Pulumi resource name reads "kaizen-dev-m1-role-cloudsql-client"
+	// rather than "kaizen-dev-m1-role-roles-cloudsql-client".
+	out = strings.TrimPrefix(out, "roles-")
+	return out
+}
+
+// sortedUnique returns roles in sorted order with duplicates removed.
+// Determinism makes Pulumi diffs stable across runs even if the caller
+// hands us the same role twice or in a different order between two
+// `pulumi up` invocations.
+func sortedUnique(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// stripScheme removes the "https://" / "http://" prefix from a Cloud Run
+// service URL so the address can be stored in a Service Directory
+// endpoint (which expects a bare host, not a URL).
+func stripScheme(u string) string {
+	for _, prefix := range []string{"https://", "http://"} {
+		if strings.HasPrefix(u, prefix) {
+			return strings.TrimPrefix(u, prefix)
+		}
+	}
+	return u
+}

--- a/infra/pkg/gcp/compute/compute_test.go
+++ b/infra/pkg/gcp/compute/compute_test.go
@@ -1,0 +1,373 @@
+// Package compute — unit tests for the pure helpers in compute.go that
+// don't need a Pulumi context. Topology behavior (resource registration,
+// IAM bindings, Service Directory wiring) is tested via mocks in
+// infra/test/gcp_compute_topology_test.go.
+package compute
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/kaizen-experimentation/infra/pkg/config"
+)
+
+// ---------------------------------------------------------------------------
+// saAccountID — derives the GCP service-account local ID for a service.
+// ---------------------------------------------------------------------------
+
+func TestSaAccountIDHappyPath(t *testing.T) {
+	cases := []struct {
+		env, name, want string
+	}{
+		{"dev", "m1-assignment", "dev-m1-assignment-run"},
+		{"dev", "m2-orchestration", "dev-m2-orchestration-run"},
+		{"staging", "m7-flags", "staging-m7-flags-run"},
+		{"prod", "m6-ui", "prod-m6-ui-run"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env+"/"+tc.name, func(t *testing.T) {
+			got, err := saAccountID(tc.env, tc.name)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSaAccountIDRejectsOverflow locks the GCP 30-char accountId ceiling.
+// Without this, deploys would surface as opaque IAM 400s at apply time.
+func TestSaAccountIDRejectsOverflow(t *testing.T) {
+	// "staging-some-very-long-service-name-run" = 39 chars > 30
+	_, err := saAccountID("staging", "some-very-long-service-name")
+	if err == nil {
+		t.Fatal("expected overflow error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds the 30-char GCP maximum") {
+		t.Errorf("error %q does not mention the 30-char ceiling", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isValidServiceName — DNS-label + length constraints
+// ---------------------------------------------------------------------------
+
+func TestIsValidServiceName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		// Valid
+		{"m1-assignment", true},
+		{"m2-orchestration", true},
+		{"a", true},
+		{"preview-canary", true},
+		{strings.Repeat("a", 49), true},
+
+		// Invalid
+		{"", false},
+		{"M1-Assignment", false}, // uppercase
+		{"-m1", false},           // leading hyphen
+		{"1m-test", false},       // leading digit
+		{"m1_test", false},       // underscore
+		{"m1.test", false},       // dot
+		{strings.Repeat("a", 50), false}, // overflow
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidServiceName(tc.name); got != tc.want {
+				t.Errorf("isValidServiceName(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// slug — IAM role to Pulumi-resource-name suffix
+// ---------------------------------------------------------------------------
+
+func TestSlug(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"roles/cloudsql.client", "cloudsql-client"},
+		{"roles/secretmanager.secretAccessor", "secretmanager-secretaccessor"},
+		{"roles/storage.objectAdmin", "storage-objectadmin"},
+		{"roles/redis.editor", "redis-editor"},
+		// Non-roles strings should still pass through cleanly.
+		{"my_custom.role", "my-custom-role"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := slug(tc.in); got != tc.want {
+				t.Errorf("slug(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sortedUnique — deterministic role list to keep Pulumi diffs stable
+// ---------------------------------------------------------------------------
+
+func TestSortedUnique(t *testing.T) {
+	got := sortedUnique([]string{
+		"roles/redis.editor",
+		"roles/cloudsql.client",
+		"roles/cloudsql.client", // duplicate
+		"roles/storage.objectAdmin",
+	})
+	want := []string{
+		"roles/cloudsql.client",
+		"roles/redis.editor",
+		"roles/storage.objectAdmin",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// stripScheme — Cloud Run URL → SD endpoint host
+// ---------------------------------------------------------------------------
+
+func TestStripScheme(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://kaizen-dev-m1-mock-us-central1.a.run.app", "kaizen-dev-m1-mock-us-central1.a.run.app"},
+		{"http://localhost:8080", "localhost:8080"},
+		{"already-stripped.example.com", "already-stripped.example.com"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := stripScheme(tc.in); got != tc.want {
+				t.Errorf("stripScheme(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// normalizeOptions — defaults applied
+// ---------------------------------------------------------------------------
+
+func TestNormalizeOptionsAppliesDefaults(t *testing.T) {
+	got := normalizeOptions(Options{}, "preview-canary")
+	if got.ContainerPort != 8080 {
+		t.Errorf("default ContainerPort = %d, want 8080", got.ContainerPort)
+	}
+	if got.ServiceID != "preview-canary" {
+		t.Errorf("default ServiceID = %q, want %q (= name)", got.ServiceID, "preview-canary")
+	}
+}
+
+func TestNormalizeOptionsPreservesOverrides(t *testing.T) {
+	got := normalizeOptions(Options{
+		ContainerPort: 50051,
+		ServiceID:     "custom-id",
+		MinInstances:  3,
+		MaxInstances:  10,
+	}, "m1-assignment")
+	if got.ContainerPort != 50051 {
+		t.Errorf("ContainerPort = %d, want 50051", got.ContainerPort)
+	}
+	if got.ServiceID != "custom-id" {
+		t.Errorf("ServiceID = %q, want %q", got.ServiceID, "custom-id")
+	}
+	if got.MinInstances != 3 {
+		t.Errorf("MinInstances = %d, want 3", got.MinInstances)
+	}
+	if got.MaxInstances != 10 {
+		t.Errorf("MaxInstances = %d, want 10", got.MaxInstances)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateInputs — each rejection path
+// ---------------------------------------------------------------------------
+
+func TestValidateInputsRejections(t *testing.T) {
+	// Build a baseline (valid) set of args; per-test mutates one field.
+	baseCfg := func() *config.Config {
+		return &config.Config{
+			Project:      "kaizen",
+			Environment:  "dev",
+			GCPProjectID: "kaizen-experimentation-dev",
+			GCPRegion:    "us-central1",
+		}
+	}
+	baseInputs := func() *Inputs {
+		return &Inputs{
+			Project: "kaizen-experimentation-dev",
+			Region:  "us-central1",
+			VpcConnectorSelfLink: pulumi.String(
+				"projects/p/locations/r/connectors/c").ToStringOutput(),
+			ServiceDirectoryNamespaceID: pulumi.String(
+				"projects/p/locations/r/namespaces/n").ToStringOutput(),
+		}
+	}
+	baseOpts := func() *Options {
+		return &Options{
+			Image:         pulumi.String("img"),
+			ContainerPort: 8080,
+		}
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(cfg **config.Config, inputs **Inputs, opts **Options, name *string)
+		wantErr string
+	}{
+		{
+			name: "nil cfg",
+			mutate: func(cfg **config.Config, _ **Inputs, _ **Options, _ *string) {
+				*cfg = nil
+			},
+			wantErr: "cfg must not be nil",
+		},
+		{
+			name: "empty GCPProjectID",
+			mutate: func(cfg **config.Config, _ **Inputs, _ **Options, _ *string) {
+				(*cfg).GCPProjectID = ""
+			},
+			wantErr: "cfg.GCPProjectID must not be empty",
+		},
+		{
+			name: "empty Environment",
+			mutate: func(cfg **config.Config, _ **Inputs, _ **Options, _ *string) {
+				(*cfg).Environment = ""
+			},
+			wantErr: "cfg.Environment must not be empty",
+		},
+		{
+			name: "empty GCPRegion",
+			mutate: func(cfg **config.Config, _ **Inputs, _ **Options, _ *string) {
+				(*cfg).GCPRegion = ""
+			},
+			wantErr: "cfg.GCPRegion must not be empty",
+		},
+		{
+			name: "nil inputs",
+			mutate: func(_ **config.Config, inputs **Inputs, _ **Options, _ *string) {
+				*inputs = nil
+			},
+			wantErr: "inputs must not be nil",
+		},
+		{
+			name: "empty name",
+			mutate: func(_ **config.Config, _ **Inputs, _ **Options, name *string) {
+				*name = ""
+			},
+			wantErr: "name must not be empty",
+		},
+		{
+			name: "invalid name (uppercase)",
+			mutate: func(_ **config.Config, _ **Inputs, _ **Options, name *string) {
+				*name = "M1-Assignment"
+			},
+			wantErr: "must match [a-z][a-z0-9-]*",
+		},
+		{
+			name: "nil opts",
+			mutate: func(_ **config.Config, _ **Inputs, opts **Options, _ *string) {
+				*opts = nil
+			},
+			wantErr: "opts must not be nil",
+		},
+		{
+			name: "missing Image",
+			mutate: func(_ **config.Config, _ **Inputs, opts **Options, _ *string) {
+				(*opts).Image = nil
+			},
+			wantErr: "opts.Image is required",
+		},
+		{
+			name: "negative MinInstances",
+			mutate: func(_ **config.Config, _ **Inputs, opts **Options, _ *string) {
+				(*opts).MinInstances = -1
+			},
+			wantErr: "MinInstances must be >= 0",
+		},
+		{
+			name: "MaxInstances < MinInstances",
+			mutate: func(_ **config.Config, _ **Inputs, opts **Options, _ *string) {
+				(*opts).MinInstances = 5
+				(*opts).MaxInstances = 2
+			},
+			wantErr: "MaxInstances (2) must be >= MinInstances (5)",
+		},
+		{
+			name: "secret missing EnvName",
+			mutate: func(_ **config.Config, _ **Inputs, opts **Options, _ *string) {
+				(*opts).Secrets = []SecretEnv{
+					{SecretID: pulumi.String("kaizen-dev-database")},
+				}
+			},
+			wantErr: "EnvName + SecretID",
+		},
+		{
+			name: "env var missing Value",
+			mutate: func(_ **config.Config, _ **Inputs, opts **Options, _ *string) {
+				(*opts).EnvVars = []EnvVar{{Name: "FOO"}}
+			},
+			wantErr: "Name + Value",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseCfg()
+			inputs := baseInputs()
+			opts := baseOpts()
+			name := "m1-assignment"
+			tc.mutate(&cfg, &inputs, &opts, &name)
+
+			err := validateInputs(cfg, inputs, name, opts)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateInputsHappyPath(t *testing.T) {
+	cfg := &config.Config{
+		Project:      "kaizen",
+		Environment:  "dev",
+		GCPProjectID: "kaizen-experimentation-dev",
+		GCPRegion:    "us-central1",
+	}
+	inputs := &Inputs{
+		Project: "kaizen-experimentation-dev",
+		Region:  "us-central1",
+		VpcConnectorSelfLink: pulumi.String(
+			"projects/p/locations/r/connectors/c").ToStringOutput(),
+		ServiceDirectoryNamespaceID: pulumi.String(
+			"projects/p/locations/r/namespaces/n").ToStringOutput(),
+	}
+	opts := &Options{
+		Image:         pulumi.String("img"),
+		ContainerPort: 8080,
+		EnvVars:       []EnvVar{{Name: "FOO", Value: pulumi.String("bar")}},
+		Secrets: []SecretEnv{
+			{EnvName: "DB", SecretID: pulumi.String("kaizen-dev-database")},
+		},
+	}
+	if err := validateInputs(cfg, inputs, "m1-assignment", opts); err != nil {
+		t.Errorf("happy-path validation failed: %v", err)
+	}
+}

--- a/infra/pkg/gcp/compute/compute_test.go
+++ b/infra/pkg/gcp/compute/compute_test.go
@@ -66,16 +66,17 @@ func TestIsValidServiceName(t *testing.T) {
 		{"m2-orchestration", true},
 		{"a", true},
 		{"preview-canary", true},
-		{strings.Repeat("a", 49), true},
+		{strings.Repeat("a", 48), true},
 
 		// Invalid
 		{"", false},
-		{"M1-Assignment", false}, // uppercase
-		{"-m1", false},           // leading hyphen
-		{"1m-test", false},       // leading digit
-		{"m1_test", false},       // underscore
-		{"m1.test", false},       // dot
-		{strings.Repeat("a", 50), false}, // overflow
+		{"M1-Assignment", false},         // uppercase
+		{"-m1", false},                   // leading hyphen
+		{"1m-test", false},               // leading digit
+		{"m1_test", false},               // underscore
+		{"m1.test", false},               // dot
+		{"m1-", false},                   // trailing hyphen
+		{strings.Repeat("a", 49), false}, // overflow
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/infra/pkg/gcp/gcp.go
+++ b/infra/pkg/gcp/gcp.go
@@ -85,6 +85,7 @@ func NewNetwork(ctx *pulumi.Context, _ *kconfig.Config) (types.NetworkOutputs, e
 		SecurityGroupIds:         fwRes.Rules,
 		ServiceDiscoveryId:       sdOut.NamespaceId,
 		ReservedPeeringRangeName: psaOut.ReservedRangeName,
+		VpcConnectorSelfLink:     connOut.ConnectorSelfLink,
 		// Zero-valued on GCP per types.NetworkOutputs documentation:
 		// PrivateRouteTableIds — GCP routes implicitly via subnet definitions.
 		// S3VpcEndpointId — no S3 gateway endpoint analogue on GCP.
@@ -249,12 +250,14 @@ func NewCICD(ctx *pulumi.Context, cfg *kconfig.Config) (types.CICDOutputs, error
 	}, nil
 }
 
-// ─── Stage 5: Compute ───────────────────────────────────────────────────────
+// ─── Stage 5: Compute (M4b stateful + Cloud Run service factory) ───────────
 
-// NewCompute provisions the GCP compute layer. Phase 1 ships only the
-// stateful M4b Policy slice — the eight stateless Cloud Run services land in
-// #486 and will populate ServiceEndpoints/ServiceArns on the returned
-// ComputeOutputs.
+// NewCompute provisions the GCP compute layer for Phase 1: the stateful
+// M4b Policy slice on GCE + persistent disk + autohealing MIG (issue #487)
+// AND the reusable Cloud Run service factory exercised with a single
+// trivial canary service so `pulumi preview --stack gcp-dev` succeeds end-to-end
+// (issue #486). Per-Kaizen-service Cloud Run deploys (M1, M2, ..., M7) land
+// in follow-up issues #488..#495.
 //
 // The M4b slice consumes:
 //   - The private subnet self-link (held in NetworkOutputs.PrivateSubnetIds[0])
@@ -262,19 +265,23 @@ func NewCICD(ctx *pulumi.Context, cfg *kconfig.Config) (types.CICDOutputs, error
 //   - The Service Directory namespace resource name (held in
 //     NetworkOutputs.ServiceDiscoveryId — see types.NetworkOutputs doc) so
 //     m4b-policy registers under kaizen-local.
-//   - The GCP region from kconfig; falls back to us-central1 to keep the
-//     gcp-dev stack working with a partially-configured Pulumi.gcp-dev.yaml.
 //
-// Returned ComputeOutputs has the M4b* fields populated and other fields
-// zero-valued; the compute-stage early-return in Deploy() exports
-// independently. When #486 lands, this function grows the Cloud Run services
-// and the early-return marker in Deploy() moves below the edge stage.
+// The Cloud Run canary uses Google's public hello-world image so this slice
+// neither blocks on Artifact Registry image builds (#482 already shipped the
+// registry, but no images have been built yet) nor leaks unrelated service
+// spec. Per-service issues replace the image with the matching Artifact
+// Registry URL from CICDOutputs.RepositoryURLs.
+//
+// Returns types.ComputeOutputs with both M4b fields AND ServiceEndpoints
+// populated for the canary. ClusterId is zero-valued — Cloud Run is
+// serverless and M4b is a single instance, not an orchestrator cluster.
 func NewCompute(ctx *pulumi.Context, cfg *kconfig.Config, netOut types.NetworkOutputs) (types.ComputeOutputs, error) {
 	region := cfg.GCPRegion
 	if region == "" {
 		region = "us-central1"
 	}
 
+	// ─── M4b slice (issue #487) ───────────────────────────────────────────
 	// Pick the first (and only — GCP private subnets are regional) self-link
 	// from the network output's array. ApplyT keeps the lazy output chain
 	// intact through the topology test.
@@ -308,12 +315,51 @@ func NewCompute(ctx *pulumi.Context, cfg *kconfig.Config, netOut types.NetworkOu
 	ctx.Export("m4bServiceDirectoryServiceName", m4bOut.ServiceName)
 	ctx.Export("m4bDataDiskName", m4bOut.DataDiskName)
 
+	// ─── Cloud Run service factory + canary (issue #486) ──────────────────
+	if cfg.GCPProjectID == "" {
+		return types.ComputeOutputs{}, fmt.Errorf(
+			"gcp.NewCompute: cfg.GCPProjectID is required when cloudProvider=gcp")
+	}
+
+	cloudRunInputs := &compute.Inputs{
+		Project:                     cfg.GCPProjectID,
+		Region:                      cfg.GCPRegion,
+		VpcConnectorSelfLink:        netOut.VpcConnectorSelfLink,
+		ServiceDirectoryNamespaceID: netOut.ServiceDiscoveryId.ToStringOutput(),
+	}
+
+	canary, err := compute.NewCloudRunService(ctx, cfg, cloudRunInputs, "preview-canary",
+		&compute.Options{
+			// Google's public hello-world image — exercises the helper
+			// against `pulumi preview` without depending on a real
+			// build/push of a Kaizen image. Replace per-service in
+			// issues #488..#495 with the matching Artifact Registry URL
+			// from CICDOutputs.RepositoryURLs.
+			Image:         pulumi.String("us-docker.pkg.dev/cloudrun/container/hello"),
+			ContainerPort: 8080,
+			MinInstances:  0,
+		})
+	if err != nil {
+		return types.ComputeOutputs{}, err
+	}
+
+	endpoints := map[string]pulumi.StringOutput{
+		"preview-canary": canary.URL,
+	}
+	arns := map[string]pulumi.StringOutput{
+		"preview-canary": canary.Service.ID().ToStringOutput(),
+	}
+
+	ctx.Export("gcpComputeCanaryUrl", canary.URL)
+	ctx.Export("gcpComputeCanarySaEmail", canary.ServiceAccountEmail)
+
 	return types.ComputeOutputs{
-		// Phase 1 ships only the M4b slice; Cloud Run services follow in #486.
-		// The cluster fields stay zero-valued until then because GCP has no
-		// orchestrator analog for Cloud Run (each service is independent).
-		M4bInstanceId: m4bOut.InstanceName,
-		M4bEndpoint:   m4bOut.Endpoint,
-		M4bAsgName:    m4bOut.MigName,
+		// ClusterId / ClusterName / ClusterArn intentionally zero-valued:
+		// Cloud Run is serverless (no cluster); M4b is a single MIG.
+		M4bInstanceId:    m4bOut.InstanceName,
+		M4bEndpoint:      m4bOut.Endpoint,
+		M4bAsgName:       m4bOut.MigName,
+		ServiceEndpoints: endpoints,
+		ServiceArns:      arns,
 	}, nil
 }

--- a/infra/pkg/types/outputs.go
+++ b/infra/pkg/types/outputs.go
@@ -53,6 +53,15 @@ type NetworkOutputs struct {
 	// Pulumi's output graph orders their creation after the PSA peering is
 	// live; the value itself is informational at the application layer.
 	ReservedPeeringRangeName pulumi.StringOutput
+
+	// VpcConnectorSelfLink is GCP-specific (Serverless VPC Access connector
+	// self-link in the form
+	// "projects/<P>/locations/<R>/connectors/<C>"). The compute stage feeds
+	// this into every Cloud Run service's template.vpcAccess.connector so
+	// requests reach private VPC resources (Cloud SQL, Memorystore, GCE M4b).
+	// Zero-valued on AWS — Cloud Run does not exist there and ECS Fargate
+	// reaches the VPC directly via task ENIs.
+	VpcConnectorSelfLink pulumi.StringOutput
 }
 
 // DatabaseOutputs holds outputs from the relational database stage

--- a/infra/test/gcp_compute_topology_test.go
+++ b/infra/test/gcp_compute_topology_test.go
@@ -1,0 +1,548 @@
+// Package test — topology test for the GCP Cloud Run service factory
+// (pkg/gcp/compute.NewCloudRunService).
+//
+// Closes the topology coverage gap called out in the multi-cloud spec
+// (Testing Strategy → Gap Mitigations #2): every Cloud Run service must
+// have a Workload Identity service account binding with the expected
+// scopes, and every Cloud Run service must register a Service Directory
+// endpoint so peer services can resolve it.
+//
+// The test runs the factory under pulumi.WithMocks so no GCP credentials
+// or network calls are required. A local mock monitor records every
+// resource the factory registers; the assertions inspect that recording.
+package test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	gcpcompute "github.com/kaizen-experimentation/infra/pkg/gcp/compute"
+)
+
+// ---------------------------------------------------------------------------
+// Mock monitor
+// ---------------------------------------------------------------------------
+
+// computeMocks records every resource registration the factory emits and
+// enriches outputs for the GCP type tokens NewCloudRunService touches.
+//
+// Kept local (not on universalMocks) because universalMocks is AWS-shaped;
+// adding GCP cases there would couple two unrelated test stacks.
+type computeMocks struct {
+	mu        sync.Mutex
+	resources []recordedComputeResource
+}
+
+type recordedComputeResource struct {
+	TypeToken string
+	Name      string
+	Inputs    resource.PropertyMap
+}
+
+func (m *computeMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	m.resources = append(m.resources, recordedComputeResource{
+		TypeToken: args.TypeToken,
+		Name:      args.Name,
+		Inputs:    args.Inputs,
+	})
+	m.mu.Unlock()
+
+	id := args.Name + "_id"
+	outputs := resource.PropertyMap{}
+	for k, v := range args.Inputs {
+		outputs[k] = v
+	}
+
+	switch args.TypeToken {
+	case "gcp:serviceaccount/account:Account":
+		// The factory chains saMember from sa.Email; without an email
+		// output, downstream IAM bindings would receive
+		// "serviceAccount:" with no local part.
+		accountID := ""
+		if v, ok := args.Inputs["accountId"]; ok && v.HasValue() {
+			accountID = v.StringValue()
+		}
+		project := ""
+		if v, ok := args.Inputs["project"]; ok && v.HasValue() {
+			project = v.StringValue()
+		}
+		email := accountID + "@" + project + ".iam.gserviceaccount.com"
+		outputs["email"] = resource.NewStringProperty(email)
+		outputs["name"] = resource.NewStringProperty(
+			"projects/" + project + "/serviceAccounts/" + email)
+		outputs["uniqueId"] = resource.NewStringProperty("100000000000000000001")
+
+	case "gcp:cloudrunv2/service:Service":
+		// Cloud Run synthesizes the runtime URL after deployment;
+		// echo a deterministic stand-in so the SD endpoint stripScheme
+		// + ApplyT chain has a string to work on.
+		name := ""
+		if v, ok := args.Inputs["name"]; ok && v.HasValue() {
+			name = v.StringValue()
+		}
+		region := ""
+		if v, ok := args.Inputs["location"]; ok && v.HasValue() {
+			region = v.StringValue()
+		}
+		outputs["uri"] = resource.NewStringProperty(
+			"https://" + name + "-mock-" + region + ".a.run.app")
+
+	case "gcp:servicedirectory/service:Service":
+		// Echo serviceId so test assertions can match on it.
+		if v, ok := args.Inputs["serviceId"]; ok {
+			outputs["serviceId"] = v
+		}
+		if v, ok := args.Inputs["namespace"]; ok {
+			outputs["namespace"] = v
+		}
+	}
+
+	return id, outputs, nil
+}
+
+func (m *computeMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func (m *computeMocks) byType(typeToken string) []recordedComputeResource {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []recordedComputeResource
+	for _, r := range m.resources {
+		if r.TypeToken == typeToken {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (m *computeMocks) count(typeToken string) int {
+	return len(m.byType(typeToken))
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+// runComputeFactory exercises NewCloudRunService against a representative
+// options bundle (one of each binding type) so a single mocked run
+// exercises every factory code path.
+func runComputeFactory(t *testing.T, name string, opts *gcpcompute.Options) *computeMocks {
+	t.Helper()
+	mocks := &computeMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &kconfig.Config{
+			Project:      "kaizen",
+			Environment:  "dev",
+			Env:          kconfig.EnvDev,
+			GCPProjectID: "kaizen-experimentation-dev",
+			GCPRegion:    "us-central1",
+		}
+		inputs := &gcpcompute.Inputs{
+			Project: "kaizen-experimentation-dev",
+			Region:  "us-central1",
+			VpcConnectorSelfLink: pulumi.String(
+				"projects/kaizen-experimentation-dev/locations/us-central1/connectors/kaizen-vpc-connector",
+			).ToStringOutput(),
+			ServiceDirectoryNamespaceID: pulumi.String(
+				"projects/kaizen-experimentation-dev/locations/us-central1/namespaces/kaizen-local",
+			).ToStringOutput(),
+		}
+
+		_, err := gcpcompute.NewCloudRunService(ctx, cfg, inputs, name, opts)
+		return err
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("NewCloudRunService failed: %v", err)
+	}
+	return mocks
+}
+
+// representativeOpts returns an Options struct that exercises every
+// factory side-effect at least once: one project role, one secret,
+// one bucket, two literal env vars.
+func representativeOpts() *gcpcompute.Options {
+	return &gcpcompute.Options{
+		Image:         pulumi.String("us-central1-docker.pkg.dev/kaizen-experimentation-dev/kaizen/m1-assignment:latest"),
+		ContainerPort: 50051,
+		MinInstances:  1, // M1 SLA — verifies override works.
+		MaxInstances:  20,
+		EnvVars: []gcpcompute.EnvVar{
+			{Name: "RUST_LOG", Value: pulumi.String("info")},
+			{Name: "ENVIRONMENT", Value: pulumi.String("dev")},
+		},
+		Secrets: []gcpcompute.SecretEnv{
+			{
+				EnvName:  "DATABASE_SECRET",
+				SecretID: pulumi.String("kaizen-dev-database"),
+				Version:  "latest",
+			},
+		},
+		Buckets: []pulumi.StringInput{
+			pulumi.String("kaizen-dev-data"),
+		},
+		ProjectRoles: []string{
+			"roles/cloudsql.client",
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gap mitigation #2: Workload Identity binding exists with expected scopes
+// ---------------------------------------------------------------------------
+
+// TestCloudRunServiceHasWorkloadIdentitySA asserts each Cloud Run service
+// gets exactly one runtime SA, and that SA's email is set on the Cloud
+// Run revision template.serviceAccount field. This locks the WI invariant
+// at test time so a future refactor cannot silently demote the service to
+// the project-default SA (which would re-introduce the IAM-binding-drift
+// risk the spec calls out).
+func TestCloudRunServiceHasWorkloadIdentitySA(t *testing.T) {
+	mocks := runComputeFactory(t, "m1-assignment", representativeOpts())
+
+	sas := mocks.byType("gcp:serviceaccount/account:Account")
+	if len(sas) != 1 {
+		t.Fatalf("expected 1 service account, got %d", len(sas))
+	}
+
+	saAccountID, ok := sas[0].Inputs["accountId"]
+	if !ok || !saAccountID.HasValue() {
+		t.Fatal("service account missing accountId input")
+	}
+	if saAccountID.StringValue() != "dev-m1-assignment-run" {
+		t.Errorf("accountId = %q, want %q", saAccountID.StringValue(), "dev-m1-assignment-run")
+	}
+
+	// Cloud Run service must reference the SA on its revision template.
+	runSvcs := mocks.byType("gcp:cloudrunv2/service:Service")
+	if len(runSvcs) != 1 {
+		t.Fatalf("expected 1 Cloud Run service, got %d", len(runSvcs))
+	}
+	template, ok := runSvcs[0].Inputs["template"]
+	if !ok || !template.IsObject() {
+		t.Fatal("Cloud Run service missing template input")
+	}
+	templateObj := template.ObjectValue()
+	saField, ok := templateObj["serviceAccount"]
+	if !ok || !saField.HasValue() {
+		t.Fatal("Cloud Run template missing serviceAccount field — would default to project SA, violating WI invariant")
+	}
+	wantSA := "dev-m1-assignment-run@kaizen-experimentation-dev.iam.gserviceaccount.com"
+	if saField.StringValue() != wantSA {
+		t.Errorf("template.serviceAccount = %q, want %q", saField.StringValue(), wantSA)
+	}
+}
+
+// TestCloudRunServiceWorkloadIdentityScopes asserts every IAM binding
+// the factory creates references the same per-service SA as a member.
+// This prevents the "right binding, wrong identity" failure mode where
+// the secret accessor role would land on the default SA but the
+// container would run as the per-service SA (or vice versa).
+func TestCloudRunServiceWorkloadIdentityScopes(t *testing.T) {
+	mocks := runComputeFactory(t, "m1-assignment", representativeOpts())
+
+	wantMember := "serviceAccount:dev-m1-assignment-run@kaizen-experimentation-dev.iam.gserviceaccount.com"
+
+	cases := []struct {
+		typeToken string
+		minCount  int
+		role      string
+	}{
+		{"gcp:projects/iAMMember:IAMMember", 1, "roles/cloudsql.client"},
+		{"gcp:secretmanager/secretIamMember:SecretIamMember", 1, "roles/secretmanager.secretAccessor"},
+		{"gcp:storage/bucketIAMMember:BucketIAMMember", 1, "roles/storage.objectAdmin"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.typeToken, func(t *testing.T) {
+			members := mocks.byType(tc.typeToken)
+			if len(members) < tc.minCount {
+				t.Fatalf("%s: got %d, want >=%d", tc.typeToken, len(members), tc.minCount)
+			}
+			for _, m := range members {
+				memberVal, ok := m.Inputs["member"]
+				if !ok || !memberVal.HasValue() {
+					t.Errorf("%s/%s: missing member input", tc.typeToken, m.Name)
+					continue
+				}
+				if memberVal.StringValue() != wantMember {
+					t.Errorf("%s/%s: member = %q, want %q",
+						tc.typeToken, m.Name, memberVal.StringValue(), wantMember)
+				}
+				roleVal, ok := m.Inputs["role"]
+				if !ok || !roleVal.HasValue() {
+					t.Errorf("%s/%s: missing role input", tc.typeToken, m.Name)
+					continue
+				}
+				if roleVal.StringValue() != tc.role {
+					t.Errorf("%s/%s: role = %q, want %q",
+						tc.typeToken, m.Name, roleVal.StringValue(), tc.role)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance criterion 3: Service Directory endpoint registration verified
+// ---------------------------------------------------------------------------
+
+// TestCloudRunServiceRegistersServiceDirectory asserts that for every
+// Cloud Run service the factory creates, the matching Service Directory
+// service + endpoint pair is registered under the namespace that came in
+// via inputs.ServiceDirectoryNamespaceID.
+func TestCloudRunServiceRegistersServiceDirectory(t *testing.T) {
+	mocks := runComputeFactory(t, "m1-assignment", representativeOpts())
+
+	sdSvcs := mocks.byType("gcp:servicedirectory/service:Service")
+	if len(sdSvcs) != 1 {
+		t.Fatalf("expected 1 Service Directory service, got %d", len(sdSvcs))
+	}
+	if v, ok := sdSvcs[0].Inputs["serviceId"]; !ok || v.StringValue() != "m1-assignment" {
+		t.Errorf("SD serviceId = %v, want %q", sdSvcs[0].Inputs["serviceId"], "m1-assignment")
+	}
+	if v, ok := sdSvcs[0].Inputs["namespace"]; !ok || !strings.HasSuffix(v.StringValue(), "/namespaces/kaizen-local") {
+		t.Errorf("SD namespace = %v, want a path ending in /namespaces/kaizen-local", sdSvcs[0].Inputs["namespace"])
+	}
+
+	sdEndpoints := mocks.byType("gcp:servicedirectory/endpoint:Endpoint")
+	if len(sdEndpoints) != 1 {
+		t.Fatalf("expected 1 Service Directory endpoint, got %d", len(sdEndpoints))
+	}
+	if v, ok := sdEndpoints[0].Inputs["endpointId"]; !ok || v.StringValue() != "primary" {
+		t.Errorf("SD endpointId = %v, want %q", sdEndpoints[0].Inputs["endpointId"], "primary")
+	}
+	if v, ok := sdEndpoints[0].Inputs["port"]; !ok || v.NumberValue() != 443 {
+		t.Errorf("SD port = %v, want 443", sdEndpoints[0].Inputs["port"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VPC connector wiring — feeds into the same gap mitigation
+// ---------------------------------------------------------------------------
+
+// TestCloudRunServiceWiresVpcConnector asserts the Cloud Run service
+// references the connector self-link from inputs.VpcConnectorSelfLink.
+// Without this, Cloud Run egress would bypass the VPC and Cloud SQL /
+// Memorystore calls would 503 at runtime.
+func TestCloudRunServiceWiresVpcConnector(t *testing.T) {
+	mocks := runComputeFactory(t, "m1-assignment", representativeOpts())
+
+	runSvcs := mocks.byType("gcp:cloudrunv2/service:Service")
+	if len(runSvcs) != 1 {
+		t.Fatalf("expected 1 Cloud Run service, got %d", len(runSvcs))
+	}
+	template, ok := runSvcs[0].Inputs["template"]
+	if !ok || !template.IsObject() {
+		t.Fatal("template missing")
+	}
+	vpcAccess, ok := template.ObjectValue()["vpcAccess"]
+	if !ok || !vpcAccess.IsObject() {
+		t.Fatal("template.vpcAccess missing — Cloud Run will not use the connector")
+	}
+	connector, ok := vpcAccess.ObjectValue()["connector"]
+	if !ok || !connector.HasValue() {
+		t.Fatal("template.vpcAccess.connector missing")
+	}
+	wantConnector := "projects/kaizen-experimentation-dev/locations/us-central1/connectors/kaizen-vpc-connector"
+	if connector.StringValue() != wantConnector {
+		t.Errorf("connector = %q, want %q", connector.StringValue(), wantConnector)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Default min-instances behavior + per-service override
+// ---------------------------------------------------------------------------
+
+// TestCloudRunServiceMinInstancesDefault asserts the factory defaults to
+// MinInstances=0 when callers do not opt in. Codifies the spec's "min-
+// instances=0 by default" Cloud Run cost-control invariant.
+func TestCloudRunServiceMinInstancesDefault(t *testing.T) {
+	opts := representativeOpts()
+	opts.MinInstances = 0 // explicit zero — most services
+	mocks := runComputeFactory(t, "m3-metrics", opts)
+
+	runSvcs := mocks.byType("gcp:cloudrunv2/service:Service")
+	if len(runSvcs) != 1 {
+		t.Fatalf("expected 1 Cloud Run service, got %d", len(runSvcs))
+	}
+	scaling := runSvcs[0].Inputs["template"].ObjectValue()["scaling"]
+	if !scaling.IsObject() {
+		t.Fatal("template.scaling missing")
+	}
+	min, ok := scaling.ObjectValue()["minInstanceCount"]
+	if !ok || !min.HasValue() {
+		t.Fatal("scaling.minInstanceCount missing")
+	}
+	if min.NumberValue() != 0 {
+		t.Errorf("default minInstanceCount = %v, want 0", min.NumberValue())
+	}
+}
+
+// TestCloudRunServiceMinInstancesOverride asserts that M1/M7-style
+// overrides (set MinInstances=1 to hold the p99 < 5ms SLA per the spec)
+// land on the Cloud Run scaling block.
+func TestCloudRunServiceMinInstancesOverride(t *testing.T) {
+	opts := representativeOpts() // sets MinInstances: 1
+	mocks := runComputeFactory(t, "m1-assignment", opts)
+
+	runSvcs := mocks.byType("gcp:cloudrunv2/service:Service")
+	if len(runSvcs) != 1 {
+		t.Fatalf("expected 1 Cloud Run service, got %d", len(runSvcs))
+	}
+	scaling := runSvcs[0].Inputs["template"].ObjectValue()["scaling"]
+	if !scaling.IsObject() {
+		t.Fatal("scaling missing")
+	}
+	min, ok := scaling.ObjectValue()["minInstanceCount"]
+	if !ok || min.NumberValue() != 1 {
+		t.Errorf("MinInstances=1 override did not propagate: got %v", min)
+	}
+	max, ok := scaling.ObjectValue()["maxInstanceCount"]
+	if !ok || max.NumberValue() != 20 {
+		t.Errorf("MaxInstances=20 override did not propagate: got %v", max)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-service topology assertion (the per-service invariant scaled up)
+// ---------------------------------------------------------------------------
+
+// TestEveryCloudRunServiceHasWIBinding runs the factory across a small
+// fleet of services and asserts the spec gap mitigation #2 invariant
+// holds for each: every Cloud Run service in the recorded stack has a
+// matching Workload Identity service account binding.
+//
+// This is the "for each Cloud Run service in the test stack" form of the
+// acceptance criterion — beyond the single-service tests above.
+func TestEveryCloudRunServiceHasWIBinding(t *testing.T) {
+	mocks := &computeMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &kconfig.Config{
+			Project:      "kaizen",
+			Environment:  "dev",
+			Env:          kconfig.EnvDev,
+			GCPProjectID: "kaizen-experimentation-dev",
+			GCPRegion:    "us-central1",
+		}
+		inputs := &gcpcompute.Inputs{
+			Project: "kaizen-experimentation-dev",
+			Region:  "us-central1",
+			VpcConnectorSelfLink: pulumi.String(
+				"projects/kaizen-experimentation-dev/locations/us-central1/connectors/kaizen-vpc-connector",
+			).ToStringOutput(),
+			ServiceDirectoryNamespaceID: pulumi.String(
+				"projects/kaizen-experimentation-dev/locations/us-central1/namespaces/kaizen-local",
+			).ToStringOutput(),
+		}
+		// A small fleet that exercises both the default (min=0) and
+		// override (min=1) paths the spec calls out.
+		fleet := []struct {
+			name string
+			min  int
+		}{
+			{"m1-assignment", 1},
+			{"m2-pipeline", 0},
+			{"m7-flags", 1},
+		}
+		for _, svc := range fleet {
+			_, err := gcpcompute.NewCloudRunService(ctx, cfg, inputs, svc.name,
+				&gcpcompute.Options{
+					Image:         pulumi.String("placeholder/" + svc.name + ":latest"),
+					ContainerPort: 8080,
+					MinInstances:  svc.min,
+				})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("multi-service factory run failed: %v", err)
+	}
+
+	runSvcs := mocks.byType("gcp:cloudrunv2/service:Service")
+	if len(runSvcs) != 3 {
+		t.Fatalf("Cloud Run services: got %d, want 3", len(runSvcs))
+	}
+
+	// One SA per service — that's the WI invariant.
+	if got := mocks.count("gcp:serviceaccount/account:Account"); got != 3 {
+		t.Errorf("service accounts: got %d, want 3 (one per Cloud Run service)", got)
+	}
+
+	// One SD service + endpoint per Cloud Run service.
+	if got := mocks.count("gcp:servicedirectory/service:Service"); got != 3 {
+		t.Errorf("Service Directory services: got %d, want 3", got)
+	}
+	if got := mocks.count("gcp:servicedirectory/endpoint:Endpoint"); got != 3 {
+		t.Errorf("Service Directory endpoints: got %d, want 3", got)
+	}
+
+	// Cross-check: every Cloud Run service references a unique
+	// per-service SA email (not the project default).
+	saEmailsPerService := map[string]string{}
+	for _, svc := range runSvcs {
+		template := svc.Inputs["template"].ObjectValue()
+		saField := template["serviceAccount"]
+		if !saField.HasValue() {
+			t.Errorf("Cloud Run service %q missing template.serviceAccount", svc.Name)
+			continue
+		}
+		saEmailsPerService[svc.Name] = saField.StringValue()
+	}
+	seen := map[string]bool{}
+	for name, email := range saEmailsPerService {
+		if seen[email] {
+			t.Errorf("service %q reuses SA email %q — WI binding must be unique per service",
+				name, email)
+		}
+		seen[email] = true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative-path: factory rejects misconfiguration loudly
+// ---------------------------------------------------------------------------
+
+// TestCloudRunServiceRejectsMissingImage locks the validation the factory
+// does at program-build time so callers get a fast, actionable error
+// instead of an opaque Cloud Run 400 at apply time.
+func TestCloudRunServiceRejectsMissingImage(t *testing.T) {
+	mocks := &computeMocks{}
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &kconfig.Config{
+			Project:      "kaizen",
+			Environment:  "dev",
+			GCPProjectID: "kaizen-experimentation-dev",
+			GCPRegion:    "us-central1",
+		}
+		inputs := &gcpcompute.Inputs{
+			Project: "kaizen-experimentation-dev",
+			Region:  "us-central1",
+			VpcConnectorSelfLink: pulumi.String("projects/p/locations/r/connectors/c").
+				ToStringOutput(),
+			ServiceDirectoryNamespaceID: pulumi.String("projects/p/locations/r/namespaces/n").
+				ToStringOutput(),
+		}
+		_, err := gcpcompute.NewCloudRunService(ctx, cfg, inputs, "m1-assignment",
+			&gcpcompute.Options{
+				// Image deliberately omitted.
+				ContainerPort: 50051,
+			})
+		return err
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err == nil {
+		t.Fatal("expected error for missing Image, got nil")
+	}
+	if !strings.Contains(err.Error(), "opts.Image is required") {
+		t.Errorf("error %q does not mention missing image", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `infra/pkg/gcp/compute.NewCloudRunService` — a per-service helper that's the GCP analogue of the AWS ECS Fargate task-def factory. Provisions one Cloud Run service plus its dedicated Workload Identity SA, all required IAM bindings (project / secret / bucket), VPC connector wiring, Secret Manager env injection, and Service Directory service+endpoint registration.
- Wires the helper into `Deploy()` via a new `gcp.NewCompute` aggregator with one trivial canary service (`preview-canary`, using Google's public hello image), so `pulumi preview --stack gcp-dev` succeeds end-to-end without depending on real Kaizen image builds.
- Topology tests (`infra/test/gcp_compute_topology_test.go`) close spec gap mitigation #2: every Cloud Run service must have a WI binding with the expected scopes and a Service Directory endpoint.

## What changed

### New files
- `infra/pkg/gcp/compute/compute.go` — the helper, `Inputs`/`Options`/`CloudRunService` types, and pure helpers (`saAccountID`, `isValidServiceName`, `slug`, `sortedUnique`, `stripScheme`, `normalizeOptions`, `validateInputs`).
- `infra/pkg/gcp/compute/compute_test.go` — 30 in-package unit tests for the helpers + validation rejection paths.
- `infra/test/gcp_compute_topology_test.go` — 9 topology tests using `pulumi.WithMocks`. Asserts WI SA presence, IAM scope correctness across project/secret/bucket bindings, Service Directory service + endpoint registration, VPC connector wiring, min-instances default + override, multi-service per-SA invariant (no SA email reuse), and the validation rejection path for missing Image.

### Modified files
- `infra/pkg/types/outputs.go` — adds `NetworkOutputs.VpcConnectorSelfLink` (GCP-only; AWS leaves zero-valued, mirroring the existing `S3VpcEndpointId` pattern).
- `infra/pkg/gcp/gcp.go` — `NewNetwork` populates the new field; new `NewCompute` aggregator stage 5 that calls the helper for the canary.
- `infra/main.go` — moves the GCP early-return marker so it runs storage → cicd → compute, then returns. Comment updated to reflect new boundary.

## Acceptance criteria

- [x] **Helper exists, takes the spec-required options.** `NewCloudRunService(ctx, cfg, inputs, name, opts)` accepts `Options{Image, ContainerPort, MinInstances, MaxInstances, EnvVars, Secrets, Buckets, ProjectRoles, ServiceID, AllowPublicInvoke}`.
- [x] **Topology test asserts: for each Cloud Run service in the test stack, a Workload Identity binding exists with the expected scopes.** See `TestCloudRunServiceHasWorkloadIdentitySA`, `TestCloudRunServiceWorkloadIdentityScopes`, and `TestEveryCloudRunServiceHasWIBinding` (multi-service fleet).
- [x] **Service Directory endpoint registration verified by topology test.** See `TestCloudRunServiceRegistersServiceDirectory` (single-service) and `TestEveryCloudRunServiceHasWIBinding` (asserts SD service + endpoint count == Cloud Run service count for a 3-service fleet).
- [x] **`pulumi preview --stack gcp-dev` succeeds with at least one trivial test service using the helper.** Pulumi CLI not available in this sandbox, but `TestFullStackDeploy_GCP` is the in-CI proxy (per the same pattern documented in `fullstack_gcp_test.go` for the CICD slice). It runs `Deploy()` end-to-end under mocks with `cloudProvider=gcp` — including the new `gcp.NewCompute` call — and passes.

## Design notes (Cloud Run vs. ECS analogue)

- **Single identity** vs. AWS's two-role split: Cloud Run uses one `template.serviceAccount` (the runtime SA), so the helper creates a single `serviceaccount.Account` and binds *all* roles (project, secret, bucket) to it. AWS's `newExecutionRole` / `newTaskRole` separation isn't needed.
- **VPC egress = `PRIVATE_RANGES_ONLY`**, not `ALL_TRAFFIC`. Routes only RFC-1918 traffic through the connector so Cloud SQL / Memorystore reach the VPC while AR image pulls keep the platform-default path. `ALL_TRAFFIC` would force everything through the connector and saturate it.
- **Ingress = `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`** (default). Service-to-service traffic stays on the VPC; only the load balancer (Phase 3) reaches Cloud Run publicly. `AllowPublicInvoke: true` is the opt-in for M6 UI behind the LB.
- **SA accountId scheme**: `<env>-<name>-run` (e.g. `dev-m1-assignment-run`). Validated against the GCP 6–30 char ceiling at program-build time so misconfigs fail loudly instead of as opaque IAM 400s at apply.
- **Service Directory model**: helper creates both the SD `Service` (parent) and an `Endpoint` (`endpointId: "primary"`, `port: 443`, `address: <Cloud Run host>`). The address strips `https://` since SD endpoints expect bare hosts.

## Out of scope (per issue)

- Per-Kaizen-service deploys for M1, M2, ..., M7 — those land in #10..#17 as separate issues. The helper is the foundation; this PR ships only the canary to exercise it.
- M4b on GCE (stateful service) — separate sibling issue under the same sprint.
- Fixing the pre-existing `pkg/aws/storage.applyVpcEndpointPolicy` panic on `pulumi.WithMocks` runs (s3.go:310 type-asserts a `pulumi.ID` value as `string`). Documented in `infra/test/topology_test.go`'s preamble; out of scope for #486.

## Blocked by (resolved)

- #479 (GCP network — VPC connector + Service Directory) — CLOSED.
- #482 (GCP CI/CD — Artifact Registry) — CLOSED. Canary uses `us-docker.pkg.dev/cloudrun/container/hello` (Google's public image) so this PR does not block on a real image build into AR; per-service issues will switch to `CICDOutputs.RepositoryURLs[<svc>]` once images exist.

## Test plan

- [x] `go test ./pkg/gcp/compute/...` — 30 unit tests pass
- [x] `go test ./test/ -run TestCloudRunService` — 9 topology tests pass
- [x] `go test ./test/ -run TestEveryCloudRunService` — multi-service fleet passes
- [x] `go test . -run TestFullStack.*_GCP` — 3 GCP fullstack tests pass (CI proxy for `pulumi preview --stack gcp-dev`)
- [x] `go test ./pkg/...` — all per-package tests pass (no regression in network/secrets/storage from `NetworkOutputs` field addition)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Manual `pulumi preview --stack gcp-dev` against real GCP creds — to run by reviewer or in CI; the in-process Deploy() proxy passes.

## Future opportunities (not implemented)

- The canary (`preview-canary`) is intentionally minimal. Once #10..#17 land per-Kaizen-service deploys, the canary can be removed in favor of the M-series services.
- A separate `NewServices()` aggregator in `pkg/gcp/compute` (mirroring `pkg/aws/compute.NewServices`) that drives the spec table — deferred to whichever per-service issue lands first so the spec table doesn't get duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes #486
