### PR TITLE
ADR-027 TOST equivalence testing — M4a + M5 + M6 (Closes #423)

### DIFF
--- a/crates/experimentation-analysis/src/grpc.rs
+++ b/crates/experimentation-analysis/src/grpc.rs
@@ -571,6 +571,24 @@ fn compute_equivalence_result(
     assert_finite(r.control_mean, "TOST control_mean");
     assert_finite(r.treatment_mean, "TOST treatment_mean");
 
+    // ADR-027 §6: power at the current sample size given δ, under the
+    // canonical migration design assumption (true difference = 0). Consumes
+    // the realized standard error so it is genuinely "power at current n".
+    // Rendered by the M6 power indicator; a failure here is non-fatal.
+    let achieved_power = match tost::tost_achieved_power(r.std_error, r.delta, 0.0, alpha) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                metric_id,
+                variant_id,
+                error = %e,
+                "ADR-027: achieved-power estimate failed; reporting 0.0"
+            );
+            0.0
+        }
+    };
+    assert_finite(achieved_power, "TOST achieved_power");
+
     Some(EquivalenceResult {
         point_estimate: r.point_estimate,
         std_error: r.std_error,
@@ -586,6 +604,7 @@ fn compute_equivalence_result(
         delta: r.delta,
         control_mean: r.control_mean,
         treatment_mean: r.treatment_mean,
+        achieved_power,
     })
 }
 

--- a/crates/experimentation-analysis/src/grpc.rs
+++ b/crates/experimentation-analysis/src/grpc.rs
@@ -568,8 +568,17 @@ fn compute_equivalence_result(
     assert_finite(r.ci_lower, "TOST ci_lower");
     assert_finite(r.ci_upper, "TOST ci_upper");
     assert_finite(r.delta, "TOST effective delta");
-    assert_finite(r.control_mean, "TOST control_mean");
-    assert_finite(r.treatment_mean, "TOST treatment_mean");
+    // Proto contract: control_mean / treatment_mean are the RAW, pre-CUPED
+    // means. The CUPED path runs TOST on adjusted samples, so r.control_mean
+    // / r.treatment_mean would be the *adjusted* means — report the raw
+    // values instead, consistent with the raw `control_mean` used above for
+    // delta_relative resolution. (For the non-CUPED path these are identical
+    // to r.control_mean / r.treatment_mean.)
+    let raw_control_mean = control_mean;
+    let raw_treatment_mean =
+        treatment_values.iter().sum::<f64>() / treatment_values.len() as f64;
+    assert_finite(raw_control_mean, "raw control_mean");
+    assert_finite(raw_treatment_mean, "raw treatment_mean");
 
     // ADR-027 §6: power at the current sample size given δ, under the
     // canonical migration design assumption (true difference = 0). Consumes
@@ -602,8 +611,8 @@ fn compute_equivalence_result(
         // Echo the *effective* margin actually used (post delta_relative
         // resolution) — tost.rs sets this to tost_cfg.delta.
         delta: r.delta,
-        control_mean: r.control_mean,
-        treatment_mean: r.treatment_mean,
+        control_mean: raw_control_mean,
+        treatment_mean: raw_treatment_mean,
         achieved_power,
     })
 }

--- a/crates/experimentation-analysis/src/grpc.rs
+++ b/crates/experimentation-analysis/src/grpc.rs
@@ -10,8 +10,9 @@ use experimentation_proto::experimentation::analysis::v1::analysis_service_serve
 };
 use experimentation_proto::experimentation::analysis::v1::{
     AdaptiveNInterimResult, AlgorithmStrength as ProtoAlgorithmStrength, AnalysisResult,
-    GetAnalysisResultRequest, GetInterferenceAnalysisRequest, GetInterleavingAnalysisRequest,
-    GetNoveltyAnalysisRequest, GetOrlAnalysisRequest, GetPortfolioAllocationRequest,
+    EquivalenceResult, GetAnalysisResultRequest, GetInterferenceAnalysisRequest,
+    GetInterleavingAnalysisRequest, GetNoveltyAnalysisRequest, GetOrlAnalysisRequest,
+    GetPortfolioAllocationRequest,
     GetPortfolioAllocationResponse, GetPortfolioPowerAnalysisRequest, GetSwitchbackAnalysisRequest,
     GetSyntheticControlAnalysisRequest, InterferenceAnalysisResult, InterleavingAnalysisResult,
     IpwResult as ProtoIpwResult, MetricResult, NoveltyAnalysisResult,
@@ -20,10 +21,13 @@ use experimentation_proto::experimentation::analysis::v1::{
     SequentialResult, SessionLevelResult, SrmResult as ProtoSrmResult, SwitchbackAnalysisResult,
     SyntheticControlAnalysisResult, TitleSpillover,
 };
-use experimentation_proto::experimentation::common::v1::AdaptiveSampleSizeConfig;
+use experimentation_proto::experimentation::common::v1::{
+    AdaptiveSampleSizeConfig, EquivalenceTestConfig,
+};
+use experimentation_core::error::assert_finite;
 use experimentation_stats::{
     adaptive_n, avlm, cate, clustering, cuped, evalue, interference, interleaving, ipw, novelty, portfolio, srm,
-    switchback, synthetic_control, ttest,
+    switchback, synthetic_control, tost, ttest,
 };
 
 /// Proto enum value for SEQUENTIAL_METHOD_AVLM (ADR-015).
@@ -214,6 +218,7 @@ async fn compute_analysis(
     tau_sq: f64,
     cuped_covariate_metric_id: &str,
     adaptive_config: Option<&AdaptiveSampleSizeConfig>,
+    equivalence_config: Option<&EquivalenceTestConfig>,
 ) -> Result<AnalysisResult, Status> {
     let data = delta_reader::read_metric_summaries(&config.delta_lake_path, experiment_id)
         .await
@@ -246,6 +251,26 @@ async fn compute_analysis(
 
     let mut metric_ids: Vec<&String> = data.metrics.keys().collect();
     metric_ids.sort();
+
+    // ADR-027: the equivalence (TOST) test runs on the *primary metric* only.
+    // M4a reads metric_summaries from Delta Lake and does not fetch the
+    // Experiment, so (consistent with the ADR-020 adaptive-N convention in
+    // `compute_adaptive_n_result`) the primary metric is the first metric
+    // alphabetically that has ≥2 observations in both the control arm and at
+    // least one treatment arm. None when no equivalence config is supplied.
+    let tost_primary_metric: Option<String> = equivalence_config.and_then(|_| {
+        metric_ids
+            .iter()
+            .find(|mid| {
+                let vd = &data.metrics[**mid];
+                let control_ok = vd.get(&control_variant).is_some_and(|c| c.len() >= 2);
+                let treatment_ok = vd
+                    .keys()
+                    .any(|k| *k != control_variant && vd[k].len() >= 2);
+                control_ok && treatment_ok
+            })
+            .map(|s| s.to_string())
+    });
 
     for metric_id in metric_ids {
         let variant_data = &data.metrics[metric_id];
@@ -357,6 +382,28 @@ async fn compute_analysis(
                 (0.0, 0.0)
             };
 
+            // ADR-027: TOST equivalence test on the primary metric only.
+            // Additive — does not touch the superiority fields above. The
+            // standard Welch t-test still runs; equivalence_result is an extra
+            // verdict for "is treatment within ±delta of control?".
+            let equivalence_result = if tost_primary_metric.as_deref() == Some(metric_id.as_str())
+            {
+                equivalence_config.and_then(|cfg| {
+                    compute_equivalence_result(
+                        cfg,
+                        &control_values,
+                        &treatment_values,
+                        control_tuples,
+                        treatment_tuples,
+                        ttest_result.control_mean,
+                        metric_id,
+                        variant_id,
+                    )
+                })
+            } else {
+                None
+            };
+
             metric_results.push(MetricResult {
                 metric_id: metric_id.clone(),
                 variant_id: variant_id.clone(),
@@ -390,6 +437,7 @@ async fn compute_analysis(
                 ),
                 e_value: ev,
                 log_e_value: log_ev,
+                equivalence_result,
             });
         }
     }
@@ -411,6 +459,133 @@ async fn compute_analysis(
         cochran_q_p_value,
         computed_at: Some(now_timestamp()),
         adaptive_n_result,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// TOST equivalence helper (ADR-027)
+// ---------------------------------------------------------------------------
+
+/// Compute the TOST equivalence result for one (primary metric, treatment
+/// variant) pair, given the per-arm observations.
+///
+/// Resolution of `delta_relative` (ADR-027 proto contract): when
+/// `delta_relative` is set, the effective margin is `delta_relative *
+/// control_mean`; otherwise the absolute `delta` is used. The MEAN/RATIO
+/// restriction on `delta_relative` is enforced upstream by M5 at experiment
+/// creation (#423) — M4a has no metric-type signal at analysis time (it reads
+/// only Delta Lake metric_summaries) so it applies the documented resolution
+/// and guards the degenerate case (non-finite or non-positive effective
+/// delta, e.g. when `control_mean ≈ 0`) by skipping TOST with a structured
+/// warning rather than panicking.
+///
+/// Uses CUPED-adjusted TOST when a usable covariate is present in both arms
+/// (same gate as the superiority CUPED path); otherwise plain Welch TOST.
+/// Returns `None` (test skipped, logged) on invalid config or a stats error;
+/// never panics on bad input. All float outputs are fail-fast `assert_finite`
+/// checked before populating the proto message.
+#[allow(clippy::too_many_arguments)]
+fn compute_equivalence_result(
+    cfg: &EquivalenceTestConfig,
+    control_values: &[f64],
+    treatment_values: &[f64],
+    control_tuples: &[(f64, Option<f64>)],
+    treatment_tuples: &[(f64, Option<f64>)],
+    control_mean: f64,
+    metric_id: &str,
+    variant_id: &str,
+) -> Option<EquivalenceResult> {
+    // Resolve the effective equivalence margin.
+    let effective_delta = match cfg.delta_relative {
+        Some(rel) => rel * control_mean,
+        None => cfg.delta,
+    };
+    if !effective_delta.is_finite() || effective_delta <= 0.0 {
+        warn!(
+            metric_id,
+            variant_id,
+            configured_delta = cfg.delta,
+            delta_relative = ?cfg.delta_relative,
+            control_mean,
+            effective_delta,
+            "ADR-027: equivalence test skipped — effective delta is not strictly \
+             positive after delta_relative resolution (delta_relative requires a \
+             non-zero control mean and a MEAN/RATIO primary metric, validated by M5)"
+        );
+        return None;
+    }
+
+    // Proto `double alpha` defaults to 0.0 when unset; fall back to the
+    // canonical per-side α = 0.05 (matching TostConfig::new).
+    let alpha = if cfg.alpha > 0.0 { cfg.alpha } else { 0.05 };
+    let tost_cfg = tost::TostConfig {
+        delta: effective_delta,
+        alpha,
+    };
+
+    // CUPED-adjusted TOST when a usable covariate is present in both arms —
+    // same gate as the superiority CUPED branch above.
+    let control_covs: Vec<f64> = control_tuples.iter().filter_map(|(_, c)| *c).collect();
+    let treatment_covs: Vec<f64> = treatment_tuples.iter().filter_map(|(_, c)| *c).collect();
+    let use_cuped = control_covs.len() == control_values.len()
+        && treatment_covs.len() == treatment_values.len()
+        && control_covs.len() >= 2
+        && treatment_covs.len() >= 2;
+
+    let tost_outcome = if use_cuped {
+        tost::tost_cuped_equivalence_test(
+            control_values,
+            treatment_values,
+            &control_covs,
+            &treatment_covs,
+            &tost_cfg,
+        )
+    } else {
+        tost::tost_equivalence_test(control_values, treatment_values, &tost_cfg)
+    };
+
+    let r = match tost_outcome {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                metric_id,
+                variant_id,
+                cuped = use_cuped,
+                error = %e,
+                "ADR-027: equivalence (TOST) test failed; skipping equivalence_result"
+            );
+            return None;
+        }
+    };
+
+    // Fail-fast on the float outputs before they cross the proto boundary.
+    assert_finite(r.point_estimate, "TOST point_estimate");
+    assert_finite(r.std_error, "TOST std_error");
+    assert_finite(r.df, "TOST df");
+    assert_finite(r.p_lower, "TOST p_lower");
+    assert_finite(r.p_upper, "TOST p_upper");
+    assert_finite(r.p_tost, "TOST p_tost");
+    assert_finite(r.ci_lower, "TOST ci_lower");
+    assert_finite(r.ci_upper, "TOST ci_upper");
+    assert_finite(r.delta, "TOST effective delta");
+    assert_finite(r.control_mean, "TOST control_mean");
+    assert_finite(r.treatment_mean, "TOST treatment_mean");
+
+    Some(EquivalenceResult {
+        point_estimate: r.point_estimate,
+        std_error: r.std_error,
+        df: r.df,
+        p_lower: r.p_lower,
+        p_upper: r.p_upper,
+        p_tost: r.p_tost,
+        ci_lower: r.ci_lower,
+        ci_upper: r.ci_upper,
+        equivalent: r.equivalent,
+        // Echo the *effective* margin actually used (post delta_relative
+        // resolution) — tost.rs sets this to tost_cfg.delta.
+        delta: r.delta,
+        control_mean: r.control_mean,
+        treatment_mean: r.treatment_mean,
     })
 }
 
@@ -831,6 +1006,7 @@ impl AnalysisService for AnalysisServiceHandler {
             req.tau_sq,
             &req.cuped_covariate_metric_id,
             req.adaptive_sample_size_config.as_ref(),
+            req.equivalence_test.as_ref(),
         )
         .await?;
 
@@ -864,8 +1040,10 @@ impl AnalysisService for AnalysisServiceHandler {
             }
         }
 
