### PR TITLE
🎨 Palette: Add keyboard shortcut and visual hint for experiment search

### DIFF
--- a/ui/src/components/experiment-filters.tsx
+++ b/ui/src/components/experiment-filters.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import type { ExperimentState, ExperimentType } from '@/lib/types';
 import { STATE_CONFIG, TYPE_LABELS } from '@/lib/utils';
 import type { ExperimentFilters as Filters } from '@/lib/use-experiment-filters';
@@ -20,6 +21,23 @@ const ALL_TYPES: ExperimentType[] = [
 ];
 
 export function ExperimentFiltersToolbar({ filters, totalCount, filteredCount }: ExperimentFiltersProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.key === '/' &&
+        !['INPUT', 'TEXTAREA', 'SELECT'].includes(document.activeElement?.tagName || '') &&
+        !(document.activeElement as HTMLElement)?.isContentEditable
+      ) {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   return (
     <div className="mb-4 flex flex-wrap items-center gap-3">
       {/* Search input */}
@@ -34,13 +52,19 @@ export function ExperimentFiltersToolbar({ filters, totalCount, filteredCount }:
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
         <input
+          ref={inputRef}
           type="text"
           placeholder="Search experiments..."
           value={filters.query}
           onChange={(e) => filters.setQuery(e.target.value)}
-          className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-3 text-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-10 text-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
           aria-label="Search experiments"
         />
+        <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center">
+          <span className="flex h-5 w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 text-[10px] font-medium text-gray-500">
+            /
+          </span>
+        </div>
       </div>
 
       {/* State filter */}


### PR DESCRIPTION
This PR adds a common micro-UX improvement: a "slash-to-search" keyboard shortcut.

### 💡 What: 
- Users can now press the `/` key to quickly focus the experiment search input.
- A subtle visual hint (`/`) is displayed on the right side of the search input to discover the shortcut.

### 🎯 Why:
- Improves navigation speed for power users who frequently search through experiments.
- Follows established design patterns seen in platforms like GitHub, Linear, and various documentation sites.

### 📸 Before/After:
- **Before:** Search input was purely mouse-driven or tab-to-focus.
- **After:** Pressing `/` focuses the input immediately. A visual hint is visible inside the input field.

### ♿ Accessibility:
- The shortcut includes guards to prevent triggering while the user is already typing in an input, textarea, select, or contenteditable element.
- `e.preventDefault()` is used to ensure the `/` character itself isn't typed into the field upon focus.

---
*PR created automatically by Jules for task [9436743933580788490](https://jules.google.com/task/9436743933580788490) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->