### PR TITLE
feat(infra): GCP Cloud SQL PostgreSQL module (Closes #484)

### DIFF
--- a/infra/database_topology_test.go
+++ b/infra/database_topology_test.go
@@ -1,0 +1,280 @@
+// Parameterized topology test for the database slice of Deploy(). Runs the
+// network → database stages with mocks for both providers and asserts the
+// private-IP enforcement contract: the relational database MUST be reachable
+// only via the private subnet path on either cloud.
+//
+// AWS RDS expresses this through publiclyAccessible=false (or unset, which
+// defaults to false) plus a DB subnet group anchored to the private subnets.
+// GCP Cloud SQL expresses it through settings.ipConfiguration.ipv4Enabled=false
+// plus a populated privateNetwork pointing at the VPC self-link.
+//
+// The test asserts on Pulumi resource INPUTS, not outputs, because the
+// inputs are the configuration the operator is committing to — outputs are
+// just mock echoes. Drift in either provider's private-IP posture trips here
+// before it reaches a preview or an apply.
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	awsfacade "github.com/kaizen-experimentation/infra/pkg/aws"
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	gcpfacade "github.com/kaizen-experimentation/infra/pkg/gcp"
+	"github.com/kaizen-experimentation/infra/pkg/types"
+)
+
+// dbTopologyMocks records resource registrations for both providers' DB
+// stages plus their network prerequisites. Reuses the resource-record shape
+// from fullstack_test.go via fsResource.
+type dbTopologyMocks struct {
+	mu        sync.Mutex
+	resources []fsResource
+}
+
+func (m *dbTopologyMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	m.resources = append(m.resources, fsResource{
+		TypeToken: args.TypeToken,
+		Name:      args.Name,
+		Inputs:    args.Inputs,
+	})
+	m.mu.Unlock()
+
+	id := args.Name + "_id"
+	outputs := resource.PropertyMap{}
+	for k, v := range args.Inputs {
+		outputs[k] = v
+	}
+
+	switch args.TypeToken {
+	// --- AWS network prerequisites ---
+	case "aws:ec2/vpc:Vpc":
+		outputs["id"] = resource.NewStringProperty("vpc-mock")
+	case "aws:ec2/subnet:Subnet":
+		outputs["id"] = resource.NewStringProperty(args.Name + "-id")
+	case "aws:ec2/securityGroup:SecurityGroup":
+		outputs["id"] = resource.NewStringProperty("sg-" + args.Name)
+
+	// --- AWS RDS ---
+	case "aws:rds/instance:Instance":
+		outputs["endpoint"] = resource.NewStringProperty(
+			"kaizen-rds.abc123.us-east-1.rds.amazonaws.com:5432")
+		outputs["port"] = resource.NewNumberProperty(5432)
+		outputs["identifier"] = resource.NewStringProperty("kaizen-rds")
+	case "aws:rds/parameterGroup:ParameterGroup",
+		"aws:rds/subnetGroup:SubnetGroup":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+
+	// --- GCP network prerequisites ---
+	case "gcp:compute/network:Network":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/networks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/subnetwork:Subnetwork":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/subnetworks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/router:Router":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/routers/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/routerNat:RouterNat":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/firewall:Firewall":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/firewalls/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:servicedirectory/namespace:Namespace":
+		outputs["name"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/namespaces/" + args.Name)
+	case "gcp:vpcaccess/connector:Connector":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/connectors/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/globalAddress:GlobalAddress":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:servicenetworking/connection:Connection":
+		outputs["peering"] = resource.NewStringProperty("servicenetworking-googleapis-com")
+
+	// --- GCP Cloud SQL ---
+	case "gcp:sql/databaseInstance:DatabaseInstance":
+		outputs["connectionName"] = resource.NewStringProperty("kaizen-test:us-central1:kaizen-sql")
+		outputs["name"] = resource.NewStringProperty(args.Name)
+		outputs["firstIpAddress"] = resource.NewStringProperty("10.99.0.3")
+		outputs["privateIpAddress"] = resource.NewStringProperty("10.99.0.3")
+		outputs["publicIpAddress"] = resource.NewStringProperty("")
+	case "gcp:sql/database:Database":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:sql/user:User":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	}
+
+	return id, outputs, nil
+}
+
+func (m *dbTopologyMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	switch args.Token {
+	case "aws:index/getAvailabilityZones:getAvailabilityZones":
+		return resource.PropertyMap{
+			"id": resource.NewStringProperty("us-east-1"),
+			"names": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("us-east-1a"),
+				resource.NewStringProperty("us-east-1b"),
+				resource.NewStringProperty("us-east-1c"),
+			}),
+			"zoneIds": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("use1-az1"),
+				resource.NewStringProperty("use1-az2"),
+				resource.NewStringProperty("use1-az3"),
+			}),
+			"groupNames": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("us-east-1"),
+				resource.NewStringProperty("us-east-1"),
+				resource.NewStringProperty("us-east-1"),
+			}),
+		}, nil
+	case "aws:index/getRegion:getRegion":
+		return resource.PropertyMap{
+			"name":        resource.NewStringProperty("us-east-1"),
+			"description": resource.NewStringProperty("US East (N. Virginia)"),
+			"endpoint":    resource.NewStringProperty("ec2.us-east-1.amazonaws.com"),
+			"id":          resource.NewStringProperty("us-east-1"),
+		}, nil
+	}
+	return resource.PropertyMap{}, nil
+}
+
+// TestDatabaseTopologyParameterized exercises network → database for both
+// providers and verifies that the chosen private-IP posture is reflected in
+// the Pulumi resource inputs. Failure means a default has been changed in a
+// way that would let traffic from outside the VPC reach the database.
+func TestDatabaseTopologyParameterized(t *testing.T) {
+	cases := []struct {
+		name        string
+		runStages   func(t *testing.T, mocks *dbTopologyMocks) types.DatabaseOutputs
+		verifyInput func(t *testing.T, mocks *dbTopologyMocks)
+	}{
+		{
+			name: "aws",
+			runStages: func(t *testing.T, mocks *dbTopologyMocks) types.DatabaseOutputs {
+				var captured types.DatabaseOutputs
+				err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+					cfg := kconfig.LoadConfig(ctx)
+					netOut, err := awsfacade.NewNetwork(ctx, cfg)
+					if err != nil {
+						return err
+					}
+					captured, err = awsfacade.NewDatabase(ctx, cfg, netOut)
+					return err
+				}, pulumi.WithMocks("kaizen", "dev", mocks),
+					configWithProvider("aws"))
+				if err != nil {
+					t.Fatalf("aws DB stage failed: %v", err)
+				}
+				return captured
+			},
+			verifyInput: func(t *testing.T, mocks *dbTopologyMocks) {
+				inst := byType(mocks.resources, "aws:rds/instance:Instance")
+				if len(inst) != 1 {
+					t.Fatalf("aws: expected 1 RDS instance, got %d", len(inst))
+				}
+				ins := inst[0].Inputs
+				// publiclyAccessible MUST NOT be true. Absent is fine — RDS
+				// defaults to false. Explicit false also fine.
+				if v, ok := ins["publiclyAccessible"]; ok && v.IsBool() && v.BoolValue() {
+					t.Errorf("aws: RDS publiclyAccessible=true is not allowed; instance would be reachable from the public internet")
+				}
+				// dbSubnetGroupName MUST be set, anchoring the instance to the
+				// private subnets the subnet group references.
+				if v, ok := ins["dbSubnetGroupName"]; !ok || !v.HasValue() {
+					t.Errorf("aws: RDS dbSubnetGroupName is unset; instance would be placed in the default VPC")
+				}
+				// vpcSecurityGroupIds MUST be set.
+				if v, ok := ins["vpcSecurityGroupIds"]; !ok || !v.HasValue() {
+					t.Errorf("aws: RDS vpcSecurityGroupIds is unset; no SG controls access")
+				}
+			},
+		},
+		{
+			name: "gcp",
+			runStages: func(t *testing.T, mocks *dbTopologyMocks) types.DatabaseOutputs {
+				var captured types.DatabaseOutputs
+				err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+					cfg := kconfig.LoadConfig(ctx)
+					netOut, err := gcpfacade.NewNetwork(ctx, cfg)
+					if err != nil {
+						return err
+					}
+					captured, err = gcpfacade.NewDatabase(ctx, cfg, netOut)
+					return err
+				}, pulumi.WithMocks("kaizen", "dev", mocks),
+					configWithProvider("gcp"))
+				if err != nil {
+					t.Fatalf("gcp DB stage failed: %v", err)
+				}
+				return captured
+			},
+			verifyInput: func(t *testing.T, mocks *dbTopologyMocks) {
+				inst := byType(mocks.resources, "gcp:sql/databaseInstance:DatabaseInstance")
+				if len(inst) != 1 {
+					t.Fatalf("gcp: expected 1 Cloud SQL instance, got %d", len(inst))
+				}
+				ins := inst[0].Inputs
+				// settings.ipConfiguration MUST set ipv4Enabled=false and a
+				// populated privateNetwork.
+				settings, ok := ins["settings"]
+				if !ok || !settings.IsObject() {
+					t.Fatalf("gcp: Cloud SQL instance missing 'settings' input")
+				}
+				ipCfg, ok := settings.ObjectValue()["ipConfiguration"]
+				if !ok || !ipCfg.IsObject() {
+					t.Fatalf("gcp: Cloud SQL settings.ipConfiguration is unset")
+				}
+				ipMap := ipCfg.ObjectValue()
+				if v, ok := ipMap["ipv4Enabled"]; !ok {
+					t.Errorf("gcp: settings.ipConfiguration.ipv4Enabled is unset; defaults to true and allows public IP")
+				} else if !v.IsBool() {
+					t.Errorf("gcp: settings.ipConfiguration.ipv4Enabled is not a bool: %v", v)
+				} else if v.BoolValue() {
+					t.Errorf("gcp: settings.ipConfiguration.ipv4Enabled=true is not allowed; instance would have a public IP")
+				}
+				priv, ok := ipMap["privateNetwork"]
+				if !ok || !priv.HasValue() || (priv.IsString() && priv.StringValue() == "") {
+					t.Errorf("gcp: settings.ipConfiguration.privateNetwork is unset; instance cannot reach the VPC privately")
+				}
+				// PSA reserved range must also have been provisioned during
+				// the network stage — Cloud SQL on private IP requires it.
+				if len(byType(mocks.resources, "gcp:compute/globalAddress:GlobalAddress")) < 1 {
+					t.Errorf("gcp: no GlobalAddress for Private Service Access reservation")
+				}
+				if len(byType(mocks.resources, "gcp:servicenetworking/connection:Connection")) < 1 {
+					t.Errorf("gcp: no servicenetworking.Connection for PSA peering")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mocks := &dbTopologyMocks{}
+			_ = tc.runStages(t, mocks)
+			tc.verifyInput(t, mocks)
+		})
+	}
+}
+
+// byType filters resources by Pulumi type token. Inlined to avoid touching
+// network_topology_test.go's countByType helper.
+func byType(records []fsResource, typeToken string) []fsResource {
+	var out []fsResource
+	for _, r := range records {
+		if r.TypeToken == typeToken {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/infra/fullstack_gcp_test.go
+++ b/infra/fullstack_gcp_test.go
@@ -44,6 +44,65 @@ func (m *gcpFullstackMocks) NewResource(args pulumi.MockResourceArgs) (string, r
 		if v, ok := args.Inputs["project"]; ok {
 			outputs["project"] = v
 		}
+
+	// --- GCP network prerequisites (VPC, subnets, firewall, etc.) ---
+	case "gcp:compute/network:Network":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/networks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/subnetwork:Subnetwork":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/subnetworks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/router:Router":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/routers/" + args.Name)
+	case "gcp:compute/firewall:Firewall":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/firewalls/" + args.Name)
+	case "gcp:servicedirectory/namespace:Namespace":
+		outputs["name"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/namespaces/" + args.Name)
+	case "gcp:vpcaccess/connector:Connector":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/connectors/" + args.Name)
+
+	// --- PSA (Private Service Access) ---
+	case "gcp:compute/globalAddress:GlobalAddress":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:servicenetworking/connection:Connection":
+		outputs["peering"] = resource.NewStringProperty("servicenetworking-googleapis-com")
+
+	// --- Cloud SQL ---
+	case "gcp:sql/databaseInstance:DatabaseInstance":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+		outputs["privateIpAddress"] = resource.NewStringProperty("10.99.0.3")
+		outputs["connectionName"] = resource.NewStringProperty("kaizen-test:us-central1:" + args.Name)
+	case "gcp:sql/database:Database":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+
+	// --- Memorystore Redis ---
+	case "gcp:redis/instance:Instance":
+		outputs["host"] = resource.NewStringProperty("10.99.1.1")
+		outputs["port"] = resource.NewNumberProperty(6379)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+
+	// --- GCE / M4b compute ---
+	case "gcp:compute/instance:Instance":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/zones/us-central1-a/instances/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/instanceGroupManager:InstanceGroupManager":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/disk:Disk":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/zones/us-central1-a/disks/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:servicedirectory/service:Service":
+		outputs["name"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/namespaces/kaizen/services/" + args.Name)
+	case "gcp:servicedirectory/endpoint:Endpoint":
+		outputs["name"] = resource.NewStringProperty(args.Name)
 	}
 	return id, outputs, nil
 }
@@ -69,6 +128,8 @@ func (m *gcpFullstackMocks) byType(t string) []fsResource {
 func gcpFullstackConfig() pulumi.RunOption {
 	return func(info *pulumi.RunInfo) {
 		info.Config = map[string]string{
+			"gcp:project":                                 "kaizen-experimentation-dev",
+			"gcp:region":                                  "us-central1",
 			"kaizen-experimentation:environment":          "dev",
 			"kaizen-experimentation:cloudProvider":        "gcp",
 			"kaizen-experimentation:gcpProjectId":         "kaizen-experimentation-dev",

--- a/infra/main.go
+++ b/infra/main.go
@@ -72,45 +72,6 @@ func Deploy(ctx *pulumi.Context) error {
 	_ = iamOut // exported via ctx.Export inside NewIAM; reserved for future stages
 
 	// =====================================================================
-	// GCP early return — Phase 1 storage + cache + cicd + M4b compute slice
-	// =====================================================================
-	// The remaining Stage 3 module (database), Stage 4 (streaming + secrets),
-	// Stage 5 stateless compute, and Stage 6 (edge) are AWS-only today; GCP
-	// arms for those stages land in subsequent Phase 1 PRs. Until they do,
-	// we run every GCP stage that's already wired (storage above, cache +
-	// cicd + M4b compute below) and return cleanly so
-	// `pulumi preview --stack gcp-dev` succeeds.
-	// Each subsequent Phase 1 PR moves this early-return marker further down
-	// Deploy() and removes it entirely once all stages are wired.
-	if cfg.CloudProvider == "gcp" {
-		cacheOut, err := gcp.NewCache(ctx, cfg, netOut)
-		if err != nil {
-			return err
-		}
-		cicdOut, err := gcp.NewCICD(ctx, cfg)
-		if err != nil {
-			return err
-		}
-		if url, ok := cicdOut.RepositoryURLs["assignment"]; ok {
-			ctx.Export("cicdAssignmentRepositoryUrl", url)
-		}
-		// M4b stateful compute slice — issue #487. Cloud Run services for
-		// the eight stateless modules land in a sibling PR (#486); when
-		// they do, this NewCompute call grows to wire them in too and the
-		// early-return marker moves below the edge stage.
-		gcpComputeOut, err := gcp.NewCompute(ctx, cfg, netOut)
-		if err != nil {
-			return err
-		}
-		ctx.Export("m4bAsgName", gcpComputeOut.M4bAsgName)
-		ctx.Export("m4bInstanceId", gcpComputeOut.M4bInstanceId)
-		ctx.Export("m4bEndpointAddress", gcpComputeOut.M4bEndpoint)
-		ctx.Export("dataBucket", storageOut.DataBucketName)
-		ctx.Export("cacheEndpoint", cacheOut.Endpoint)
-		return nil
-	}
-
-	// =====================================================================
 	// Stage 3: Data Stores
 	// =====================================================================
 	var (
@@ -124,11 +85,52 @@ func Deploy(ctx *pulumi.Context) error {
 			return err
 		}
 		dbOut, err = aws.NewDatabase(ctx, cfg, netOut)
+	case "gcp":
+		cacheOut, err = gcp.NewCache(ctx, cfg, netOut)
+		if err != nil {
+			return err
+		}
+		dbOut, err = gcp.NewDatabase(ctx, cfg, netOut)
 	default:
 		return unsupportedCloud(cfg.CloudProvider)
 	}
 	if err != nil {
 		return err
+	}
+
+	// =====================================================================
+	// GCP early return — Phase 1 storage + cache + database + cicd + M4b compute slice
+	// =====================================================================
+	// Stage 4 (streaming + secrets), Stage 5 stateless compute, and Stage 6
+	// (edge) are AWS-only today. GCP arms for those stages land in subsequent
+	// Phase 1 PRs. Until they do, we run every GCP stage that's already wired
+	// (network, storage, cache, database above; cicd + M4b compute below) and
+	// return cleanly so `pulumi preview --stack gcp-dev` succeeds.
+	// Each subsequent Phase 1 PR moves this early-return marker further down
+	// Deploy() and removes it entirely once all stages are wired.
+	if cfg.CloudProvider == "gcp" {
+		cicdOut, err := gcp.NewCICD(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		if url, ok := cicdOut.RepositoryURLs["assignment"]; ok {
+			ctx.Export("cicdAssignmentRepositoryUrl", url)
+		}
+		// M4b stateful compute slice — issue #487. Cloud Run services for
+		// the eight stateless modules land in #486; when they do, this
+		// NewCompute call grows to wire them in too and the early-return
+		// marker moves below the edge stage.
+		gcpComputeOut, err := gcp.NewCompute(ctx, cfg, netOut)
+		if err != nil {
+			return err
+		}
+		ctx.Export("m4bAsgName", gcpComputeOut.M4bAsgName)
+		ctx.Export("m4bInstanceId", gcpComputeOut.M4bInstanceId)
+		ctx.Export("m4bEndpointAddress", gcpComputeOut.M4bEndpoint)
+		ctx.Export("dataBucket", storageOut.DataBucketName)
+		ctx.Export("cacheEndpoint", cacheOut.Endpoint)
+		ctx.Export("databaseEndpoint", dbOut.Endpoint)
+		return nil
 	}
 
 	// =====================================================================
@@ -263,13 +265,14 @@ func Deploy(ctx *pulumi.Context) error {
 func unsupportedCloud(provider string) error {
 	switch provider {
 	case "gcp":
-		// Phase 1 supports storage (Stage 2), cache (Stage 3), and cicd on
-		// GCP. Stages 4–6 plus the remaining Stage 3 modules are AWS-only
-		// today; GCP should never reach their switches because Deploy()
-		// early-returns after the cache + cicd block. Hitting this is a
-		// programming error: a stage switch is missing a gcp case or the
-		// early-return was removed without wiring the remaining stages.
-		return fmt.Errorf("internal: cloudProvider=gcp reached an unimplemented stage (Phase 1 supports Storage + Cache + CICD only)")
+		// Phase 1 supports network, storage, cache, database (Stage 3), cicd,
+		// and M4b compute on GCP. Stage 4 (streaming + secrets), Stage 5
+		// stateless compute, and Stage 6 (edge) are AWS-only today; GCP
+		// should never reach their switches because Deploy() early-returns
+		// after the cicd + M4b block. Hitting this is a programming error:
+		// a stage switch is missing a gcp case or the early-return was
+		// removed without wiring the remaining stages.
+		return fmt.Errorf("internal: cloudProvider=gcp reached an unimplemented stage (Phase 1 supports Network + Storage + Cache + Database + CICD + M4b only)")
 	default:
 		return fmt.Errorf("unsupported cloudProvider %q (expected \"aws\" or \"gcp\")", provider)
 	}

--- a/infra/pkg/gcp/database/database.go
+++ b/infra/pkg/gcp/database/database.go
@@ -69,9 +69,15 @@ func NewCloudSQL(ctx *pulumi.Context, kcfg *kconfig.Config, inputs *CloudSQLInpu
 	}
 
 	cfg := config.New(ctx, "kaizen-experimentation")
-	gcpCfg := config.New(ctx, "gcp")
 
-	region := gcpCfg.Get("region")
+	// Region: prefer the app-level gcpRegion (consistent with cache and
+	// compute modules which read cfg.GCPRegion) then fall back to the
+	// provider-level gcp:region, then to the hard-coded default.
+	region := kcfg.GCPRegion
+	if region == "" {
+		gcpCfg := config.New(ctx, "gcp")
+		region = gcpCfg.Get("region")
+	}
 	if region == "" {
 		region = "us-central1"
 	}
@@ -133,7 +139,7 @@ func NewCloudSQL(ctx *pulumi.Context, kcfg *kconfig.Config, inputs *CloudSQLInpu
 	labels := pulumi.StringMap{
 		"project":     pulumi.String("kaizen"),
 		"environment": pulumi.String(kcfg.Environment),
-		"managed-by":  pulumi.String("pulumi"),
+		"managed_by":  pulumi.String("pulumi"),
 	}
 	if inputs.PsaReservedRangeName != nil {
 		labels["psa-range"] = inputs.PsaReservedRangeName.ToStringOutput()

--- a/infra/pkg/gcp/database/database.go
+++ b/infra/pkg/gcp/database/database.go
@@ -1,0 +1,215 @@
+// Package database provisions Cloud SQL PostgreSQL for the Kaizen
+// experimentation platform on GCP. Configured for parity with pkg/aws/database
+// (RDS PostgreSQL 16): regional HA in staging/prod, daily backups with PITR,
+// matching maintenance window and 7-day backup retention, IAM-DB authentication
+// enabled, private IP only (reachable via the VPC through Private Service
+// Access).
+//
+// The instance does not provision a built-in admin user. Operators authenticate
+// via IAM database auth (the `cloud_sql.iam_authentication` database flag is
+// set to `on`), with specific service-account → DB user bindings created
+// alongside compute (#486). The DatabaseSecret entry in pkg/gcp/secrets
+// remains as a placeholder for service-account credentials; password-based
+// access is intentionally not configured at provisioning time.
+package database
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/sql"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+)
+
+// CloudSQLOutputs holds outputs that downstream GCP modules (compute, secrets)
+// consume. The facade adapts these into the cross-cloud types.DatabaseOutputs.
+type CloudSQLOutputs struct {
+	// Endpoint is host:port form (e.g., "10.99.0.3:5432"), matching what the
+	// AWS RDS endpoint output produces. Composed from the private IP and the
+	// PostgreSQL default port.
+	Endpoint pulumi.StringOutput
+
+	// Port is the listener port (always 5432 for PostgreSQL).
+	Port pulumi.IntOutput
+
+	// InstanceId is the bare Cloud SQL instance name, used by ops tooling
+	// (gcloud sql connect, gcloud sql describe).
+	InstanceId pulumi.StringOutput
+
+	// PrivateIp is the assigned RFC1918 address. Exported so the secrets
+	// module can populate DatabaseSecret.Host without round-tripping through
+	// the Endpoint string parser.
+	PrivateIp pulumi.StringOutput
+}
+
+// CloudSQLInputs carries the wiring from upstream stages. PrivateNetwork is
+// the VPC self-link (NetworkOutputs.VpcId on GCP). PsaReservedRangeName flows
+// in from the same source — its presence here creates an implicit Pulumi
+// dependency on the Private Service Access peering so the instance is not
+// created before the peering is live.
+type CloudSQLInputs struct {
+	// PrivateNetwork is the VPC self-link the Cloud SQL instance peers into.
+	PrivateNetwork pulumi.StringInput
+
+	// PsaReservedRangeName is the name of the Private Service Access reserved
+	// range. Attached as a UserLabel so Pulumi's output graph orders this
+	// instance after the PSA peering completes.
+	PsaReservedRangeName pulumi.StringInput
+}
+
+// NewCloudSQL creates a Cloud SQL for PostgreSQL 16 instance with the
+// configuration matching pkg/aws/database/rds.go. Sizing, HA, backup, and
+// maintenance windows are read from the same kaizen-experimentation namespace
+// as the AWS module; provider-specific keys live under the gcpDb* prefix.
+func NewCloudSQL(ctx *pulumi.Context, kcfg *kconfig.Config, inputs *CloudSQLInputs) (*CloudSQLOutputs, error) {
+	if inputs == nil || inputs.PrivateNetwork == nil {
+		return nil, fmt.Errorf("gcp/database.NewCloudSQL: PrivateNetwork input is required (pass NetworkOutputs.VpcId)")
+	}
+
+	cfg := config.New(ctx, "kaizen-experimentation")
+	gcpCfg := config.New(ctx, "gcp")
+
+	region := gcpCfg.Get("region")
+	if region == "" {
+		region = "us-central1"
+	}
+
+	// --- Tier (machine type) ---
+	// Parity with AWS RDS sizing:
+	//   dev:            db.t4g.medium   →  db-custom-2-4096   (2 vCPU, 4 GB)
+	//   staging/prod:   db.r6g.large    →  db-custom-4-16384  (4 vCPU, 16 GB)
+	tier := cfg.Get("gcpDbTier")
+	if tier == "" {
+		if kcfg.IsProd() || kcfg.IsStaging() {
+			tier = "db-custom-4-16384"
+		} else {
+			tier = "db-custom-2-4096"
+		}
+	}
+
+	// --- Availability type ---
+	// Cloud SQL's REGIONAL availability is the analog of RDS MultiAz: the
+	// instance fails over to a standby in another zone within the region.
+	availability := "ZONAL"
+	if kcfg.IsProd() || kcfg.IsStaging() {
+		availability = "REGIONAL"
+	}
+	if v := cfg.Get("gcpDbAvailabilityType"); v != "" {
+		availability = v
+	}
+
+	// --- Deletion protection ---
+	// Prod-only, matching RDS. Non-prod stacks can be torn down freely.
+	deletionProtection := kcfg.IsProd()
+
+	// --- Disk sizing ---
+	// AWS RDS: AllocatedStorage=100 GB, MaxAllocatedStorage=500 GB, gp3, encrypted.
+	// Cloud SQL: DiskSize=100, DiskAutoresize=true, DiskAutoresizeLimit=500,
+	// DiskType=PD_SSD. Disk-level encryption with Google-managed KMS is on by
+	// default (CMEK opt-in is a follow-up).
+	diskSize := 100
+	if v, err := cfg.TryInt("gcpDbDiskSizeGb"); err == nil {
+		diskSize = v
+	}
+	diskAutoresizeLimit := 500
+	if v, err := cfg.TryInt("gcpDbDiskAutoresizeLimitGb"); err == nil {
+		diskAutoresizeLimit = v
+	}
+
+	// --- Instance name ---
+	// Cloud SQL instance names are unique within a project and CANNOT be
+	// reused for 7 days after deletion — so we tie the name to the env to
+	// reduce churn during day-1 stack iteration.
+	instanceName := fmt.Sprintf("kaizen-sql-%s", kcfg.Environment)
+
+	// --- Resource labels carrying PSA dependency ---
+	// Cloud SQL doesn't reference the PSA range directly via API, but Pulumi's
+	// resource graph needs *some* data-flow link from the peering output to
+	// this instance so creation order is enforced. Attaching the range name as
+	// a user label gives us that edge while also recording the provisioning
+	// link for ops auditing.
+	labels := pulumi.StringMap{
+		"project":     pulumi.String("kaizen"),
+		"environment": pulumi.String(kcfg.Environment),
+		"managed-by":  pulumi.String("pulumi"),
+	}
+	if inputs.PsaReservedRangeName != nil {
+		labels["psa-range"] = inputs.PsaReservedRangeName.ToStringOutput()
+	}
+
+	// --- Cloud SQL instance ---
+	instance, err := sql.NewDatabaseInstance(ctx, instanceName, &sql.DatabaseInstanceArgs{
+		Name:               pulumi.String(instanceName),
+		DatabaseVersion:    pulumi.String("POSTGRES_16"),
+		Region:             pulumi.String(region),
+		DeletionProtection: pulumi.Bool(deletionProtection),
+		Settings: &sql.DatabaseInstanceSettingsArgs{
+			Tier:                pulumi.String(tier),
+			AvailabilityType:    pulumi.String(availability),
+			DiskSize:            pulumi.Int(diskSize),
+			DiskType:            pulumi.String("PD_SSD"),
+			DiskAutoresize:      pulumi.Bool(true),
+			DiskAutoresizeLimit: pulumi.Int(diskAutoresizeLimit),
+			UserLabels:          labels,
+
+			IpConfiguration: &sql.DatabaseInstanceSettingsIpConfigurationArgs{
+				// Public IP disabled — the instance is only reachable via the
+				// VPC peering established by Private Service Access.
+				Ipv4Enabled:    pulumi.Bool(false),
+				PrivateNetwork: inputs.PrivateNetwork,
+			},
+
+			BackupConfiguration: &sql.DatabaseInstanceSettingsBackupConfigurationArgs{
+				Enabled:                     pulumi.Bool(true),
+				PointInTimeRecoveryEnabled:  pulumi.Bool(true),
+				StartTime:                   pulumi.String("03:00"),
+				TransactionLogRetentionDays: pulumi.Int(7),
+				BackupRetentionSettings: &sql.DatabaseInstanceSettingsBackupConfigurationBackupRetentionSettingsArgs{
+					RetainedBackups: pulumi.Int(7),
+					RetentionUnit:   pulumi.String("COUNT"),
+				},
+			},
+
+			MaintenanceWindow: &sql.DatabaseInstanceSettingsMaintenanceWindowArgs{
+				// Cloud SQL day-of-week is 1=Monday..7=Sunday. Sunday 05:00 UTC
+				// matches the RDS `sun:05:00-sun:06:00` maintenance window.
+				Day:         pulumi.Int(7),
+				Hour:        pulumi.Int(5),
+				UpdateTrack: pulumi.String("stable"),
+			},
+
+			DatabaseFlags: sql.DatabaseInstanceSettingsDatabaseFlagArray{
+				&sql.DatabaseInstanceSettingsDatabaseFlagArgs{
+					Name:  pulumi.String("cloud_sql.iam_authentication"),
+					Value: pulumi.String("on"),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating Cloud SQL instance: %w", err)
+	}
+
+	// --- Application database ---
+	// Matches the AWS RDS module's DbName: "kaizen".
+	if _, err = sql.NewDatabase(ctx, "kaizen-sql-db", &sql.DatabaseArgs{
+		Name:     pulumi.String("kaizen"),
+		Instance: instance.Name,
+	}); err != nil {
+		return nil, fmt.Errorf("creating Cloud SQL database: %w", err)
+	}
+
+	// Endpoint composition: Cloud SQL exposes PrivateIpAddress; combine with
+	// 5432 to produce the host:port shape the cross-cloud DatabaseOutputs
+	// contract requires.
+	endpoint := pulumi.Sprintf("%s:5432", instance.PrivateIpAddress)
+
+	return &CloudSQLOutputs{
+		Endpoint:   endpoint,
+		Port:       pulumi.Int(5432).ToIntOutput(),
+		InstanceId: instance.Name,
+		PrivateIp:  instance.PrivateIpAddress,
+	}, nil
+}

--- a/infra/pkg/gcp/gcp.go
+++ b/infra/pkg/gcp/gcp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kaizen-experimentation/infra/pkg/gcp/cache"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/cicd"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/compute"
+	"github.com/kaizen-experimentation/infra/pkg/gcp/database"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/network"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/storage"
 	"github.com/kaizen-experimentation/infra/pkg/types"
@@ -65,12 +66,25 @@ func NewNetwork(ctx *pulumi.Context, _ *kconfig.Config) (types.NetworkOutputs, e
 	ctx.Export("vpcConnectorId", connOut.ConnectorId)
 	ctx.Export("vpcConnectorSelfLink", connOut.ConnectorSelfLink)
 
+	// Private Service Access — VPC peering with Google's managed services
+	// tenant projects so Cloud SQL (#484) and Memorystore (#485) can be
+	// reached via private IPs. Provisioned here because PSA is VPC-scoped:
+	// one peering serves every Google-managed data store on the VPC.
+	psaOut, err := network.NewPrivateServiceAccess(ctx, &network.PrivateServiceAccessArgs{
+		NetworkId: vpcOut.NetworkId,
+	})
+	if err != nil {
+		return types.NetworkOutputs{}, err
+	}
+	ctx.Export("psaReservedRangeName", psaOut.ReservedRangeName)
+
 	return types.NetworkOutputs{
-		VpcId:              vpcOut.NetworkId,
-		PublicSubnetIds:    vpcOut.PublicSubnetIds,
-		PrivateSubnetIds:   vpcOut.PrivateSubnetIds,
-		SecurityGroupIds:   fwRes.Rules,
-		ServiceDiscoveryId: sdOut.NamespaceId,
+		VpcId:                    vpcOut.NetworkId,
+		PublicSubnetIds:          vpcOut.PublicSubnetIds,
+		PrivateSubnetIds:         vpcOut.PrivateSubnetIds,
+		SecurityGroupIds:         fwRes.Rules,
+		ServiceDiscoveryId:       sdOut.NamespaceId,
+		ReservedPeeringRangeName: psaOut.ReservedRangeName,
 		// Zero-valued on GCP per types.NetworkOutputs documentation:
 		// PrivateRouteTableIds — GCP routes implicitly via subnet definitions.
 		// S3VpcEndpointId — no S3 gateway endpoint analogue on GCP.
@@ -151,6 +165,29 @@ func NewCache(ctx *pulumi.Context, cfg *kconfig.Config, netOut types.NetworkOutp
 	}, nil
 }
 
+// NewDatabase creates the Cloud SQL for PostgreSQL instance and returns the
+// shared types.DatabaseOutputs (Endpoint as host:port, Port, InstanceId).
+// The instance is configured for parity with pkg/aws.NewDatabase: regional
+// HA in staging/prod, daily backups with PITR, 7-day retention, IAM-DB
+// authentication enabled, and reachable only via the VPC through Private
+// Service Access.
+func NewDatabase(ctx *pulumi.Context, cfg *kconfig.Config, netOut types.NetworkOutputs) (types.DatabaseOutputs, error) {
+	out, err := database.NewCloudSQL(ctx, cfg, &database.CloudSQLInputs{
+		PrivateNetwork:       netOut.VpcId.ToStringOutput(),
+		PsaReservedRangeName: netOut.ReservedPeeringRangeName,
+	})
+	if err != nil {
+		return types.DatabaseOutputs{}, err
+	}
+	ctx.Export("cloudSqlEndpoint", out.Endpoint)
+	ctx.Export("cloudSqlInstanceId", out.InstanceId)
+	return types.DatabaseOutputs{
+		Endpoint:   out.Endpoint,
+		Port:       out.Port,
+		InstanceId: out.InstanceId,
+	}, nil
+}
+
 // gcpLabels returns the standard label set for GCP resources. GCP label
 // values must match [a-z0-9_-]+, so we lowercase and substitute the AWS
 // tag values that don't fit. Kept private until a second module needs the
@@ -166,6 +203,7 @@ func gcpLabels(cfg *kconfig.Config) pulumi.StringMap {
 		"managed_by":  pulumi.String("pulumi"),
 	}
 }
+
 
 // ─── Stage 4: Streaming + Secrets + CICD ────────────────────────────────────
 

--- a/infra/pkg/gcp/network/private_service_access.go
+++ b/infra/pkg/gcp/network/private_service_access.go
@@ -94,8 +94,20 @@ func NewPrivateServiceAccess(ctx *pulumi.Context, args *PrivateServiceAccessArgs
 		return nil, err
 	}
 
+	// Derive ReservedRangeName from BOTH psaRange.Name AND conn.Peering so
+	// downstream consumers transitively wait for the Connection to finish
+	// establishing — not just the GlobalAddress. Without this, Cloud SQL /
+	// Memorystore instances that consume ReservedRangeName depend only on
+	// the GlobalAddress and Pulumi can schedule them before the VPC peering
+	// is ready, surfacing as opaque "network not authorized" errors at
+	// instance-creation time. The resolved value is identical (the range
+	// name string); pulumi.All purely extends the dependency graph.
+	rangeNameWithConnDep := pulumi.All(psaRange.Name, conn.Peering).ApplyT(func(args []interface{}) string {
+		return args[0].(string)
+	}).(pulumi.StringOutput)
+
 	return &PrivateServiceAccessOutputs{
-		ReservedRangeName: psaRange.Name,
+		ReservedRangeName: rangeNameWithConnDep,
 		ConnectionPeering: conn.Peering,
 	}, nil
 }

--- a/infra/pkg/gcp/network/private_service_access.go
+++ b/infra/pkg/gcp/network/private_service_access.go
@@ -1,0 +1,101 @@
+// Private Service Access (PSA) — the VPC peering that lets Cloud SQL,
+// Memorystore, and other Google-managed services be reachable via private
+// IPs inside the Kaizen VPC. PSA is a one-time, VPC-scoped concern: a single
+// peering serves every downstream consumer (#484 Cloud SQL, #485 Memorystore,
+// future managed services), so it lives in the network module rather than
+// being co-located with any one data store.
+//
+// Provisioning is two resources:
+//   1. A compute.GlobalAddress with purpose=VPC_PEERING — reserves an RFC1918
+//      range that Google's tenant projects will assign IPs from.
+//   2. A servicenetworking.Connection — establishes the peering with the
+//      servicenetworking.googleapis.com service.
+//
+// Operational note: servicenetworking.Connection is known to leave residue on
+// `pulumi destroy` because GCP's API does not always fully release the peering
+// state. Stack teardown procedures should run
+//   gcloud services vpc-peerings delete --service=servicenetworking.googleapis.com --network=<vpc>
+// after destroy if the connection lingers. This is a GCP-API quirk, not a
+// Pulumi bug.
+package network
+
+import (
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/compute"
+	"github.com/pulumi/pulumi-gcp/sdk/v8/go/gcp/servicenetworking"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+// PrivateServiceAccessArgs carries the network references needed to attach
+// the peering. NetworkId is the VPC self-link (from VpcOutputs.NetworkId).
+type PrivateServiceAccessArgs struct {
+	NetworkId pulumi.IDOutput
+}
+
+// PrivateServiceAccessOutputs exposes the reserved range name so downstream
+// modules (Cloud SQL) can pass it as `privateNetwork` to their service
+// instances. The Connection resource itself is not exported — consumers only
+// need to depend on it implicitly via the resource graph.
+type PrivateServiceAccessOutputs struct {
+	// ReservedRangeName is the bare name of the reserved IP range
+	// (e.g. "kaizen-psa-range"). Cloud SQL and Memorystore reference the
+	// range by name when binding to private IPs.
+	ReservedRangeName pulumi.StringOutput
+
+	// ConnectionPeering is the peering identifier
+	// (servicenetworking.googleapis.com). Exported for test introspection.
+	ConnectionPeering pulumi.StringOutput
+}
+
+// NewPrivateServiceAccess provisions the PSA peering. The reserved range is
+// /20 by default (1024 IPs) which leaves headroom for many managed-service
+// instances; override via `kaizen-experimentation:gcpPsaPrefixLength`.
+//
+// Network sequencing: this must be created before any Cloud SQL or Memorystore
+// instance binds to the VPC for private IP. The peering is a one-shot per
+// VPC — multiple invocations would error.
+func NewPrivateServiceAccess(ctx *pulumi.Context, args *PrivateServiceAccessArgs, opts ...pulumi.ResourceOption) (*PrivateServiceAccessOutputs, error) {
+	cfg := config.New(ctx, "kaizen-experimentation")
+
+	prefixLength := 20
+	if v, err := cfg.TryInt("gcpPsaPrefixLength"); err == nil {
+		prefixLength = v
+	}
+
+	// Reserved range. Address omitted → Google auto-allocates from the
+	// privately-owned RFC1918 space; pin via gcpPsaAddress only if you need
+	// a deterministic CIDR (e.g. for VPN advertisement).
+	rangeArgs := &compute.GlobalAddressArgs{
+		Name:         pulumi.String("kaizen-psa-range"),
+		Purpose:      pulumi.String("VPC_PEERING"),
+		AddressType:  pulumi.String("INTERNAL"),
+		PrefixLength: pulumi.Int(prefixLength),
+		Network:      args.NetworkId.ToStringOutput(),
+		Description:  pulumi.String("Kaizen — reserved range for Private Service Access (Cloud SQL, Memorystore)"),
+	}
+	if v := cfg.Get("gcpPsaAddress"); v != "" {
+		rangeArgs.Address = pulumi.String(v)
+	}
+
+	psaRange, err := compute.NewGlobalAddress(ctx, "kaizen-psa-range", rangeArgs, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// servicenetworking.Connection — the peering itself.
+	conn, err := servicenetworking.NewConnection(ctx, "kaizen-psa-connection", &servicenetworking.ConnectionArgs{
+		Network: args.NetworkId.ToStringOutput(),
+		Service: pulumi.String("servicenetworking.googleapis.com"),
+		ReservedPeeringRanges: pulumi.StringArray{
+			psaRange.Name,
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PrivateServiceAccessOutputs{
+		ReservedRangeName: psaRange.Name,
+		ConnectionPeering: conn.Peering,
+	}, nil
+}

--- a/infra/pkg/types/outputs.go
+++ b/infra/pkg/types/outputs.go
@@ -43,6 +43,16 @@ type NetworkOutputs struct {
 	// Kept as IDOutput because the storage module's bucket-policy ApplyT chain
 	// type-asserts the underlying value as pulumi.ID, not string.
 	S3VpcEndpointId pulumi.IDOutput
+
+	// ReservedPeeringRangeName is GCP-specific: the name of the reserved
+	// global address used for Private Service Access (VPC peering with
+	// Google's tenant projects for Cloud SQL, Memorystore, etc.). Zero-valued
+	// on AWS — RDS sits in the VPC directly via DB subnet group.
+	//
+	// Cloud SQL and Memorystore modules attach this as a resource label so
+	// Pulumi's output graph orders their creation after the PSA peering is
+	// live; the value itself is informational at the application layer.
+	ReservedPeeringRangeName pulumi.StringOutput
 }
 
 // DatabaseOutputs holds outputs from the relational database stage


### PR DESCRIPTION
## Summary

Provisions Cloud SQL for PostgreSQL 16 on GCP with parity to `pkg/aws/database/rds.go`: regional HA in staging/prod, daily backups with PITR, 7-day backup retention, IAM-DB authentication enabled, and private-IP only (reachable via VPC through Private Service Access).

Closes #484. Unblocks the remaining Phase 1 GCP work that depends on a relational store: #485 (Memorystore — reuses the same PSA peering), #486 (Cloud Run + Workload Identity — binds compute SAs to the IAM DB users), and the per-service deploy PRs (#488–#495) that read `databaseEndpoint` from stack output.

## What ships

- **`pkg/gcp/network/private_service_access.go`** — global address reservation + `servicenetworking.Connection`. PSA is VPC-scoped, so one peering serves Cloud SQL today and Memorystore (#485) when it lands. Lives in the network module (not coupled to database) per design decision documented in the module comment.
- **`pkg/gcp/database/database.go`** — Cloud SQL `DatabaseInstance` + `Database`, configured for cross-cloud parity. No built-in admin user is created; operators bootstrap via `gcloud sql connect` with IAM auth.
- **`pkg/gcp/gcp.go`** — `NewDatabase` facade matching `aws.NewDatabase` signature; returns `types.DatabaseOutputs` (`Endpoint`, `Port`, `InstanceId`).
- **`types.NetworkOutputs.ReservedPeeringRangeName`** — GCP-specific output, zero-valued on AWS. Used as a resource label on Cloud SQL so Pulumi orders DB provisioning after the PSA peering completes.
- **`main.go`** — `gcp` case added to Stage 3 (Data Stores) dispatch; early-return moved past Stage 3 so `pulumi preview --stack gcp-dev` exercises the new slice.
- **`database_topology_test.go`** — parameterized test asserting private-IP posture per provider on the Pulumi resource inputs (AWS: `publiclyAccessible!=true` + DB subnet group set; GCP: `ipv4Enabled=false` + `privateNetwork` populated; both PSA resources present).

## Parity table (AWS RDS → GCP Cloud SQL)

| Knob | AWS RDS | GCP Cloud SQL |
|---|---|---|
| Engine | postgres 16 | `POSTGRES_16` |
| dev sizing | `db.t4g.medium` | `db-custom-2-4096` (2 vCPU / 4 GB) |
| staging/prod sizing | `db.r6g.large` | `db-custom-4-16384` (4 vCPU / 16 GB) |
| HA | `MultiAz: true` (staging+prod) | `availability_type: REGIONAL` |
| Backup retention | 7 days | `retained_backups=7` + 7d transaction log |
| PITR | implicit via 7-day retention | `point_in_time_recovery_enabled: true` |
| Backup window | 03:00-04:00 UTC | `start_time: "03:00"` |
| Maintenance window | `sun:05:00-sun:06:00` | day=7 (Sunday), hour=5, `update_track: stable` |
| Deletion guard | prod only | prod only |
| Storage | `gp3`, 100 GB, autogrow to 500 GB | `PD_SSD`, 100 GB, autoresize to 500 GB |
| Encryption | `storage_encrypted: true` | Google-managed CMEK (default) |
| Auth | password in Secrets Manager (managed) | `cloud_sql.iam_authentication=on` flag |

## Test plan

- [x] Build: `go build ./...` — green
- [x] Topology test (RED → GREEN): `go test -run TestDatabaseTopologyParameterized -v .` passes for both `aws` and `gcp` arms
- [x] GCP fullstack tests: `TestFullStackDeploy_GCP`, `TestFullStackResourceCounts_GCP`, `TestFullStackDeploy_GCP_RejectsMissingProject` all pass — these are the unit-level proxy for `pulumi preview --stack gcp-dev`
- [x] Existing `TestNetworkTopologyParameterized` still passes — no regression to the AWS/GCP network contract
- [ ] CI `pulumi preview --stack gcp-dev` (CI-only; not runnable locally — Pulumi CLI not installed in the worker environment)

## Notes / known issues

- **Pre-existing AWS test failure observed:** `TestFullStackDeploy`, `TestFullStackResourceCounts`, `TestFullStackExports` panic in `pkg/aws/storage/s3.go:310` (`interface conversion: interface {} is pulumi.ID, not string`). This reproduces on `main` with these changes stashed — it is **not** a regression from this PR. Should be addressed in a separate issue.
- **`servicenetworking.Connection` cleanup:** Known GCP-API quirk leaves the peering behind after `pulumi destroy`. Manual cleanup via `gcloud services vpc-peerings delete` is documented in the module docstring.
- **Password-based admin user is intentionally absent.** Bootstrap is IAM-only. The `DatabaseSecret` placeholder in `pkg/gcp/secrets/secrets.go` keeps the `"CHANGE_ME"` value until #486 adds the SA→DB user bindings.
- **PSA reserved range:** Default `/20` (1024 IPs); override via `kaizen-experimentation:gcpPsaPrefixLength`. Address auto-allocated by Google unless `kaizen-experimentation:gcpPsaAddress` is set.

## Follow-up opportunities (NOT in this PR)

- Fix the AWS fullstack panic in `pkg/aws/storage/s3.go:310` — file as a separate bug.
- Wire `pkg/gcp/secrets/secrets.go` `DatabaseSecret` placeholder to a real SA-bound IAM DB user once compute (#486) lands.
- Consider CMEK opt-in for Cloud SQL disk encryption.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->