### PR TITLE
docs(adrs): ADR-029 cross-modal calibration + renumber shadow ADR 027→030

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ gh issue view 42 --json body -q '.body' | multiclaude worker create "$(cat -)"
 | --- | --- |
 | This file (agent context) | `CLAUDE.md` (repo root) |
 | Design document | `docs/design/design_doc_v7.0.md` |
-| ADRs (001–027) | `docs/adrs/` |
+| ADRs (001–030) | `docs/adrs/` |
 | ADR index | `docs/adrs/README.md` |
 | Agent definitions (modules) | `.multiclaude/agents/agent-N-*.md` |
 | Agent definitions (infra) | `.multiclaude/agents/infra-{1..5}-*.md` |

--- a/docs/adrs/028-m4b-shadow-inference.md
+++ b/docs/adrs/028-m4b-shadow-inference.md
@@ -30,7 +30,7 @@ acted upon. Netflix's Switchboard explicitly enumerates shadow mode as a first-c
 lifecycle stage for this reason
 ([Netflix Tech Blog, May 2026](https://netflixtechblog.com/state-of-routing-in-model-serving-16e22fe18741)).
 
-ADR-027 establishes shadow mode as a property of an experiment phase: a flag
+ADR-030 establishes shadow mode as a property of an experiment phase: a flag
 `is_shadow` on `Experiment`, with `SHADOWING` and `LIVE` sub-states of `RUNNING`, and
 state transitions between them recorded in the audit trail. This ADR specifies the
 M4b-side mechanism that gives that flag operational meaning for `CONTEXTUAL_BANDIT`
@@ -66,7 +66,7 @@ production LMAX core, with three critical isolation properties:
 The shadow core's arm selections are emitted to a new Kafka topic `shadow_arm_events`,
 consumed by M4a for offline comparison against logged production arm selections.
 
-### Lifecycle integration with ADR-027
+### Lifecycle integration with ADR-030
 
 The shadow core's lifecycle is **driven by M5's experiment state machine**, not by
 direct operator RPCs. This is the key change from earlier drafts: shadow inference is
@@ -85,7 +85,7 @@ The triggers and actions are:
 
 `LoadShadowModel`, `PromoteShadow`, and `UnloadShadow` are M5-internal RPCs on M4b —
 operators do not call them directly. The operator-facing surface is
-`TransitionShadowMode` on M5 (per ADR-027). M4b additionally exposes `GetShadowDiff`
+`TransitionShadowMode` on M5 (per ADR-030). M4b additionally exposes `GetShadowDiff`
 as a read-only RPC for M4a and M6 to query offline comparison results.
 
 ```protobuf
@@ -361,7 +361,7 @@ On M4b startup (cold or post-crash):
 Earlier draft. M4b exposed `LoadShadowModel`, `PromoteShadow`, etc. as
 operator-facing RPCs, with the experiment lifecycle and the shadow lifecycle as
 parallel concerns the operator coordinated manually. Rejected in favor of
-lifecycle-driven shadow management (per ADR-027) — drift between experiment state
+lifecycle-driven shadow management (per ADR-030) — drift between experiment state
 and shadow state was a real and recurring failure mode. The RPCs still exist but
 are M5-internal.
 
@@ -410,7 +410,7 @@ production state.
 - ADR-002 (LMAX bandit core) — extended by this ADR
 - ADR-003 (RocksDB policy state) — extended via column families
 - ADR-011 (Candle ML framework) — applicable to shadow neural bandit inference
-- ADR-027 (Shadow mode for experiments) — companion ADR; defines the experiment-level
+- ADR-030 (Shadow mode for experiments) — companion ADR; defines the experiment-level
   flag, sub-states, and transitions that drive this ADR's lifecycle integration
 - Design doc v5.1, Section 8 (M4b Bandit Policy Service), Section 2.3 (LMAX threading)
 - Netflix Tech Blog, "State of Routing in Model Serving" (May 2026):

--- a/docs/adrs/029-cross-modal-score-calibration.md
+++ b/docs/adrs/029-cross-modal-score-calibration.md
@@ -131,15 +131,24 @@ pub struct JointCalibrator {
 impl JointCalibrator {
     pub fn calibrate_slate(&self, items: &[RawSlateItem]) -> Vec<CalibratedSlateItem> {
         items.iter().map(|item| {
-            let nev = self.calibrators[&item.modality]
-                .calibrate_to_nev(item.raw_score, &item.context);
-            let weighted = nev * self.modality_weights[&item.modality];
+            // Bind the calibrator + weight once per item. The slate path
+            // deliberately bypasses the trait's `calibrate_to_nev` convenience
+            // method and inlines the two-step (calibrate_raw → to_nev) so the
+            // native_calibrated value can be both surfaced in the output AND
+            // reused for to_nev without recomputing — one `calibrate_raw` call
+            // per item, not two.
+            let calibrator = &self.calibrators[&item.modality];
+            let weight = self.modality_weights[&item.modality];
+
+            let native = calibrator.calibrate_raw(item.raw_score, &item.context);
+            let nev = calibrator.to_nev(native, &item.context);
+            let weighted = nev * weight;
             assert_finite!(weighted);  // mandatory per CLAUDE.md fail-fast rule
+
             CalibratedSlateItem {
                 item_id: item.item_id.clone(),
                 modality: item.modality.clone(),
-                native_calibrated: self.calibrators[&item.modality]
-                    .calibrate_raw(item.raw_score, &item.context),
+                native_calibrated: native,
                 nev,
                 weighted_nev: weighted,
             }

--- a/docs/adrs/029-cross-modal-score-calibration.md
+++ b/docs/adrs/029-cross-modal-score-calibration.md
@@ -1,0 +1,385 @@
+# ADR-029: Cross-Modal Score Calibration for Heterogeneous Slates
+
+**Status**: Proposed
+**Date**: 2026-05-16
+**Deciders**: Agent-4 (M4a/M4b — statistical methods), Personalization service owners
+**Cluster**: G — Personalization Orchestration (new cluster)
+
+---
+
+## Context
+
+The personalization integration (see #543, #544, #545) produces slates that mix
+content types within a single shelf: long-form video, short-form video, manga
+series, manga chapters, commerce SKUs, commerce bundles, and editorial collections.
+Each modality has a fundamentally different outcome distribution:
+
+| Modality | Native outcome | Typical range | Tail |
+|----------|----------------|---------------|------|
+| Long-form video | Minutes watched | 0–180 | Right-skewed |
+| Short-form video | Completion rate | [0, 1] | Bimodal (skip vs complete) |
+| Manga series | Chapters read in 7d | 0–~50 | Heavy right tail |
+| Manga chapter | Completion rate | [0, 1] | Bimodal |
+| Commerce SKU | GMV (currency) | $0–$10K | Sparse, heavy-tailed |
+| Commerce bundle | GMV + attach rate | $0–$10K + [0, 1] | Compound |
+
+Production rankers emit raw scores in modality-native units. Two failure modes
+follow if these are mixed directly:
+
+1. **Slate composition becomes incoherent.** A commerce ranker predicting $5 GMV
+   and a video ranker predicting 30 watch-minutes cannot be compared by raw score —
+   the slate composer ends up sorting on units that have no shared meaning.
+2. **Kaizen's analysis silently misleads.** ADR-011's multi-objective reward composer
+   scalarizes per-objective rewards into a single value. If the per-modality
+   predicted outcomes (`ModalityPredictions` in the personalization proto) are
+   uncalibrated, the scalarization's weights are meaningless — a 0.1 reward from
+   video and a 0.1 reward from commerce represent different real-world value.
+
+This problem does not exist in single-modality kaizen experiments and has no
+precedent in the existing ADRs. ADR-011 (multi-objective reward) provides the
+scalarization machinery once values are comparable but does not address how to
+make them comparable.
+
+### Research grounding
+
+Calibrated recommendation is well-studied. The most directly relevant prior art:
+
+- **Platt scaling** (Platt, 1999) — logistic regression mapping raw scores to
+  calibrated probabilities. Works well for bounded outputs (CTR, completion rate).
+- **Isotonic regression** (Zadrozny & Elkan, 2002) — non-parametric monotonic
+  mapping. More flexible than Platt; handles non-sigmoid score distributions.
+- **Beta calibration** (Kull, Silva Filho, Flach 2017) — three-parameter family
+  generalizing Platt; useful for skewed outputs.
+- **Spline calibration** (Lucena, 2018) — for continuous-valued outputs like
+  watch-minutes or GMV.
+- **Netflix calibrated recommendations** (Steck, 2018 — Calibrated Recommendations,
+  RecSys 2018) — distinct from score calibration; addresses *category* calibration
+  (slate composition diversity). Out of scope here.
+
+The novel piece is **cross-modal calibration**: not just calibrating each ranker to
+its own outcome distribution, but mapping every modality's calibrated output to a
+*single shared utility scale* so that values can be summed, compared, and traded
+off in slate composition and reward computation.
+
+---
+
+## Decision
+
+Implement a per-modality calibration layer that maps raw ranker scores to a unified
+**normalized expected value (NEV)** in `[0, 1]`, where NEV represents predicted
+contribution to a user's normalized engagement-equivalent value. Build this in a
+new Rust crate (`experimentation-calibration`) consumed by the personalization
+service at scoring time and validated by M4a at analysis time.
+
+The crate is owned by Agent-4 (the same agent that owns `experimentation-stats`)
+because calibration is a statistical concern, not a personalization concern. The
+personalization service is a *consumer* of calibration models; it is not the owner
+of calibration methodology.
+
+### 1. Crate Structure
+
+```
+crates/experimentation-calibration/
+├── src/
+│   ├── lib.rs
+│   ├── modality.rs         # ModalityCalibrator trait + per-modality impls
+│   ├── isotonic.rs         # Isotonic regression (delegated to existing if exists)
+│   ├── platt.rs            # Platt scaling
+│   ├── spline.rs           # Smoothing-spline for continuous outputs
+│   ├── joint.rs            # Cross-modal joint calibration (NEV mapping)
+│   ├── persistence.rs      # RocksDB serialization (matches ADR-002 pattern)
+│   ├── validation.rs       # Coverage tests, ECE/MCE computation
+│   └── proto.rs            # Conversion to/from CalibrationProvenance proto
+├── Cargo.toml
+└── tests/
+    ├── golden/             # Reference outputs vs scikit-learn calibration
+    └── proptests/
+```
+
+### 2. Public API
+
+```rust
+pub trait ModalityCalibrator: Send + Sync {
+    /// Map a raw ranker score for a single item to a calibrated probability or
+    /// expected outcome in the modality's native units.
+    fn calibrate_raw(&self, raw_score: f64, context: &CalibrationContext) -> f64;
+
+    /// Map the modality-native calibrated value to the unified NEV scale [0, 1].
+    /// This is the cross-modal step. Implementations are responsible for the
+    /// modality-to-NEV mapping (e.g., 30 watch-minutes → 0.45 NEV).
+    fn to_nev(&self, native_calibrated: f64, context: &CalibrationContext) -> f64;
+
+    /// Convenience: raw_score → NEV in one call.
+    fn calibrate_to_nev(&self, raw_score: f64, context: &CalibrationContext) -> f64 {
+        let native = self.calibrate_raw(raw_score, context);
+        self.to_nev(native, context)
+    }
+
+    fn calibrator_id(&self) -> &str;
+    fn calibrator_version(&self) -> &str;
+    fn modality(&self) -> ContentTypeKey;
+}
+
+pub struct JointCalibrator {
+    calibrators: HashMap<ContentTypeKey, Box<dyn ModalityCalibrator>>,
+    /// Per-modality scalar weights applied AFTER `to_nev` to encode business
+    /// priorities (e.g., commerce gets a 0.7 multiplier to discount its higher
+    /// volatility). These are NOT learned — they are policy.
+    modality_weights: HashMap<ContentTypeKey, f64>,
+}
+
+impl JointCalibrator {
+    pub fn calibrate_slate(&self, items: &[RawSlateItem]) -> Vec<CalibratedSlateItem> {
+        items.iter().map(|item| {
+            let nev = self.calibrators[&item.modality]
+                .calibrate_to_nev(item.raw_score, &item.context);
+            let weighted = nev * self.modality_weights[&item.modality];
+            assert_finite!(weighted);  // mandatory per CLAUDE.md fail-fast rule
+            CalibratedSlateItem {
+                item_id: item.item_id.clone(),
+                modality: item.modality.clone(),
+                native_calibrated: self.calibrators[&item.modality]
+                    .calibrate_raw(item.raw_score, &item.context),
+                nev,
+                weighted_nev: weighted,
+            }
+        }).collect()
+    }
+}
+```
+
+Every floating-point path uses `assert_finite!()` per CLAUDE.md fail-fast policy.
+
+### 3. Calibrator Training (Out of Scope; Hooked)
+
+Calibration models are trained offline (Spark or Python notebook) against logged
+exposures and ground-truth outcomes from M3. Training is **not** in this crate's
+scope. The crate provides:
+
+- A `CalibratorBuilder` that ingests fitted parameters (knot positions for splines,
+  Beta distribution parameters for Beta calibration, etc.).
+- A binary format for shipping fitted calibrators to P8 via RocksDB snapshot
+  (matches existing ADR-002 single-thread + crash-only pattern).
+- A `validate_against_holdout` function that computes Expected Calibration Error
+  (ECE) and Maximum Calibration Error (MCE) and rejects calibrators that exceed
+  thresholds (default: ECE > 0.05 → reject).
+
+### 4. Proto Integration
+
+The personalization proto's `CalibrationProvenance` (in
+`personalization/v1/ranking.proto`) populates from the calibrator metadata:
+
+```protobuf
+message CalibrationProvenance {
+  string calibrator_id = 1;
+  string calibrator_version = 2;
+  string calibration_method = 3;
+  // Per-modality method used. Populated when slate is heterogeneous.
+  map<string, string> per_modality_method = 4;
+  // ECE/MCE at the calibrator's last validation. Lets M4a flag analyses where the
+  // calibrator was already known to be miscalibrated.
+  double last_known_ece = 5;
+  double last_known_mce = 6;
+}
+```
+
+### 5. Integration with ADR-011 Multi-Objective Reward Composer
+
+ADR-011's `RewardComposer` accepts a vector of per-objective rewards and scalarizes
+via a configurable scalarization (linear, Tchebycheff, etc.). Today it has no
+opinion on whether the inputs are comparable.
+
+After this ADR, the reward composer's contract becomes:
+- Per-objective rewards MUST be in NEV-comparable units before scalarization.
+- The composer takes a `JointCalibrator` reference at construction and refuses to
+  scalarize rewards whose modalities are not registered with the calibrator.
+- A new field `composer_config.require_calibrated = true` enforces this for
+  personalization experiments. Default `false` preserves backward compatibility for
+  single-modality experiments.
+
+### 6. Integration with M4a Analysis
+
+M4a's slate analysis (IPW-adjusted, LIPS estimator in `slate.rs:532`) gains a
+calibration-aware mode:
+
+- When `ExposureEvent.bandit_context_json` includes a `CalibrationProvenance` block,
+  M4a uses the recorded `calibrator_id + version` to reproduce the NEV mapping
+  offline.
+- M4a refuses to compute aggregate treatment effects across modalities unless every
+  exposure in the analysis window used the same `calibrator_id` (or a calibrator
+  the analyst explicitly mapped via a migration table).
+- This prevents the silent-mislead failure mode at the cost of strict version
+  discipline.
+
+---
+
+## Consequences
+
+### Benefits
+
+1. **Heterogeneous slates have a coherent ordering criterion.** Slate composers can
+   sort by NEV across modalities without unit confusion.
+2. **Multi-objective rewards (ADR-011) become trustworthy** for cross-modality
+   experiments — the scalarization operates on commensurable quantities.
+3. **M4a analyses are reproducible.** The recorded `calibrator_id + version` lets
+   any historical exposure be re-scored offline against the same calibration model.
+4. **Calibration drift becomes observable.** ECE/MCE are tracked over time; analysts
+   see "the calibrator that produced these exposures had ECE 0.08" rather than
+   debugging mysterious effect-size shifts.
+5. **The personalization service stays modality-agnostic.** P8 ships modality
+   rankers; the calibration crate is the unifying layer. Adding a new modality is a
+   new calibrator, not a P8 rewrite.
+
+### Trade-offs
+
+1. **Calibrators must be trained and maintained.** New infrastructure: training
+   pipeline, validation gates, model registry, deployment cadence. Estimate: one
+   full-time owner once steady-state.
+2. **Strict version discipline.** Mid-experiment calibrator changes invalidate
+   ongoing analyses. Calibrator rollouts must be coordinated with experiment
+   lifecycle.
+3. **The "unified NEV scale" is a policy choice, not a discovered truth.** The
+   `modality_weights` encode business judgment (does $1 GMV count as more or less
+   than 1 watch-minute?). This choice will be contested.
+4. **Calibration is a single point of failure.** A bad calibrator update silently
+   degrades every personalization experiment downstream. Mitigation: shadow
+   evaluation (ADR-030) of every calibrator update before promotion.
+5. **NEV is a derived metric, not a real-world quantity.** Stakeholders who want
+   "minutes watched" or "GMV" still need the native-units view. M4a must surface
+   both: native-units treatment effect AND NEV-units treatment effect.
+
+---
+
+## Implementation Details
+
+### Proto Schema
+
+```protobuf
+// In personalization/v1/ranking.proto (already drafted; this adds fields)
+message CalibrationProvenance {
+  string calibrator_id = 1;
+  string calibrator_version = 2;
+  string calibration_method = 3;
+  map<string, string> per_modality_method = 4;
+  double last_known_ece = 5;
+  double last_known_mce = 6;
+}
+```
+
+No changes to kaizen common protos. `ExposureEvent.bandit_context_json` carries the
+serialized `RankingProvenance` (which includes `CalibrationProvenance`) per #543.
+
+### Crate Layout / Public API
+
+See "Decision" section above for full API. The crate exports one trait
+(`ModalityCalibrator`), three concrete calibrators (`PlattCalibrator`,
+`IsotonicCalibrator`, `SplineCalibrator`), one composer (`JointCalibrator`), and
+the validation utilities.
+
+### Integration
+
+| Module | Integration |
+|--------|-------------|
+| M3 Metrics | Feeds ground-truth outcomes to the offline training pipeline. No code change. |
+| M4a Analysis | Consumes `CalibrationProvenance` from exposures; refuses cross-calibrator aggregation. |
+| M4b Bandit | When slate bandits run in Path B (#544), the reward composer uses `JointCalibrator`. |
+| M5 Management | Strategy registry (#545) references calibrator IDs as part of strategy config. |
+| M7 Flags | Gates calibrator rollouts (e.g., `calibrator_v3_canary`). |
+| P8 (new) | Loads calibrators from RocksDB at startup; calls `calibrate_slate` during slate composition. |
+
+---
+
+## Validation
+
+### Unit Tests / Proptest Invariants
+
+For each calibrator:
+- **Monotonicity within modality**: `raw_score_a ≥ raw_score_b → calibrated_a ≥ calibrated_b`.
+- **NEV bounded**: `0.0 ≤ to_nev(x) ≤ 1.0` for all finite x in domain.
+- **Deterministic**: identical inputs produce identical outputs across runs.
+- **Round-trip persistence**: `from_bytes(to_bytes(calibrator)) == calibrator`.
+- **Joint calibrator handles empty slates**: returns empty vector, no panic.
+- **`assert_finite!` triggers on NaN/Inf raw scores**: fail-fast policy enforced.
+
+Proptest cases per CLAUDE.md: 10K cases nightly.
+
+### Golden-File Tests
+
+Reference implementations and precision targets:
+
+| Calibrator | Reference | Precision |
+|------------|-----------|-----------|
+| `PlattCalibrator` | scikit-learn `CalibratedClassifierCV(method='sigmoid')` | 6 decimal places |
+| `IsotonicCalibrator` | scikit-learn `IsotonicRegression` | 6 decimal places |
+| `SplineCalibrator` | scipy `UnivariateSpline` | 4 decimal places |
+| `JointCalibrator.calibrate_slate` | Reference notebook (committed to `golden/`) | 6 decimal places |
+| ECE / MCE | sklearn-style `expected_calibration_error` (re-implementation; cross-checked against `netcal` library) | 6 decimal places |
+
+Golden files live in `crates/experimentation-calibration/tests/golden/`.
+
+### Integration / Contract Tests
+
+- **M4a refuses cross-calibrator aggregation**: integration test creates two
+  exposures with different `calibrator_version` values and asserts that M4a's
+  aggregate analysis returns a clear error rather than a silent number.
+- **Reward composer requires registered modalities**: with
+  `require_calibrated = true`, scalarizing rewards from an unknown modality returns
+  `Err`, not a default value.
+- **Provenance round-trip**: `RankingProvenance` serialized to
+  `bandit_context_json` by P8 deserializes losslessly in M4a.
+
+---
+
+## Dependencies
+
+- **ADR-002** (M4b LMAX single-thread persistence): RocksDB snapshot pattern reused
+  for calibrator persistence.
+- **ADR-011** (Multi-Objective Reward Composition): consumer; reward composer
+  contract extends to require calibrated inputs.
+- **ADR-021** (Feedback Loop Interference): `ModelRetrainingEvent` already tracks
+  model retraining; this ADR adds calibrator retraining as a logged event of the
+  same shape.
+- **#543** (Personalization event emission): the provenance JSON path through
+  `ExposureEvent.bandit_context_json` is the channel by which M4a sees calibration
+  metadata.
+- **#544** (Slate-bandit composition path): both Path A and Path B benefit from
+  calibration; Path B requires it for the reward composer.
+- **#545** (Strategy configuration contract): strategy configs reference
+  calibrator IDs; the JSON Schema registry validates calibrator references.
+- **Enables future ADR**: cross-modality treatment effect transport (using calibrated
+  values to project effects from one modality to another).
+
+---
+
+## Rejected Alternatives
+
+| Alternative | Reason Rejected |
+|-------------|-----------------|
+| **No calibration; raw scores compared directly** | Demonstrably wrong — units don't compose. Production failure mode within weeks of multi-modal rollout. |
+| **Per-modality experiments only; never mix modalities in a slate** | Forfeits the core product capability driving SVOD orchestration (heterogeneous discovery). Forces analysts to run N parallel experiments where 1 would do. |
+| **Learn the calibration end-to-end in the ranker** | Ties calibration to ranker training cycle; calibration drift becomes a ranker problem. Loses the audit trail (`calibrator_id`) that M4a depends on for reproducibility. |
+| **Use a single global ranker that outputs NEV directly** | A unified multi-modal ranker is a large research project. Per-modality rankers + a calibration layer is incremental, well-understood, and lets each modality team move independently. Defer the unified ranker as a future direction. |
+| **Calibration in P8, not in a dedicated crate** | Calibration is a statistical method (ADR-cluster B/E). Putting it in P8 mixes statistical and engineering concerns and bypasses Agent-4's review. Crate ownership matches existing pattern. |
+
+---
+
+## References
+
+- Platt, J. (1999). *Probabilistic outputs for support vector machines and
+  comparisons to regularized likelihood methods.* Advances in large margin
+  classifiers.
+- Zadrozny, B. & Elkan, C. (2002). *Transforming classifier scores into accurate
+  multiclass probability estimates.* KDD.
+- Kull, M., Silva Filho, T. M., Flach, P. (2017). *Beyond sigmoids: How to obtain
+  well-calibrated probabilities from binary classifiers with beta calibration.*
+  Electronic Journal of Statistics.
+- Steck, H. (2018). *Calibrated Recommendations.* RecSys 2018. (Context, not direct
+  prior art — addresses category calibration, complementary problem.)
+- Niculescu-Mizil, A. & Caruana, R. (2005). *Predicting good probabilities with
+  supervised learning.* ICML.
+- `netcal` Python library — cross-checked golden-file reference for ECE/MCE.
+- `crates/experimentation-bandit/src/reward_composer.rs` — consumer.
+- `crates/experimentation-bandit/src/slate.rs:532` — LIPS estimator, downstream
+  beneficiary of consistent NEV-scaled rewards.
+- ADR-011, ADR-016, ADR-026 — adjacent decisions.
+- #543, #544, #545 — companion design discussions.

--- a/docs/adrs/030-shadow-experiment-mode.md
+++ b/docs/adrs/030-shadow-experiment-mode.md
@@ -1,4 +1,4 @@
-# ADR-027: Shadow Mode for Experiments
+# ADR-030: Shadow Mode for Experiments
 
 ## Status
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -33,6 +33,9 @@ This directory contains the architectural decisions that shaped the experimentat
 | [025](025-m5-conditional-rust-port.md) | Conditional port of M5 Management Service from Go to Rust | **Proposed (conditional)** | M5 |
 | [026](026-custom-metrics-layer.md) | Custom metrics definition layer (composite, derived, joined metrics beyond the 6 built-in types) | **Proposed** | M5, M3, M4a |
 | [027](027-tost-equivalence-testing.md) | Two One-Sided Tests (TOST) for proving statistical equivalence in infrastructure migrations | **Proposed** | M4a, M5, M6 |
+| [028](028-m4b-shadow-inference.md) | M4b shadow inference path for bandit policy promotion (dedicated shadow core, column-family isolation) | **Proposed** | M4b, M4a, M5, M6 |
+| [029](029-cross-modal-score-calibration.md) | Cross-modal score calibration for heterogeneous slates (unified NEV scale across video, manga, commerce) | **Proposed** | M4a, M4b, M5, Personalization service |
+| [030](030-shadow-experiment-mode.md) | Shadow mode flag on experiments — run candidate variants on production traffic without user exposure | **Proposed** | M1, M4a, M4b, M5, M6 |
 
 ## Proposed ADR Clusters
 


### PR DESCRIPTION
## Summary

- **Add ADR-029** (Proposed) — Cross-modal score calibration for heterogeneous slates. Maps per-modality ranker outputs (video minutes, manga chapters, commerce GMV) into a unified normalized expected-value (NEV) scale via a new `experimentation-calibration` crate owned by Agent-4.
- **Renumber 027-shadow-experiment-mode → 030** to resolve a number collision with 027-tost-equivalence-testing (canonical 027 referenced across CLAUDE.md, agent docs, proto, and source).
- **Fill in the ADR index** — `docs/adrs/README.md` was missing entries for 028, 029, 030.

## What changed

| File | Change |
|------|--------|
| `docs/adrs/029-cross-modal-score-calibration.md` | New (Proposed) |
| `docs/adrs/030-shadow-experiment-mode.md` | Renamed from `027-shadow-experiment-mode.md`; title updated |
| `docs/adrs/028-m4b-shadow-inference.md` | 5 references ADR-027 → ADR-030 |
| `docs/adrs/README.md` | Added rows for 028, 029, 030 |

## Companion design discussions (GitHub Issues, `rfc` label)

These three pre-decision design questions are tracked as Issues rather than docs, per project preference:

- #543 — RFC-001: Personalization Service Event Emission Boundary
- #544 — RFC-002: Slate-Bandit Composition Path
- #545 — RFC-003: Strategy Configuration Contract

ADR-029 references these by issue number.

## Context

This work emerged from a design discussion on whether kaizen-experimentation can serve as an orchestration platform for an SVOD personalization service. The conclusion: kaizen remains the experimentation harness; a separate personalization service (working name P8) would integrate via the proto surface sketched in the discussion. ADR-029 captures the one architectural decision that cleanly belongs to kaizen (cross-modal calibration is a statistical method, per CLAUDE.md's "no statistical computation outside Rust" rule). The remaining design tradeoffs are open RFCs.

## Test plan

- [ ] Markdown renders correctly in GitHub preview for ADR-029
- [ ] All `ADR-027` references in `docs/adrs/028-m4b-shadow-inference.md` now point to ADR-030
- [ ] `docs/adrs/README.md` index includes 028, 029, 030 rows in correct order
- [ ] Companion issues (#543, #544, #545) load and have the `rfc` label
- [ ] No remaining `RFC-NNN` textual references in ADR-029 (all converted to `#NNN`)
- [ ] No stray references to `027-shadow-experiment-mode.md` anywhere in `docs/`

## Out of scope

- Implementing the `experimentation-calibration` crate (covered by ADR-029 once Accepted)
- Resolving the RFCs into ADRs (each RFC graduates to an ADR once consensus reached)
- The personalization service itself (lives outside this repo)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->