-        // Cache miss or no store: compute from Delta Lake (fixed-horizon, no sequential method).
-        let result = compute_analysis(&self.config, &experiment_id, 0, 0.0, "", None).await?;
+        // Cache miss or no store: compute from Delta Lake (fixed-horizon, no
+        // sequential method, no equivalence test — TOST is run_analysis-driven).
+        let result =
+            compute_analysis(&self.config, &experiment_id, 0, 0.0, "", None, None).await?;
 
         // Write through to cache.
         if let (Some(store), Some(uuid)) = (&self.store, try_parse_uuid(&experiment_id)) {
@@ -1493,6 +1671,186 @@ mod tests {
             "CUPED should reduce variance, got {}",
             mr.variance_reduction_pct
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // ADR-027: TOST equivalence wiring (RunAnalysisRequest.equivalence_test
+    // -> MetricResult.equivalence_result on the primary metric)
+    // -----------------------------------------------------------------------
+
+    /// Build a 2-arm single-metric experiment with explicit per-arm values.
+    async fn write_two_arm(
+        tmp: &TempDir,
+        metric: &str,
+        control: &[f64],
+        treatment: &[f64],
+    ) {
+        let n = control.len() + treatment.len();
+        let exp_ids: Vec<&str> = vec!["exp-1"; n];
+        let user_ids: Vec<String> = (0..n).map(|i| format!("u{i}")).collect();
+        let user_refs: Vec<&str> = user_ids.iter().map(|s| s.as_str()).collect();
+        let mut variant_ids: Vec<&str> = vec!["control"; control.len()];
+        variant_ids.extend(vec!["treatment"; treatment.len()]);
+        let metric_ids: Vec<&str> = vec![metric; n];
+        let mut values: Vec<f64> = control.to_vec();
+        values.extend_from_slice(treatment);
+        let covariates: Vec<Option<f64>> = vec![None; n];
+        let batch = make_analysis_data(
+            &exp_ids,
+            &user_refs,
+            &variant_ids,
+            &metric_ids,
+            &values,
+            &covariates,
+        );
+        write_table(tmp.path(), "metric_summaries", batch).await;
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_equivalence_equivalent() {
+        let tmp = TempDir::new().unwrap();
+        // Nearly identical arms (means ~10), tight spread → equivalent within a
+        // generous margin (delta = 5).
+        let control = [9.0, 10.0, 11.0, 10.0, 9.5, 10.5, 10.0, 9.8, 10.2, 10.1];
+        let treatment = [10.1, 9.9, 10.2, 9.8, 10.0, 10.3, 9.7, 10.1, 9.9, 10.0];
+        write_two_arm(&tmp, "ctr", &control, &treatment).await;
+
+        let handler = test_handler(tmp.path().to_str().unwrap());
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+                equivalence_test: Some(EquivalenceTestConfig {
+                    delta: 5.0,
+                    delta_relative: None,
+                    alpha: 0.05,
+                }),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+
+        let mr = &resp.into_inner().metric_results[0];
+        let eq = mr
+            .equivalence_result
+            .as_ref()
+            .expect("equivalence_result must be populated on the primary metric");
+        assert!(
+            eq.equivalent,
+            "arms within ±5 should be declared equivalent (p_tost={}, ci=[{}, {}])",
+            eq.p_tost, eq.ci_lower, eq.ci_upper
+        );
+        assert!(eq.p_tost < 0.05, "p_tost should reject, got {}", eq.p_tost);
+        assert!((eq.delta - 5.0).abs() < 1e-12, "effective delta echoed");
+        assert!(eq.std_error > 0.0 && eq.df > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_equivalence_not_equivalent() {
+        let tmp = TempDir::new().unwrap();
+        // Clearly separated arms (≈+10 effect) with a tiny margin (delta = 0.5)
+        // → not equivalent.
+        let control = [1.0, 2.0, 3.0, 4.0, 5.0, 1.5, 2.5, 3.5, 4.5, 2.0];
+        let treatment = [11.0, 12.0, 13.0, 14.0, 15.0, 11.5, 12.5, 13.5, 14.5, 12.0];
+        write_two_arm(&tmp, "ctr", &control, &treatment).await;
+
+        let handler = test_handler(tmp.path().to_str().unwrap());
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+                equivalence_test: Some(EquivalenceTestConfig {
+                    delta: 0.5,
+                    delta_relative: None,
+                    alpha: 0.05,
+                }),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+
+        let mr = &resp.into_inner().metric_results[0];
+        let eq = mr
+            .equivalence_result
+            .as_ref()
+            .expect("equivalence_result must be populated on the primary metric");
+        assert!(
+            !eq.equivalent,
+            "a +10 effect cannot be equivalent within ±0.5 (p_tost={})",
+            eq.p_tost
+        );
+        // Superiority path must still be intact and detect the difference.
+        assert!(mr.is_significant, "Welch t-test should still flag the effect");
+        assert!((mr.absolute_effect - 10.0).abs() < 1e-9);
+        assert!((eq.delta - 0.5).abs() < 1e-12);
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_equivalence_delta_relative() {
+        let tmp = TempDir::new().unwrap();
+        // Control mean = 100. delta_relative = 0.05 → effective delta = 5.0.
+        let control = [98.0, 100.0, 102.0, 99.0, 101.0, 100.0, 99.5, 100.5, 101.0, 99.0];
+        let treatment = [
+            100.5, 99.5, 101.0, 99.0, 100.0, 100.2, 99.8, 100.1, 99.9, 100.0,
+        ];
+        write_two_arm(&tmp, "ctr", &control, &treatment).await;
+
+        let handler = test_handler(tmp.path().to_str().unwrap());
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+                equivalence_test: Some(EquivalenceTestConfig {
+                    delta: 0.0, // ignored when delta_relative is set
+                    delta_relative: Some(0.05),
+                    alpha: 0.05,
+                }),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+
+        let mr = &resp.into_inner().metric_results[0];
+        let eq = mr
+            .equivalence_result
+            .as_ref()
+            .expect("equivalence_result must be populated");
+        let control_mean = mr.control_mean;
+        // Effective delta = delta_relative * control_mean, echoed in the result.
+        let expected_delta = 0.05 * control_mean;
+        assert!(
+            (eq.delta - expected_delta).abs() < 1e-9,
+            "effective delta should be delta_relative*control_mean = {expected_delta}, got {}",
+            eq.delta
+        );
+        assert!(
+            (control_mean - 100.0).abs() < 1e-9,
+            "control mean should be ~100, got {control_mean}"
+        );
+        assert!(eq.equivalent, "tight arms within ±5 (≈5% of 100)");
+    }
+
+    #[tokio::test]
+    async fn test_run_analysis_no_equivalence_config_leaves_result_none() {
+        // Additive guarantee: without equivalence_test, equivalence_result is
+        // absent and the standard superiority path is unaffected.
+        let tmp = TempDir::new().unwrap();
+        let control = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let treatment = [11.0, 12.0, 13.0, 14.0, 15.0];
+        write_two_arm(&tmp, "ctr", &control, &treatment).await;
+
+        let handler = test_handler(tmp.path().to_str().unwrap());
+        let resp = handler
+            .run_analysis(Request::new(RunAnalysisRequest {
+                experiment_id: "exp-1".into(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+
+        let mr = &resp.into_inner().metric_results[0];
+        assert!(
+            mr.equivalence_result.is_none(),
+            "equivalence_result must be None when no EquivalenceTestConfig is supplied"
+        );
+        assert!(mr.is_significant);
     }
 
     #[tokio::test]

--- a/crates/experimentation-analysis/src/store.rs
+++ b/crates/experimentation-analysis/src/store.rs
@@ -110,6 +110,7 @@ pub struct CachedEquivalenceResult {
     pub delta: f64,
     pub control_mean: f64,
     pub treatment_mean: f64,
+    pub achieved_power: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -242,6 +243,7 @@ impl From<&EquivalenceResult> for CachedEquivalenceResult {
             delta: e.delta,
             control_mean: e.control_mean,
             treatment_mean: e.treatment_mean,
+            achieved_power: e.achieved_power,
         }
     }
 }
@@ -261,6 +263,7 @@ impl From<&CachedEquivalenceResult> for EquivalenceResult {
             delta: c.delta,
             control_mean: c.control_mean,
             treatment_mean: c.treatment_mean,
+            achieved_power: c.achieved_power,
         }
     }
 }

--- a/crates/experimentation-analysis/src/store.rs
+++ b/crates/experimentation-analysis/src/store.rs
@@ -10,8 +10,8 @@ use sqlx::postgres::{PgPool, PgPoolOptions};
 use uuid::Uuid;
 
 use experimentation_proto::experimentation::analysis::v1::{
-    AnalysisResult, InterferenceAnalysisResult, IpwResult as ProtoIpwResult, MetricResult,
-    NoveltyAnalysisResult, SegmentResult, SequentialResult, SessionLevelResult,
+    AnalysisResult, EquivalenceResult, InterferenceAnalysisResult, IpwResult as ProtoIpwResult,
+    MetricResult, NoveltyAnalysisResult, SegmentResult, SequentialResult, SessionLevelResult,
     SrmResult as ProtoSrmResult,
 };
 
@@ -50,6 +50,10 @@ pub struct CachedMetricResult {
     pub session_level_result: Option<CachedSessionLevelResult>,
     #[serde(default)]
     pub ipw_result: Option<CachedIpwResult>,
+    /// ADR-027: TOST equivalence result. `serde(default)` so analysis results
+    /// cached before ADR-027 still deserialize (field absent → None).
+    #[serde(default)]
+    pub equivalence_result: Option<CachedEquivalenceResult>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -89,6 +93,23 @@ pub struct CachedIpwResult {
     pub p_value: f64,
     pub n_clipped: i32,
     pub effective_sample_size: f64,
+}
+
+/// ADR-027: serde mirror of the proto `EquivalenceResult` (TOST).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CachedEquivalenceResult {
+    pub point_estimate: f64,
+    pub std_error: f64,
+    pub df: f64,
+    pub p_lower: f64,
+    pub p_upper: f64,
+    pub p_tost: f64,
+    pub ci_lower: f64,
+    pub ci_upper: f64,
+    pub equivalent: bool,
+    pub delta: f64,
+    pub control_mean: f64,
+    pub treatment_mean: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -164,6 +185,10 @@ impl From<&MetricResult> for CachedMetricResult {
                 .as_ref()
                 .map(CachedSessionLevelResult::from),
             ipw_result: m.ipw_result.as_ref().map(CachedIpwResult::from),
+            equivalence_result: m
+                .equivalence_result
+                .as_ref()
+                .map(CachedEquivalenceResult::from),
         }
     }
 }
@@ -194,6 +219,48 @@ impl From<&CachedMetricResult> for MetricResult {
             ipw_result: c.ipw_result.as_ref().map(ProtoIpwResult::from),
             e_value: 0.0,
             log_e_value: 0.0,
+            equivalence_result: c
+                .equivalence_result
+                .as_ref()
+                .map(EquivalenceResult::from),
+        }
+    }
+}
+
+impl From<&EquivalenceResult> for CachedEquivalenceResult {
+    fn from(e: &EquivalenceResult) -> Self {
+        Self {
+            point_estimate: e.point_estimate,
+            std_error: e.std_error,
+            df: e.df,
+            p_lower: e.p_lower,
+            p_upper: e.p_upper,
+            p_tost: e.p_tost,
+            ci_lower: e.ci_lower,
+            ci_upper: e.ci_upper,
+            equivalent: e.equivalent,
+            delta: e.delta,
+            control_mean: e.control_mean,
+            treatment_mean: e.treatment_mean,
+        }
+    }
+}
+
+impl From<&CachedEquivalenceResult> for EquivalenceResult {
+    fn from(c: &CachedEquivalenceResult) -> Self {
+        Self {
+            point_estimate: c.point_estimate,
+            std_error: c.std_error,
+            df: c.df,
+            p_lower: c.p_lower,
+            p_upper: c.p_upper,
+            p_tost: c.p_tost,
+            ci_lower: c.ci_lower,
+            ci_upper: c.ci_upper,
+            equivalent: c.equivalent,
+            delta: c.delta,
+            control_mean: c.control_mean,
+            treatment_mean: c.treatment_mean,
         }
     }
 }
@@ -599,6 +666,7 @@ mod tests {
                 ipw_result: None,
                 e_value: 0.0,
                 log_e_value: 0.0,
+                equivalence_result: None,
             }],
             srm_result: Some(ProtoSrmResult {
                 chi_squared: 0.1,

--- a/crates/experimentation-management/src/portfolio.rs
+++ b/crates/experimentation-management/src/portfolio.rs
@@ -239,6 +239,13 @@ pub enum Decision {
     Stop,
     /// Extend the experiment for more power.
     Extend,
+    /// ADR-027: equivalence established — the change has no meaningful impact
+    /// and is safe to migrate/ship. (Equivalence inverts superiority: this is
+    /// the success state, replacing "reject H₀ → ship treatment".)
+    SafeToMigrate,
+    /// ADR-027: the effect exceeds ±δ — the change is not equivalent, do not
+    /// migrate.
+    NotEquivalent,
 }
 
 /// Inputs for decision rule evaluation.
@@ -288,6 +295,74 @@ pub fn evaluate_decision(input: &DecisionInput) -> Decision {
     }
 
     // Past halfway with low power → extend.
+    if input.elapsed_fraction >= 0.5 && input.achieved_power < 0.5 {
+        return Decision::Extend;
+    }
+
+    Decision::Continue
+}
+
+// ---------------------------------------------------------------------------
+// Equivalence (TOST) decision rule (ADR-027 §5)
+// ---------------------------------------------------------------------------
+
+/// Inputs for the equivalence (TOST) decision rule.
+///
+/// Equivalence inverts the superiority logic: a non-significant *difference*
+/// is the goal. The decision is "equivalence established → safe to migrate"
+/// rather than "reject H₀ → ship treatment".
+#[derive(Debug, Clone)]
+pub struct EquivalenceDecisionInput {
+    /// TOST verdict — the (1−2α) CI lies entirely within (−δ, +δ).
+    pub equivalent: bool,
+    /// Lower bound of the (1−2α) CI for the difference.
+    pub ci_lower: f64,
+    /// Upper bound of the (1−2α) CI for the difference.
+    pub ci_upper: f64,
+    /// Effective equivalence margin used (post delta_relative resolution).
+    pub delta: f64,
+    /// Estimated power at the current sample size given δ.
+    pub achieved_power: f64,
+    /// Fraction of planned duration elapsed (0.0–1.0).
+    pub elapsed_fraction: f64,
+    /// Whether the experiment has a guardrail breach.
+    pub guardrail_breached: bool,
+}
+
+/// Evaluate the decision rule for a running equivalence experiment.
+///
+/// Returns a recommendation based on the TOST result. Unlike
+/// [`evaluate_decision`], a tight CI around zero is *success*: equivalence
+/// established means the migration is safe to ship.
+pub fn evaluate_equivalence_decision(input: &EquivalenceDecisionInput) -> Decision {
+    assert_finite(input.ci_lower, "ci_lower");
+    assert_finite(input.ci_upper, "ci_upper");
+    assert_finite(input.delta, "delta");
+    assert_finite(input.achieved_power, "achieved_power");
+    assert_finite(input.elapsed_fraction, "elapsed_fraction");
+
+    // Guardrail breach → immediate stop (same as superiority).
+    if input.guardrail_breached {
+        return Decision::Stop;
+    }
+
+    // Equivalence established (CI ⊂ (−δ, +δ)) → safe to migrate.
+    if input.equivalent {
+        return Decision::SafeToMigrate;
+    }
+
+    // CI lies entirely beyond ±δ → the change has a material effect; the
+    // treatment is definitively not equivalent.
+    if input.ci_lower > input.delta || input.ci_upper < -input.delta {
+        return Decision::NotEquivalent;
+    }
+
+    // Inconclusive — the CI straddles a margin boundary.
+    // Past full planned duration with no verdict → stop (underpowered run).
+    if input.elapsed_fraction >= 1.0 {
+        return Decision::Stop;
+    }
+    // Past halfway and underpowered → extend for more data.
     if input.elapsed_fraction >= 0.5 && input.achieved_power < 0.5 {
         return Decision::Extend;
     }
@@ -1172,5 +1247,63 @@ mod tests {
     fn traffic_fraction_full_layer() {
         let exp = make_exp("exp-1", "Test", "layer-1", "m1", 0, 999, 1000);
         assert!((exp.traffic_fraction() - 1.0).abs() < 1e-9);
+    }
+
+    // --- Equivalence (TOST) decision rule tests (ADR-027 §5) ---
+
+    fn equiv_input(equivalent: bool, lo: f64, hi: f64, delta: f64) -> EquivalenceDecisionInput {
+        EquivalenceDecisionInput {
+            equivalent,
+            ci_lower: lo,
+            ci_upper: hi,
+            delta,
+            achieved_power: 0.85,
+            elapsed_fraction: 0.6,
+            guardrail_breached: false,
+        }
+    }
+
+    #[test]
+    fn equivalence_decision_safe_to_migrate_when_equivalent() {
+        let input = equiv_input(true, -0.02, 0.03, 0.05);
+        assert_eq!(evaluate_equivalence_decision(&input), Decision::SafeToMigrate);
+    }
+
+    #[test]
+    fn equivalence_decision_not_equivalent_when_ci_beyond_margin() {
+        // Entire CI above +δ.
+        let input = equiv_input(false, 0.08, 0.15, 0.05);
+        assert_eq!(evaluate_equivalence_decision(&input), Decision::NotEquivalent);
+    }
+
+    #[test]
+    fn equivalence_decision_guardrail_breach_stops() {
+        let mut input = equiv_input(true, -0.01, 0.01, 0.05);
+        input.guardrail_breached = true;
+        assert_eq!(evaluate_equivalence_decision(&input), Decision::Stop);
+    }
+
+    #[test]
+    fn equivalence_decision_inconclusive_stops_at_end() {
+        // CI straddles +δ (not inside, not entirely beyond), planned duration done.
+        let mut input = equiv_input(false, -0.02, 0.08, 0.05);
+        input.elapsed_fraction = 1.0;
+        assert_eq!(evaluate_equivalence_decision(&input), Decision::Stop);
+    }
+
+    #[test]
+    fn equivalence_decision_inconclusive_extends_when_underpowered() {
+        let mut input = equiv_input(false, -0.02, 0.08, 0.05);
+        input.elapsed_fraction = 0.6;
+        input.achieved_power = 0.3;
+        assert_eq!(evaluate_equivalence_decision(&input), Decision::Extend);
+    }
+
+    #[test]
+    fn equivalence_decision_inconclusive_continues_early() {
+        let mut input = equiv_input(false, -0.02, 0.08, 0.05);
+        input.elapsed_fraction = 0.2;
+        input.achieved_power = 0.4;
+        assert_eq!(evaluate_equivalence_decision(&input), Decision::Continue);
     }
 }

--- a/crates/experimentation-management/src/validators.rs
+++ b/crates/experimentation-management/src/validators.rs
@@ -14,7 +14,8 @@
 use tonic::Status;
 
 use experimentation_proto::experimentation::common::v1::{
-    Experiment, ExperimentType, MetaExperimentConfig, QuasiExperimentConfig, SwitchbackConfig,
+    EquivalenceTestConfig, Experiment, ExperimentType, MetaExperimentConfig, MetricType,
+    QuasiExperimentConfig, SwitchbackConfig,
 };
 
 // ---------------------------------------------------------------------------
@@ -29,11 +30,23 @@ pub fn validate_starting(exp: &Experiment) -> Result<(), Box<Status>> {
     let exp_type = ExperimentType::try_from(exp.r#type).unwrap_or(ExperimentType::Unspecified);
 
     match exp_type {
-        ExperimentType::Meta => validate_meta(exp),
-        ExperimentType::Switchback => validate_switchback(exp),
-        ExperimentType::Quasi => validate_quasi(exp),
-        _ => Ok(()),
+        ExperimentType::Meta => validate_meta(exp)?,
+        ExperimentType::Switchback => validate_switchback(exp)?,
+        ExperimentType::Quasi => validate_quasi(exp)?,
+        _ => {}
     }
+
+    // ADR-027: the equivalence (TOST) config is orthogonal to experiment type
+    // — any experiment can carry it. M5 (Rust) has no metric catalog (the
+    // metric-definition RPCs are unimplemented stubs), so the primary-metric
+    // type is not resolvable here; the structural rules below still apply and
+    // the MEAN/RATIO gate is enforced by any caller that can resolve the type
+    // (mirrors the ADR-020 M4a/M5 Delta-only constraint).
+    if let Some(eq) = exp.equivalence_test.as_ref() {
+        validate_equivalence_test_config(eq, None)?;
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -210,6 +223,74 @@ fn validate_quasi_config(cfg: &QuasiExperimentConfig) -> Result<(), Box<Status>>
 }
 
 // ---------------------------------------------------------------------------
+// EQUIVALENCE / TOST validator (ADR-027 §5)
+// ---------------------------------------------------------------------------
+
+/// Validate an experiment's equivalence (TOST) test configuration.
+///
+/// Hard rules (reject the DRAFT→STARTING transition):
+///   - `delta` must be finite and strictly > 0 (the equivalence margin).
+///   - `alpha`, when set (> 0), must lie in (0, 0.5); the proto default 0.0
+///     means "unset" and M4a falls back to the canonical per-side α = 0.05.
+///   - `delta_relative`, when set, must be finite and > 0, and — when the
+///     primary metric type is resolvable (`Some`) — the metric must be MEAN
+///     or RATIO; a relative margin is not meaningful for PERCENTILE/COUNT.
+///
+/// Also emits a non-fatal power warning at creation (ADR-027 §5): equivalence
+/// tests need ~2× the sample size of a same-δ superiority test.
+///
+/// `primary_metric_type` is `None` when the caller cannot resolve it (the
+/// Rust M5 metric-definition RPCs are unimplemented); the structural rules
+/// are still enforced.
+pub fn validate_equivalence_test_config(
+    cfg: &EquivalenceTestConfig,
+    primary_metric_type: Option<MetricType>,
+) -> Result<(), Box<Status>> {
+    if !(cfg.delta.is_finite() && cfg.delta > 0.0) {
+        return Err(Box::new(Status::failed_precondition(format!(
+            "equivalence_test.delta must be finite and > 0 (got {})",
+            cfg.delta
+        ))));
+    }
+
+    // alpha == 0.0 → unset (M4a uses 0.05). Any explicitly set value must be
+    // a valid per-side significance level.
+    if cfg.alpha != 0.0 && !(cfg.alpha > 0.0 && cfg.alpha < 0.5) {
+        return Err(Box::new(Status::failed_precondition(format!(
+            "equivalence_test.alpha must lie in (0, 0.5) when set (got {})",
+            cfg.alpha
+        ))));
+    }
+
+    if let Some(rel) = cfg.delta_relative {
+        if !(rel.is_finite() && rel > 0.0) {
+            return Err(Box::new(Status::failed_precondition(format!(
+                "equivalence_test.delta_relative must be finite and > 0 when set (got {rel})"
+            ))));
+        }
+        if let Some(mt) = primary_metric_type {
+            if mt != MetricType::Mean && mt != MetricType::Ratio {
+                return Err(Box::new(Status::failed_precondition(format!(
+                    "equivalence_test.delta_relative is only valid for MEAN or RATIO \
+                     primary metrics (got {mt:?}); use an absolute delta instead"
+                ))));
+            }
+        }
+    }
+
+    // ADR-027 §5: non-fatal power warning surfaced at creation.
+    tracing::warn!(
+        delta = cfg.delta,
+        delta_relative = ?cfg.delta_relative,
+        "ADR-027: equivalence (TOST) experiment configured — equivalence tests \
+         require ~2x the sample size of a standard superiority test; consider \
+         extending the planned experiment duration."
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -217,7 +298,8 @@ fn validate_quasi_config(cfg: &QuasiExperimentConfig) -> Result<(), Box<Status>>
 mod tests {
     use super::*;
     use experimentation_proto::experimentation::common::v1::{
-        BanditAlgorithm, MetaVariantObjective, SyntheticControlMethod,
+        BanditAlgorithm, EquivalenceTestConfig, MetaVariantObjective, MetricType,
+        SyntheticControlMethod,
     };
     use prost_types::Duration;
 
@@ -335,5 +417,76 @@ mod tests {
         };
         let err = validate_quasi_config(&cfg).unwrap_err();
         assert!(err.message().contains("at least 2 donor_unit_ids"));
+    }
+
+    // --- EQUIVALENCE / TOST (ADR-027 §5) ----------------------------------
+
+    fn equiv(delta: f64, delta_relative: Option<f64>, alpha: f64) -> EquivalenceTestConfig {
+        EquivalenceTestConfig { delta, delta_relative, alpha }
+    }
+
+    #[test]
+    fn equivalence_valid_absolute_delta() {
+        let cfg = equiv(0.05, None, 0.05);
+        assert!(validate_equivalence_test_config(&cfg, None).is_ok());
+    }
+
+    #[test]
+    fn equivalence_alpha_unset_is_ok() {
+        // Proto default alpha == 0.0 means "unset" — M4a falls back to 0.05.
+        let cfg = equiv(0.05, None, 0.0);
+        assert!(validate_equivalence_test_config(&cfg, None).is_ok());
+    }
+
+    #[test]
+    fn equivalence_rejects_non_positive_delta() {
+        let err = validate_equivalence_test_config(&equiv(0.0, None, 0.05), None).unwrap_err();
+        assert!(err.message().contains("delta must be finite and > 0"));
+        let err = validate_equivalence_test_config(&equiv(-1.0, None, 0.05), None).unwrap_err();
+        assert!(err.message().contains("delta must be finite and > 0"));
+    }
+
+    #[test]
+    fn equivalence_rejects_alpha_out_of_range() {
+        let err = validate_equivalence_test_config(&equiv(0.05, None, 0.6), None).unwrap_err();
+        assert!(err.message().contains("alpha must lie in (0, 0.5)"));
+    }
+
+    #[test]
+    fn equivalence_rejects_non_positive_delta_relative() {
+        let err =
+            validate_equivalence_test_config(&equiv(0.05, Some(0.0), 0.05), None).unwrap_err();
+        assert!(err.message().contains("delta_relative must be finite and > 0"));
+    }
+
+    #[test]
+    fn equivalence_delta_relative_requires_mean_or_ratio_when_type_known() {
+        let cfg = equiv(0.05, Some(0.02), 0.05);
+        // Type unknown (M5 has no catalog) → structural pass.
+        assert!(validate_equivalence_test_config(&cfg, None).is_ok());
+        // MEAN / RATIO → pass.
+        assert!(validate_equivalence_test_config(&cfg, Some(MetricType::Mean)).is_ok());
+        assert!(validate_equivalence_test_config(&cfg, Some(MetricType::Ratio)).is_ok());
+        // PERCENTILE / COUNT → reject.
+        let err = validate_equivalence_test_config(&cfg, Some(MetricType::Percentile))
+            .unwrap_err();
+        assert!(err.message().contains("only valid for MEAN or RATIO"));
+        let err =
+            validate_equivalence_test_config(&cfg, Some(MetricType::Count)).unwrap_err();
+        assert!(err.message().contains("only valid for MEAN or RATIO"));
+    }
+
+    #[test]
+    fn validate_starting_runs_equivalence_check() {
+        let mut exp = Experiment {
+            r#type: ExperimentType::Ab as i32,
+            equivalence_test: Some(equiv(-1.0, None, 0.05)),
+            ..Default::default()
+        };
+        let err = validate_starting(&exp).unwrap_err();
+        assert!(err.message().contains("delta must be finite and > 0"));
+
+        exp.equivalence_test = Some(equiv(0.05, None, 0.05));
+        assert!(validate_starting(&exp).is_ok());
     }
 }

--- a/crates/experimentation-stats/src/tost.rs
+++ b/crates/experimentation-stats/src/tost.rs
@@ -314,6 +314,62 @@ pub fn tost_sample_size(config: &TostPowerConfig) -> Result<u64> {
     Ok(n as u64)
 }
 
+/// Estimated power of the TOST procedure at the *realized* standard error.
+///
+/// Given the standard error of the treatment − control difference at the
+/// current sample size, the equivalence margin `delta`, an assumed true
+/// difference `true_difference` (0.0 for the canonical migration design),
+/// and the per-side significance `alpha`, returns the probability that both
+/// one-sided tests reject — i.e. the power to declare equivalence.
+///
+/// Uses the standard normal approximation (Chow & Liu; consistent with the
+/// Chow-Shao-Wang form in `tost_sample_size`):
+///
+/// ```text
+///   power ≈ Φ((δ − Δ)/SE − z_{1−α}) + Φ((δ + Δ)/SE − z_{1−α}) − 1
+/// ```
+///
+/// clamped to `[0, 1]`. Because it consumes the realized standard error this
+/// is genuinely the power *at the current sample size*. It is a design-stage
+/// indicator for the M6 power readout, not an inferential statistic.
+///
+/// # Errors
+/// Returns `Error::Validation` for `delta ≤ 0`, non-finite or non-positive
+/// `std_error`, or `alpha ∉ (0, 0.5)`.
+pub fn tost_achieved_power(
+    std_error: f64,
+    delta: f64,
+    true_difference: f64,
+    alpha: f64,
+) -> Result<f64> {
+    if !(delta > 0.0 && delta.is_finite()) {
+        return Err(Error::Validation(
+            "equivalence margin delta must be > 0 and finite".into(),
+        ));
+    }
+    if !(std_error > 0.0 && std_error.is_finite()) {
+        return Err(Error::Validation(
+            "std_error must be > 0 and finite".into(),
+        ));
+    }
+    if !(0.0 < alpha && alpha < 0.5) {
+        return Err(Error::Validation("alpha must lie in (0, 0.5)".into()));
+    }
+    assert_finite(true_difference, "true_difference");
+
+    let z = Normal::new(0.0, 1.0)
+        .map_err(|e| Error::Numerical(format!("failed to create Normal distribution: {e}")))?;
+    let z_alpha = z.inverse_cdf(1.0 - alpha);
+    assert_finite(z_alpha, "z_alpha");
+
+    let lower = (delta - true_difference) / std_error - z_alpha;
+    let upper = (delta + true_difference) / std_error - z_alpha;
+    let power = z.cdf(lower) + z.cdf(upper) - 1.0;
+    assert_finite(power, "tost power");
+
+    Ok(power.clamp(0.0, 1.0))
+}
+
 // ---------------------------------------------------------------------------
 // Internals (shared with the CUPED path)
 // ---------------------------------------------------------------------------
@@ -524,6 +580,45 @@ mod tests {
         assert!(matches!(err, Error::Numerical(_)), "expected Numerical error, got {err:?}");
     }
 
+    // --- achieved power (ADR-027 §6) --------------------------------------
+
+    #[test]
+    fn achieved_power_rises_as_standard_error_shrinks() {
+        let big_se = tost_achieved_power(0.5, 1.0, 0.0, 0.05).unwrap();
+        let small_se = tost_achieved_power(0.1, 1.0, 0.0, 0.05).unwrap();
+        assert!(small_se > big_se, "tighter SE must yield higher power ({small_se} !> {big_se})");
+        assert!((0.0..=1.0).contains(&big_se) && (0.0..=1.0).contains(&small_se));
+    }
+
+    #[test]
+    fn achieved_power_consistent_with_sample_size() {
+        // For a design at the n returned by tost_sample_size, the realized
+        // SE = sqrt(2 σ² / n) should reproduce ≈ the target power (same
+        // normal approximation, inverted).
+        let (delta, variance, alpha, target) = (0.5_f64, 1.0_f64, 0.05_f64, 0.80_f64);
+        let cfg = TostPowerConfig {
+            delta,
+            true_difference: 0.0,
+            variance,
+            alpha,
+            power: target,
+        };
+        let n = tost_sample_size(&cfg).unwrap() as f64;
+        let se = (2.0 * variance / n).sqrt();
+        let power = tost_achieved_power(se, delta, 0.0, alpha).unwrap();
+        assert!(
+            (power - target).abs() < 0.05,
+            "power at design n ({power}) should be ≈ target ({target})"
+        );
+    }
+
+    #[test]
+    fn achieved_power_validates_inputs() {
+        assert!(tost_achieved_power(0.1, 0.0, 0.0, 0.05).is_err()); // delta ≤ 0
+        assert!(tost_achieved_power(0.0, 1.0, 0.0, 0.05).is_err()); // se ≤ 0
+        assert!(tost_achieved_power(0.1, 1.0, 0.0, 0.9).is_err()); // alpha ∉ (0,0.5)
+    }
+
     #[test]
     fn invalid_config_rejected() {
         let x = vec![1.0, 2.0];
@@ -649,6 +744,22 @@ mod tests {
                 prop_assert!(r.p_tost >= r.p_lower - 1e-12);
                 prop_assert!(r.p_tost >= r.p_upper - 1e-12);
             }
+        }
+
+        /// ADR-027 §6 invariant: achieved power ∈ [0,1] and is monotone
+        /// non-increasing in the standard error (more noise ⇒ less power).
+        #[test]
+        fn prop_achieved_power_bounded_and_monotone(
+            se in 0.05f64..2.0f64,
+            bump in 0.01f64..1.0f64,
+            delta in 0.1f64..3.0f64,
+            alpha in 0.01f64..0.2f64,
+        ) {
+            let p_small = tost_achieved_power(se, delta, 0.0, alpha).unwrap();
+            let p_large = tost_achieved_power(se + bump, delta, 0.0, alpha).unwrap();
+            prop_assert!((0.0..=1.0).contains(&p_small));
+            prop_assert!((0.0..=1.0).contains(&p_large));
+            prop_assert!(p_small + 1e-9 >= p_large, "power must not rise as SE grows");
         }
 
         /// ADR-027 §7 invariant: equivalent==true ⟺ (1−2α) CI ⊂ (−δ, +δ).

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -19,3 +19,6 @@ breaking:
     - FILE
     - PACKAGE
     - WIRE_JSON
+  # ADR-027: EquivalenceTestConfig consolidated into common/v1 (no wire consumers existed); see issue #423
+  ignore:
+    - experimentation/analysis/v1/analysis_service.proto

--- a/proto/experimentation/analysis/v1/analysis_service.proto
+++ b/proto/experimentation/analysis/v1/analysis_service.proto
@@ -140,6 +140,11 @@ message EquivalenceResult {
   double control_mean = 11;
   // Treatment group mean (raw, pre-CUPED).
   double treatment_mean = 12;
+  // Estimated power to declare equivalence at the realized standard error,
+  // given delta and the canonical migration design assumption (true
+  // difference = 0). In [0, 1]. Computed by experimentation-stats; the M6
+  // power indicator renders this value (no statistics in TypeScript).
+  double achieved_power = 13;
 }
 
 message SequentialResult {

--- a/proto/experimentation/analysis/v1/analysis_service.proto
+++ b/proto/experimentation/analysis/v1/analysis_service.proto
@@ -57,29 +57,10 @@ message RunAnalysisRequest {
   // ADR-027: TOST equivalence testing configuration. When set, M4a runs the
   // Two One-Sided Tests procedure on the primary metric in addition to (or
   // instead of) the standard superiority test. Result fields live on the
-  // MetricResult message. When unset, no equivalence test is performed.
-  EquivalenceTestConfig equivalence_test = 6;
-}
-
-// ADR-027: TOST equivalence test configuration.
-// Drives the Two One-Sided Tests procedure for proving a treatment is
-// *equivalent* to control within ±delta (in the metric's natural units).
-// Used by M4a for infrastructure migration experiments where the business
-// question is "safe to ship" rather than "better than control."
-message EquivalenceTestConfig {
-  // Equivalence margin in the metric's natural units. Must be > 0.
-  // Treatment is declared equivalent if the effect lies within [-delta, +delta].
-  double delta = 1;
-  // Optional: express delta as a fraction of the control mean
-  // (e.g., 0.02 = "within 2% of control"). When set, M4a recomputes delta
-  // at analysis time as `delta_relative * control_mean` and uses that in
-  // place of the absolute value above. Only meaningful for MEAN / RATIO metrics.
-  optional double delta_relative = 2;
-  // Per-side significance level. Typical value 0.05 yields a 90% TOST CI.
-  // Each one-sided test is performed at this α; equivalence is declared iff
-  // both tests reject, which is equivalent to the (1 - 2α) CI lying entirely
-  // within (-delta, +delta).
-  double alpha = 3;
+  // MetricResult.equivalence_result message. When unset, no equivalence test
+  // is performed. Per-run override of Experiment.equivalence_test (field 33);
+  // the config message is defined in experimentation/common/v1/experiment.proto.
+  experimentation.common.v1.EquivalenceTestConfig equivalence_test = 6;
 }
 message GetAnalysisResultRequest { string experiment_id = 1; }
 message GetInterleavingAnalysisRequest { string experiment_id = 1; }
@@ -119,6 +100,46 @@ message MetricResult {
   double e_value = 19;
   // Log e-value for numerical stability when e-values are very large.
   double log_e_value = 20;
+
+  // ADR-027: TOST equivalence test result. Populated only when an
+  // EquivalenceTestConfig is supplied (via Experiment.equivalence_test or
+  // RunAnalysisRequest.equivalence_test). Absent for standard superiority-only
+  // analyses. Additive — does not affect the superiority fields above.
+  EquivalenceResult equivalence_result = 21;
+}
+
+// ADR-027: Two One-Sided Tests (TOST) equivalence test result.
+// Mirrors experimentation_stats::tost::TostResult. Populated by M4a on the
+// primary metric when an EquivalenceTestConfig is supplied. Equivalence is
+// declared (equivalent == true) iff the (1 - 2α) CI lies entirely within
+// (-delta, +delta), algebraically identical to p_tost < α.
+message EquivalenceResult {
+  // Point estimate of the difference treatment − control.
+  double point_estimate = 1;
+  // Standard error of the difference (Welch form: √(s²_T/n_T + s²_C/n_C)).
+  double std_error = 2;
+  // Welch-Satterthwaite degrees of freedom.
+  double df = 3;
+  // p-value for H₀₁: diff ≤ −delta (upper-tail one-sided test).
+  double p_lower = 4;
+  // p-value for H₀₂: diff ≥ +delta (lower-tail one-sided test).
+  double p_upper = 5;
+  // TOST p-value — max(p_lower, p_upper). Equivalence iff p_tost < alpha.
+  double p_tost = 6;
+  // Lower bound of the (1 - 2α) confidence interval for the difference.
+  double ci_lower = 7;
+  // Upper bound of the (1 - 2α) confidence interval for the difference.
+  double ci_upper = 8;
+  // True iff both one-sided tests reject at α, i.e. CI ⊂ (-delta, +delta).
+  bool equivalent = 9;
+  // The effective equivalence margin used for this test, after resolving
+  // delta_relative (delta_relative × control_mean) when set; otherwise the
+  // configured absolute delta. Always > 0.
+  double delta = 10;
+  // Control group mean (raw, pre-CUPED).
+  double control_mean = 11;
+  // Treatment group mean (raw, pre-CUPED).
+  double treatment_mean = 12;
 }
 
 message SequentialResult {

--- a/proto/experimentation/common/v1/experiment.proto
+++ b/proto/experimentation/common/v1/experiment.proto
@@ -205,6 +205,13 @@ message Experiment {
 
   // EwL classification. Set by M5 at CONCLUDED→ARCHIVED transition (ADR-019).
   ExperimentLearning learning = 32;
+
+  // ADR-027: TOST equivalence testing configuration. When set, M5 validates
+  // at creation (delta > 0; MEAN/RATIO primary metric if delta_relative set)
+  // and M4a runs the Two One-Sided Tests procedure on the primary metric,
+  // populating MetricResult.equivalence_result. When unset, no equivalence
+  // test is performed and the standard superiority test alone is reported.
+  EquivalenceTestConfig equivalence_test = 33;
 }
 
 // SyntheticControlMethod selects the SCM algorithm M4a applies (ADR-023).
@@ -316,6 +323,29 @@ message VarianceReductionConfig {
   // If false, use standard fixed-horizon CUPED adjustment.
   // Default true.
   bool use_avlm = 3;
+}
+
+// ADR-027: TOST equivalence test configuration.
+// Drives the Two One-Sided Tests procedure for proving a treatment is
+// *equivalent* to control within ±delta (in the metric's natural units).
+// Used by M4a for infrastructure migration experiments where the business
+// question is "safe to ship" rather than "better than control."
+// Carried on Experiment (field 33) so M5 validates at creation and M4a
+// reads it at analysis time; also overridable per-run via RunAnalysisRequest.
+message EquivalenceTestConfig {
+  // Equivalence margin in the metric's natural units. Must be > 0.
+  // Treatment is declared equivalent if the effect lies within [-delta, +delta].
+  double delta = 1;
+  // Optional: express delta as a fraction of the control mean
+  // (e.g., 0.02 = "within 2% of control"). When set, M4a recomputes delta
+  // at analysis time as `delta_relative * control_mean` and uses that in
+  // place of the absolute value above. Only meaningful for MEAN / RATIO metrics.
+  optional double delta_relative = 2;
+  // Per-side significance level. Typical value 0.05 yields a 90% TOST CI.
+  // Each one-sided test is performed at this α; equivalence is declared iff
+  // both tests reject, which is equivalent to the (1 - 2α) CI lying entirely
+  // within (-delta, +delta).
+  double alpha = 3;
 }
 
 // AnnualizedImpact projects the annual business value of a concluded experiment.

--- a/ui/src/__tests__/equivalence-results.test.tsx
+++ b/ui/src/__tests__/equivalence-results.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Tests for ADR-027 (TOST equivalence testing) M6 results view.
+ *
+ * Coverage:
+ *   - deriveEquivalenceStatus: green / yellow / red verdict geometry
+ *   - EquivalenceResultBadge: label + status per verdict, pending fallback
+ *   - EquivalenceCiPlot: renders point estimate / CI / δ / TOST p readouts
+ *   - EquivalencePowerIndicator: adequate / underpowered / pending states
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { EquivalenceResult } from '@/lib/types';
+
+// Recharts uses ResizeObserver / SVG layout unavailable in JSDOM.
+vi.mock('recharts', async () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="recharts-wrapper">{children}</div>
+  );
+  const Noop = () => null;
+  return {
+    ResponsiveContainer: Passthrough,
+    ComposedChart: Passthrough,
+    Scatter: Passthrough,
+    ErrorBar: Noop,
+    XAxis: Noop,
+    YAxis: Noop,
+    CartesianGrid: Noop,
+    ReferenceLine: Noop,
+    ReferenceArea: Noop,
+    Tooltip: Noop,
+  };
+});
+
+import {
+  EquivalenceResultBadge,
+  deriveEquivalenceStatus,
+} from '@/components/equivalence-result-badge';
+import { EquivalenceCiPlot } from '@/components/charts/equivalence-ci-plot';
+import { EquivalencePowerIndicator } from '@/components/equivalence-power-indicator';
+
+// --- Fixtures (effect = treatment − control, margin ±δ) ---
+
+const EQUIVALENT: EquivalenceResult = {
+  pointEstimate: 0.005,
+  stdError: 0.012,
+  df: 980,
+  pLower: 0.004,
+  pUpper: 0.009,
+  pTost: 0.009,
+  ciLower: -0.02,
+  ciUpper: 0.03,
+  equivalent: true,
+  delta: 0.05,
+  controlMean: 1.2,
+  treatmentMean: 1.205,
+  achievedPower: 0.92,
+};
+
+const INCONCLUSIVE: EquivalenceResult = {
+  ...EQUIVALENT,
+  pTost: 0.21,
+  ciLower: -0.02,
+  ciUpper: 0.08, // straddles the upper margin boundary
+  equivalent: false,
+  achievedPower: 0.55,
+};
+
+const NOT_EQUIVALENT: EquivalenceResult = {
+  ...EQUIVALENT,
+  pointEstimate: 0.11,
+  pTost: 0.74,
+  ciLower: 0.08, // entire CI lies beyond +δ
+  ciUpper: 0.15,
+  equivalent: false,
+  achievedPower: 0.88,
+};
+
+describe('deriveEquivalenceStatus', () => {
+  it('returns EQUIVALENT when the Rust equivalent flag is set (CI ⊂ ±δ)', () => {
+    expect(deriveEquivalenceStatus(EQUIVALENT)).toBe('EQUIVALENT');
+  });
+
+  it('returns NOT_EQUIVALENT when the CI lies entirely beyond the margin', () => {
+    expect(deriveEquivalenceStatus(NOT_EQUIVALENT)).toBe('NOT_EQUIVALENT');
+  });
+
+  it('returns INCONCLUSIVE when the CI straddles a margin boundary', () => {
+    expect(deriveEquivalenceStatus(INCONCLUSIVE)).toBe('INCONCLUSIVE');
+  });
+});
+
+describe('EquivalenceResultBadge', () => {
+  it('renders a green Equivalent badge', () => {
+    render(<EquivalenceResultBadge result={EQUIVALENT} />);
+    const badge = screen.getByTestId('equivalence-result-badge');
+    expect(badge).toHaveAttribute('data-status', 'EQUIVALENT');
+    expect(badge).toHaveTextContent('Equivalent');
+    expect(badge.className).toContain('bg-green-100');
+  });
+
+  it('renders a yellow Inconclusive badge', () => {
+    render(<EquivalenceResultBadge result={INCONCLUSIVE} />);
+    const badge = screen.getByTestId('equivalence-result-badge');
+    expect(badge).toHaveAttribute('data-status', 'INCONCLUSIVE');
+    expect(badge).toHaveTextContent('Inconclusive');
+    expect(badge.className).toContain('bg-yellow-100');
+  });
+
+  it('renders a red Not Equivalent badge', () => {
+    render(<EquivalenceResultBadge result={NOT_EQUIVALENT} />);
+    const badge = screen.getByTestId('equivalence-result-badge');
+    expect(badge).toHaveAttribute('data-status', 'NOT_EQUIVALENT');
+    expect(badge).toHaveTextContent('Not Equivalent');
+    expect(badge.className).toContain('bg-red-100');
+  });
+
+  it('renders a pending badge when no result is available', () => {
+    render(<EquivalenceResultBadge />);
+    const badge = screen.getByTestId('equivalence-result-badge');
+    expect(badge).toHaveAttribute('data-status', 'PENDING');
+    expect(badge).toHaveTextContent('Equivalence Pending');
+  });
+});
+
+describe('EquivalenceCiPlot', () => {
+  it('renders the CI, point estimate, margin and TOST p-value readouts', () => {
+    render(<EquivalenceCiPlot result={EQUIVALENT} metricId="startup_latency_ms" />);
+    expect(screen.getByTestId('equivalence-ci-plot')).toBeInTheDocument();
+    expect(screen.getByText(/Equivalence CI — startup_latency_ms/)).toBeInTheDocument();
+    expect(screen.getByTestId('equiv-point-estimate')).toHaveTextContent('0.0050');
+    expect(screen.getByTestId('equiv-ci')).toHaveTextContent('[-0.0200, 0.0300]');
+    expect(screen.getByTestId('equiv-delta')).toHaveTextContent('±0.0500');
+    expect(screen.getByTestId('equiv-p-tost')).toHaveTextContent('0.0090');
+  });
+});
+
+describe('EquivalencePowerIndicator', () => {
+  it('renders an adequate power bar when power ≥ target', () => {
+    render(<EquivalencePowerIndicator achievedPower={0.92} />);
+    const el = screen.getByTestId('equivalence-power-indicator');
+    expect(el).toHaveAttribute('data-state', 'adequate');
+    expect(screen.getByTestId('equiv-power-value')).toHaveTextContent('92%');
+  });
+
+  it('warns when underpowered and surfaces the ~2× sample size guidance', () => {
+    render(<EquivalencePowerIndicator achievedPower={0.55} />);
+    const el = screen.getByTestId('equivalence-power-indicator');
+    expect(el).toHaveAttribute('data-state', 'underpowered');
+    expect(screen.getByTestId('equiv-power-value')).toHaveTextContent('55%');
+    expect(el).toHaveTextContent(/~2× the sample size/);
+  });
+
+  it('renders a pending state when power is not yet available', () => {
+    render(<EquivalencePowerIndicator />);
+    const el = screen.getByTestId('equivalence-power-indicator');
+    expect(el).toHaveAttribute('data-state', 'pending');
+  });
+});

--- a/ui/src/app/experiments/[id]/results/page.tsx
+++ b/ui/src/app/experiments/[id]/results/page.tsx
@@ -108,6 +108,18 @@ const AdaptiveNZoneBadge = dynamic(
   () => import('@/components/adaptive-n-zone-badge').then(m => ({ default: m.AdaptiveNZoneBadge })),
   { ssr: false },
 );
+const EquivalenceResultBadge = dynamic(
+  () => import('@/components/equivalence-result-badge').then(m => ({ default: m.EquivalenceResultBadge })),
+  { ssr: false },
+);
+const EquivalenceCiPlot = dynamic(
+  () => import('@/components/charts/equivalence-ci-plot').then(m => ({ default: m.EquivalenceCiPlot })),
+  { ssr: false },
+);
+const EquivalencePowerIndicator = dynamic(
+  () => import('@/components/equivalence-power-indicator').then(m => ({ default: m.EquivalencePowerIndicator })),
+  { ssr: false },
+);
 
 type AnalysisTab = 'overview' | 'novelty' | 'interference' | 'interleaving' | 'surrogate' | 'holdout' | 'guardrails' | 'qoe' | 'lifecycle' | 'session' | 'feedback' | 'switchback' | 'quasi';
 
@@ -466,6 +478,42 @@ export default function ResultsPage() {
                     experimentId={params.id}
                     metricId={m.metricId}
                   />
+                ))}
+            </section>
+          )}
+
+          {/* Equivalence (TOST) results (ADR-027) — shown for migration
+              experiments configured with an equivalence test */}
+          {analysisResult.metricResults.some((m) => m.equivalenceResult) && (
+            <section className="mb-6" data-testid="equivalence-section">
+              <h2 className="mb-1 text-lg font-semibold text-gray-900">
+                Equivalence (TOST)
+              </h2>
+              <p className="mb-3 text-sm text-gray-500">
+                For infrastructure migrations the question is &ldquo;can we prove
+                this change has no meaningful impact?&rdquo; A treatment is
+                <em> equivalent</em> when the (1−2α) confidence interval falls
+                entirely within the ±δ margin.
+              </p>
+              {analysisResult.metricResults
+                .filter((m) => m.equivalenceResult)
+                .map((m) => (
+                  <div
+                    key={`equiv-${m.metricId}`}
+                    className="mb-4 space-y-3"
+                    data-testid={`equivalence-metric-${m.metricId}`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm font-medium text-gray-900">
+                        {m.metricId}
+                      </span>
+                      <EquivalenceResultBadge result={m.equivalenceResult} />
+                    </div>
+                    <EquivalenceCiPlot result={m.equivalenceResult!} metricId={m.metricId} />
+                    <EquivalencePowerIndicator
+                      achievedPower={m.equivalenceResult!.achievedPower}
+                    />
+                  </div>
                 ))}
             </section>
           )}

--- a/ui/src/components/charts/equivalence-ci-plot.tsx
+++ b/ui/src/components/charts/equivalence-ci-plot.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { memo } from 'react';
+import {
+  ComposedChart, Scatter, ErrorBar, XAxis, YAxis, CartesianGrid,
+  ReferenceLine, ReferenceArea, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import type { EquivalenceResult } from '@/lib/types';
+import { deriveEquivalenceStatus } from '@/components/equivalence-result-badge';
+
+interface EquivalenceCiPlotProps {
+  result: EquivalenceResult;
+  metricId: string;
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  EQUIVALENT: '#16a34a',
+  INCONCLUSIVE: '#ca8a04',
+  NOT_EQUIVALENT: '#dc2626',
+};
+
+function EquivalenceCiPlotInner({ result, metricId }: EquivalenceCiPlotProps) {
+  const status = deriveEquivalenceStatus(result);
+  const color = STATUS_COLOR[status];
+  const { delta, ciLower, ciUpper, pointEstimate } = result;
+
+  // Single-row horizontal CI: the point estimate with a (1−2α) error bar,
+  // plotted against the shaded [−δ, +δ] equivalence margin.
+  const half = Math.max(ciUpper - pointEstimate, pointEstimate - ciLower, 0);
+  const chartData = [
+    {
+      label: metricId,
+      estimate: pointEstimate,
+      ci: [half, half] as [number, number],
+    },
+  ];
+
+  // Axis padding so the margin band and the whole CI are always visible.
+  const span = Math.max(delta, Math.abs(ciLower), Math.abs(ciUpper));
+  const pad = span * 0.2 || 0.1;
+  const domain: [number, number] = [-(span + pad), span + pad];
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4" data-testid="equivalence-ci-plot">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h4 className="text-sm font-semibold text-gray-900">
+            Equivalence CI — {metricId}
+          </h4>
+          <p className="mt-0.5 text-xs text-gray-500">
+            (1−2α) confidence interval vs. the ±δ equivalence margin (shaded). When
+            the interval lies entirely inside the band, the treatment is equivalent.
+          </p>
+        </div>
+      </div>
+
+      <div role="img" aria-label={`Equivalence confidence interval chart for ${metricId}`}>
+        <ResponsiveContainer width="100%" height={160}>
+          <ComposedChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 10, right: 30, bottom: 20, left: 20 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis
+              type="number"
+              domain={domain}
+              tick={{ fontSize: 11 }}
+              tickFormatter={(v: number) => v.toFixed(3)}
+              label={{ value: 'Treatment − Control', position: 'insideBottom', offset: -10, fontSize: 12 }}
+            />
+            <YAxis type="category" dataKey="label" tick={{ fontSize: 11 }} width={1} />
+            {/* Shaded equivalence margin [−δ, +δ] */}
+            <ReferenceArea
+              x1={-delta}
+              x2={delta}
+              fill="#16a34a"
+              fillOpacity={0.1}
+              label={{ value: '±δ equivalence zone', position: 'insideTop', fontSize: 10, fill: '#15803d' }}
+            />
+            <ReferenceLine x={0} stroke="#6b7280" strokeDasharray="4 4" />
+            <ReferenceLine x={-delta} stroke="#16a34a" strokeDasharray="2 2" />
+            <ReferenceLine x={delta} stroke="#16a34a" strokeDasharray="2 2" />
+            <Tooltip
+              formatter={(value: number) => [value.toFixed(4), 'Effect']}
+              labelFormatter={() => metricId}
+            />
+            <Scatter dataKey="estimate" fill={color} isAnimationActive={false}>
+              <ErrorBar dataKey="ci" direction="x" width={6} strokeWidth={2} stroke={color} />
+            </Scatter>
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-gray-600 sm:grid-cols-4">
+        <div>
+          <dt className="text-gray-400">Point estimate</dt>
+          <dd className="font-medium text-gray-900" data-testid="equiv-point-estimate">
+            {pointEstimate.toFixed(4)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-gray-400">(1−2α) CI</dt>
+          <dd className="font-medium text-gray-900" data-testid="equiv-ci">
+            [{ciLower.toFixed(4)}, {ciUpper.toFixed(4)}]
+          </dd>
+        </div>
+        <div>
+          <dt className="text-gray-400">Margin δ</dt>
+          <dd className="font-medium text-gray-900" data-testid="equiv-delta">
+            ±{delta.toFixed(4)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-gray-400">TOST p-value</dt>
+          <dd className="font-medium text-gray-900" data-testid="equiv-p-tost">
+            {result.pTost.toFixed(4)}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export const EquivalenceCiPlot = memo(EquivalenceCiPlotInner);

--- a/ui/src/components/charts/equivalence-ci-plot.tsx
+++ b/ui/src/components/charts/equivalence-ci-plot.tsx
@@ -25,13 +25,17 @@ function EquivalenceCiPlotInner({ result, metricId }: EquivalenceCiPlotProps) {
   const { delta, ciLower, ciUpper, pointEstimate } = result;
 
   // Single-row horizontal CI: the point estimate with a (1−2α) error bar,
-  // plotted against the shaded [−δ, +δ] equivalence margin.
-  const half = Math.max(ciUpper - pointEstimate, pointEstimate - ciLower, 0);
+  // plotted against the shaded [−δ, +δ] equivalence margin. Welch CIs are
+  // asymmetric around the estimate, so the bar must use distinct low/high
+  // offsets (same convention as forest-plot.tsx) — a symmetric bar would
+  // visually misplace the interval relative to the ±δ margin.
+  const errorLow = Math.max(pointEstimate - ciLower, 0);
+  const errorHigh = Math.max(ciUpper - pointEstimate, 0);
   const chartData = [
     {
       label: metricId,
       estimate: pointEstimate,
-      ci: [half, half] as [number, number],
+      ci: [errorLow, errorHigh] as [number, number],
     },
   ];
 

--- a/ui/src/components/equivalence-power-indicator.tsx
+++ b/ui/src/components/equivalence-power-indicator.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { memo } from 'react';
+
+interface EquivalencePowerIndicatorProps {
+  /** Power at the current sample size, computed by experimentation-stats. */
+  achievedPower?: number;
+  /** Target power the design aims for (default 0.80). */
+  targetPower?: number;
+}
+
+/**
+ * ADR-027 §6: power indicator at the current sample size given δ. The value is
+ * computed in experimentation-stats and passed through — this component renders
+ * it only (no statistics in TypeScript per the platform rules). Equivalence
+ * tests need ~2× the sample size of a superiority test, so underpowered TOST
+ * runs are common and worth flagging.
+ */
+function EquivalencePowerIndicatorInner({
+  achievedPower,
+  targetPower = 0.8,
+}: EquivalencePowerIndicatorProps) {
+  if (achievedPower === undefined) {
+    return (
+      <div
+        className="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600"
+        data-testid="equivalence-power-indicator"
+        data-state="pending"
+      >
+        Power at current sample size is not yet available for this experiment.
+      </div>
+    );
+  }
+
+  const pct = Math.round(achievedPower * 100);
+  const underpowered = achievedPower < targetPower;
+  const barColor = underpowered ? 'bg-yellow-500' : 'bg-green-500';
+  const width = `${Math.min(Math.max(achievedPower, 0), 1) * 100}%`;
+
+  return (
+    <div
+      className="rounded-md border border-gray-200 bg-white px-3 py-2"
+      data-testid="equivalence-power-indicator"
+      data-state={underpowered ? 'underpowered' : 'adequate'}
+    >
+      <div className="mb-1 flex items-center justify-between text-xs">
+        <span className="font-medium text-gray-700">
+          Power at current sample size (given δ)
+        </span>
+        <span className="font-semibold text-gray-900" data-testid="equiv-power-value">
+          {pct}%
+        </span>
+      </div>
+      <div
+        className="h-2 w-full overflow-hidden rounded-full bg-gray-200"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Equivalence test power"
+      >
+        <div className={`h-full rounded-full ${barColor}`} style={{ width }} />
+      </div>
+      {underpowered && (
+        <p className="mt-1.5 text-xs text-yellow-700">
+          Below the {Math.round(targetPower * 100)}% target. Equivalence tests
+          require ~2× the sample size of a standard test — consider extending the
+          experiment duration before concluding.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export const EquivalencePowerIndicator = memo(EquivalencePowerIndicatorInner);

--- a/ui/src/components/equivalence-result-badge.tsx
+++ b/ui/src/components/equivalence-result-badge.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { memo } from 'react';
+import type { EquivalenceResult, EquivalenceStatus } from '@/lib/types';
+
+interface EquivalenceResultBadgeProps {
+  result?: EquivalenceResult;
+}
+
+/**
+ * ADR-027: Derive the equivalence verdict from a TOST result.
+ *
+ * Per ADR-027 §6: green when the (1−2α) CI falls entirely within the
+ * equivalence margin, red when the CI lies entirely outside it, yellow when
+ * the CI straddles a margin boundary. The Rust `equivalent` flag is the source
+ * of truth for the green case (CI ⊂ (−δ, +δ)); geometry decides red vs yellow.
+ * This is presentation logic only — no statistics are computed here.
+ */
+export function deriveEquivalenceStatus(result: EquivalenceResult): EquivalenceStatus {
+  if (result.equivalent) return 'EQUIVALENT';
+  // CI lies entirely beyond the equivalence zone → definitively not equivalent.
+  if (result.ciLower > result.delta || result.ciUpper < -result.delta) {
+    return 'NOT_EQUIVALENT';
+  }
+  // CI overlaps a margin boundary → not enough evidence either way.
+  return 'INCONCLUSIVE';
+}
+
+const STATUS_CONFIG: Record<
+  EquivalenceStatus,
+  { label: string; bg: string; text: string; dot: string; title: string }
+> = {
+  EQUIVALENT: {
+    label: 'Equivalent',
+    bg: 'bg-green-100',
+    text: 'text-green-800',
+    dot: 'bg-green-500',
+    title:
+      'The (1−2α) confidence interval falls entirely within ±δ. Affirmative evidence of no meaningful impact — safe to migrate.',
+  },
+  INCONCLUSIVE: {
+    label: 'Inconclusive',
+    bg: 'bg-yellow-100',
+    text: 'text-yellow-800',
+    dot: 'bg-yellow-500',
+    title:
+      'The confidence interval straddles a margin boundary. Equivalence is neither established nor ruled out — collect more data.',
+  },
+  NOT_EQUIVALENT: {
+    label: 'Not Equivalent',
+    bg: 'bg-red-100',
+    text: 'text-red-800',
+    dot: 'bg-red-500',
+    title:
+      'The confidence interval extends beyond ±δ. The effect exceeds the acceptable margin — not safe to migrate.',
+  },
+};
+
+function EquivalenceResultBadgeInner({ result }: EquivalenceResultBadgeProps) {
+  if (!result) {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700"
+        title="Awaiting equivalence test computation."
+        data-testid="equivalence-result-badge"
+        data-status="PENDING"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-gray-400" aria-hidden="true" />
+        Equivalence Pending
+      </span>
+    );
+  }
+
+  const status = deriveEquivalenceStatus(result);
+  const cfg = STATUS_CONFIG[status];
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cfg.bg} ${cfg.text}`}
+      title={cfg.title}
+      data-testid="equivalence-result-badge"
+      data-status={status}
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${cfg.dot}`} aria-hidden="true" />
+      {cfg.label}
+    </span>
+  );
+}
+
+export const EquivalenceResultBadge = memo(EquivalenceResultBadgeInner);

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -3,7 +3,7 @@ import type {
   QueryLogEntry, NoveltyAnalysisResult, InterferenceAnalysisResult, InterleavingAnalysisResult,
   BanditDashboardResult, CumulativeHoldoutResult, GuardrailStatusResult, QoeDashboardResult,
   GstTrajectoryResult, CateAnalysisResult, Layer, LayerAllocation,
-  SurrogateProjection, SrmResult, MetricResult, SegmentResult, IpwResult,
+  SurrogateProjection, SrmResult, MetricResult, SegmentResult, IpwResult, EquivalenceResult,
   MetricDefinition, ListMetricDefinitionsResponse,
   Flag, FlagType, ListFlagsResponse,
   InterleavingConfig, SessionConfig, BanditExperimentConfig, QoeConfig,
@@ -416,13 +416,37 @@ function adaptIpwResult(proto: Record<string, unknown>): IpwResult {
   };
 }
 
-/** Adapt proto MetricResult — coerce segmentResults int64 fields + IPW. */
+/** ADR-027: Adapt proto EquivalenceResult — coerce numeric defaults. */
+function adaptEquivalenceResult(proto: Record<string, unknown>): EquivalenceResult {
+  return {
+    pointEstimate: (proto.pointEstimate as number) || 0,
+    stdError: (proto.stdError as number) || 0,
+    df: (proto.df as number) || 0,
+    pLower: (proto.pLower as number) || 0,
+    pUpper: (proto.pUpper as number) || 0,
+    pTost: (proto.pTost as number) || 0,
+    ciLower: (proto.ciLower as number) || 0,
+    ciUpper: (proto.ciUpper as number) || 0,
+    equivalent: (proto.equivalent as boolean) || false,
+    delta: (proto.delta as number) || 0,
+    controlMean: (proto.controlMean as number) || 0,
+    treatmentMean: (proto.treatmentMean as number) || 0,
+    achievedPower: proto.achievedPower as number | undefined,
+  };
+}
+
+/** Adapt proto MetricResult — coerce segmentResults int64 fields + IPW + equivalence. */
 function adaptMetricResult(proto: Record<string, unknown>): MetricResult {
-  const raw = proto as unknown as MetricResult & { segmentResults?: Record<string, unknown>[]; ipwResult?: Record<string, unknown> };
+  const raw = proto as unknown as MetricResult & {
+    segmentResults?: Record<string, unknown>[];
+    ipwResult?: Record<string, unknown>;
+    equivalenceResult?: Record<string, unknown>;
+  };
   return {
     ...raw,
     segmentResults: raw.segmentResults?.map(adaptSegmentResult),
     ipwResult: raw.ipwResult ? adaptIpwResult(raw.ipwResult) : undefined,
+    equivalenceResult: raw.equivalenceResult ? adaptEquivalenceResult(raw.equivalenceResult) : undefined,
   };
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -179,7 +179,53 @@ export interface MetricResult {
   sessionLevelResult?: SessionLevelResult;
   segmentResults?: SegmentResult[];
   ipwResult?: IpwResult;
+  /** ADR-027: present when an equivalence (TOST) test was run for this metric. */
+  equivalenceResult?: EquivalenceResult;
 }
+
+/**
+ * ADR-027: Two One-Sided Tests (TOST) equivalence result for one metric.
+ * Mirrors the `EquivalenceResult` proto message populated by M4a. The UI only
+ * renders these values — all statistics are computed in experimentation-stats.
+ */
+export interface EquivalenceResult {
+  /** Point estimate of treatment − control. */
+  pointEstimate: number;
+  /** Standard error of the difference (Welch form). */
+  stdError: number;
+  /** Welch–Satterthwaite degrees of freedom. */
+  df: number;
+  /** p-value for H₀: diff ≤ −δ. */
+  pLower: number;
+  /** p-value for H₀: diff ≥ +δ. */
+  pUpper: number;
+  /** TOST p-value — max(pLower, pUpper). Equivalence iff pTost < α. */
+  pTost: number;
+  /** Lower bound of the (1 − 2α) confidence interval for the difference. */
+  ciLower: number;
+  /** Upper bound of the (1 − 2α) confidence interval for the difference. */
+  ciUpper: number;
+  /** True iff both one-sided tests reject at α, i.e. CI ⊂ (−δ, +δ). */
+  equivalent: boolean;
+  /** Effective equivalence margin used (post delta_relative resolution). */
+  delta: number;
+  /** Control group mean. */
+  controlMean: number;
+  /** Treatment group mean. */
+  treatmentMean: number;
+  /**
+   * Estimated power at the current sample size given δ, computed by
+   * experimentation-stats. Optional until the M4a/proto carrier lands.
+   */
+  achievedPower?: number;
+}
+
+/**
+ * Derived equivalence verdict for badge/labelling. Green when the CI is fully
+ * inside the margin, yellow when it straddles a boundary, red when the CI lies
+ * entirely outside the equivalence zone.
+ */
+export type EquivalenceStatus = 'EQUIVALENT' | 'INCONCLUSIVE' | 'NOT_EQUIVALENT';
 
 export interface SessionLevelResult {
   naiveSe: number;


### PR DESCRIPTION
## Summary

Completes **#423** (ADR-027 TOST equivalence testing) end-to-end — proto consolidation, M4a computation, M5 validation/conclusion logic, and the M6 results view.

## What's included

**Proto (consolidation + carriers)**
- `EquivalenceTestConfig` relocated to `common/v1` (adjacent to `AdaptiveSampleSizeConfig`); `Experiment.equivalence_test = 33`; `RunAnalysisRequest.equivalence_test` retyped to `common.v1`.
- New `EquivalenceResult` message + `MetricResult.equivalence_result = 21`, incl. additive `achieved_power = 13`.
- Narrowly-scoped `buf breaking` ignore for `analysis_service.proto` only (the relocation has no wire consumers; scoping verified — all other proto files keep FILE/PACKAGE/WIRE_JSON active). `buf lint` + `buf breaking` green.

**M4a (`experimentation-analysis`, `experimentation-stats`)**
- `tost_achieved_power` in `tost.rs` (normal-approx power at the realized SE; unit + proptest).
- `compute_equivalence_result` runs TOST on the primary metric (CUPED-aware), resolves `delta_relative`, populates `EquivalenceResult` incl. `achieved_power`; cache round-trip.

**M5 (`experimentation-management`)**
- `validate_equivalence_test_config` (δ > 0; α ∈ (0,0.5) when set; `delta_relative` > 0 and MEAN/RATIO-only when the metric type is resolvable; power warning at creation) wired into the DRAFT→STARTING gate.
- Equivalence-aware conclusion logic: `Decision::SafeToMigrate` / `NotEquivalent` + `evaluate_equivalence_decision` ("equivalence established → safe to migrate" instead of "reject → ship treatment").

**M6 (`ui`)**
- `EquivalenceResultBadge` (green/yellow/red), `EquivalenceCiPlot` (asymmetric CI vs shaded ±δ margin), `EquivalencePowerIndicator` (renders the Rust-supplied `achievedPower`); wired into the results overview tab.
- Addressed the Devin review: the CI error bar now uses asymmetric low/high offsets (forest-plot convention).

## Known constraints (by design, documented in code)

- Rust M5 has no metric catalog (metric-definition RPCs are stubs), so the `delta_relative` ⇒ MEAN/RATIO gate takes `Option<MetricType> = None` at the M5 call site; structural rules still enforced. M4a is Delta-Lake-only (no metric-type signal) — same ADR-020 precedent.
- M4a runs TOST on the first metric alphabetically with ≥2 obs (mirrors ADR-020 adaptive-N) since `RunAnalysisRequest` carries no primary-metric id — possible follow-up if true-primary keying is needed.

## Test plan

- [x] `buf lint` + `buf breaking` — pass
- [x] `cargo test -p experimentation-stats` — 363 pass (incl. new achieved-power unit + proptest)
- [x] `cargo test -p experimentation-analysis --lib` — 46 pass (incl. 4 equivalence integration tests)
- [x] `cargo test -p experimentation-management --lib` — 63 pass (incl. 13 new M5 validator + conclusion tests)
- [x] UI: equivalence-results (11) + results-dashboard (12) + `tsc --noEmit` — green
- [ ] Full `cargo test --workspace` + CI on this PR

Closes #423