### PR TITLE
docs(claude): add ADR-028/029/030 to Active Work proposed list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,9 @@ See `docs/coordination/phase5-implementation-plan.md` and `docs/coordination/CHA
 **New ADRs (Proposed)**:
 - **ADR-026** (`docs/adrs/026-custom-metrics-layer.md`) — Custom metrics definition layer (composite / derived / joined metrics beyond the six built-in types). Impact: M5, M3, M4a.
 - **ADR-027** (`docs/adrs/027-tost-equivalence-testing.md`) — Two One-Sided Tests for proving equivalence (infra migrations, refactor validation). Impact: M4a, M5, M6. Core impl landed (#443); see `crates/experimentation-stats/src/tost.rs`.
+- **ADR-028** (`docs/adrs/028-m4b-shadow-inference.md`) — M4b shadow inference path for bandit policy promotion (dedicated shadow core, column-family isolation). Impact: M4b, M4a, M5, M6.
+- **ADR-029** (`docs/adrs/029-cross-modal-score-calibration.md`) — Cross-modal score calibration for heterogeneous slates (unified NEV scale across video, manga, commerce). Introduces a new `experimentation-calibration` Rust crate owned by Agent-4 and opens cluster **G — Personalization Orchestration**. Impact: M4a, M4b, M5, Personalization service.
+- **ADR-030** (`docs/adrs/030-shadow-experiment-mode.md`) — Shadow mode flag on experiments — run candidate variants on production traffic without user exposure. Impact: M1, M4a, M4b, M5, M6.
 
 **Infrastructure sprint (Pulumi + Go on AWS)**: `infra/` contains Pulumi stacks (`Pulumi.{dev,staging,prod}.yaml`) and a full Go test suite (`fullstack_test.go`). Sprint I.0 (all 13 modules) and I.1/I.2 (wiring + hardening) merged; ECR repos exist for all 9 Kaizen services.
 


### PR DESCRIPTION
## Summary

Adds ADR-028, ADR-029, and ADR-030 to the **Active Work (Post-Phase 5) → New ADRs (Proposed)** section in `CLAUDE.md`. Follow-up to #548, which added the ADRs themselves but deliberately scoped CLAUDE.md changes to a separate PR.

## Why

CLAUDE.md is the primary project-context file every agent session pulls in automatically. The three newly-proposed ADRs (028 M4b shadow inference, 029 cross-modal calibration, 030 shadow experiment mode) were invisible to future agents until they appeared here — a contributor running \`grep ADR-028 CLAUDE.md\` would have come up empty.

## Format

Matches the existing ADR-026 / ADR-027 entries:
- 1-line bullet per ADR
- Bold ADR ID + relative path
- One-sentence description
- \`Impact: <modules>\` callout

ADR-029's entry additionally notes the new \`experimentation-calibration\` Rust crate ownership and the opening of cluster **G — Personalization Orchestration**, since both are project-architecture facts that affect future agent work.

## Explicitly NOT changed in this PR

- **Line 7 \"Sprint 5.6\" callout** — sprint slotting for 028/029/030 is a planning decision, not a docs decision. Flagged for whoever owns next sprint planning.
- **Line 36 \`experimentation-stats\` crate comment** — \`experimentation-calibration\` is a NEW crate ADR-029 will create, not existing workspace state. Adding it pre-creation would be premature; CLAUDE.md should describe reality, not roadmap.
- **Phase 5 cluster table (lines 81-86)** — cluster G is post-Phase 5; doesn't belong in the Phase 5 status grid.

## Test plan

- [ ] Reviewer reads the diff (3 added lines) and confirms each ADR entry's impact list matches the corresponding ADR doc + \`docs/adrs/README.md\` row.
- [ ] No code touched. No tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->