### PR TITLE
Phase 1: Deploy M2-Orch to Cloud Run on GCP (Closes #490)

### DIFF
--- a/infra/fullstack_gcp_test.go
+++ b/infra/fullstack_gcp_test.go
@@ -103,6 +103,77 @@ func (m *gcpFullstackMocks) NewResource(args pulumi.MockResourceArgs) (string, r
 			"projects/test/locations/us-central1/namespaces/kaizen/services/" + args.Name)
 	case "gcp:servicedirectory/endpoint:Endpoint":
 		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/instanceTemplate:InstanceTemplate":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/instanceTemplates/" + args.Name)
+	case "gcp:compute/healthCheck:HealthCheck":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/healthChecks/" + args.Name)
+	case "gcp:compute/address:Address":
+		outputs["address"] = resource.NewStringProperty("10.0.16.20")
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/addresses/" + args.Name)
+
+	// --- Stage 4 streaming: Redpanda Cloud (TF-bridge type tokens) ---
+	// Mirrors infra/test/testutil_test.go so the Stage 4 arm now wired into
+	// the GCP path (#490) resolves bootstrap brokers + schema registry.
+	case "redpanda:index/resourceGroup:ResourceGroup":
+		outputs["id"] = resource.NewStringProperty("rg_" + args.Name)
+	case "redpanda:index/network:Network":
+		outputs["id"] = resource.NewStringProperty("net_" + args.Name)
+	case "redpanda:index/cluster:Cluster":
+		outputs["bootstrapBrokers"] = resource.NewStringProperty(
+			"seed-0." + args.Name + ".fmc.prd.cloud.redpanda.com:9092," +
+				"seed-1." + args.Name + ".fmc.prd.cloud.redpanda.com:9092")
+		outputs["schemaRegistryUrl"] = resource.NewStringProperty(
+			"https://schema-registry-" + args.Name + ".fmc.prd.cloud.redpanda.com:30081")
+		outputs["clusterApiUrl"] = resource.NewStringProperty(
+			"https://api-" + args.Name + ".fmc.prd.cloud.redpanda.com:9644")
+	case "redpanda:index/user:User",
+		"redpanda:index/acl:Acl",
+		"pulumi:providers:kafka",
+		"kafka:index/topic:Topic":
+		// Inputs already copied to outputs; no extra computed fields needed.
+
+	// --- Stage 4 secrets: Secret Manager ---
+	case "gcp:secretmanager/secret:Secret":
+		secretID := args.Name
+		if v, ok := args.Inputs["secretId"]; ok && v.HasValue() {
+			secretID = v.StringValue()
+		}
+		outputs["name"] = resource.NewStringProperty(
+			"projects/kaizen-experimentation-dev/secrets/" + secretID)
+		outputs["secretId"] = resource.NewStringProperty(secretID)
+	case "gcp:secretmanager/secretVersion:SecretVersion",
+		"gcp:secretmanager/secretIamMember:SecretIamMember":
+		// Default copy is sufficient (no computed fields read downstream).
+
+	// --- Stage 5 compute: per-service Cloud Run runtime identity + service ---
+	case "gcp:serviceaccount/account:Account":
+		accountID := ""
+		if v, ok := args.Inputs["accountId"]; ok && v.HasValue() {
+			accountID = v.StringValue()
+		}
+		project := ""
+		if v, ok := args.Inputs["project"]; ok && v.HasValue() {
+			project = v.StringValue()
+		}
+		email := accountID + "@" + project + ".iam.gserviceaccount.com"
+		outputs["email"] = resource.NewStringProperty(email)
+		outputs["name"] = resource.NewStringProperty(
+			"projects/" + project + "/serviceAccounts/" + email)
+		outputs["uniqueId"] = resource.NewStringProperty("100000000000000000001")
+	case "gcp:cloudrunv2/service:Service":
+		name := args.Name
+		if v, ok := args.Inputs["name"]; ok && v.HasValue() {
+			name = v.StringValue()
+		}
+		region := "us-central1"
+		if v, ok := args.Inputs["location"]; ok && v.HasValue() {
+			region = v.StringValue()
+		}
+		outputs["uri"] = resource.NewStringProperty(
+			"https://" + name + "-mock-" + region + ".a.run.app")
 	}
 	return id, outputs, nil
 }
@@ -124,7 +195,11 @@ func (m *gcpFullstackMocks) byType(t string) []fsResource {
 }
 
 // gcpFullstackConfig sets the minimal stack config that Pulumi.gcp-dev.yaml
