### PR TITLE
🎨 Palette: Improve Audit Log pagination and filter UX

### DIFF
--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -132,6 +132,7 @@ export default function AuditLogPage() {
           <button
             onClick={clearFilters}
             className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+            data-testid="clear-filters-empty"
           >
             Clear filters
           </button>
@@ -144,9 +145,33 @@ export default function AuditLogPage() {
               <button
                 onClick={loadMore}
                 disabled={loadingMore}
-                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 data-testid="load-more-button"
               >
+                {loadingMore && (
+                  <svg
+                    className="h-4 w-4 animate-spin text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    data-testid="load-more-spinner"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                )}
                 {loadingMore ? 'Loading...' : 'Load More'}
               </button>
             </div>

--- a/ui/src/components/audit-filters.tsx
+++ b/ui/src/components/audit-filters.tsx
@@ -106,6 +106,7 @@ export function AuditFilters({
         <button
           onClick={onClear}
           className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+          data-testid="clear-filters-toolbar"
         >
           Clear filters
         </button>


### PR DESCRIPTION
I've implemented a micro-UX enhancement for the Audit Log page to improve feedback during background data fetching.

### 💡 What:
- Added an animated loading spinner to the "Load More" button in `ui/src/app/audit/page.tsx` when data is being fetched.
- Standardized `data-testid` attributes for "Clear filters" buttons in both the toolbar (`ui/src/components/audit-filters.tsx`) and empty result states (`ui/src/app/audit/page.tsx`) to match the platform's testing standards.

### 🎯 Why:
Users previously had no visual confirmation that more data was being loaded after clicking "Load More," which could lead to redundant clicks. Differentiating "Clear filters" test IDs improves maintainability and automated testing reliability.

### ♿ Accessibility:
- The loading spinner uses `aria-hidden="true"` as it is accompanied by descriptive "Loading..." text.
- The button maintains a `disabled` state during loading to prevent multiple concurrent requests.

### ✅ Verification:
- Verified with unit tests in `ui/src/__tests__/audit-log.test.tsx`.
- Visually verified using Playwright screenshots in mock mode.
- Cleaned up development artifacts (`next_dev.log`) and updated the `.Jules/palette.md` journal with learnings.

---
*PR created automatically by Jules for task [10449211516871293068](https://jules.google.com/task/10449211516871293068) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->