### PR TITLE
Phase 1: Deploy M2 Pipeline to Cloud Run (Closes #489)

### DIFF
--- a/infra/Pulumi.gcp-dev.yaml
+++ b/infra/Pulumi.gcp-dev.yaml
@@ -4,9 +4,9 @@ config:
   # streamingProvider=redpanda selects the cloud-agnostic Redpanda Cloud module at
   # infra/pkg/streaming/redpanda.go. The Redpanda Cloud control plane provisions the
   # underlying cluster on GCP and surfaces a Kafka-protocol bootstrap endpoint plus a
-  # built-in Schema Registry. The GCP early-return in Deploy() means the streaming
-  # dispatch is not yet exercised for cloudProvider=gcp; this key is present so that
-  # once the GCP streaming arm lands, this stack picks up Redpanda automatically.
+  # built-in Schema Registry. The GCP streaming arm is wired via Deploy()'s Stage 4
+  # block (#533 onward), and M2 Pipeline (#489) consumes the bootstrap brokers + schema
+  # registry URL through gcp.NewCompute.
   kaizen-experimentation:streamingProvider: redpanda
 
   # Core identification

--- a/infra/fullstack_gcp_test.go
+++ b/infra/fullstack_gcp_test.go
@@ -350,6 +350,7 @@ func gcpComputeInputs() (*kconfig.Config, types.NetworkOutputs, types.CICDOutput
 			"assignment":    pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/assignment").ToStringOutput(),
 			"metrics":       pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/metrics").ToStringOutput(),
 			"flags":         pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/flags").ToStringOutput(),
+			"pipeline":      pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/pipeline").ToStringOutput(),
 		},
 	}
 	storageOut := types.StorageOutputs{

--- a/infra/gcp_compute_m6_test.go
+++ b/infra/gcp_compute_m6_test.go
@@ -125,6 +125,9 @@ func runM6Compute(t *testing.T) (*m6Mocks, map[string]string) {
 				"flags": pulumi.String(
 					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/flags",
 				).ToStringOutput(),
+				"pipeline": pulumi.String(
+					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/pipeline",
+				).ToStringOutput(),
 			},
 		}
 		dbOut := types.DatabaseOutputs{

--- a/infra/m1_topology_test.go
+++ b/infra/m1_topology_test.go
@@ -221,6 +221,9 @@ func runM1Compute(t *testing.T) (*m1TopologyMocks, types.ComputeOutputs, string)
 				"flags": pulumi.String(
 					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen-flags",
 				).ToStringOutput(),
+				"pipeline": pulumi.String(
+					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen-pipeline",
+				).ToStringOutput(),
 			},
 		}
 		dbOut := types.DatabaseOutputs{

--- a/infra/m4b_topology_test.go
+++ b/infra/m4b_topology_test.go
@@ -365,9 +365,9 @@ func TestM4bGcpComputeFacade(t *testing.T) {
 	// Deploy(gcp) registers one Service Directory entry per Cloud Run service
 	// plus one for M4b: m4b-policy, preview-canary, m2-orchestration (#490),
 	// m6-ui (#494), m4a-analysis (#492), m1-assignment (#488), m3-metrics
-	// (#491), and m7-flags (#495). Each subsequent per-service Cloud Run
-	// deploy (#489/#493) adds one as it lands.
-	if got := len(mocks.byType("gcp:servicedirectory/service:Service")); got != 8 {
-		t.Errorf("expected 8 SD Services from Deploy(gcp) (M4b + canary + M2-Orch + M6 + M4a + M1 + M3 + M7), got %d", got)
+	// (#491), m7-flags (#495), and m2-pipeline (#489). Each subsequent
+	// per-service Cloud Run deploy (#493) adds one as it lands.
+	if got := len(mocks.byType("gcp:servicedirectory/service:Service")); got != 9 {
+		t.Errorf("expected 9 SD Services from Deploy(gcp) (M4b + canary + M2-Orch + M6 + M4a + M1 + M3 + M7 + M2-Pipe), got %d", got)
 	}
 }

--- a/infra/pkg/gcp/gcp.go
+++ b/infra/pkg/gcp/gcp.go
@@ -722,6 +722,20 @@ func NewCompute(
 	ctx.Export("gcpComputeM7Url", m7.URL)
 	ctx.Export("gcpComputeM7SaEmail", m7.ServiceAccountEmail)
 
+	// ─── M2 Pipeline (issue #489) ─────────────────────────────────────────
+	// High-throughput Kafka producer (Rust experimentation-ingest). gRPC
+	// ingest on 50052, elevated max-instances for throughput, MinInstances=0
+	// (no p99 cold-start SLA). Reads KAFKA_BROKERS / SCHEMA_REGISTRY_URL
+	// directly so the same image runs unmodified on AWS and GCP.
+	m2pipe, err := newM2PipelineService(ctx, cfg, cloudRunInputs, cicdOut, streamOut, secretsOut)
+	if err != nil {
+		return types.ComputeOutputs{}, err
+	}
+	endpoints["m2-pipeline"] = m2pipe.URL
+	arns["m2-pipeline"] = m2pipe.Service.ID().ToStringOutput()
+	ctx.Export("gcpComputeM2PipelineUrl", m2pipe.URL)
+	ctx.Export("gcpComputeM2PipelineSaEmail", m2pipe.ServiceAccountEmail)
+
 	return types.ComputeOutputs{
 		// ClusterId / ClusterName / ClusterArn intentionally zero-valued:
 		// Cloud Run is serverless (no cluster); M4b is a single MIG.
@@ -731,4 +745,51 @@ func NewCompute(
 		ServiceEndpoints: endpoints,
 		ServiceArns:      arns,
 	}, nil
+}
+
+// m2PipelinePort is the gRPC ingest port M2 Pipeline binds to. Matches the
+// AWS Cloud Map registration (pkg/aws/compute/services.go: m2-pipeline →
+// 50052) and the value the experimentation-pipeline container listens on.
+const m2PipelinePort = 50052
+
+// m2PipelineMaxInstances caps M2's Cloud Run autoscaling. M2 is a high-
+// throughput Kafka producer, so its ceiling is raised well above the
+// cost-control default; floor stays at 0 (M2 carries no p99 cold-start SLA).
+const m2PipelineMaxInstances = 100
+
+// newM2PipelineService wires M2 Pipeline (Rust experimentation-ingest) onto
+// Cloud Run via the shared factory. Issue #489. The env-var contract mirrors
+// crates/experimentation-pipeline/src/main.rs (KAFKA_BROKERS) and the AWS
+// service contract so the same image runs unmodified on both clouds.
+func newM2PipelineService(
+	ctx *pulumi.Context,
+	cfg *kconfig.Config,
+	inputs *compute.Inputs,
+	cicdOut types.CICDOutputs,
+	streamOut types.StreamingOutputs,
+	secretsOut types.SecretsOutputs,
+) (*compute.CloudRunService, error) {
+	repoURL, ok := cicdOut.RepositoryURLs["pipeline"]
+	if !ok {
+		return nil, fmt.Errorf(
+			"gcp.NewCompute: cicdOut.RepositoryURLs is missing the \"pipeline\" Artifact Registry repo required by M2")
+	}
+
+	return compute.NewCloudRunService(ctx, cfg, inputs, "m2-pipeline",
+		&compute.Options{
+			Image:         pulumi.Sprintf("%s:latest", repoURL),
+			ContainerPort: m2PipelinePort,
+			MinInstances:  0,
+			MaxInstances:  m2PipelineMaxInstances,
+			EnvVars: []compute.EnvVar{
+				{Name: "ENVIRONMENT", Value: pulumi.String(cfg.Environment)},
+				{Name: "RUST_LOG", Value: pulumi.String("info")},
+				{Name: "KAFKA_BROKERS", Value: streamOut.BootstrapBrokers},
+				{Name: "SCHEMA_REGISTRY_URL", Value: streamOut.SchemaRegistryUrl},
+				{Name: "OTEL_SERVICE_NAME", Value: pulumi.String("m2-pipeline")},
+			},
+			Secrets: []compute.SecretEnv{
+				{EnvName: "KAFKA_SECRET", SecretID: secretsOut.KafkaSecretRef, Version: "latest"},
+			},
+		})
 }

--- a/infra/pkg/gcp/gcp_test.go
+++ b/infra/pkg/gcp/gcp_test.go
@@ -176,6 +176,9 @@ func runNewCompute(t *testing.T) (*computeMocks, types.ComputeOutputs) {
 				"flags": pulumi.String(
 					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/flags",
 				).ToStringOutput(),
+				"pipeline": pulumi.String(
+					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/pipeline",
+				).ToStringOutput(),
 			},
 		}
 		storageOut := types.StorageOutputs{

--- a/infra/test/gcp_m2_pipeline_topology_test.go
+++ b/infra/test/gcp_m2_pipeline_topology_test.go
@@ -1,0 +1,374 @@
+// Package test — acceptance topology test for the GCP M2 Pipeline Cloud Run
+// deployment (issue #489).
+//
+// M2 Pipeline is the Rust ingest service: a high-throughput Kafka producer
+// that must reach Redpanda via the Serverless VPC Access connector. This
+// test runs the gcp.NewCompute facade under pulumi.WithMocks (no GCP
+// credentials) and asserts the three issue-#489 acceptance criteria at the
+// topology layer — the layer the spec's Testing Strategy assigns to "every
+// PR, no credentials" (the literal "200 health check" and "publishes to
+// Redpanda end-to-end" criteria are exercised by the nightly preview and
+// weekly smoke layers against a real GCP project):
+//
+//  1. M2 appears in ComputeOutputs.ServiceEndpoints["m2-pipeline"].
+//  2. M2's container/health port is 50052 and it registers a Service
+//     Directory endpoint so the platform health check + peer discovery
+//     resolve it.
+//  3. M2 is wired to Redpanda end-to-end: KAFKA_BROKERS + SCHEMA_REGISTRY_URL
+//     env vars, the Kafka SASL secret mounted from Secret Manager, and the
+//     roles/secretmanager.secretAccessor binding on M2's runtime SA that lets
+//     it read those credentials.
+package test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	kconfig "github.com/kaizen-experimentation/infra/pkg/config"
+	"github.com/kaizen-experimentation/infra/pkg/gcp"
+	"github.com/kaizen-experimentation/infra/pkg/types"
+)
+
+// m2ComputeMocks records every resource gcp.NewCompute registers and
+// enriches the outputs the M4b + Cloud Run ApplyT chains depend on. It is a
+// superset of computeMocks (gcp_compute_topology_test.go) because NewCompute
+// builds the stateful M4b slice alongside the Cloud Run services.
+type m2ComputeMocks struct {
+	mu        sync.Mutex
+	resources []recordedComputeResource
+}
+
+func (m *m2ComputeMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	m.mu.Lock()
+	m.resources = append(m.resources, recordedComputeResource{
+		TypeToken: args.TypeToken,
+		Name:      args.Name,
+		Inputs:    args.Inputs,
+	})
+	m.mu.Unlock()
+
+	id := args.Name + "_id"
+	outputs := resource.PropertyMap{}
+	for k, v := range args.Inputs {
+		outputs[k] = v
+	}
+
+	switch args.TypeToken {
+	case "gcp:serviceaccount/account:Account":
+		accountID := ""
+		if v, ok := args.Inputs["accountId"]; ok && v.HasValue() {
+			accountID = v.StringValue()
+		}
+		project := ""
+		if v, ok := args.Inputs["project"]; ok && v.HasValue() {
+			project = v.StringValue()
+		}
+		email := accountID + "@" + project + ".iam.gserviceaccount.com"
+		outputs["email"] = resource.NewStringProperty(email)
+		outputs["name"] = resource.NewStringProperty(
+			"projects/" + project + "/serviceAccounts/" + email)
+	case "gcp:cloudrunv2/service:Service":
+		name := ""
+		if v, ok := args.Inputs["name"]; ok && v.HasValue() {
+			name = v.StringValue()
+		}
+		region := ""
+		if v, ok := args.Inputs["location"]; ok && v.HasValue() {
+			region = v.StringValue()
+		}
+		outputs["uri"] = resource.NewStringProperty(
+			"https://" + name + "-mock-" + region + ".a.run.app")
+	case "gcp:compute/address:Address":
+		outputs["address"] = resource.NewStringProperty("10.0.16.42")
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/regions/us-central1/addresses/" + args.Name)
+	case "gcp:compute/disk:Disk", "gcp:compute/instanceTemplate:InstanceTemplate":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/" + args.Name)
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:compute/healthCheck:HealthCheck":
+		outputs["selfLink"] = resource.NewStringProperty(
+			"https://www.googleapis.com/compute/v1/projects/test/global/healthChecks/" + args.Name)
+	case "gcp:compute/instanceGroupManager:InstanceGroupManager":
+		outputs["name"] = resource.NewStringProperty(args.Name)
+	case "gcp:servicedirectory/service:Service":
+		if v, ok := args.Inputs["serviceId"]; ok {
+			outputs["serviceId"] = v
+		}
+		if v, ok := args.Inputs["namespace"]; ok {
+			outputs["namespace"] = v
+		}
+		outputs["name"] = resource.NewStringProperty(
+			"projects/test/locations/us-central1/namespaces/kaizen-local/services/" + args.Name)
+	case "gcp:servicedirectory/endpoint:Endpoint":
+		if v, ok := args.Inputs["address"]; ok {
+			outputs["address"] = v
+		}
+		if v, ok := args.Inputs["port"]; ok {
+			outputs["port"] = v
+		}
+	}
+	return id, outputs, nil
+}
+
+func (m *m2ComputeMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func (m *m2ComputeMocks) byType(typeToken string) []recordedComputeResource {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []recordedComputeResource
+	for _, r := range m.resources {
+		if r.TypeToken == typeToken {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// runM2Compute runs gcp.NewCompute with a representative Phase-1 GCP stack
+// (CICD pipeline repo, Redpanda streaming outputs, Secret Manager refs) and
+// returns the recorded resources plus the ComputeOutputs.
+func runM2Compute(t *testing.T) (*m2ComputeMocks, types.ComputeOutputs) {
+	t.Helper()
+	mocks := &m2ComputeMocks{}
+	var out types.ComputeOutputs
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		cfg := &kconfig.Config{
+			Project:      "kaizen",
+			Environment:  "dev",
+			Env:          kconfig.EnvDev,
+			GCPProjectID: "kaizen-experimentation-dev",
+			GCPRegion:    "us-central1",
+		}
+		netOut := types.NetworkOutputs{
+			PrivateSubnetIds: pulumi.ToStringArrayOutput([]pulumi.StringOutput{
+				pulumi.String("projects/kaizen-experimentation-dev/regions/us-central1/subnetworks/kaizen-dev-private").ToStringOutput(),
+			}),
+			ServiceDiscoveryId: pulumi.ID(
+				"projects/kaizen-experimentation-dev/locations/us-central1/namespaces/kaizen-local").ToIDOutput(),
+			VpcConnectorSelfLink: pulumi.String(
+				"projects/kaizen-experimentation-dev/locations/us-central1/connectors/kaizen-vpc-connector").ToStringOutput(),
+		}
+		cicdOut := types.CICDOutputs{
+			RepositoryURLs: map[string]pulumi.StringOutput{
+				"pipeline": pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/pipeline").ToStringOutput(),
+				// NewCompute provisions every wired per-service Cloud Run service
+				// in one call, so this fixture must satisfy each service's image
+				// lookup even when the test is scoped to M2 Pipeline.
+				"orchestration": pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/orchestration").ToStringOutput(),
+				"ui":            pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/ui").ToStringOutput(),
+				"analysis":      pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/analysis").ToStringOutput(),
+				"assignment":    pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/assignment").ToStringOutput(),
+				"metrics":       pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/metrics").ToStringOutput(),
+				"flags":         pulumi.String("us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/flags").ToStringOutput(),
+			},
+		}
+		dbOut := types.DatabaseOutputs{
+			Endpoint: pulumi.String("10.99.0.3:5432").ToStringOutput(),
+		}
+		cacheOut := types.CacheOutputs{
+			Endpoint: pulumi.String("10.99.1.1:6379").ToStringOutput(),
+		}
+		streamOut := types.StreamingOutputs{
+			BootstrapBrokers:  pulumi.String("seed-abc.redpanda.cloud:9092").ToStringOutput(),
+			SchemaRegistryUrl: pulumi.String("https://seed-abc.redpanda.cloud:30081").ToStringOutput(),
+			ClusterName:       pulumi.String("kaizen-dev").ToStringOutput(),
+		}
+		storageOut := types.StorageOutputs{
+			DataBucketName: pulumi.String("kaizen-dev-data").ToStringOutput(),
+			DataBucketRef:  pulumi.String("gs://kaizen-dev-data").ToStringOutput(),
+		}
+		// SecretsOutputs.*Ref is the bare local secret ID (e.g.
+		// "kaizen-dev-kafka"), matching what NewSecrets returns in production
+		// — Cloud Run's secretKeyRef.secret expects exactly this form, NOT
+		// the projects/<P>/secrets/<S> path or version-qualified accessor.
+		secretsOut := types.SecretsOutputs{
+			KafkaSecretRef:    pulumi.String("kaizen-dev-kafka").ToStringOutput(),
+			DatabaseSecretRef: pulumi.String("kaizen-dev-database").ToStringOutput(),
+			RedisSecretRef:    pulumi.String("kaizen-dev-redis").ToStringOutput(),
+			AuthSecretRef:     pulumi.String("kaizen-dev-auth").ToStringOutput(),
+		}
+
+		var err error
+		out, err = gcp.NewCompute(ctx, cfg, netOut, cicdOut, dbOut, streamOut, secretsOut, storageOut, cacheOut)
+		return err
+	}, pulumi.WithMocks("kaizen", "dev", mocks))
+	if err != nil {
+		t.Fatalf("gcp.NewCompute failed: %v", err)
+	}
+	return mocks, out
+}
+
+// findM2Service returns the recorded Cloud Run service resource for
+// m2-pipeline (Pulumi name kaizen-<env>-m2-pipeline-run).
+func findM2Service(t *testing.T, mocks *m2ComputeMocks) recordedComputeResource {
+	t.Helper()
+	for _, r := range mocks.byType("gcp:cloudrunv2/service:Service") {
+		if v, ok := r.Inputs["name"]; ok && v.HasValue() &&
+			v.StringValue() == "kaizen-dev-m2-pipeline" {
+			return r
+		}
+	}
+	t.Fatal("no Cloud Run service named kaizen-dev-m2-pipeline registered")
+	return recordedComputeResource{}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance criterion 1: M2 in ComputeOutputs.ServiceEndpoints["m2-pipeline"]
+// ---------------------------------------------------------------------------
+
+func TestM2PipelineInServiceEndpoints(t *testing.T) {
+	_, out := runM2Compute(t)
+	if out.ServiceEndpoints == nil {
+		t.Fatal("ComputeOutputs.ServiceEndpoints is nil")
+	}
+	if _, ok := out.ServiceEndpoints["m2-pipeline"]; !ok {
+		t.Errorf("ServiceEndpoints missing key %q; keys present: %v",
+			"m2-pipeline", keysOfOutputs(out.ServiceEndpoints))
+	}
+	if _, ok := out.ServiceArns["m2-pipeline"]; !ok {
+		t.Errorf("ServiceArns missing key %q", "m2-pipeline")
+	}
+}
+
+func keysOfOutputs(m map[string]pulumi.StringOutput) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance criterion 2: health/container port + Service Directory endpoint
+// ---------------------------------------------------------------------------
+
+func TestM2PipelineContainerPortAndDiscovery(t *testing.T) {
+	mocks, _ := runM2Compute(t)
+	svc := findM2Service(t, mocks)
+
+	tmpl, ok := svc.Inputs["template"]
+	if !ok || !tmpl.IsObject() {
+		t.Fatal("m2 Cloud Run service missing template")
+	}
+	containers := tmpl.ObjectValue()["containers"]
+	if !containers.IsArray() || len(containers.ArrayValue()) == 0 {
+		t.Fatal("m2 template has no containers")
+	}
+	ports := containers.ArrayValue()[0].ObjectValue()["ports"]
+	if !ports.IsObject() {
+		t.Fatal("m2 container missing ports")
+	}
+	cp := ports.ObjectValue()["containerPort"]
+	if !cp.IsNumber() || cp.NumberValue() != 50052 {
+		t.Errorf("m2 containerPort = %v, want 50052 (M2 gRPC ingest port)", cp)
+	}
+
+	// Service Directory service + endpoint so the platform health check and
+	// peer services can resolve m2-pipeline.
+	var sdFound bool
+	for _, sd := range mocks.byType("gcp:servicedirectory/service:Service") {
+		if v, ok := sd.Inputs["serviceId"]; ok && v.StringValue() == "m2-pipeline" {
+			sdFound = true
+		}
+	}
+	if !sdFound {
+		t.Error("no Service Directory service registered with serviceId m2-pipeline")
+	}
+	if len(mocks.byType("gcp:servicedirectory/endpoint:Endpoint")) == 0 {
+		t.Error("m2-pipeline registered no Service Directory endpoint")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance criterion 3: Redpanda end-to-end wiring (env + secret + IAM)
+// ---------------------------------------------------------------------------
+
+func TestM2PipelineRedpandaWiring(t *testing.T) {
+	mocks, _ := runM2Compute(t)
+	svc := findM2Service(t, mocks)
+
+	envs := svc.Inputs["template"].ObjectValue()["containers"].
+		ArrayValue()[0].ObjectValue()["envs"]
+	if !envs.IsArray() {
+		t.Fatal("m2 container has no envs array")
+	}
+
+	literals := map[string]string{}
+	secretEnvs := map[string]string{} // env name -> secret id
+	for _, e := range envs.ArrayValue() {
+		eo := e.ObjectValue()
+		name := eo["name"].StringValue()
+		if val, ok := eo["value"]; ok && val.HasValue() {
+			literals[name] = val.StringValue()
+			continue
+		}
+		if vs, ok := eo["valueSource"]; ok && vs.IsObject() {
+			skr := vs.ObjectValue()["secretKeyRef"]
+			if skr.IsObject() {
+				secretEnvs[name] = skr.ObjectValue()["secret"].StringValue()
+			}
+		}
+	}
+
+	// Redpanda bootstrap brokers + Schema Registry URL as literal env vars.
+	if got := literals["KAFKA_BROKERS"]; got != "seed-abc.redpanda.cloud:9092" {
+		t.Errorf("KAFKA_BROKERS = %q, want the Redpanda bootstrap brokers", got)
+	}
+	if got := literals["SCHEMA_REGISTRY_URL"]; got != "https://seed-abc.redpanda.cloud:30081" {
+		t.Errorf("SCHEMA_REGISTRY_URL = %q, want the Redpanda schema registry URL", got)
+	}
+
+	// Kafka SASL credentials mounted from Secret Manager.
+	kafkaSecret, ok := secretEnvs["KAFKA_SECRET"]
+	if !ok {
+		t.Fatalf("KAFKA_SECRET not mounted from Secret Manager; secret envs: %v", secretEnvs)
+	}
+	// The factory's secretKeyRef.secret takes the bare local secret ID
+	// (resolved via secretIDForRef → secrets.SecretID(cfg, "kafka")).
+	if kafkaSecret != "kaizen-dev-kafka" {
+		t.Errorf("KAFKA_SECRET secret ref = %q, want the kaizen-dev-kafka Secret Manager secret", kafkaSecret)
+	}
+
+	// IAM: M2's runtime SA must be able to READ the Kafka secret.
+	wantMember := "serviceAccount:dev-m2-pipeline-run@kaizen-experimentation-dev.iam.gserviceaccount.com"
+	var bound bool
+	for _, b := range mocks.byType("gcp:secretmanager/secretIamMember:SecretIamMember") {
+		role := b.Inputs["role"]
+		member := b.Inputs["member"]
+		if role.HasValue() && role.StringValue() == "roles/secretmanager.secretAccessor" &&
+			member.HasValue() && member.StringValue() == wantMember {
+			bound = true
+		}
+	}
+	if !bound {
+		t.Errorf("no roles/secretmanager.secretAccessor binding for %s on the Kafka secret", wantMember)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// M2 is a high-throughput producer: default min-instances, elevated max.
+// ---------------------------------------------------------------------------
+
+func TestM2PipelineScaling(t *testing.T) {
+	mocks, _ := runM2Compute(t)
+	svc := findM2Service(t, mocks)
+
+	scaling := svc.Inputs["template"].ObjectValue()["scaling"]
+	if !scaling.IsObject() {
+		t.Fatal("m2 template missing scaling block")
+	}
+	min := scaling.ObjectValue()["minInstanceCount"]
+	if !min.IsNumber() || min.NumberValue() != 0 {
+		t.Errorf("m2 minInstanceCount = %v, want 0 (default — M2 has no cold-start SLA)", min)
+	}
+	max := scaling.ObjectValue()["maxInstanceCount"]
+	if !max.IsNumber() || max.NumberValue() != 100 {
+		t.Errorf("m2 maxInstanceCount = %v, want 100 (elevated for Kafka-producer throughput)", max)
+	}
+}

--- a/infra/test/gcp_m2orch_topology_test.go
+++ b/infra/test/gcp_m2orch_topology_test.go
@@ -69,6 +69,9 @@ func m2OrchUpstreams() (types.NetworkOutputs, types.CICDOutputs, types.DatabaseO
 			"flags": pulumi.String(
 				"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/flags",
 			).ToStringOutput(),
+			"pipeline": pulumi.String(
+				"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/pipeline",
+			).ToStringOutput(),
 		},
 	}
 	dbOut := types.DatabaseOutputs{

--- a/infra/test/gcp_m7_flags_topology_test.go
+++ b/infra/test/gcp_m7_flags_topology_test.go
@@ -186,6 +186,8 @@ func runM7Facade(t *testing.T) (*m7FacadeMocks, types.ComputeOutputs) {
 					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/assignment").ToStringOutput(),
 				"metrics": pulumi.String(
 					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/metrics").ToStringOutput(),
+				"pipeline": pulumi.String(
+					"us-docker.pkg.dev/kaizen-experimentation-dev/kaizen/pipeline").ToStringOutput(),
 			},
 		}
 		dbOut := types.DatabaseOutputs{


### PR DESCRIPTION
## Summary

Wires **M2 Pipeline** (Rust `experimentation-ingest`, a high-throughput Kafka producer) into the GCP stack via the Cloud Run service factory, following the documented per-service tracer-bullet pattern established by #488 (M1) and #493 (M5).

`gcp.NewCompute` gains a `newM2PipelineService` helper (sibling of `newM5ManagementService`):

| Aspect | Value |
|---|---|
| Image | `cicdOut.RepositoryURLs["pipeline"]` (Artifact Registry) |
| Container port | `50052` — parity with the AWS Cloud Map registration |
| Scaling | `MinInstances=0` (no p99 cold-start SLA), **`MaxInstances=100`** (elevated for Kafka-producer throughput) |
| Env (literal) | `KAFKA_BROKERS`, `SCHEMA_REGISTRY_URL` (from Redpanda `streamOut`), `ENVIRONMENT`, `RUST_LOG`, `OTEL_SERVICE_NAME` |
| Secret | `KAFKA_SECRET` mounted from the Kafka Secret Manager secret via the factory `secretKeyRef` |
| IAM | factory auto-creates `roles/secretmanager.secretAccessor` on M2's per-service Workload Identity SA → "read Kafka creds" |
| Networking | reaches Redpanda over the Serverless VPC Access connector (already on `cloudRunInputs`) |

`ComputeOutputs.ServiceEndpoints["m2-pipeline"]` + `ServiceArns` are populated; `main.go` auto-exports `cloudRunUrl_m2-pipeline`. The M2 binary reads `KAFKA_BROKERS` directly (`crates/experimentation-pipeline/src/main.rs`), so the same image runs unmodified on AWS and GCP (spec: Streaming → "App code changes: None").

## Acceptance criteria (#489)

- [x] **M2 in `ComputeOutputs.ServiceEndpoints["m2-pipeline"]`** — `TestM2PipelineInServiceEndpoints`.
- [x] **M2 health check returns 200 in a deployed dev stack** — topology proxy: container port `50052` + Service Directory service/endpoint registered (`TestM2PipelineContainerPortAndDiscovery`). The literal "200 on a real deploy" is the nightly *preview* / weekly *smoke* layer per the spec's Testing Strategy (needs a real GCP project; no creds at PR layer).
- [x] **M2 publishes a synthetic event to Redpanda end-to-end** — topology proxy: `KAFKA_BROKERS`/`SCHEMA_REGISTRY_URL` env + `KAFKA_SECRET` secret-mount + `secretmanager.secretAccessor` IAM binding on M2's SA (`TestM2PipelineRedpandaWiring`); end-to-end publish runs at the weekly smoke layer (issue referenced by #25 / spec).

## Test plan

```
cd infra
go test ./... -count=1 -skip '^TestFullStackDeploy$|^TestFullStackResourceCounts$|^TestFullStackExports$'
```

- ✅ `infra/test` — 4 new M2 acceptance topology tests + existing GCP Cloud Run factory tests.
- ✅ `infra` (root) — `TestM4bGcpComputeFacade` (fixed, see below), `TestFullStackDeploy_GCP*`.
- ✅ all `pkg/*` packages.
- The `-skip` set is **pre-existing breakage on clean `main`**, NOT a regression from this PR — see below.

## Notes / coordination

**Stacked on shared-worktree foundation.** This branch was cut from `main` (3ff2687) but the multiclaude shared worktree carried the uncommitted GCP **Stage 4 wiring** (#488/M1 PR #536) and **M5 Management** (#493) on which M2 structurally depends (8-arg `NewCompute`, Redpanda→Secret Manager dispatch, shared `applyGCPStage4ComputeOutputs` mock). The commit therefore also contains that base. **Recommended merge order: #536 (M1+Stage4) → #493 (M5) → this (#489)**; the CI-gated merge queue rebase will collapse the overlapping hunks so this PR reduces to the M2 delta. (This is the documented per-service collaboration model for #488–#495.)

**Pre-existing, out-of-scope failure.** `TestFullStackDeploy`, `TestFullStackResourceCounts`, `TestFullStackExports` panic `interface conversion: interface {} is pulumi.ID, not string` on **pristine `main` HEAD 3ff2687** (verified in a fresh `git worktree`, zero uncommitted changes). It is an AWS-fullstack `IDOutput`-asserted-as-`string` bug, already flagged from PR #536. Not introduced by #489; needs its own infra-AWS owner.

**Opportunities (not implemented — out of scope):** retire the `preview-canary` once 2+ real services are wired; extract the duplicated `secretIDForRef` closure into a shared `pkg/gcp` helper once 3+ per-service helpers exist.

Closes #489
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->