-// declares plus a CI push principal so the IAM bindings get exercised.
+// declares plus a CI push principal so the IAM bindings get exercised. The
+// redpanda:* keys mirror Pulumi.gcp-dev.yaml so the Stage 4 streaming arm
+// (now wired into the GCP path by #490) reads valid config; kafkaPassword is
+// supplied as a plain value because RequireSecret reads test config the same
+// way Require does.
 func gcpFullstackConfig() pulumi.RunOption {
 	return func(info *pulumi.RunInfo) {
 		info.Config = map[string]string{
@@ -132,11 +207,20 @@ func gcpFullstackConfig() pulumi.RunOption {
 			"gcp:region":                                  "us-central1",
 			"kaizen-experimentation:environment":          "dev",
 			"kaizen-experimentation:cloudProvider":        "gcp",
+			"kaizen-experimentation:streamingProvider":    "redpanda",
 			"kaizen-experimentation:gcpProjectId":         "kaizen-experimentation-dev",
 			"kaizen-experimentation:gcpRegion":            "us-central1",
 			"kaizen-experimentation:gcpArLocation":        "us",
 			"kaizen-experimentation:gcpCiPushPrincipal":   "serviceAccount:ci@kaizen-experimentation-dev.iam.gserviceaccount.com",
 			"kaizen-experimentation:gcpRunPullPrincipals": "serviceAccount:run@kaizen-experimentation-dev.iam.gserviceaccount.com",
+			"redpanda:cloudProvider":                      "gcp",
+			"redpanda:region":                             "us-central1",
+			"redpanda:zones":                              "us-central1-a,us-central1-b,us-central1-c",
+			"redpanda:throughputTier":                     "tier-1-gcp-v2",
+			"redpanda:clusterType":                        "dedicated",
+			"redpanda:connectionType":                     "private",
+			"redpanda:kafkaUsername":                      "kaizen-redpanda-user",
+			"redpanda:kafkaPassword":                      "test-kafka-password",
 		}
 	}
 }

--- a/infra/fullstack_gcp_test.go
+++ b/infra/fullstack_gcp_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -276,19 +277,35 @@ func TestFullStackResourceCounts_GCP(t *testing.T) {
 // TestFullStackDeploy_GCP_RejectsMissingProject ensures Deploy() fails fast
 // when the GCP project is not configured. Without this guard, AR would 400
 // at apply time and waste an apply cycle.
+//
+// The config includes streamingProvider=redpanda (+ the minimum Redpanda
+// keys Stage 4a needs) so the streaming stage passes and Deploy() actually
+// reaches the gcpProjectId check in gcp.NewCICD (Stage 4c). Without these
+// keys the streaming switch rejects "msk" first, masking the real
+// validation this test is meant to pin.
 func TestFullStackDeploy_GCP_RejectsMissingProject(t *testing.T) {
 	mocks := &gcpFullstackMocks{}
 	err := pulumi.RunErr(Deploy,
 		pulumi.WithMocks("kaizen", "dev", mocks),
 		func(info *pulumi.RunInfo) {
 			info.Config = map[string]string{
-				"kaizen-experimentation:environment":   "dev",
-				"kaizen-experimentation:cloudProvider": "gcp",
-				// no gcpProjectId
+				"kaizen-experimentation:environment":       "dev",
+				"kaizen-experimentation:cloudProvider":     "gcp",
+				"kaizen-experimentation:streamingProvider": "redpanda",
+				// Minimum Redpanda keys so Stage 4a (streaming) passes.
+				"redpanda:region":         "us-central1",
+				"redpanda:zones":          "us-central1-a,us-central1-b,us-central1-c",
+				"redpanda:throughputTier": "tier-1-gcp-v2",
+				"redpanda:kafkaUsername":  "kaizen-redpanda-user",
+				"redpanda:kafkaPassword":  "test-kafka-password",
+				// no gcpProjectId — this is what we are testing
 			}
 		},
 	)
 	if err == nil {
 		t.Fatal("expected error for missing gcpProjectId, got nil")
+	}
+	if !strings.Contains(err.Error(), "gcpProjectId") && !strings.Contains(err.Error(), "GCPProjectID") {
+		t.Fatalf("expected gcpProjectId validation error, got: %v", err)
 	}
 }

--- a/infra/m4b_topology_test.go
+++ b/infra/m4b_topology_test.go
@@ -362,7 +362,9 @@ func TestM4bGcpComputeFacade(t *testing.T) {
 	if got := len(mocks.byType("gcp:compute/disk:Disk")); got != 1 {
 		t.Errorf("expected 1 standalone Disk from Deploy(gcp), got %d", got)
 	}
-	if got := len(mocks.byType("gcp:servicedirectory/service:Service")); got != 1 {
-		t.Errorf("expected 1 SD Service from Deploy(gcp), got %d", got)
+	// M4b + canary + M2-Orch: each Cloud Run service also registers an SD
+	// service via the factory, so the total is 3 (1 M4b + 2 Cloud Run).
+	if got := len(mocks.byType("gcp:servicedirectory/service:Service")); got != 3 {
+		t.Errorf("expected 3 SD Services from Deploy(gcp) (M4b + canary + M2-Orch), got %d", got)
 	}
 }

--- a/infra/m4b_topology_test.go
+++ b/infra/m4b_topology_test.go
@@ -362,8 +362,11 @@ func TestM4bGcpComputeFacade(t *testing.T) {
 	if got := len(mocks.byType("gcp:compute/disk:Disk")); got != 1 {
 		t.Errorf("expected 1 standalone Disk from Deploy(gcp), got %d", got)
 	}
-	// M4b + canary + M2-Orch: each Cloud Run service also registers an SD
-	// service via the factory, so the total is 3 (1 M4b + 2 Cloud Run).
+	// Deploy(gcp) registers one Service Directory entry per Cloud Run
+	// service plus one for M4b: M4b's own SD service from
+	// compute.NewM4bInstance, the Cloud Run canary from #486
+	// (gcp.NewCompute), and M2-Orch from #490 (compute.NewCloudRunService).
+	// Each per-service Cloud Run deploy (#488..#495) adds one as it lands.
 	if got := len(mocks.byType("gcp:servicedirectory/service:Service")); got != 3 {
 		t.Errorf("expected 3 SD Services from Deploy(gcp) (M4b + canary + M2-Orch), got %d", got)
 	}

--- a/infra/main.go
+++ b/infra/main.go
@@ -133,8 +133,14 @@ func Deploy(ctx *pulumi.Context) error {
 		case "redpanda":
 			gcpStreamOut, err = cloudstreaming.NewRedpanda(ctx, cfg, netOut)
 		default:
+			// streamingProvider defaults to "msk" when unset (see
+			// pkg/config/config.go), so a GCP stack with the key omitted will
+			// land here. Spell out the remedy so operators don't have to
+			// chase the default through config code.
 			return fmt.Errorf(
-				"cloudProvider=gcp requires streamingProvider=redpanda (got %q)",
+				"cloudProvider=gcp requires streamingProvider=redpanda (got %q — "+
+					"MSK is AWS-only; set explicitly with "+
+					"`pulumi config set kaizen-experimentation:streamingProvider redpanda`)",
 				cfg.StreamingProvider)
 		}
 		if err != nil {

--- a/infra/main.go
+++ b/infra/main.go
@@ -113,6 +113,17 @@ func Deploy(ctx *pulumi.Context) error {
 	// PR moves this early-return marker further down Deploy() and removes it
 	// entirely once all stages (incl. edge) are wired.
 	if cfg.CloudProvider == "gcp" {
+		// Required-config gate. Validated upfront so the fail-fast behavior
+		// (and `TestFullStackDeploy_GCP_RejectsMissingProject`) is preserved
+		// regardless of where each downstream stage's own config check lives
+		// — without this, the streaming stage below would shadow the
+		// gcp.NewCICD check by erroring on the default streamingProvider=msk.
+		if cfg.GCPProjectID == "" {
+			return fmt.Errorf(
+				"cloudProvider=gcp requires kaizen-experimentation:gcpProjectId " +
+					"(set via `pulumi config set kaizen-experimentation:gcpProjectId <ID>`)")
+		}
+
 		// ── Stage 4a: Streaming ──────────────────────────────────────────
 		// GCP tenants use Redpanda Cloud (cloud-agnostic module, gated on
 		// streamingProvider). MSK is AWS-only, so reject any other value

--- a/infra/main.go
+++ b/infra/main.go
@@ -99,18 +99,44 @@ func Deploy(ctx *pulumi.Context) error {
 	}
 
 	// =====================================================================
-	// GCP early return — Phase 1 storage + cache + database + cicd + M4b + Cloud Run compute slice
+	// GCP early return — Phase 1 storage + cache + database + streaming +
+	// secrets + cicd + M4b + Cloud Run compute slice
 	// =====================================================================
-	// Stage 4 (streaming + secrets), Stage 5 per-service stateless Cloud Run
-	// deploys, and Stage 6 (edge) are AWS-only today. GCP arms for those
-	// stages land in subsequent Phase 1 PRs. Until they do, we run every GCP
-	// stage that's already wired (network, storage, cache, database above;
-	// cicd + compute below — the latter covering both M4b stateful (issue
-	// #487) and the Cloud Run service factory + canary (issue #486)) and
-	// return cleanly so `pulumi preview --stack gcp-dev` succeeds.
-	// Each subsequent Phase 1 PR moves this early-return marker further down
-	// Deploy() and removes it entirely once all stages are wired.
+	// Stage 4 (streaming + secrets) is now wired for GCP: the per-service
+	// Cloud Run deploys (#488..#495) need Redpanda bootstrap brokers + Secret
+	// Manager refs threaded into compute. Stage 6 (edge) remains AWS-only
+	// today. We run every wired GCP stage (network, storage, cache, database
+	// above; streaming + secrets + cicd + compute below — compute covering
+	// M4b stateful (#487), the Cloud Run factory + canary (#486), and the
+	// per-service deploys as they land, M2-Orch via #490) and return cleanly
+	// so `pulumi preview --stack gcp-dev` succeeds. Each subsequent Phase 1
+	// PR moves this early-return marker further down Deploy() and removes it
+	// entirely once all stages (incl. edge) are wired.
 	if cfg.CloudProvider == "gcp" {
+		// ── Stage 4a: Streaming ──────────────────────────────────────────
+		// GCP tenants use Redpanda Cloud (cloud-agnostic module, gated on
+		// streamingProvider). MSK is AWS-only, so reject any other value
+		// loudly rather than silently shipping a brokerless stack.
+		var gcpStreamOut types.StreamingOutputs
+		switch cfg.StreamingProvider {
+		case "redpanda":
+			gcpStreamOut, err = cloudstreaming.NewRedpanda(ctx, cfg, netOut)
+		default:
+			return fmt.Errorf(
+				"cloudProvider=gcp requires streamingProvider=redpanda (got %q)",
+				cfg.StreamingProvider)
+		}
+		if err != nil {
+			return err
+		}
+
+		// ── Stage 4b: Secrets ────────────────────────────────────────────
+		gcpSecretsOut, err := gcp.NewSecrets(ctx, cfg, dbOut, gcpStreamOut, cacheOut)
+		if err != nil {
+			return err
+		}
+
+		// ── Stage 4c: CICD ───────────────────────────────────────────────
 		cicdOut, err := gcp.NewCICD(ctx, cfg)
 		if err != nil {
 			return err
@@ -118,15 +144,17 @@ func Deploy(ctx *pulumi.Context) error {
 		if url, ok := cicdOut.RepositoryURLs["assignment"]; ok {
 			ctx.Export("cicdAssignmentRepositoryUrl", url)
 		}
-		// gcp.NewCompute provisions both the stateful M4b slice (issue #487)
-		// and the Cloud Run service factory + canary (issue #486). Per-service
-		// stateless Cloud Run deploys (M1, M2, ..., M7) land in follow-up
-		// issues #488..#495; when they do, this NewCompute call grows to wire
-		// them in too and the early-return marker moves below the edge stage.
-		gcpComputeOut, err := gcp.NewCompute(ctx, cfg, netOut)
+
+		// ── Stage 5: Compute ─────────────────────────────────────────────
+		// gcp.NewCompute provisions the stateful M4b slice (#487), the Cloud
+		// Run service factory + canary (#486), and the per-service stateless
+		// Cloud Run deploys as they land — M2 Orchestration via #490. Sibling
+		// services (#488, #489, #491..#495) extend the same call.
+		gcpComputeOut, err := gcp.NewCompute(ctx, cfg, netOut, cicdOut, dbOut, gcpStreamOut, gcpSecretsOut)
 		if err != nil {
 			return err
 		}
+		ctx.Export("streamingBootstrapBrokers", gcpStreamOut.BootstrapBrokers)
 		ctx.Export("m4bAsgName", gcpComputeOut.M4bAsgName)
 		ctx.Export("m4bInstanceId", gcpComputeOut.M4bInstanceId)
 		ctx.Export("m4bEndpointAddress", gcpComputeOut.M4bEndpoint)

--- a/infra/pkg/gcp/gcp.go
+++ b/infra/pkg/gcp/gcp.go
@@ -258,6 +258,12 @@ func NewSecrets(
 	}
 	ctx.Export("secretManagerDatabaseName", out.DatabaseSecretName)
 	ctx.Export("secretManagerKafkaName", out.KafkaSecretName)
+	// *SecretName → *SecretRef is intentional, not a mapping bug: the GCP
+	// "native reference" for the SecretsOutputs contract is the bare
+	// `projects/<P>/secrets/<S>` path that Cloud Run's secretKeyRef.secret
+	// and Secret Manager IAM bindings consume, NOT the version-qualified
+	// `/versions/latest` accessor path. See the function preamble and
+	// types.SecretsOutputs docs for the full contract.
 	return types.SecretsOutputs{
 		DatabaseSecretRef: out.DatabaseSecretName,
 		KafkaSecretRef:    out.KafkaSecretName,

--- a/infra/pkg/gcp/gcp.go
+++ b/infra/pkg/gcp/gcp.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kaizen-experimentation/infra/pkg/gcp/compute"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/database"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/network"
+	"github.com/kaizen-experimentation/infra/pkg/gcp/secrets"
 	"github.com/kaizen-experimentation/infra/pkg/gcp/storage"
 	"github.com/kaizen-experimentation/infra/pkg/types"
 )
@@ -189,6 +190,22 @@ func NewDatabase(ctx *pulumi.Context, cfg *kconfig.Config, netOut types.NetworkO
 	}, nil
 }
 
+// serviceImage resolves a Kaizen service's container image reference from the
+// CICD stage's Artifact Registry repository map and pins the :latest tag.
+// Returns an error (fail-fast at program-build time) when the registry key is
+// absent, rather than letting Cloud Run surface an opaque image-pull failure
+// at apply. registryKey is the pkg/gcp/cicd repository key (e.g.
+// "orchestration"), NOT the ServiceEndpoints map key.
+func serviceImage(cicdOut types.CICDOutputs, registryKey string) (pulumi.StringInput, error) {
+	repoURL, ok := cicdOut.RepositoryURLs[registryKey]
+	if !ok {
+		return nil, fmt.Errorf(
+			"gcp.NewCompute: CICDOutputs.RepositoryURLs missing key %q (Artifact Registry repo not provisioned by gcp.NewCICD)",
+			registryKey)
+	}
+	return pulumi.Sprintf("%s:latest", repoURL), nil
+}
+
 // gcpLabels returns the standard label set for GCP resources. GCP label
 // values must match [a-z0-9_-]+, so we lowercase and substitute the AWS
 // tag values that don't fit. Kept private until a second module needs the
@@ -205,8 +222,49 @@ func gcpLabels(cfg *kconfig.Config) pulumi.StringMap {
 	}
 }
 
-
 // ─── Stage 4: Streaming + Secrets + CICD ────────────────────────────────────
+
+// NewSecrets provisions the four GCP Secret Manager secrets (database, kafka,
+// redis, auth) and narrows pkg/gcp/secrets' richer output to the cross-cloud
+// types.SecretsOutputs contract. It mirrors pkg/aws.NewSecrets so Deploy()
+// composes either provider identically.
+//
+// Inputs flow lazily through Pulumi outputs from the upstream Stage 3
+// (database, cache) and Stage 4 (streaming) modules:
+//   - dbOut.Endpoint        → DatabaseSecret.Host
+//   - streamOut.BootstrapBrokers → KafkaSecret.BootstrapBrokers
+//   - cacheOut.Endpoint     → RedisSecret.Endpoint
+//
+// Contract note: types.SecretsOutputs.*SecretRef is documented as the native
+// reference — on GCP that is the bare "projects/<P>/secrets/<S>" resource
+// name (NOT the version-qualified accessor path). That is exactly what Cloud
+// Run's container env secretKeyRef.secret and Secret Manager IAM bindings
+// expect, with the version supplied separately ("latest"). We therefore map
+// the secrets module's *SecretName (bare path) onto *SecretRef here.
+func NewSecrets(
+	ctx *pulumi.Context,
+	cfg *kconfig.Config,
+	dbOut types.DatabaseOutputs,
+	streamOut types.StreamingOutputs,
+	cacheOut types.CacheOutputs,
+) (types.SecretsOutputs, error) {
+	out, err := secrets.NewSecrets(ctx, cfg, &secrets.SecretsInputs{
+		CloudSqlEndpoint:      dbOut.Endpoint,
+		KafkaBootstrapBrokers: streamOut.BootstrapBrokers,
+		RedisEndpoint:         cacheOut.Endpoint,
+	})
+	if err != nil {
+		return types.SecretsOutputs{}, err
+	}
+	ctx.Export("secretManagerDatabaseName", out.DatabaseSecretName)
+	ctx.Export("secretManagerKafkaName", out.KafkaSecretName)
+	return types.SecretsOutputs{
+		DatabaseSecretRef: out.DatabaseSecretName,
+		KafkaSecretRef:    out.KafkaSecretName,
+		RedisSecretRef:    out.RedisSecretName,
+		AuthSecretRef:     out.AuthSecretName,
+	}, nil
+}
 
 // NewCICD provisions Artifact Registry repositories for all Kaizen services.
 // Returns the same shared types.CICDOutputs shape as pkg/aws.NewCICD so the
@@ -253,11 +311,11 @@ func NewCICD(ctx *pulumi.Context, cfg *kconfig.Config) (types.CICDOutputs, error
 // ─── Stage 5: Compute (M4b stateful + Cloud Run service factory) ───────────
 
 // NewCompute provisions the GCP compute layer for Phase 1: the stateful
-// M4b Policy slice on GCE + persistent disk + autohealing MIG (issue #487)
-// AND the reusable Cloud Run service factory exercised with a single
-// trivial canary service so `pulumi preview --stack gcp-dev` succeeds end-to-end
-// (issue #486). Per-Kaizen-service Cloud Run deploys (M1, M2, ..., M7) land
-// in follow-up issues #488..#495.
+// M4b Policy slice on GCE + persistent disk + autohealing MIG (issue #487),
+// the reusable Cloud Run service factory + a trivial canary so
+// `pulumi preview --stack gcp-dev` succeeds end-to-end (issue #486), and the
+// per-Kaizen-service Cloud Run deploys as they land (issues #488..#495).
+// This PR wires M2 Orchestration (issue #490).
 //
 // The M4b slice consumes:
 //   - The private subnet self-link (held in NetworkOutputs.PrivateSubnetIds[0])
@@ -266,16 +324,30 @@ func NewCICD(ctx *pulumi.Context, cfg *kconfig.Config) (types.CICDOutputs, error
 //     NetworkOutputs.ServiceDiscoveryId — see types.NetworkOutputs doc) so
 //     m4b-policy registers under kaizen-local.
 //
-// The Cloud Run canary uses Google's public hello-world image so this slice
-// neither blocks on Artifact Registry image builds (#482 already shipped the
-// registry, but no images have been built yet) nor leaks unrelated service
-// spec. Per-service issues replace the image with the matching Artifact
-// Registry URL from CICDOutputs.RepositoryURLs.
+// The stateless Cloud Run services consume:
+//   - cicdOut.RepositoryURLs[<registry key>] for the container image.
+//   - dbOut.Endpoint / streamOut.BootstrapBrokers as literal env vars so the
+//     service can dial Cloud SQL (through the VPC connector) and Redpanda.
+//   - secretsOut.*SecretRef for Secret Manager-backed env vars; the factory
+//     auto-creates the matching roles/secretmanager.secretAccessor bindings.
 //
-// Returns types.ComputeOutputs with both M4b fields AND ServiceEndpoints
-// populated for the canary. ClusterId is zero-valued — Cloud Run is
-// serverless and M4b is a single instance, not an orchestrator cluster.
-func NewCompute(ctx *pulumi.Context, cfg *kconfig.Config, netOut types.NetworkOutputs) (types.ComputeOutputs, error) {
+// The Cloud Run canary uses Google's public hello-world image so the slice
+// never blocks on a real Kaizen image build. It is retained until all of
+// #488..#495 land, at which point it can be retired.
+//
+// Returns types.ComputeOutputs with M4b fields AND ServiceEndpoints populated
+// for every Cloud Run service (canary + per-service). ClusterId is
+// zero-valued — Cloud Run is serverless and M4b is a single instance, not an
+// orchestrator cluster.
+func NewCompute(
+	ctx *pulumi.Context,
+	cfg *kconfig.Config,
+	netOut types.NetworkOutputs,
+	cicdOut types.CICDOutputs,
+	dbOut types.DatabaseOutputs,
+	streamOut types.StreamingOutputs,
+	secretsOut types.SecretsOutputs,
+) (types.ComputeOutputs, error) {
 	region := cfg.GCPRegion
 	if region == "" {
 		region = "us-central1"
@@ -352,6 +424,54 @@ func NewCompute(ctx *pulumi.Context, cfg *kconfig.Config, netOut types.NetworkOu
 
 	ctx.Export("gcpComputeCanaryUrl", canary.URL)
 	ctx.Export("gcpComputeCanarySaEmail", canary.ServiceAccountEmail)
+
+	// ─── M2 Orchestration (issue #490) ────────────────────────────────────
+	// Stateless coordinator. Needs Cloud SQL for orchestration state and
+	// Redpanda for event flow. Service name "m2-orchestration" (matches the
+	// AWS Cloud Map name + the dev-m2-orchestration-run SA convention); the
+	// ServiceEndpoints map key is "m2-orch" (matches the AWS service key and
+	// the #490 acceptance criterion). Default min-instances (0) — the spec's
+	// Compute Model marks M2-Orch a stateless orchestrator, NOT an M1/M7
+	// cold-start-sensitive service.
+	m2OrchImage, err := serviceImage(cicdOut, "orchestration")
+	if err != nil {
+		return types.ComputeOutputs{}, err
+	}
+	m2Orch, err := compute.NewCloudRunService(ctx, cfg, cloudRunInputs, "m2-orchestration",
+		&compute.Options{
+			Image:         m2OrchImage,
+			ContainerPort: 50058,
+			MinInstances:  0,
+			EnvVars: []compute.EnvVar{
+				{Name: "ENVIRONMENT", Value: pulumi.String(cfg.Environment)},
+				{Name: "LOG_LEVEL", Value: pulumi.String("info")},
+				// Cloud SQL host:port — reachable from the container only
+				// through the Serverless VPC Access connector wired by the
+				// factory (acceptance criterion #3).
+				{Name: "DATABASE_ENDPOINT", Value: dbOut.Endpoint},
+				// Redpanda Kafka-protocol bootstrap brokers for event flow.
+				{Name: "KAFKA_BOOTSTRAP_BROKERS", Value: streamOut.BootstrapBrokers},
+			},
+			Secrets: []compute.SecretEnv{
+				// secretsOut.*SecretRef is the bare projects/<P>/secrets/<S>
+				// path on GCP (see gcp.NewSecrets contract note); the factory
+				// grants roles/secretmanager.secretAccessor on each — i.e.
+				// "read DB creds, read Kafka creds".
+				{EnvName: "DATABASE_SECRET", SecretID: secretsOut.DatabaseSecretRef, Version: "latest"},
+				{EnvName: "KAFKA_SECRET", SecretID: secretsOut.KafkaSecretRef, Version: "latest"},
+			},
+			// Cloud SQL connection scope. The secret-accessor bindings above
+			// cover credential reads; this grants the IAM scope to open the
+			// connection itself.
+			ProjectRoles: []string{"roles/cloudsql.client"},
+		})
+	if err != nil {
+		return types.ComputeOutputs{}, err
+	}
+	endpoints["m2-orch"] = m2Orch.URL
+	arns["m2-orch"] = m2Orch.Service.ID().ToStringOutput()
+	ctx.Export("gcpComputeM2OrchUrl", m2Orch.URL)
+	ctx.Export("gcpComputeM2OrchSaEmail", m2Orch.ServiceAccountEmail)
 
 	return types.ComputeOutputs{
 		// ClusterId / ClusterName / ClusterArn intentionally zero-valued:

--- a/infra/test/gcp_m2orch_topology_test.go
+++ b/infra/test/gcp_m2orch_topology_test.go
@@ -119,9 +119,9 @@ func runM2OrchCompute(t *testing.T) (*computeMocks, map[string]string) {
 // findCloudRunService returns the recorded Cloud Run service whose `name`
 // input matches want, or nil.
 func findCloudRunService(mocks *computeMocks, want string) *recordedComputeResource {
-	for i, r := range mocks.byType("gcp:cloudrunv2/service:Service") {
+	svcs := mocks.byType("gcp:cloudrunv2/service:Service")
+	for i, r := range svcs {
 		if v, ok := r.Inputs["name"]; ok && v.HasValue() && v.StringValue() == want {
-			svcs := mocks.byType("gcp:cloudrunv2/service:Service")
 			return &svcs[i]
 		}
 	}

--- a/infra/test/gcp_m2orch_topology_test.go
+++ b/infra/test/gcp_m2orch_topology_test.go
@@ -1,0 +1,313 @@
+// Package test — contract/topology test for the M2 Orchestration (M2-Orch)
+// Cloud Run deploy on GCP (issue #490).
+//
+// Closes the acceptance criteria for #490:
+//
+//  1. M2-Orch Cloud Run service appears in
+//     ComputeOutputs.ServiceEndpoints["m2-orch"].
+//  2. M2-Orch health check returns 200 in a deployed dev stack — proxied
+//     here by asserting the Cloud Run service is created on the correct
+//     container port (50058) so the platform's built-in startup probe
+//     targets the right listener.
+//  3. M2-Orch can connect to Cloud SQL via the VPC connector — proxied by
+//     asserting (a) the service's revision template wires the Serverless
+//     VPC Access connector and (b) the runtime SA is granted
+//     roles/cloudsql.client + a secretAccessor binding on the DB secret.
+//
+// The factory runs under pulumi.WithMocks so no GCP credentials or network
+// calls are required. gcp.NewCompute is exercised directly with hand-built
+// upstream-stage outputs (network, cicd, database, streaming, secrets) so the
+// test pins the cross-module wiring contract without standing up the whole
+// Deploy() pipeline.
+package test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/gcp"
+	"github.com/kaizen-experimentation/infra/pkg/types"
+)
+
+// m2OrchUpstreams builds the five upstream-stage outputs gcp.NewCompute
+// consumes, with deterministic stand-in values so the recorded Cloud Run
+// resource has resolvable env vars and secret refs.
+func m2OrchUpstreams() (types.NetworkOutputs, types.CICDOutputs, types.DatabaseOutputs, types.StreamingOutputs, types.SecretsOutputs) {
+	netOut := types.NetworkOutputs{
+		PrivateSubnetIds: pulumi.ToStringArray([]string{
+			"projects/kaizen-experimentation-dev/regions/us-central1/subnetworks/kaizen-dev-private",
+		}).ToStringArrayOutput(),
+		ServiceDiscoveryId: pulumi.ID(
+			"projects/kaizen-experimentation-dev/locations/us-central1/namespaces/kaizen-local",
+		).ToIDOutput(),
+		VpcConnectorSelfLink: pulumi.String(
+			"projects/kaizen-experimentation-dev/locations/us-central1/connectors/kaizen-vpc-connector",
+		).ToStringOutput(),
+	}
+	cicdOut := types.CICDOutputs{
+		RepositoryURLs: map[string]pulumi.StringOutput{
+			"orchestration": pulumi.String(
+				"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/orchestration",
+			).ToStringOutput(),
+		},
+	}
+	dbOut := types.DatabaseOutputs{
+		Endpoint: pulumi.String("10.99.0.3:5432").ToStringOutput(),
+		Port:     pulumi.Int(5432).ToIntOutput(),
+	}
+	streamOut := types.StreamingOutputs{
+		BootstrapBrokers: pulumi.String(
+			"seed-0.kaizen-dev.fmc.prd.cloud.redpanda.com:9092",
+		).ToStringOutput(),
+	}
+	secretsOut := types.SecretsOutputs{
+		DatabaseSecretRef: pulumi.String(
+			"projects/kaizen-experimentation-dev/secrets/kaizen-dev-database",
+		).ToStringOutput(),
+		KafkaSecretRef: pulumi.String(
+			"projects/kaizen-experimentation-dev/secrets/kaizen-dev-kafka",
+		).ToStringOutput(),
+		RedisSecretRef: pulumi.String(
+			"projects/kaizen-experimentation-dev/secrets/kaizen-dev-redis",
+		).ToStringOutput(),
+		AuthSecretRef: pulumi.String(
+			"projects/kaizen-experimentation-dev/secrets/kaizen-dev-auth",
+		).ToStringOutput(),
+	}
+	return netOut, cicdOut, dbOut, streamOut, secretsOut
+}
+
+// runM2OrchCompute exercises gcp.NewCompute under mocks and returns the
+// recorded resources plus the resolved ServiceEndpoints map.
+func runM2OrchCompute(t *testing.T) (*computeMocks, map[string]string) {
+	t.Helper()
+	mocks := &computeMocks{}
+	endpoints := map[string]string{}
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &kconfig.Config{
+			Project:      "kaizen",
+			Environment:  "dev",
+			Env:          kconfig.EnvDev,
+			GCPProjectID: "kaizen-experimentation-dev",
+			GCPRegion:    "us-central1",
+		}
+		netOut, cicdOut, dbOut, streamOut, secretsOut := m2OrchUpstreams()
+		out, err := gcp.NewCompute(ctx, cfg, netOut, cicdOut, dbOut, streamOut, secretsOut)
+		if err != nil {
+			return err
+		}
+		for name, url := range out.ServiceEndpoints {
+			name, url := name, url
+			url.ApplyT(func(s string) string {
+				mocks.mu.Lock()
+				endpoints[name] = s
+				mocks.mu.Unlock()
+				return s
+			})
+		}
+		return nil
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("gcp.NewCompute failed: %v", err)
+	}
+	return mocks, endpoints
+}
+
+// findCloudRunService returns the recorded Cloud Run service whose `name`
+// input matches want, or nil.
+func findCloudRunService(mocks *computeMocks, want string) *recordedComputeResource {
+	for i, r := range mocks.byType("gcp:cloudrunv2/service:Service") {
+		if v, ok := r.Inputs["name"]; ok && v.HasValue() && v.StringValue() == want {
+			svcs := mocks.byType("gcp:cloudrunv2/service:Service")
+			return &svcs[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// AC #1: M2-Orch appears in ComputeOutputs.ServiceEndpoints["m2-orch"]
+// ---------------------------------------------------------------------------
+
+func TestM2OrchInServiceEndpoints(t *testing.T) {
+	_, endpoints := runM2OrchCompute(t)
+
+	url, ok := endpoints["m2-orch"]
+	if !ok {
+		t.Fatalf("ServiceEndpoints missing key %q; got keys %v", "m2-orch", keysOf(endpoints))
+	}
+	if url == "" {
+		t.Errorf("ServiceEndpoints[\"m2-orch\"] resolved to empty string")
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// AC #2: Cloud Run service created on the M2-Orch container port (50058)
+// ---------------------------------------------------------------------------
+
+func TestM2OrchCloudRunServicePortAndName(t *testing.T) {
+	mocks, _ := runM2OrchCompute(t)
+
+	svc := findCloudRunService(mocks, "kaizen-dev-m2-orchestration")
+	if svc == nil {
+		t.Fatal("no Cloud Run service named kaizen-dev-m2-orchestration was registered")
+	}
+
+	tmpl := svc.Inputs["template"]
+	if !tmpl.IsObject() {
+		t.Fatal("Cloud Run service missing template")
+	}
+	containers := tmpl.ObjectValue()["containers"]
+	if !containers.IsArray() || len(containers.ArrayValue()) == 0 {
+		t.Fatal("Cloud Run template missing containers")
+	}
+	c0 := containers.ArrayValue()[0].ObjectValue()
+	ports := c0["ports"]
+	if !ports.IsObject() {
+		t.Fatal("container missing ports")
+	}
+	cp := ports.ObjectValue()["containerPort"]
+	if !cp.HasValue() || cp.NumberValue() != 50058 {
+		t.Errorf("containerPort = %v, want 50058", cp)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// In-scope env vars: DB endpoint + Redpanda bootstrap brokers
+// ---------------------------------------------------------------------------
+
+func TestM2OrchEnvVars(t *testing.T) {
+	mocks, _ := runM2OrchCompute(t)
+
+	svc := findCloudRunService(mocks, "kaizen-dev-m2-orchestration")
+	if svc == nil {
+		t.Fatal("no Cloud Run service named kaizen-dev-m2-orchestration was registered")
+	}
+	c0 := svc.Inputs["template"].ObjectValue()["containers"].ArrayValue()[0].ObjectValue()
+	envs := c0["envs"]
+	if !envs.IsArray() {
+		t.Fatal("container missing envs array")
+	}
+
+	literals := map[string]string{} // name -> literal value
+	secretEnvs := map[string]bool{} // name -> has secretKeyRef
+	for _, e := range envs.ArrayValue() {
+		eo := e.ObjectValue()
+		name := eo["name"].StringValue()
+		if v, ok := eo["value"]; ok && v.HasValue() {
+			literals[name] = v.StringValue()
+		}
+		if vs, ok := eo["valueSource"]; ok && vs.IsObject() {
+			if _, ok := vs.ObjectValue()["secretKeyRef"]; ok {
+				secretEnvs[name] = true
+			}
+		}
+	}
+
+	if got := literals["DATABASE_ENDPOINT"]; got != "10.99.0.3:5432" {
+		t.Errorf("DATABASE_ENDPOINT = %q, want %q", got, "10.99.0.3:5432")
+	}
+	if got := literals["KAFKA_BOOTSTRAP_BROKERS"]; got != "seed-0.kaizen-dev.fmc.prd.cloud.redpanda.com:9092" {
+		t.Errorf("KAFKA_BOOTSTRAP_BROKERS = %q, want the Redpanda bootstrap brokers", got)
+	}
+	if _, ok := literals["ENVIRONMENT"]; !ok {
+		t.Errorf("ENVIRONMENT env var missing")
+	}
+	if !secretEnvs["DATABASE_SECRET"] {
+		t.Errorf("DATABASE_SECRET secret env (secretKeyRef) missing")
+	}
+	if !secretEnvs["KAFKA_SECRET"] {
+		t.Errorf("KAFKA_SECRET secret env (secretKeyRef) missing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AC #3: VPC connector wired + DB/Kafka credential IAM on the M2-Orch SA
+// ---------------------------------------------------------------------------
+
+func TestM2OrchVpcConnectorWired(t *testing.T) {
+	mocks, _ := runM2OrchCompute(t)
+
+	svc := findCloudRunService(mocks, "kaizen-dev-m2-orchestration")
+	if svc == nil {
+		t.Fatal("no Cloud Run service named kaizen-dev-m2-orchestration was registered")
+	}
+	vpcAccess := svc.Inputs["template"].ObjectValue()["vpcAccess"]
+	if !vpcAccess.IsObject() {
+		t.Fatal("template.vpcAccess missing — M2-Orch could not reach Cloud SQL")
+	}
+	conn := vpcAccess.ObjectValue()["connector"]
+	want := "projects/kaizen-experimentation-dev/locations/us-central1/connectors/kaizen-vpc-connector"
+	if !conn.HasValue() || conn.StringValue() != want {
+		t.Errorf("vpcAccess.connector = %v, want %q", conn, want)
+	}
+}
+
+func TestM2OrchCloudSqlAndSecretIAM(t *testing.T) {
+	mocks, _ := runM2OrchCompute(t)
+
+	wantMember := "serviceAccount:dev-m2-orchestration-run@kaizen-experimentation-dev.iam.gserviceaccount.com"
+
+	// roles/cloudsql.client at project level — lets M2-Orch open a Cloud SQL
+	// connection through the VPC connector.
+	foundCloudSQL := false
+	for _, m := range mocks.byType("gcp:projects/iAMMember:IAMMember") {
+		role, _ := m.Inputs["role"]
+		member, _ := m.Inputs["member"]
+		if role.HasValue() && role.StringValue() == "roles/cloudsql.client" &&
+			member.HasValue() && member.StringValue() == wantMember {
+			foundCloudSQL = true
+		}
+	}
+	if !foundCloudSQL {
+		t.Errorf("missing roles/cloudsql.client IAMMember bound to the M2-Orch SA (%s)", wantMember)
+	}
+
+	// One secretAccessor binding per secret env (DB + Kafka) — "read DB
+	// creds, read Kafka creds".
+	secretBindings := 0
+	for _, m := range mocks.byType("gcp:secretmanager/secretIamMember:SecretIamMember") {
+		role, _ := m.Inputs["role"]
+		member, _ := m.Inputs["member"]
+		if role.HasValue() && role.StringValue() == "roles/secretmanager.secretAccessor" &&
+			member.HasValue() && member.StringValue() == wantMember {
+			secretBindings++
+		}
+	}
+	if secretBindings < 2 {
+		t.Errorf("secretAccessor bindings on M2-Orch SA = %d, want >= 2 (DB + Kafka)", secretBindings)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Default min-instances: M2-Orch is a stateless orchestrator (NOT M1/M7),
+// so it must NOT pin min-instances=1.
+// ---------------------------------------------------------------------------
+
+func TestM2OrchUsesDefaultMinInstances(t *testing.T) {
+	mocks, _ := runM2OrchCompute(t)
+
+	svc := findCloudRunService(mocks, "kaizen-dev-m2-orchestration")
+	if svc == nil {
+		t.Fatal("no Cloud Run service named kaizen-dev-m2-orchestration was registered")
+	}
+	scaling := svc.Inputs["template"].ObjectValue()["scaling"]
+	if !scaling.IsObject() {
+		t.Fatal("template.scaling missing")
+	}
+	min := scaling.ObjectValue()["minInstanceCount"]
+	if !min.HasValue() || min.NumberValue() != 0 {
+		t.Errorf("M2-Orch minInstanceCount = %v, want 0 (stateless orchestrator, default)", min)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1: Deploy M2-Orch to Cloud Run on GCP. Wires M2 Orchestration (issue #490) into the GCP compute layer as a stateless Cloud Run service, with Cloud SQL + Redpanda connectivity via the VPC connector and Secret Manager-backed credentials.

**Devin Review fix commit** (`931df05`): addresses all actionable findings from automated review:
- `TestFullStackDeploy_GCP_RejectsMissingProject`: supplies `streamingProvider=redpanda` + minimum Redpanda config so the streaming stage passes and the test validates the `gcpProjectId` guard (not the streaming reject). Adds error-message assertion.
- `findCloudRunService`: removes redundant second `byType()` call.
- `TestM4bGcpComputeFacade`: updates SD-service count 1→3 (M4b + canary + M2-Orch).

## Agent
Infra-4 (Compute)

## Type
feat + fix

## Related Issues
Closes #490

## Contract Changes
N/A — `gcp.NewCompute` signature expanded (internal package, all in-tree callers updated).

## Testing
- [x] `gofmt` clean
- [x] `go vet ./...` clean
- [ ] CI (`go test -race -count=1 -timeout=3m ./pkg/... ./test/...`) — awaiting

## Checklist
- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] Proto changes are backward-compatible (or ADR documents the break)
- [x] Documentation updated (if user-facing)
- [x] No new warnings from linters

Link to Devin session: https://app.devin.ai/sessions/ce24b4c8aed249edb67e8eafc0ef0e63
Requested by: @wunderkennd