### PR TITLE
feat(metrics): ADR-026 Phase 1 — M3 topo-order scheduling for COMPOSITE (Closes #475)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ See `docs/coordination/phase5-implementation-plan.md` and `docs/coordination/CHA
 ## Active Work (Post-Phase 5)
 
 **New ADRs (Proposed)**:
-- **ADR-026** (`docs/adrs/026-custom-metrics-layer.md`) — Custom metrics definition layer (composite / derived / joined metrics beyond the six built-in types). Impact: M5, M3, M4a. **Phase 1 implemented** (Rust M5 + M6 UI — FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT; #552, #555); Phase 2 (MetricQL DSL, #435/#436) and Phase 3 (CUSTOM deprecation, #437) remain Proposed.
+- **ADR-026** (`docs/adrs/026-custom-metrics-layer.md`) — Custom metrics definition layer (composite / derived / joined metrics beyond the six built-in types). Impact: M5, M3, M4a. **Phase 1 implemented** (Rust M5 + M6 UI + M3 topo-order scheduling — FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT; #552, #555, #475 — M3 dependency ordering via Kahn's algorithm with `metric_computation_status` table); Phase 2 (MetricQL DSL, #435/#436) and Phase 3 (CUSTOM deprecation, #437) remain Proposed.
 - **ADR-027** (`docs/adrs/027-tost-equivalence-testing.md`) — Two One-Sided Tests for proving equivalence (infra migrations, refactor validation). Impact: M4a, M5, M6. Core impl landed (#443); see `crates/experimentation-stats/src/tost.rs`.
 - **ADR-028** (`docs/adrs/028-m4b-shadow-inference.md`) — M4b shadow inference path for bandit policy promotion (dedicated shadow core, column-family isolation). Impact: M4b, M4a, M5, M6.
 - **ADR-029** (`docs/adrs/029-cross-modal-score-calibration.md`) — Cross-modal score calibration for heterogeneous slates (unified NEV scale across video, manga, commerce). Introduces a new `experimentation-calibration` Rust crate owned by Agent-4 and opens cluster **G — Personalization Orchestration**. Impact: M4a, M4b, M5, Personalization service.

--- a/docs/adrs/026-custom-metrics-layer.md
+++ b/docs/adrs/026-custom-metrics-layer.md
@@ -1,15 +1,16 @@
 # ADR-026: Custom Metrics Definition Layer
 
-- **Status**: Phase 1 Implemented (Rust M5) · Phase 2 / Phase 3 Proposed
-- **Date**: 2026-03-17 (proposed) · 2026-05-17 (Phase 1 implemented)
+- **Status**: Phase 1 Implemented (Rust M5 + M6 UI + M3 topo-order scheduling) · Phase 2 / Phase 3 Proposed
+- **Date**: 2026-03-17 (proposed) · 2026-05-17 (Phase 1 implemented) · 2026-05-18 (M3 dependency ordering)
 - **Author**: Agent-6 / Devin (requested by @wunderkennd)
 
 ## Implementation status
 
 | Phase | Scope | Status | PR |
 |-------|-------|--------|----|
-| **Phase 1** | Tier 1 structured types: `FILTERED_MEAN`, `COMPOSITE`, `WINDOWED_COUNT`. M5 Rust validators (cycle detection, filter_sql allowlist), Rust `ManagementStore` CRUD, PG migration 011, M3↔M5 + M3↔M4a contract tests | **Implemented** (Closes #433) | PR opened by this branch |
-| Phase 1 (M6 UI) | Metric creation form for new types + operator runbook | **Implemented** (Closes #434) | PR #555 |
+| **Phase 1** | Tier 1 structured types: `FILTERED_MEAN`, `COMPOSITE`, `WINDOWED_COUNT`. M5 Rust validators (cycle detection, filter_sql allowlist), Rust `ManagementStore` CRUD, PG migration 011, M3↔M5 + M3↔M4a contract tests | **Implemented** (Closes #433) | #552 |
+| Phase 1 (M6 UI) | Metric creation form for new types + operator runbook | **Implemented** (Closes #434) | #555 |
+| **Phase 1 (M3 dependency ordering)** | M3 scheduler computes a topological DAG over COMPOSITE operand dependencies (Kahn's algorithm with defense-in-depth cycle detection); new `metric_computation_status` table (migration 012) so M4a can distinguish `skipped_upstream_failure` from `missing`; downstream COMPOSITEs marked skipped even when fail-fast short-circuits the loop | **Implemented** (Closes #475) | PR opened by this branch |
 | Phase 2 | Tier 2 MetricQL DSL: lexer/parser/AST/codegen, `@metric_ref` resolution, M5 expression validation, M6 expression editor | Proposed | #435, #436 |
 | Phase 3 | Deprecate `METRIC_TYPE_CUSTOM`: migrate existing CUSTOM metrics, deprecation warnings, UI removal | Proposed | #437 |
 

--- a/docs/superpowers/plans/2026-05-17-adr-026-phase-1-m3-scheduler.md
+++ b/docs/superpowers/plans/2026-05-17-adr-026-phase-1-m3-scheduler.md
@@ -1,0 +1,1315 @@
+# ADR-026 Phase 1: M3 Scheduler Dependency Ordering for COMPOSITE Metrics
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Issue:** [#475](https://github.com/wunderkennd/kaizen-experimentation/issues/475) — P1, `sprint-5.6`, `cluster-a`, owner `agent-3`.
+
+**Goal:** Make M3 compute COMPOSITE metrics in topological order over their operand dependencies — so a COMPOSITE never runs before the metrics it reads from `delta.metric_summaries` have been written for the same `computation_date`.
+
+**Architecture:** Build an in-memory dependency DAG before each scheduling pass (`metric_id` → operand `metric_id`s), topo-sort it (Kahn's algorithm), execute metrics in order, and on operand failure skip the dependent COMPOSITE + record a status row in a new `metric_computation_status` table. Defense-in-depth: detect cycles at scheduling time even though M5 already rejects them at creation (per #433 / `crates/experimentation-management/src/validators/composite_cycle.rs`). Pure scheduling change — no SQL template edits, no proto changes.
+
+**Tech Stack:** Go 1.22 (M3 = `services/metrics/`), PostgreSQL (status table), Spark SQL via existing `executor.ExecuteAndWrite` (unchanged), Kahn's topological sort (pure Go, no new dependencies).
+
+---
+
+## Context
+
+**What's already there** (do not duplicate):
+
+- COMPOSITE template — `services/metrics/internal/spark/templates/composite.sql.tmpl` reads `delta.metric_summaries` directly. **No change needed.**
+- COMPOSITE renderer dispatch — `services/metrics/internal/spark/renderer.go::RenderForType` (line 173-243) already validates operands + operator and calls `RenderComposite`. **No change needed.**
+- M5 cycle detection at *creation* time — `crates/experimentation-management/src/validators/composite_cycle.rs` (iterative DFS 3-color, depth cap 5). M3 cycle detection here is *defense-in-depth at scheduling time* so the scheduler can't loop forever if a bad cycle ever slips through.
+- `OperandConfig` shape — `services/metrics/internal/config/loader.go:98-101` defines `{MetricID string; Weight float64}`. Operands arrive at M3 already populated; **no M5 round-trip needed during scheduling.**
+- Sequential scheduler loop — `services/metrics/internal/jobs/standard.go::Run` line 68: `for _, m := range metrics`. **This is the single insertion point** for topo-order iteration.
+
+**What's missing** (the work):
+
+1. No DAG / topo-sort utility anywhere in M3.
+2. No way to express "metric was skipped because its operand failed" — `metric_summaries` is success-only writes; `querylog.Entry` has no status/error field and is observability-only (M4a doesn't query it).
+3. No multi-metric integration test that exercises COMPOSITE-with-operand ordering.
+
+---
+
+## Locked-in scope decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Topo-sort algorithm | **Kahn's (BFS, in-degree based)** | Naturally detects cycles by leaving non-zero in-degree nodes unemitted. Simpler than 3-color DFS for "skip cycles, don't crash" defense-in-depth. M5 already does the deep validation. |
+| Cycle handling at scheduling time | **Skip + log structured warning** | M5 has already rejected cycles at creation. If a cycle slipped through, skipping is safer than crashing the whole job. Status table records each skipped node with reason `"cycle"`. |
+| Status visibility | **New `metric_computation_status` table** | `metric_summaries` schema stays untouched (avoids M4a regression). `querylog` is internal observability — M4a doesn't query it. New table is queryable by M4a and self-documenting. |
+| Failure semantics for the whole job | **Collect errors, return aggregated at end** | Current fail-fast aborts before later COMPOSITEs can even attempt. Aggregated return preserves error visibility while letting the topo iteration complete. |
+| Failure semantics for non-COMPOSITE | **Same: log failure, mark in status map, continue** | Was fail-fast. This is the behavior change that unblocks COMPOSITE skipping. Existing tests that rely on fail-fast (count: 0, per survey — `standard_test.go` only asserts success) need no change. |
+| Failure semantics for COMPOSITE | **Skip if any operand status ≠ `completed`** | Operand could be `failed`, `skipped_upstream_failure`, or `skipped_cycle`. All three poison the COMPOSITE. |
+| Cross-experiment COMPOSITEs | **Out of scope** (per issue) | Phase 1 assumes operand + COMPOSITE share `experiment_id` and `computation_date`. |
+| Real-time COMPOSITE for guardrails | **Out of scope** (per issue) | Phase 1 is daily scheduling only. |
+| Parallelism | **Stay sequential** | Today M3 runs metrics serially. Parallelizing the DAG is a separate optimization; doing it here would entangle correctness and concurrency review. File as follow-up if needed. |
+
+---
+
+## Reusable patterns (cite these — do not invent new abstractions)
+
+| Pattern | Source | Usage in this plan |
+|---------|--------|--------------------|
+| Job iteration shell | `services/metrics/internal/jobs/standard.go::Run` lines 49-432 | Wrap the metric loop body in topo-order iteration; keep the existing `ExecuteAndWrite` call site unchanged |
+| MetricConfig + OperandConfig | `services/metrics/internal/config/loader.go::82-101` | Read `m.Type == "COMPOSITE"` to identify nodes with edges; iterate `m.Operands` for edge targets |
+| Test scaffold | `services/metrics/internal/jobs/standard_test.go::setupTestJob` (line 19) | Reuse for new dependency-ordering tests; extend `seed_adr026_phase1.json` with a 2-level COMPOSITE chain |
+| Integration test harness | `services/metrics/internal/integration_test.go` (`//go:build integration`) | Mirror its docker-compose-test-stack pattern for the operand-failure-skips-dependent test |
+| Migration shape | `sql/migrations/011_adr026_phase1_metric_types.sql` | Copy the `CREATE TABLE ... IF NOT EXISTS` + `CREATE INDEX` pattern; same migration tooling |
+| Cycle algorithm reference | `crates/experimentation-management/src/validators/composite_cycle.rs::check_no_cycles` | Mirror only the *intent* (reject back edges, cap depth) — implementation can be Kahn's instead of DFS since our requirement is "skip cycles" not "explain the cycle path" |
+| Querylog writer interface | `services/metrics/internal/querylog/pg_writer.go` | Mirror the `Writer` interface shape for the new status writer |
+
+---
+
+## Architecture
+
+### New / modified files under `services/metrics/`
+
+```
+internal/jobs/
+  standard.go                    # MODIFY — wrap loop in topo-order iteration, add status tracking
+  dag.go                         # NEW — Kahn's topo sort + cycle detection (pure Go, no I/O)
+  dag_test.go                    # NEW — unit tests for topo sort
+  status_map.go                  # NEW — in-memory status tracking during a single Run
+  standard_test.go               # MODIFY — add multi-metric COMPOSITE-chain tests
+  integration_test.go            # MODIFY — add operand-failure-skips-dependent test
+internal/status/                 # NEW package
+  status.go                      # NEW — Status enum + Entry type
+  pg_writer.go                   # NEW — PostgreSQL writer (mirrors querylog/pg_writer.go shape)
+  mock_writer.go                 # NEW — in-memory writer for tests
+sql/migrations/
+  012_metric_computation_status.sql  # NEW — CREATE TABLE for status rows
+```
+
+### Status enum (the contract M4a will read against)
+
+```go
+// internal/status/status.go
+package status
+
+type Status string
+
+const (
+    StatusCompleted             Status = "completed"
+    StatusFailed                Status = "failed"
+    StatusSkippedUpstreamFailure Status = "skipped_upstream_failure"
+    StatusSkippedCycle          Status = "skipped_cycle"
+)
+
+type Entry struct {
+    ExperimentID    string
+    MetricID        string
+    ComputationDate string  // YYYY-MM-DD
+    Status          Status
+    Reason          string  // free-form explanation, e.g., "operand watch_time failed: <err>"
+    RecordedAt      time.Time
+}
+```
+
+### DAG types
+
+```go
+// internal/jobs/dag.go
+package jobs
+
+// TopologicalOrder returns (sorted, skipped_cycle, error).
+//   - `sorted` is the topo order; iterate in this order to ensure operands run before COMPOSITEs.
+//   - `skipped_cycle` is the set of metric IDs that participate in a cycle and must be skipped.
+//   - `error` is non-nil only for genuine algorithmic bugs (e.g., negative in-degree) — bad input
+//     produces (sorted, skipped_cycle, nil) instead.
+func TopologicalOrder(metrics []*config.MetricConfig) (
+    sorted []*config.MetricConfig,
+    skippedCycle map[string]bool,
+    err error,
+)
+```
+
+### StatusMap shape
+
+```go
+// internal/jobs/status_map.go
+type statusMap struct {
+    entries map[string]status.Status  // metric_id → status
+}
+
+func (s *statusMap) markCompleted(metricID string)
+func (s *statusMap) markFailed(metricID string, reason string) string  // returns reason for chaining
+func (s *statusMap) markSkippedUpstream(metricID string, blocker string)
+func (s *statusMap) markSkippedCycle(metricID string)
+func (s *statusMap) blockerFor(operands []config.OperandConfig) (blocker string, ok bool)
+func (s *statusMap) snapshot() map[string]status.Status  // for status writer flush
+```
+
+---
+
+## Task DAG
+
+```
+                   Phase A — Foundations (parallel — both pure / I/O-isolated)
+                   ┌──────────────────────────────────────────────────┐
+                   │  A1: DAG utility (jobs/dag.go + dag_test.go)     │
+                   │  A2: Status table + writer (migration + status/) │
+                   └──────────────────┬───────────────────────────────┘
+                                      ▼
+                   Phase B — Scheduler integration (sequential, gated on A1+A2)
+                   ┌──────────────────────────────────────────────────┐
+                   │  B1: status_map.go + Run() topo-order rewrite    │
+                   │  B2: Status writer wiring into Run() lifecycle   │
+                   └──────────────────┬───────────────────────────────┘
+                                      ▼
+                   Phase C — Tests (parallel, gated on B2)
+                   ┌──────────────────────────────────────────────────┐
+                   │  C1: Multi-metric COMPOSITE-chain unit test      │
+                   │  C2: Integration test — happy path multi-cycle    │
+                   │  C3: Integration test — operand failure skips    │
+                   └──────────────────┬───────────────────────────────┘
+                                      ▼
+                   Phase D — Convergence
+                   ┌──────────────────────────────────────────────────┐
+                   │  D1: ADR-026 status update + CLAUDE.md + PR      │
+                   └──────────────────────────────────────────────────┘
+```
+
+**Parallelization payoff**: Phase A is two cleanly-separable streams (pure-Go DAG vs. SQL migration + new package). Phase C is three independent test additions — they touch different files and can be authored in parallel subagents.
+
+---
+
+## Phase A — Foundations (parallel)
+
+### Task A1: DAG utility (Kahn's topo sort + cycle skip)
+
+**Files:**
+- Create: `services/metrics/internal/jobs/dag.go`
+- Create: `services/metrics/internal/jobs/dag_test.go`
+
+- [ ] **Step 1: Write the failing test for a simple two-node linear chain**
+
+```go
+// dag_test.go
+package jobs
+
+import (
+    "testing"
+
+    "github.com/wunderkennd/kaizen-experimentation/services/metrics/internal/config"
+)
+
+func TestTopologicalOrder_LinearChain(t *testing.T) {
+    // operand=watch_time, composite=engagement_score depending on watch_time
+    metrics := []*config.MetricConfig{
+        {MetricID: "engagement_score", Type: "COMPOSITE", Operands: []config.OperandConfig{
+            {MetricID: "watch_time", Weight: 1.0},
+        }},
+        {MetricID: "watch_time", Type: "MEAN"},
+    }
+
+    sorted, skipped, err := TopologicalOrder(metrics)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if len(skipped) != 0 {
+        t.Fatalf("expected no skipped, got %v", skipped)
+    }
+    if len(sorted) != 2 {
+        t.Fatalf("expected 2 sorted, got %d", len(sorted))
+    }
+    if sorted[0].MetricID != "watch_time" {
+        t.Fatalf("expected watch_time first, got %s", sorted[0].MetricID)
+    }
+    if sorted[1].MetricID != "engagement_score" {
+        t.Fatalf("expected engagement_score second, got %s", sorted[1].MetricID)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/metrics && go test ./internal/jobs/ -run TestTopologicalOrder_LinearChain -v`
+Expected: `FAIL — undefined: TopologicalOrder`
+
+- [ ] **Step 3: Implement Kahn's topo sort**
+
+```go
+// dag.go
+package jobs
+
+import (
+    "github.com/wunderkennd/kaizen-experimentation/services/metrics/internal/config"
+)
+
+// TopologicalOrder returns (sorted, skipped_cycle, error). See plan §Architecture.
+func TopologicalOrder(metrics []*config.MetricConfig) (
+    []*config.MetricConfig,
+    map[string]bool,
+    error,
+) {
+    byID := make(map[string]*config.MetricConfig, len(metrics))
+    for _, m := range metrics {
+        byID[m.MetricID] = m
+    }
+
+    // Build in-degree map + adjacency: edges go FROM operand TO composite (operand must run first).
+    inDeg := make(map[string]int, len(metrics))
+    children := make(map[string][]string, len(metrics))
+    for _, m := range metrics {
+        if _, ok := inDeg[m.MetricID]; !ok {
+            inDeg[m.MetricID] = 0
+        }
+        if m.Type != "COMPOSITE" {
+            continue
+        }
+        for _, op := range m.Operands {
+            // Only consider operands that are part of this scheduling pass; operands defined
+            // elsewhere (cross-experiment, out of scope per #475) leave the COMPOSITE blocked
+            // — caller skips it as `skipped_upstream_failure` with reason "operand not in pass".
+            if _, ok := byID[op.MetricID]; !ok {
+                continue
+            }
+            inDeg[m.MetricID]++
+            children[op.MetricID] = append(children[op.MetricID], m.MetricID)
+        }
+    }
+
+    // Kahn's: seed queue with in-degree-zero nodes, peel layers.
+    queue := make([]string, 0, len(metrics))
+    for id, d := range inDeg {
+        if d == 0 {
+            queue = append(queue, id)
+        }
+    }
+
+    sorted := make([]*config.MetricConfig, 0, len(metrics))
+    for len(queue) > 0 {
+        id := queue[0]
+        queue = queue[1:]
+        sorted = append(sorted, byID[id])
+        for _, child := range children[id] {
+            inDeg[child]--
+            if inDeg[child] == 0 {
+                queue = append(queue, child)
+            }
+        }
+    }
+
+    // Any node still with in-degree > 0 is in (or downstream of) a cycle.
+    skipped := make(map[string]bool)
+    for id, d := range inDeg {
+        if d > 0 {
+            skipped[id] = true
+        }
+    }
+    return sorted, skipped, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/metrics && go test ./internal/jobs/ -run TestTopologicalOrder_LinearChain -v`
+Expected: `PASS`
+
+- [ ] **Step 5: Add test for COMPOSITE-of-COMPOSITE 3-level chain**
+
+```go
+func TestTopologicalOrder_NestedComposite(t *testing.T) {
+    // a (MEAN) -> b (COMPOSITE of a) -> c (COMPOSITE of b)
+    metrics := []*config.MetricConfig{
+        {MetricID: "c", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "b", Weight: 1}}},
+        {MetricID: "b", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "a", Weight: 1}}},
+        {MetricID: "a", Type: "MEAN"},
+    }
+    sorted, skipped, _ := TopologicalOrder(metrics)
+    if len(skipped) != 0 {
+        t.Fatalf("expected no skipped, got %v", skipped)
+    }
+    got := []string{sorted[0].MetricID, sorted[1].MetricID, sorted[2].MetricID}
+    want := []string{"a", "b", "c"}
+    for i := range want {
+        if got[i] != want[i] {
+            t.Fatalf("position %d: want %s, got %s (full: %v)", i, want[i], got[i], got)
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Add test for cycle detection (defense-in-depth)**
+
+```go
+func TestTopologicalOrder_CycleIsSkipped(t *testing.T) {
+    // a -> b -> a (cycle); c is independent and should still be sorted.
+    metrics := []*config.MetricConfig{
+        {MetricID: "a", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "b", Weight: 1}}},
+        {MetricID: "b", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "a", Weight: 1}}},
+        {MetricID: "c", Type: "MEAN"},
+    }
+    sorted, skipped, err := TopologicalOrder(metrics)
+    if err != nil {
+        t.Fatalf("expected no error (cycles are reported via skipped map), got %v", err)
+    }
+    if !skipped["a"] || !skipped["b"] {
+        t.Fatalf("expected a + b skipped (cycle), got %v", skipped)
+    }
+    if len(sorted) != 1 || sorted[0].MetricID != "c" {
+        t.Fatalf("expected only c sorted, got %v", sorted)
+    }
+}
+```
+
+- [ ] **Step 7: Add test for operand outside the pass (treated as available — caller handles)**
+
+```go
+func TestTopologicalOrder_OperandOutsidePass(t *testing.T) {
+    // c references operand x that's not in this scheduling pass — c remains in-degree 0
+    // (Kahn's emits it). The caller's status_map gates skipping on operand status at runtime.
+    metrics := []*config.MetricConfig{
+        {MetricID: "c", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "x", Weight: 1}}},
+    }
+    sorted, skipped, _ := TopologicalOrder(metrics)
+    if len(skipped) != 0 {
+        t.Fatalf("expected no skipped, got %v", skipped)
+    }
+    if len(sorted) != 1 || sorted[0].MetricID != "c" {
+        t.Fatalf("expected c sorted, got %v", sorted)
+    }
+}
+```
+
+- [ ] **Step 8: Run all dag_test tests**
+
+Run: `cd services/metrics && go test ./internal/jobs/ -run TestTopologicalOrder -v`
+Expected: 4 PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add services/metrics/internal/jobs/dag.go services/metrics/internal/jobs/dag_test.go
+git commit -m "feat(metrics): topological DAG utility for COMPOSITE scheduling (#475)"
+```
+
+---
+
+### Task A2: Status table + writer package
+
+**Files:**
+- Create: `sql/migrations/012_metric_computation_status.sql`
+- Create: `services/metrics/internal/status/status.go`
+- Create: `services/metrics/internal/status/pg_writer.go`
+- Create: `services/metrics/internal/status/mock_writer.go`
+- Create: `services/metrics/internal/status/pg_writer_test.go`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- sql/migrations/012_metric_computation_status.sql
+-- ADR-026 Phase 1 follow-up (#475): record metric computation outcome per (experiment, metric, date)
+-- so M4a can distinguish "missing because not scheduled" from "skipped because upstream failed".
+
+CREATE TABLE IF NOT EXISTS metric_computation_status (
+    experiment_id     TEXT NOT NULL,
+    metric_id         TEXT NOT NULL,
+    computation_date  DATE NOT NULL,
+    status            TEXT NOT NULL CHECK (status IN (
+        'completed',
+        'failed',
+        'skipped_upstream_failure',
+        'skipped_cycle'
+    )),
+    reason            TEXT,
+    recorded_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (experiment_id, metric_id, computation_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metric_computation_status_lookup
+    ON metric_computation_status (experiment_id, computation_date, status);
+```
+
+- [ ] **Step 2: Apply migration locally to verify SQL**
+
+Run: `just migrate 012_metric_computation_status.sql`
+Expected: clean apply; `psql -c "\d metric_computation_status"` shows the table.
+
+- [ ] **Step 3: Write the status enum + Entry**
+
+```go
+// services/metrics/internal/status/status.go
+package status
+
+import "time"
+
+type Status string
+
+const (
+    Completed              Status = "completed"
+    Failed                 Status = "failed"
+    SkippedUpstreamFailure Status = "skipped_upstream_failure"
+    SkippedCycle           Status = "skipped_cycle"
+)
+
+type Entry struct {
+    ExperimentID    string
+    MetricID        string
+    ComputationDate string  // YYYY-MM-DD; matches Spark SQL templates' date format
+    Status          Status
+    Reason          string
+    RecordedAt      time.Time
+}
+
+type Writer interface {
+    Write(ctx context.Context, entry Entry) error
+}
+```
+
+- [ ] **Step 4: Write the PostgreSQL writer**
+
+```go
+// services/metrics/internal/status/pg_writer.go
+package status
+
+import (
+    "context"
+    "database/sql"
+    "fmt"
+)
+
+type PgWriter struct {
+    db *sql.DB
+}
+
+func NewPgWriter(db *sql.DB) *PgWriter {
+    return &PgWriter{db: db}
+}
+
+func (w *PgWriter) Write(ctx context.Context, entry Entry) error {
+    // UPSERT so re-runs of the same (experiment, metric, date) overwrite the prior outcome.
+    _, err := w.db.ExecContext(ctx, `
+        INSERT INTO metric_computation_status
+            (experiment_id, metric_id, computation_date, status, reason, recorded_at)
+        VALUES ($1, $2, $3, $4, $5, NOW())
+        ON CONFLICT (experiment_id, metric_id, computation_date) DO UPDATE
+        SET status = EXCLUDED.status,
+            reason = EXCLUDED.reason,
+            recorded_at = NOW()
+    `, entry.ExperimentID, entry.MetricID, entry.ComputationDate, string(entry.Status), entry.Reason)
+    if err != nil {
+        return fmt.Errorf("status: write %s/%s/%s: %w",
+            entry.ExperimentID, entry.MetricID, entry.ComputationDate, err)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 5: Write the mock writer (for unit tests)**
+
+```go
+// services/metrics/internal/status/mock_writer.go
+package status
+
+import (
+    "context"
+    "sync"
+)
+
+type MockWriter struct {
+    mu      sync.Mutex
+    Entries []Entry
+}
+
+func NewMockWriter() *MockWriter {
+    return &MockWriter{Entries: nil}
+}
+
+func (w *MockWriter) Write(ctx context.Context, entry Entry) error {
+    w.mu.Lock()
+    defer w.mu.Unlock()
+    w.Entries = append(w.Entries, entry)
+    return nil
+}
+
+// Snapshot returns a copy of recorded entries (safe to inspect from tests).
+func (w *MockWriter) Snapshot() []Entry {
+    w.mu.Lock()
+    defer w.mu.Unlock()
+    out := make([]Entry, len(w.Entries))
+    copy(out, w.Entries)
+    return out
+}
+```
+
+- [ ] **Step 6: Write the writer integration test (requires test PG)**
+
+```go
+// services/metrics/internal/status/pg_writer_test.go
+//go:build integration
+
+package status
+
+import (
+    "context"
+    "database/sql"
+    "os"
+    "testing"
+    "time"
+
+    _ "github.com/lib/pq"
+)
+
+func TestPgWriter_UpsertOverwritesPrior(t *testing.T) {
+    dsn := os.Getenv("TEST_DATABASE_URL")
+    if dsn == "" {
+        dsn = "postgres://experimentation:localdev@localhost:5432/experimentation?sslmode=disable"
+    }
+    db, err := sql.Open("postgres", dsn)
+    if err != nil { t.Fatal(err) }
+    defer db.Close()
+
+    // Clean slate
+    _, _ = db.Exec(`DELETE FROM metric_computation_status WHERE experiment_id = 'test_exp_475'`)
+
+    w := NewPgWriter(db)
+    ctx := context.Background()
+
+    if err := w.Write(ctx, Entry{
+        ExperimentID: "test_exp_475", MetricID: "m1", ComputationDate: "2026-05-17",
+        Status: Failed, Reason: "first try", RecordedAt: time.Now(),
+    }); err != nil {
+        t.Fatal(err)
+    }
+
+    if err := w.Write(ctx, Entry{
+        ExperimentID: "test_exp_475", MetricID: "m1", ComputationDate: "2026-05-17",
+        Status: Completed, Reason: "", RecordedAt: time.Now(),
+    }); err != nil {
+        t.Fatal(err)
+    }
+
+    var status, reason string
+    err = db.QueryRow(`
+        SELECT status, COALESCE(reason, '') FROM metric_computation_status
+        WHERE experiment_id = 'test_exp_475' AND metric_id = 'm1' AND computation_date = '2026-05-17'
+    `).Scan(&status, &reason)
+    if err != nil { t.Fatal(err) }
+    if status != "completed" {
+        t.Errorf("upsert failed: status = %q want completed", status)
+    }
+    if reason != "" {
+        t.Errorf("upsert failed: reason = %q want empty", reason)
+    }
+}
+```
+
+- [ ] **Step 7: Run integration test**
+
+Run: `cd services/metrics && go test -tags=integration ./internal/status/ -v`
+Expected: `PASS` (requires `docker-compose -f docker-compose.test.yml up -d postgres`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add sql/migrations/012_metric_computation_status.sql \
+        services/metrics/internal/status/status.go \
+        services/metrics/internal/status/pg_writer.go \
+        services/metrics/internal/status/mock_writer.go \
+        services/metrics/internal/status/pg_writer_test.go
+git commit -m "feat(metrics): metric_computation_status table + writer package (#475)"
+```
+
+---
+
+## Phase B — Scheduler integration (sequential)
+
+### Task B1: status_map + topo-order Run() rewrite
+
+**Files:**
+- Create: `services/metrics/internal/jobs/status_map.go`
+- Create: `services/metrics/internal/jobs/status_map_test.go`
+- Modify: `services/metrics/internal/jobs/standard.go::Run`
+
+- [ ] **Step 1: Write the status_map unit test**
+
+```go
+// services/metrics/internal/jobs/status_map_test.go
+package jobs
+
+import (
+    "testing"
+
+    "github.com/wunderkennd/kaizen-experimentation/services/metrics/internal/config"
+    "github.com/wunderkennd/kaizen-experimentation/services/metrics/internal/status"
+)
+
+func TestStatusMap_BlockerForOperands(t *testing.T) {
+    sm := newStatusMap()
+    sm.markCompleted("watch_time")
+    sm.markFailed("ctr", "spark timeout")
+
+    // engagement_score depends on watch_time (completed) + ctr (failed).
+    operands := []config.OperandConfig{
+        {MetricID: "watch_time", Weight: 1.0},
+        {MetricID: "ctr", Weight: 1.0},
+    }
+    blocker, ok := sm.blockerFor(operands)
+    if !ok {
+        t.Fatalf("expected blocker, got none")
+    }
+    if blocker != "ctr" {
+        t.Fatalf("expected blocker=ctr, got %s", blocker)
+    }
+}
+
+func TestStatusMap_NoBlockerWhenAllCompleted(t *testing.T) {
+    sm := newStatusMap()
+    sm.markCompleted("a"); sm.markCompleted("b")
+    _, ok := sm.blockerFor([]config.OperandConfig{{MetricID: "a"}, {MetricID: "b"}})
+    if ok {
+        t.Fatalf("expected no blocker")
+    }
+}
+
+func TestStatusMap_OperandNotYetRunIsBlocker(t *testing.T) {
+    // An operand not in the status map (e.g., out-of-pass or not yet processed) blocks the
+    // dependent. The caller must have iterated in topo order so this case = upstream not in pass.
+    sm := newStatusMap()
+    sm.markCompleted("a")
+    blocker, ok := sm.blockerFor([]config.OperandConfig{{MetricID: "a"}, {MetricID: "missing"}})
+    if !ok || blocker != "missing" {
+        t.Fatalf("expected blocker=missing, got blocker=%q ok=%v", blocker, ok)
+    }
+    _ = status.Completed  // keep import
+}
+```
+
+- [ ] **Step 2: Implement status_map**
+
+```go
+// services/metrics/internal/jobs/status_map.go
+package jobs
+
+import (
+    "github.com/wunderkennd/kaizen-experimentation/services/metrics/internal/config"
+    "github.com/wunderkennd/kaizen-experimentation/services/metrics/internal/status"
+)
+
+type statusMap struct {
+    entries map[string]status.Status
+    reasons map[string]string
+}
+
+func newStatusMap() *statusMap {
+    return &statusMap{
+        entries: make(map[string]status.Status),
+        reasons: make(map[string]string),
+    }
+}
+
+func (s *statusMap) markCompleted(id string) {
+    s.entries[id] = status.Completed
+}
+
+func (s *statusMap) markFailed(id, reason string) {
+    s.entries[id] = status.Failed
+    s.reasons[id] = reason
+}
+
+func (s *statusMap) markSkippedUpstream(id, blocker string) {
+    s.entries[id] = status.SkippedUpstreamFailure
+    s.reasons[id] = "operand " + blocker + " did not complete"
+}
+
+func (s *statusMap) markSkippedCycle(id string) {
+    s.entries[id] = status.SkippedCycle
+    s.reasons[id] = "metric participates in a COMPOSITE cycle"
+}
+
+// blockerFor returns the first operand whose status is not Completed (or "" if all completed).
+func (s *statusMap) blockerFor(operands []config.OperandConfig) (string, bool) {
+    for _, op := range operands {
+        st, ok := s.entries[op.MetricID]
+        if !ok || st != status.Completed {
+            return op.MetricID, true
+        }
+    }
+    return "", false
+}
+
+// statusOf returns the current status (or empty Status if unrecorded).
+func (s *statusMap) statusOf(id string) status.Status {
+    return s.entries[id]
+}
+
+// reasonOf returns the recorded reason (or empty string if unrecorded).
+func (s *statusMap) reasonOf(id string) string {
+    return s.reasons[id]
+}
+```
+
+- [ ] **Step 3: Run status_map tests**
+
+Run: `cd services/metrics && go test ./internal/jobs/ -run TestStatusMap -v`
+Expected: 3 PASS
+
+- [ ] **Step 4: Read current Run() to plan the rewrite**
+
+Run: `sed -n '49,140p' services/metrics/internal/jobs/standard.go`
+Expected: see the existing `for _, m := range metrics` loop body.
+
+- [ ] **Step 5: Rewrite Run() to use topo order + status_map**
+
+Replace the metric loop in `StandardJob.Run` (currently lines ~68-112 per the survey). Key changes:
+
+```go
+// services/metrics/internal/jobs/standard.go (excerpt — inside Run() after metrics are fetched)
+
+// --- ADR-026 #475: topological scheduling for COMPOSITE metrics --------------------
+sorted, cycleNodes, err := TopologicalOrder(metrics)
+if err != nil {
+    return fmt.Errorf("jobs: topological sort: %w", err)
+}
+
+sm := newStatusMap()
+// Record cycle-skipped nodes upfront so the writer flush at the end has them.
+for id := range cycleNodes {
+    sm.markSkippedCycle(id)
+    j.logger.Warn("metric skipped (cycle)",
+        "experiment_id", experimentID,
+        "metric_id", id,
+        "computation_date", computationDate,
+    )
+}
+
+var firstErr error
+for _, m := range sorted {
+    // COMPOSITE: gate on operand status BEFORE attempting execution.
+    if m.Type == "COMPOSITE" {
+        if blocker, blocked := sm.blockerFor(m.Operands); blocked {
+            sm.markSkippedUpstream(m.MetricID, blocker)
+            j.logger.Warn("composite skipped (operand failed or missing)",
+                "experiment_id", experimentID,
+                "metric_id", m.MetricID,
+                "blocker", blocker,
+                "computation_date", computationDate,
+            )
+            continue
+        }
+    }
+
+    sql, err := j.renderer.RenderForType(m.Type, j.paramsFor(m, experiment, computationDate))
+    if err != nil {
+        reason := fmt.Sprintf("render: %v", err)
+        sm.markFailed(m.MetricID, reason)
+        if firstErr == nil {
+            firstErr = fmt.Errorf("jobs: render metric %s: %w", m.MetricID, err)
+        }
+        j.logger.Error("metric render failed", "metric_id", m.MetricID, "err", err)
+        continue
+    }
+
+    if err := j.executor.ExecuteAndWrite(ctx, sql, "delta.metric_summaries"); err != nil {
+        reason := fmt.Sprintf("execute: %v", err)
+        sm.markFailed(m.MetricID, reason)
+        if firstErr == nil {
+            firstErr = fmt.Errorf("jobs: execute metric %s: %w", m.MetricID, err)
+        }
+        j.logger.Error("metric execute failed", "metric_id", m.MetricID, "err", err)
+        continue
+    }
+    sm.markCompleted(m.MetricID)
+}
+
+// Flush all status entries (including non-COMPOSITE failures and cycle-skipped) to PG.
+if err := j.flushStatus(ctx, experimentID, computationDate, sm); err != nil {
+    j.logger.Error("status flush failed (non-fatal)",
+        "experiment_id", experimentID,
+        "computation_date", computationDate,
+        "err", err,
+    )
+}
+
+return firstErr
+```
+
+Add the `flushStatus` helper at the bottom of `standard.go`:
+
+```go
+func (j *StandardJob) flushStatus(
+    ctx context.Context,
+    experimentID, computationDate string,
+    sm *statusMap,
+) error {
+    for id, st := range sm.entries {
+        entry := status.Entry{
+            ExperimentID:    experimentID,
+            MetricID:        id,
+            ComputationDate: computationDate,
+            Status:          st,
+            Reason:          sm.reasonOf(id),
+            RecordedAt:      time.Now(),
+        }
+        if err := j.statusWriter.Write(ctx, entry); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+Add `statusWriter status.Writer` to the `StandardJob` struct and inject it via the constructor.
+
+- [ ] **Step 6: Wire status writer in cmd/main.go**
+
+```go
+// services/metrics/cmd/main.go (excerpt)
+statusWriter := status.NewPgWriter(db)
+job := jobs.NewStandardJob(
+    cfg, renderer, executor, queryLogWriter,
+    jobs.WithStatusWriter(statusWriter),  // new functional option, or required ctor arg
+)
+```
+
+Use whichever construction pattern matches existing `NewStandardJob`. If it currently takes positional args, add `statusWriter` as the next positional; if it uses options, add `WithStatusWriter`.
+
+- [ ] **Step 7: Update setupTestJob() in standard_test.go to inject a MockWriter**
+
+```go
+// services/metrics/internal/jobs/standard_test.go (in setupTestJob)
+mockStatus := status.NewMockWriter()
+job := NewStandardJob(/* existing args */, mockStatus)
+return job, mockExecutor, queryLog, mockStatus
+```
+
+- [ ] **Step 8: Run existing standard_test suite (should still pass)**
+
+Run: `cd services/metrics && go test ./internal/jobs/ -v`
+Expected: all existing tests PASS; if any rely on fail-fast on the first error, update them to assert per-metric status via `mockStatus.Snapshot()` instead.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add services/metrics/internal/jobs/status_map.go \
+        services/metrics/internal/jobs/status_map_test.go \
+        services/metrics/internal/jobs/standard.go \
+        services/metrics/internal/jobs/standard_test.go \
+        services/metrics/cmd/main.go
+git commit -m "feat(metrics): topo-order scheduling + skip-on-upstream-failure in StandardJob (#475)"
+```
+
+---
+
+### Task B2: confirm querylog still works alongside status writer
+
+**Files:**
+- Read-only: `services/metrics/internal/querylog/*.go`
+
+- [ ] **Step 1: Verify querylog writes still fire on success in the new loop**
+
+Re-read the loop body in `standard.go` and confirm the existing `queryLogWriter.Write(...)` call (or equivalent) is still invoked inside the success branch (after `ExecuteAndWrite` returns nil but before `markCompleted`). If it was inside the old loop body, port it.
+
+- [ ] **Step 2: Run integration_test in services/metrics to confirm querylog wiring**
+
+Run: `cd services/metrics && go test -tags=integration ./internal/ -run TestComputeMetricsIntegration -v`
+Expected: PASS — query_log rows still persisted as today.
+
+- [ ] **Step 3: (If anything regressed) Commit fix; otherwise skip commit**
+
+---
+
+## Phase C — Tests (parallel)
+
+### Task C1: Unit test — multi-metric COMPOSITE chain (happy path, mocked)
+
+**Files:**
+- Modify: `services/metrics/internal/jobs/standard_test.go`
+- Modify: `services/metrics/internal/jobs/testdata/seed_adr026_phase1.json` (add a 2-level chain)
+
+- [ ] **Step 1: Extend the seed file**
+
+Add to the existing array in `seed_adr026_phase1.json`:
+
+```json
+{
+  "metric_id": "session_score",
+  "type": "MEAN",
+  "source_event_type": "session_end",
+  "value_column": "session_score"
+},
+{
+  "metric_id": "click_rate",
+  "type": "PROPORTION",
+  "numerator_event_type": "click",
+  "denominator_event_type": "impression"
+},
+{
+  "metric_id": "engagement_index",
+  "type": "COMPOSITE",
+  "operator": "WEIGHTED_SUM",
+  "operands": [
+    { "metric_id": "session_score", "weight": 0.6 },
+    { "metric_id": "click_rate",    "weight": 0.4 }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the happy-path test**
+
+```go
+// standard_test.go
+func TestStandardJob_Run_CompositeRunsAfterOperands(t *testing.T) {
+    job, mockExec, _, mockStatus := setupTestJob(t)
+    ctx := context.Background()
+
+    if err := job.Run(ctx, "exp-475-happy"); err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+
+    // Verify execution order: session_score + click_rate before engagement_index.
+    queries := mockExec.Queries()
+    var sessionIdx, clickIdx, compositeIdx = -1, -1, -1
+    for i, q := range queries {
+        switch {
+        case strings.Contains(q, "metric_id = 'session_score'"):
+            sessionIdx = i
+        case strings.Contains(q, "metric_id = 'click_rate'"):
+            clickIdx = i
+        case strings.Contains(q, "metric_id = 'engagement_index'"):
+            compositeIdx = i
+        }
+    }
+    if sessionIdx == -1 || clickIdx == -1 || compositeIdx == -1 {
+        t.Fatalf("missing metrics in execution; got order: %v", queryIDs(queries))
+    }
+    if compositeIdx < sessionIdx || compositeIdx < clickIdx {
+        t.Fatalf("composite ran before operands: session=%d click=%d composite=%d",
+            sessionIdx, clickIdx, compositeIdx)
+    }
+
+    // Verify status rows.
+    snap := mockStatus.Snapshot()
+    statuses := map[string]status.Status{}
+    for _, e := range snap {
+        statuses[e.MetricID] = e.Status
+    }
+    for _, id := range []string{"session_score", "click_rate", "engagement_index"} {
+        if statuses[id] != status.Completed {
+            t.Errorf("metric %s: status = %v want completed", id, statuses[id])
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd services/metrics && go test ./internal/jobs/ -run TestStandardJob_Run_CompositeRunsAfterOperands -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/metrics/internal/jobs/standard_test.go \
+        services/metrics/internal/jobs/testdata/seed_adr026_phase1.json
+git commit -m "test(metrics): COMPOSITE-after-operands happy path (#475)"
+```
+
+---
+
+### Task C2: Unit test — operand failure skips dependent COMPOSITE
+
+**Files:**
+- Modify: `services/metrics/internal/jobs/standard_test.go`
+
+- [ ] **Step 1: Write the test using a fail-injecting executor**
+
+```go
+// standard_test.go
+func TestStandardJob_Run_OperandFailureSkipsComposite(t *testing.T) {
+    job, mockExec, _, mockStatus := setupTestJob(t)
+    ctx := context.Background()
+
+    // Inject a failure for any query that targets metric_id = 'click_rate'.
+    mockExec.FailOn(func(sql string) bool {
+        return strings.Contains(sql, "metric_id = 'click_rate'")
+    })
+
+    err := job.Run(ctx, "exp-475-skip")
+    if err == nil {
+        t.Fatalf("expected aggregated error from job, got nil")
+    }
+    if !strings.Contains(err.Error(), "click_rate") {
+        t.Fatalf("expected error to mention click_rate, got: %v", err)
+    }
+
+    // engagement_index depends on click_rate → must be marked SkippedUpstreamFailure, not Failed.
+    snap := mockStatus.Snapshot()
+    statuses := map[string]status.Status{}
+    reasons := map[string]string{}
+    for _, e := range snap {
+        statuses[e.MetricID] = e.Status
+        reasons[e.MetricID]  = e.Reason
+    }
+    if statuses["click_rate"] != status.Failed {
+        t.Errorf("click_rate: status = %v want failed", statuses["click_rate"])
+    }
+    if statuses["session_score"] != status.Completed {
+        t.Errorf("session_score: status = %v want completed (independent of click_rate)",
+            statuses["session_score"])
+    }
+    if statuses["engagement_index"] != status.SkippedUpstreamFailure {
+        t.Errorf("engagement_index: status = %v want skipped_upstream_failure",
+            statuses["engagement_index"])
+    }
+    if !strings.Contains(reasons["engagement_index"], "click_rate") {
+        t.Errorf("engagement_index reason should mention click_rate, got: %q",
+            reasons["engagement_index"])
+    }
+}
+```
+
+- [ ] **Step 2: Add FailOn() to MockExecutor if not present**
+
+Check `services/metrics/internal/spark/executor.go` (or wherever the mock lives). If `FailOn(func(sql string) bool)` doesn't exist, add it:
+
+```go
+type MockExecutor struct {
+    queries []string
+    failPredicate func(string) bool
+}
+
+func (m *MockExecutor) FailOn(pred func(string) bool) {
+    m.failPredicate = pred
+}
+
+func (m *MockExecutor) ExecuteAndWrite(ctx context.Context, sql, _ string) error {
+    if m.failPredicate != nil && m.failPredicate(sql) {
+        return fmt.Errorf("mock: injected failure")
+    }
+    m.queries = append(m.queries, sql)
+    return nil
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd services/metrics && go test ./internal/jobs/ -run TestStandardJob_Run_OperandFailureSkipsComposite -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/metrics/internal/jobs/standard_test.go \
+        services/metrics/internal/spark/executor.go
+git commit -m "test(metrics): operand failure skips dependent COMPOSITE (#475)"
+```
+
+---
+
+### Task C3: Integration test — multi-cycle determinism with real Postgres
+
+**Files:**
+- Modify: `services/metrics/internal/integration_test.go`
+
+- [ ] **Step 1: Write the multi-cycle test**
+
+```go
+// integration_test.go (under //go:build integration)
+func TestComputeMetrics_CompositeOrdering_MultiCycle(t *testing.T) {
+    db := openTestDB(t)
+    defer db.Close()
+    seedLayerAndExperiment(t, db, "exp-475-cycle")
+
+    job := newRealJob(t, db)  // uses real PG status writer + MockExecutor
+
+    // Run 3 cycles back-to-back; output must be deterministic.
+    var snapshots [3][]string
+    for i := 0; i < 3; i++ {
+        if err := job.Run(context.Background(), "exp-475-cycle"); err != nil {
+            t.Fatalf("cycle %d: %v", i, err)
+        }
+        rows, err := db.Query(`
+            SELECT metric_id, status FROM metric_computation_status
+            WHERE experiment_id = 'exp-475-cycle'
+            ORDER BY metric_id
+        `)
+        if err != nil { t.Fatal(err) }
+        var got []string
+        for rows.Next() {
+            var id, st string
+            if err := rows.Scan(&id, &st); err != nil { t.Fatal(err) }
+            got = append(got, id+"="+st)
+        }
+        rows.Close()
+        snapshots[i] = got
+    }
+    if !reflect.DeepEqual(snapshots[0], snapshots[1]) || !reflect.DeepEqual(snapshots[1], snapshots[2]) {
+        t.Fatalf("non-deterministic across cycles:\n  c0=%v\n  c1=%v\n  c2=%v",
+            snapshots[0], snapshots[1], snapshots[2])
+    }
+}
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `just test-m3-integration` (or `cd services/metrics && go test -tags=integration ./internal/ -run TestComputeMetrics_CompositeOrdering_MultiCycle -v`)
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/metrics/internal/integration_test.go
+git commit -m "test(metrics): multi-cycle determinism for COMPOSITE ordering (#475)"
+```
+
+---
+
+## Phase D — Convergence
+
+### Task D1: ADR-026 status + CLAUDE.md + PR
+
+**Files:**
+- Modify: `docs/adrs/026-custom-metrics-layer.md`
+- Modify: `CLAUDE.md` (the Phase 1 status line ~94)
+- Modify: `justfile` (add `test-adr026-m3` recipe)
+
+- [ ] **Step 1: Update ADR-026 status block**
+
+Append to the Phase 1 status section:
+
+```markdown
+**Phase 1 M3 dependency ordering (#475):** Implemented in PR #NNN (2026-MM-DD).
+Topological scheduling via `services/metrics/internal/jobs/dag.go`; skip semantics
+recorded in `metric_computation_status` (migration 012).
+```
+
+- [ ] **Step 2: Update CLAUDE.md Phase 1 line**
+
+The relevant CLAUDE.md line currently reads:
+
+> **Phase 1 implemented** (Rust M5 + M6 UI — FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT; #552, #555)
+
+Extend to:
+
+> **Phase 1 implemented** (Rust M5 + M6 UI + M3 topo-order scheduling — FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT; #552, #555, #NNN)
+
+- [ ] **Step 3: Add justfile recipe**
+
+```just
+test-adr026-m3: # ADR-026 Phase 1 #475 — M3 dependency ordering tests
+    cd services/metrics && go test ./internal/jobs/ -run "TestTopologicalOrder|TestStatusMap|TestStandardJob_Run_Composite|TestStandardJob_Run_OperandFailure" -v
+    cd services/metrics && go test -tags=integration ./internal/ -run "TestComputeMetrics_CompositeOrdering" -v
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin agent-3/feat/adr-026-m3-dependency-ordering
+gh pr create --title "feat(metrics): ADR-026 Phase 1 — M3 topo-order scheduling for COMPOSITE (Closes #475)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Topological scheduling of metrics in M3 via Kahn's algorithm (`services/metrics/internal/jobs/dag.go`).
+- COMPOSITE metrics are gated on operand status; failed/missing operand → skip + structured log + `metric_computation_status` row.
+- Defense-in-depth cycle detection at scheduling time (M5 already rejects at creation per #433).
+- New `metric_computation_status` table (`sql/migrations/012`) so M4a can distinguish `missing` from `skipped_upstream_failure`.
+
+Closes #475. Companion to ADR-026 Phase 1 backend (#552) and M6 UI (#555).
+
+## Test plan
+
+- [ ] `cd services/metrics && go test ./internal/jobs/ -v` — DAG + statusMap + scheduler tests pass
+- [ ] `just test-adr026-m3` — bundled regression suite
+- [ ] `just test-m3-integration` — multi-cycle determinism passes
+- [ ] `psql -c "\d metric_computation_status"` after `just migrate` shows the new table
+- [ ] Manual: kill a Spark job for one operand mid-run and confirm dependent COMPOSITE lands a `skipped_upstream_failure` row
+EOF
+)"
+```
+
+---
+
+## Critical files to modify
+
+| File | Touch type | Phase |
+|------|-----------|-------|
+| `services/metrics/internal/jobs/dag.go` | **Create** | A1 |
+| `services/metrics/internal/jobs/dag_test.go` | **Create** | A1 |
+| `sql/migrations/012_metric_computation_status.sql` | **Create** | A2 |
+| `services/metrics/internal/status/status.go` | **Create** | A2 |
+| `services/metrics/internal/status/pg_writer.go` | **Create** | A2 |
+| `services/metrics/internal/status/mock_writer.go` | **Create** | A2 |
+| `services/metrics/internal/status/pg_writer_test.go` | **Create** | A2 |
+| `services/metrics/internal/jobs/status_map.go` | **Create** | B1 |
+| `services/metrics/internal/jobs/status_map_test.go` | **Create** | B1 |
+| `services/metrics/internal/jobs/standard.go` | Modify (rewrite loop) | B1 |
+| `services/metrics/internal/jobs/standard_test.go` | Modify (+3 tests) | B1, C1, C2 |
+| `services/metrics/internal/spark/executor.go` | Modify (+FailOn helper) | C2 |
+| `services/metrics/cmd/main.go` | Modify (wire status writer) | B1 |
+| `services/metrics/internal/integration_test.go` | Modify (+multi-cycle test) | C3 |
+| `services/metrics/internal/jobs/testdata/seed_adr026_phase1.json` | Modify (+2 metrics + COMPOSITE) | C1 |
+| `justfile` | Modify (+recipe) | D1 |
+| `docs/adrs/026-custom-metrics-layer.md` | Modify (status block) | D1 |
+| `CLAUDE.md` | Modify (Phase 1 line) | D1 |
+
+**Out of scope (do not touch)**:
+- `services/metrics/internal/spark/templates/composite.sql.tmpl` — already complete; reads `delta.metric_summaries`
+- `services/metrics/internal/spark/renderer.go::RenderForType` — already complete (case "COMPOSITE")
+- M4a (`crates/experimentation-analysis/`, `crates/experimentation-stats/`) — consumes the new status table later; not in this PR's scope
+- M5 (`crates/experimentation-management/`) — operand validation + cycle detection at creation already shipped via #552
+- Proto schemas (`proto/`) — no wire-format changes
+- Parallelizing the DAG — file as follow-up if scheduler latency becomes a concern
+
+---
+
+## Verification (end-to-end)
+
+| Gate | Command | Expected |
+|------|---------|----------|
+| DAG unit | `cd services/metrics && go test ./internal/jobs/ -run TestTopologicalOrder -v` | 4 PASS |
+| statusMap unit | `cd services/metrics && go test ./internal/jobs/ -run TestStatusMap -v` | 3 PASS |
+| Status writer (integration) | `cd services/metrics && go test -tags=integration ./internal/status/ -v` | PASS |
+| Migration | `just migrate` | Clean apply; `\d metric_computation_status` shows the table |
+| Scheduler unit (happy + skip) | `cd services/metrics && go test ./internal/jobs/ -run "TestStandardJob_Run_Composite\|TestStandardJob_Run_OperandFailure" -v` | 2 PASS |
+| Full jobs suite (no regression) | `cd services/metrics && go test ./internal/jobs/ -v` | All PASS, including existing `TestStandardJob_Run_*` tests |
+| Integration (multi-cycle) | `cd services/metrics && go test -tags=integration ./internal/ -run TestComputeMetrics_CompositeOrdering_MultiCycle -v` | PASS |
+| ADR-026 bundle | `just test-adr026-m3` | All of the above bundled |
+| Sanity build | `cd services/metrics && go build ./...` | No build regressions |
+| Existing contract tests | `go test ./services/metrics/internal/ -run "TestM3M5\|TestM3M4" -v` | No regression (we don't change SQL output or wire format) |
+
+---
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Behavior change from fail-fast → collect-then-return breaks an existing caller | Survey confirmed only `standard_test.go` asserts success on happy-path runs; no test relies on first-error-aborts-job semantics. If a caller does rely on early-abort, expose a `FailFast bool` option on `StandardJob`. |
+| Status writer failures mask real metric failures | Status flush is best-effort: if it errors, log and continue, do not overwrite `firstErr`. Status table is observability, not authoritative. |
+| Cycle detection at scheduling time loops infinitely | Kahn's terminates in O(V+E) regardless of input. Cycles are reported via `skippedCycle` map, never via infinite recursion. |
+| Operand defined in a different scheduling pass (cross-experiment, out-of-scope per #475) | DAG treats out-of-pass operands as "not present" → leaves the COMPOSITE in-degree at 0 → it gets scheduled, but `statusMap.blockerFor` finds the operand un-recorded and marks it skipped at runtime. Both the DAG and the runtime check are correct in isolation. |
+| `metric_computation_status` table grows unbounded | Status rows are upserted per `(experiment_id, metric_id, computation_date)` — bounded by `O(experiments × metrics × dates)`. File a retention follow-up if growth becomes a concern; not Phase 1 scope. |
+| The new `metric_computation_status` table requires migration coordination with all environments | Migration is `IF NOT EXISTS` + additive only — safe to run multiple times. Add to `just migrate` recipe; no rollback needed. |
+| Subagent reads this plan and over-engineers parallelism | Plan explicitly locks "stay sequential" — flag in PR description; reject any PR diff that introduces goroutines without an out-of-band conversation. |
+
+---
+
+## Execution mode
+
+This plan has 9 tasks across 4 phases. Phase A is genuinely parallel (DAG vs status table); Phase C is genuinely parallel (3 independent test additions). Recommended dispatch:
+
+1. **A1 / A2 in parallel** via subagents (single message, two `Agent` tool calls).
+2. **B1 → B2 sequentially** in the CLI with subagent-per-task.
+3. **C1 / C2 / C3 in parallel** via subagents.
+4. **D1 sequentially** in the CLI, PR opens at the end.
+
+Total: ~9 commits on one branch `agent-3/feat/adr-026-m3-dependency-ordering`; one PR `Closes #475` referencing the rest of the ADR-026 issue chain. Estimated execution time at subagent throughput (per #552/#555 calibration): ~2-3 hours real time including review-between-tasks.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ "M3 scheduler computes a metric DAG before each scheduling pass" → Task A1 + B1.
+- ✅ "Scheduler executes metrics in topological order; COMPOSITE metrics run only after all their operands have completed for the same computation_date" → Task B1 (topo iteration + `blockerFor` gate).
+- ✅ "Cycle detection at scheduling time (defence-in-depth)" → Task A1 (Kahn's leaves cycle nodes unemitted, reported via `skippedCycle`).
+- ✅ "Failure semantics: if any operand metric fails, dependent COMPOSITEs are skipped for that computation_date and a structured warning is logged" → Task B1 (`sm.markSkippedUpstream` + `j.logger.Warn`).
+- ✅ "Skipped status is reflected in metric_summaries (or an analogous status table) so M4a can distinguish 'missing' from 'failed-upstream'" → Task A2 (`metric_computation_status` table with 4-value enum).
+- ✅ "Integration test: COMPOSITE metric with two operand chains runs correctly and produces deterministic output across multiple scheduling cycles" → Task C3.
+
+**Type consistency:** `MetricConfig.Type` is string ("COMPOSITE"); `OperandConfig.MetricID` matches; `status.Status` is a string-newtype with 4 known values; `statusMap.blockerFor(operands []config.OperandConfig)` matches the operand iteration in Run().
+
+**No placeholders:** Every step has runnable code or a concrete command. No "implement appropriately" or "similar to above."
+
+Plan complete.

--- a/justfile
+++ b/justfile
@@ -203,6 +203,15 @@ test-adr026:
 migrate-adr026:
     @echo "  Applying ADR-026 Phase 1 migration (011)..."
     psql $DATABASE_URL -f sql/migrations/011_adr026_phase1_metric_types.sql
+    @echo "  Applying ADR-026 Phase 1 #475 migration (012)..."
+    psql $DATABASE_URL -f sql/migrations/012_metric_computation_status.sql
+
+# Run ADR-026 Phase 1 #475 M3 dependency-ordering tests (unit + integration)
+test-adr026-m3:
+    @echo "  Running ADR-026 #475 M3 scheduler unit tests..."
+    cd {{ services_dir }} && {{ go }} test ./metrics/internal/jobs/ -run "TestTopologicalOrder|TestStatusMap|TestStandardJob_Run_Composite|TestStandardJob_Run_FailFast" -v
+    @echo "  Running ADR-026 #475 multi-cycle integration test (requires migration 012 + test DB up)..."
+    cd {{ services_dir }} && {{ go }} test -tags=integration ./metrics/internal/ -run "TestComputeMetrics_CompositeOrdering" -v
 
 # Run integration tests against local infra
 test-integration: infra

--- a/services/metrics/cmd/main.go
+++ b/services/metrics/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/recalconsumer"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/status"
 	"github.com/org/experimentation-platform/services/metrics/internal/surrogate"
 )
 
@@ -43,17 +44,21 @@ func main() {
 	baseExecutor := spark.NewMockExecutor(500)
 	executor := spark.NewRetryExecutor(baseExecutor, spark.DefaultRetryConfig())
 	var qlWriter querylog.Writer
+	var statusWriter status.Writer
 	pgURL := os.Getenv("POSTGRES_URL")
 	if pgURL != "" {
 		pool, err := pgxpool.New(context.Background(), pgURL)
 		if err != nil { slog.Error("failed to connect to PostgreSQL", "error", err); os.Exit(1) }
 		defer pool.Close()
 		qlWriter = querylog.NewPgWriter(pool)
+		// ADR-026 #475: same pool feeds the metric_computation_status writer.
+		statusWriter = status.NewPgWriter(pool)
 	} else {
 		qlWriter = querylog.NewMemWriter()
-		slog.Warn("POSTGRES_URL not set, using in-memory query log")
+		statusWriter = status.NewMockWriter()
+		slog.Warn("POSTGRES_URL not set, using in-memory query log + status writer")
 	}
-	stdJob := jobs.NewStandardJob(cfgStore, renderer, executor, qlWriter)
+	stdJob := jobs.NewStandardJob(cfgStore, renderer, executor, qlWriter, jobs.WithStatusWriter(statusWriter))
 	kafkaBrokers := os.Getenv("KAFKA_BROKERS")
 	if kafkaBrokers == "" {
 		kafkaBrokers = "localhost:9092"

--- a/services/metrics/internal/integration_test.go
+++ b/services/metrics/internal/integration_test.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -38,6 +41,7 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/jobs"
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/status"
 	"github.com/org/experimentation-platform/services/metrics/internal/surrogate"
 )
 
@@ -905,5 +909,173 @@ func TestAllSQLTemplatesRenderWithoutError(t *testing.T) {
 			assert.Contains(t, strings.ToUpper(sql), "SELECT",
 				"rendered SQL should contain a SELECT statement")
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: ADR-026 #475 — topo-order COMPOSITE scheduling is deterministic
+// across multiple back-to-back scheduling cycles.
+//
+// Acceptance criterion (#475): COMPOSITE metric with two operand chains runs
+// correctly and produces deterministic output across multiple scheduling
+// cycles. This test exercises the real status.PgWriter round-trip (the
+// MockWriter path is covered by standard_test.go) so a regression in the
+// upsert (e.g., losing ON CONFLICT, accidentally INSERT-only) would surface
+// as a uniqueness violation or duplicated rows on cycle 2/3.
+// ---------------------------------------------------------------------------
+
+func TestComputeMetrics_CompositeOrdering_MultiCycle(t *testing.T) {
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, defaultDSN)
+	require.NoError(t, err, "cannot connect to PostgreSQL — is docker-compose.test.yml running?")
+	t.Cleanup(pool.Close)
+	require.NoError(t, pool.Ping(ctx), "PostgreSQL ping failed")
+
+	// Graceful skip if migration 012 hasn't been applied. The status table has
+	// no FK to experiments and is independent of the rest of the schema, so a
+	// fresh DB without `just migrate` will be missing only this table. Probe
+	// information_schema rather than catching the SQL error at write time so
+	// the skip reason is unambiguous.
+	var probe int
+	probeErr := pool.QueryRow(ctx,
+		`SELECT 1 FROM information_schema.tables WHERE table_name = 'metric_computation_status' LIMIT 1`,
+	).Scan(&probe)
+	if probeErr != nil || probe != 1 {
+		t.Skip("metric_computation_status table not present; run `just migrate` to apply migration 012")
+	}
+
+	// Inline JSON fixture seeded into t.TempDir() — same pattern the unit
+	// tests in jobs/standard_test.go use (TestStandardJob_Run_CompositeRunsAfterOperands).
+	// Three metrics on a single experiment:
+	//   it_session_score    MEAN over session_end events (value_column session_score)
+	//   it_click_rate       PROPORTION over click events
+	//   it_engagement_index COMPOSITE WEIGHTED_SUM(session*0.6 + click*0.4)
+	// The `it_` prefix keeps the cleanup query unambiguous if a previous run
+	// left rows behind.
+	const expIDStr = "exp-475-cycle"
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "seed_475_multicycle.json")
+	const fixture = `{
+		"experiments": [
+			{
+				"experiment_id": "exp-475-cycle",
+				"name": "adr026_475_multicycle",
+				"type": "STANDARD",
+				"state": "RUNNING",
+				"started_at": "2026-05-01",
+				"primary_metric_id": "it_engagement_index",
+				"secondary_metric_ids": ["it_session_score", "it_click_rate"],
+				"variants": [
+					{"variant_id": "control", "name": "Control", "traffic_fraction": 0.5, "is_control": true},
+					{"variant_id": "treatment", "name": "Treatment", "traffic_fraction": 0.5, "is_control": false}
+				]
+			}
+		],
+		"metrics": [
+			{
+				"metric_id": "it_session_score",
+				"name": "IT session score (MEAN)",
+				"type": "MEAN",
+				"source_event_type": "session_end",
+				"value_column": "session_score"
+			},
+			{
+				"metric_id": "it_click_rate",
+				"name": "IT click rate (PROPORTION)",
+				"type": "PROPORTION",
+				"source_event_type": "click"
+			},
+			{
+				"metric_id": "it_engagement_index",
+				"name": "IT engagement index (COMPOSITE)",
+				"type": "COMPOSITE",
+				"source_event_type": "n/a",
+				"operator": "WEIGHTED_SUM",
+				"operands": [
+					{"metric_id": "it_session_score", "weight": 0.6},
+					{"metric_id": "it_click_rate", "weight": 0.4}
+				]
+			}
+		]
+	}`
+	require.NoError(t, os.WriteFile(fixturePath, []byte(fixture), 0o600))
+
+	cfgStore, err := config.LoadFromFile(fixturePath)
+	require.NoError(t, err)
+
+	renderer, err := spark.NewSQLRenderer()
+	require.NoError(t, err)
+
+	executor := spark.NewMockExecutor(500)
+	// Use an in-memory query log writer: the query_log PG table has an FK to
+	// experiments(experiment_id UUID), and we deliberately use a TEXT
+	// experiment_id here so the status writer is exercised standalone. The
+	// status table has no FK — that decoupling is what lets this test run
+	// without seeding a layer/experiment row.
+	qlWriter := querylog.NewMemWriter()
+	statusWriter := status.NewPgWriter(pool)
+
+	job := jobs.NewStandardJob(cfgStore, renderer, executor, qlWriter, jobs.WithStatusWriter(statusWriter))
+
+	// Always clean status rows for this experiment_id on entry and exit so a
+	// previous interrupted run does not poison the determinism check.
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM metric_computation_status WHERE experiment_id = $1`, expIDStr)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// snapshotKeys reads "metric_id=status" rows for this experiment in a
+	// stable ORDER BY so the result is byte-comparable across cycles.
+	snapshotKeys := func(t *testing.T) []string {
+		t.Helper()
+		rows, err := pool.Query(ctx, `
+			SELECT metric_id, status FROM metric_computation_status
+			WHERE experiment_id = $1
+			ORDER BY metric_id
+		`, expIDStr)
+		require.NoError(t, err)
+		defer rows.Close()
+		var out []string
+		for rows.Next() {
+			var mid, st string
+			require.NoError(t, rows.Scan(&mid, &st))
+			out = append(out, mid+"="+st)
+		}
+		require.NoError(t, rows.Err())
+		return out
+	}
+
+	const cycles = 3
+	snapshots := make([][]string, 0, cycles)
+	for i := 0; i < cycles; i++ {
+		_, runErr := job.Run(ctx, expIDStr)
+		require.NoErrorf(t, runErr, "cycle %d: Run must succeed", i+1)
+		snap := snapshotKeys(t)
+		snapshots = append(snapshots, snap)
+	}
+
+	// All three snapshots must be byte-identical: ON CONFLICT upsert means
+	// repeated runs overwrite rather than duplicate, and topo-order scheduling
+	// guarantees the same per-metric outcome each cycle.
+	require.Len(t, snapshots[0], 3,
+		"snapshot must contain exactly one row per metric (got %v)", snapshots[0])
+	for i := 1; i < cycles; i++ {
+		assert.Truef(t,
+			reflect.DeepEqual(snapshots[0], snapshots[i]),
+			"cycle 1 snapshot != cycle %d snapshot\n  cycle 1: %v\n  cycle %d: %v",
+			i+1, snapshots[0], i+1, snapshots[i])
+	}
+
+	// COMPOSITE must land `completed` in every cycle — never skipped_*. If
+	// topo-order regressed (COMPOSITE scheduled before operands) the gate in
+	// StandardJob.Run would mark it skipped_upstream_failure because the
+	// operands would not yet be in the statusMap.
+	const compositeExpected = "it_engagement_index=completed"
+	for i, snap := range snapshots {
+		assert.Containsf(t, snap, compositeExpected,
+			"cycle %d: COMPOSITE must be completed, got snapshot %v", i+1, snap)
 	}
 }

--- a/services/metrics/internal/jobs/coverage_improvements_test.go
+++ b/services/metrics/internal/jobs/coverage_improvements_test.go
@@ -42,7 +42,7 @@ func TestStandardJob_Run_QoEEngagementCorrelation_MixedExperiment(t *testing.T) 
 	// mixed_qoe_engagement_test (e7) has ttff_mean (QoE) + watch_time_minutes (non-QoE MEAN).
 	// It also has session_level=true and lifecycle_stratification_enabled=true.
 	// This exercises: QoE-engagement correlation, session-level, and lifecycle paths.
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000007")
@@ -142,7 +142,7 @@ func TestMockInputMetricsProvider_WithInputs(t *testing.T) {
 func TestStandardJob_Run_QoEMetricRendering(t *testing.T) {
 	// playback_qoe_test (e4) has only QoE metrics.
 	// Verify the QoE rendering path is exercised.
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000004")
@@ -172,7 +172,7 @@ func TestStandardJob_Run_QoEMetricRendering(t *testing.T) {
 func TestStandardJob_Run_LifecycleMetrics(t *testing.T) {
 	// playback_qoe_test (e4) has lifecycle_stratification_enabled=true.
 	// QoE metrics are excluded from lifecycle segmentation.
-	job, _, qlWriter := setupTestJob(t)
+	job, _, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000004")

--- a/services/metrics/internal/jobs/dag.go
+++ b/services/metrics/internal/jobs/dag.go
@@ -1,6 +1,8 @@
 package jobs
 
 import (
+	"strings"
+
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
 )
 
@@ -41,7 +43,13 @@ func TopologicalOrder(metrics []*config.MetricConfig) (
 		if _, ok := inDeg[m.MetricID]; !ok {
 			inDeg[m.MetricID] = 0
 		}
-		if m.Type != "COMPOSITE" {
+		// Case-insensitive match: standard.go, renderer.go, and isLegacyStyle
+		// all normalize via strings.ToUpper. A lowercase / mixed-case "composite"
+		// in a metric config would silently skip edge-building here while the
+		// scheduler loop still gates on operand status — the COMPOSITE would land
+		// before its operands in topo order and get marked SkippedUpstreamFailure
+		// even though every operand would have succeeded. Devin BUG-0001 on #556.
+		if strings.ToUpper(m.Type) != "COMPOSITE" {
 			continue
 		}
 		for _, op := range m.Operands {

--- a/services/metrics/internal/jobs/dag.go
+++ b/services/metrics/internal/jobs/dag.go
@@ -1,0 +1,87 @@
+package jobs
+
+import (
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+)
+
+// TopologicalOrder returns (sorted, skipped_cycle, error) for the given metrics
+// using Kahn's algorithm over the COMPOSITE → operand dependency graph.
+//
+//   - `sorted` is the topo order; iterate in this order to ensure operands run
+//     before COMPOSITEs that reference them.
+//   - `skipped_cycle` is the set of metric IDs that participate in a cycle and
+//     must be skipped (defense-in-depth — M5 already rejects cycles at
+//     creation per ADR-026 / crates/experimentation-management/src/validators/
+//     composite_cycle.rs, but the scheduler must not loop forever if a bad
+//     cycle ever slips through).
+//   - `error` is non-nil only for genuine algorithmic bugs; bad input produces
+//     (sorted, skipped_cycle, nil) so the caller can keep going.
+//
+// Operands referencing metrics not in the current scheduling pass
+// (cross-experiment, out of scope for ADR-026 #475) are ignored when building
+// the in-degree map — the dependent COMPOSITE stays in-degree 0 and is
+// emitted. The caller's statusMap.blockerFor gate then marks it
+// skipped_upstream_failure at runtime because the operand has no recorded
+// status.
+func TopologicalOrder(metrics []*config.MetricConfig) (
+	[]*config.MetricConfig,
+	map[string]bool,
+	error,
+) {
+	byID := make(map[string]*config.MetricConfig, len(metrics))
+	for _, m := range metrics {
+		byID[m.MetricID] = m
+	}
+
+	// Build in-degree map + adjacency list. Edges go FROM operand TO composite
+	// (operand must run first).
+	inDeg := make(map[string]int, len(metrics))
+	children := make(map[string][]string, len(metrics))
+	for _, m := range metrics {
+		if _, ok := inDeg[m.MetricID]; !ok {
+			inDeg[m.MetricID] = 0
+		}
+		if m.Type != "COMPOSITE" {
+			continue
+		}
+		for _, op := range m.Operands {
+			if _, ok := byID[op.MetricID]; !ok {
+				// Operand defined outside this pass — leave the COMPOSITE in
+				// in-degree 0 and let the runtime status check skip it.
+				continue
+			}
+			inDeg[m.MetricID]++
+			children[op.MetricID] = append(children[op.MetricID], m.MetricID)
+		}
+	}
+
+	// Kahn's: seed queue with in-degree-zero nodes, peel layers.
+	queue := make([]string, 0, len(metrics))
+	for id, d := range inDeg {
+		if d == 0 {
+			queue = append(queue, id)
+		}
+	}
+
+	sorted := make([]*config.MetricConfig, 0, len(metrics))
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		sorted = append(sorted, byID[id])
+		for _, child := range children[id] {
+			inDeg[child]--
+			if inDeg[child] == 0 {
+				queue = append(queue, child)
+			}
+		}
+	}
+
+	// Any node still with in-degree > 0 is in (or downstream of) a cycle.
+	skipped := make(map[string]bool)
+	for id, d := range inDeg {
+		if d > 0 {
+			skipped[id] = true
+		}
+	}
+	return sorted, skipped, nil
+}

--- a/services/metrics/internal/jobs/dag.go
+++ b/services/metrics/internal/jobs/dag.go
@@ -56,10 +56,14 @@ func TopologicalOrder(metrics []*config.MetricConfig) (
 	}
 
 	// Kahn's: seed queue with in-degree-zero nodes, peel layers.
+	// Iterate the original `metrics` slice rather than `inDeg` so the output
+	// order is stable across runs (Go map iteration is randomized). Downstream
+	// tests assert that non-COMPOSITE metrics keep their seed-file ordering;
+	// only COMPOSITE metrics get reshuffled to land after their operands.
 	queue := make([]string, 0, len(metrics))
-	for id, d := range inDeg {
-		if d == 0 {
-			queue = append(queue, id)
+	for _, m := range metrics {
+		if inDeg[m.MetricID] == 0 {
+			queue = append(queue, m.MetricID)
 		}
 	}
 

--- a/services/metrics/internal/jobs/dag_test.go
+++ b/services/metrics/internal/jobs/dag_test.go
@@ -1,0 +1,89 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+)
+
+func TestTopologicalOrder_LinearChain(t *testing.T) {
+	// operand=watch_time, composite=engagement_score depending on watch_time
+	metrics := []*config.MetricConfig{
+		{MetricID: "engagement_score", Type: "COMPOSITE", Operands: []config.OperandConfig{
+			{MetricID: "watch_time", Weight: 1.0},
+		}},
+		{MetricID: "watch_time", Type: "MEAN"},
+	}
+
+	sorted, skipped, err := TopologicalOrder(metrics)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("expected no skipped, got %v", skipped)
+	}
+	if len(sorted) != 2 {
+		t.Fatalf("expected 2 sorted, got %d", len(sorted))
+	}
+	if sorted[0].MetricID != "watch_time" {
+		t.Fatalf("expected watch_time first, got %s", sorted[0].MetricID)
+	}
+	if sorted[1].MetricID != "engagement_score" {
+		t.Fatalf("expected engagement_score second, got %s", sorted[1].MetricID)
+	}
+}
+
+func TestTopologicalOrder_NestedComposite(t *testing.T) {
+	// a (MEAN) -> b (COMPOSITE of a) -> c (COMPOSITE of b)
+	metrics := []*config.MetricConfig{
+		{MetricID: "c", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "b", Weight: 1}}},
+		{MetricID: "b", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "a", Weight: 1}}},
+		{MetricID: "a", Type: "MEAN"},
+	}
+	sorted, skipped, _ := TopologicalOrder(metrics)
+	if len(skipped) != 0 {
+		t.Fatalf("expected no skipped, got %v", skipped)
+	}
+	got := []string{sorted[0].MetricID, sorted[1].MetricID, sorted[2].MetricID}
+	want := []string{"a", "b", "c"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("position %d: want %s, got %s (full: %v)", i, want[i], got[i], got)
+		}
+	}
+}
+
+func TestTopologicalOrder_CycleIsSkipped(t *testing.T) {
+	// a -> b -> a (cycle); c is independent and should still be sorted.
+	metrics := []*config.MetricConfig{
+		{MetricID: "a", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "b", Weight: 1}}},
+		{MetricID: "b", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "a", Weight: 1}}},
+		{MetricID: "c", Type: "MEAN"},
+	}
+	sorted, skipped, err := TopologicalOrder(metrics)
+	if err != nil {
+		t.Fatalf("expected no error (cycles are reported via skipped map), got %v", err)
+	}
+	if !skipped["a"] || !skipped["b"] {
+		t.Fatalf("expected a + b skipped (cycle), got %v", skipped)
+	}
+	if len(sorted) != 1 || sorted[0].MetricID != "c" {
+		t.Fatalf("expected only c sorted, got %v", sorted)
+	}
+}
+
+func TestTopologicalOrder_OperandOutsidePass(t *testing.T) {
+	// c references operand x that's not in this scheduling pass — c remains
+	// in-degree 0 (Kahn's emits it). The caller's status_map gates skipping on
+	// operand status at runtime.
+	metrics := []*config.MetricConfig{
+		{MetricID: "c", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "x", Weight: 1}}},
+	}
+	sorted, skipped, _ := TopologicalOrder(metrics)
+	if len(skipped) != 0 {
+		t.Fatalf("expected no skipped, got %v", skipped)
+	}
+	if len(sorted) != 1 || sorted[0].MetricID != "c" {
+		t.Fatalf("expected c sorted, got %v", sorted)
+	}
+}

--- a/services/metrics/internal/jobs/dag_test.go
+++ b/services/metrics/internal/jobs/dag_test.go
@@ -72,6 +72,31 @@ func TestTopologicalOrder_CycleIsSkipped(t *testing.T) {
 	}
 }
 
+func TestTopologicalOrder_LowercaseCompositeType(t *testing.T) {
+	// Devin BUG-0001 regression on #556: the loader / renderer / scheduler all
+	// normalize Type via strings.ToUpper, so a config with "composite" must
+	// build the same DAG as "COMPOSITE". Before the fix, edges weren't built
+	// for lowercase entries — the COMPOSITE landed before its operands in
+	// topo order and was wrongly marked SkippedUpstreamFailure at runtime.
+	metrics := []*config.MetricConfig{
+		{MetricID: "engagement", Type: "composite", Operands: []config.OperandConfig{
+			{MetricID: "watch_time", Weight: 1.0},
+		}},
+		{MetricID: "watch_time", Type: "mean"},
+	}
+	sorted, skipped, err := TopologicalOrder(metrics)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("expected no skipped, got %v", skipped)
+	}
+	if len(sorted) != 2 || sorted[0].MetricID != "watch_time" || sorted[1].MetricID != "engagement" {
+		ids := []string{sorted[0].MetricID, sorted[1].MetricID}
+		t.Fatalf("expected [watch_time, engagement], got %v", ids)
+	}
+}
+
 func TestTopologicalOrder_OperandOutsidePass(t *testing.T) {
 	// c references operand x that's not in this scheduling pass — c remains
 	// in-degree 0 (Kahn's emits it). The caller's status_map gates skipping on

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -12,6 +12,7 @@ import (
 	m3metrics "github.com/org/experimentation-platform/services/metrics/internal/metrics"
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/status"
 )
 
 // JobResult summarizes the outcome of a computation run.
@@ -24,28 +25,60 @@ type JobResult struct {
 
 // StandardJob orchestrates daily metric computation for a single experiment.
 type StandardJob struct {
-	config   *config.ConfigStore
-	renderer *spark.SQLRenderer
-	executor spark.SQLExecutor
-	queryLog querylog.Writer
+	config       *config.ConfigStore
+	renderer     *spark.SQLRenderer
+	executor     spark.SQLExecutor
+	queryLog     querylog.Writer
+	statusWriter status.Writer // ADR-026 #475: per-metric outcome flushed to PG; nil → flush is a no-op.
 }
 
-// NewStandardJob creates a new standard metric computation job.
+// StandardJobOption configures optional StandardJob behavior (ADR-026 #475).
+// Functional options keep the legacy 4-arg constructor wire-compatible while
+// letting cmd/main.go inject the production status.PgWriter.
+type StandardJobOption func(*StandardJob)
+
+// WithStatusWriter wires a status.Writer for per-metric computation outcome
+// recording. When unset (the default for existing tests), status flushes are
+// no-ops — the topo-order scheduling and skip-on-upstream-failure semantics
+// still apply, but nothing is persisted.
+func WithStatusWriter(w status.Writer) StandardJobOption {
+	return func(j *StandardJob) { j.statusWriter = w }
+}
+
+// NewStandardJob creates a new standard metric computation job. Options are
+// optional and additive; the 4-arg form is preserved for backwards-compatibility
+// with the dozen+ test sites still using it.
 func NewStandardJob(
 	cfg *config.ConfigStore,
 	renderer *spark.SQLRenderer,
 	executor spark.SQLExecutor,
 	ql querylog.Writer,
+	opts ...StandardJobOption,
 ) *StandardJob {
-	return &StandardJob{
+	j := &StandardJob{
 		config:   cfg,
 		renderer: renderer,
 		executor: executor,
 		queryLog: ql,
 	}
+	for _, opt := range opts {
+		opt(j)
+	}
+	return j
 }
 
 // Run computes all metrics for the given experiment.
+//
+// ADR-026 #475: metrics are executed in topological order so that COMPOSITE
+// metrics run after every operand they reference. If any operand fails (or is
+// missing from this scheduling pass), the dependent COMPOSITE is marked
+// SkippedUpstreamFailure rather than attempted — preserving the operator
+// expectation that a COMPOSITE never silently aggregates incomplete inputs.
+//
+// Fail-fast semantics for non-COMPOSITE errors are preserved: render/execute
+// failures still return the first wrapped error to the caller (the chaos suite
+// asserts this). The deferred status flush ensures statuses recorded up to the
+// failure are still persisted.
 func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult, error) {
 	exp, err := j.config.GetExperiment(experimentID)
 	if err != nil {
@@ -65,7 +98,59 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 	controlVariantID := exp.ControlVariantID()
 
-	for _, m := range metrics {
+	// ADR-026 #475: topo-order scheduling for COMPOSITE metrics.
+	// metrics is []config.MetricConfig (by value); TopologicalOrder takes
+	// []*config.MetricConfig — adapt with pointer slice.
+	ordered := make([]*config.MetricConfig, len(metrics))
+	for i := range metrics {
+		ordered[i] = &metrics[i]
+	}
+	sortedMetrics, cycleNodes, err := TopologicalOrder(ordered)
+	if err != nil {
+		return nil, fmt.Errorf("jobs: topological sort: %w", err)
+	}
+
+	sm := newStatusMap()
+	// Record cycle-skipped nodes upfront so the deferred flush has them.
+	for id := range cycleNodes {
+		sm.markSkippedCycle(id)
+		slog.Warn("metric skipped (cycle)",
+			"experiment_id", experimentID,
+			"metric_id", id,
+			"computation_date", computationDate,
+		)
+	}
+
+	// Flush statuses to PG after the loop (or after an early-return failure).
+	defer func() {
+		if flushErr := j.flushStatus(ctx, experimentID, computationDate, sm); flushErr != nil {
+			slog.Error("status flush failed (non-fatal)",
+				"experiment_id", experimentID,
+				"computation_date", computationDate,
+				"err", flushErr,
+			)
+		}
+	}()
+
+	for _, mPtr := range sortedMetrics {
+		// COMPOSITE: gate on operand status BEFORE attempting execution.
+		if strings.ToUpper(mPtr.Type) == "COMPOSITE" {
+			if blocker, blocked := sm.blockerFor(mPtr.Operands); blocked {
+				sm.markSkippedUpstream(mPtr.MetricID, blocker)
+				slog.Warn("composite skipped (operand failed or missing)",
+					"experiment_id", experimentID,
+					"metric_id", mPtr.MetricID,
+					"blocker", blocker,
+					"computation_date", computationDate,
+				)
+				continue
+			}
+		}
+
+		// Dereference into a local value so the existing loop body — written
+		// against a value `m` — keeps working unchanged below.
+		m := *mPtr
+
 		params := spark.TemplateParams{
 			ExperimentID:         exp.ExperimentID,
 			MetricID:             m.MetricID,
@@ -108,6 +193,7 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 		result, err := j.executor.ExecuteAndWrite(ctx, sql, "delta.metric_summaries")
 		if err != nil {
+			sm.markFailed(m.MetricID, fmt.Sprintf("execute: %v", err))
 			return nil, fmt.Errorf("jobs: execute metric %s: %w", m.MetricID, err)
 		}
 		m3metrics.SparkQueryDuration.WithLabelValues(jobType).Observe(result.Duration.Seconds())
@@ -121,6 +207,7 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 			DurationMs:   result.Duration.Milliseconds(),
 			JobType:      jobType,
 		}); err != nil {
+			sm.markFailed(m.MetricID, fmt.Sprintf("query_log: %v", err))
 			return nil, fmt.Errorf("jobs: log query for metric %s: %w", m.MetricID, err)
 		}
 
@@ -320,6 +407,7 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 			}
 		}
 
+		sm.markCompleted(m.MetricID)
 		slog.Info("computed metric",
 			"experiment_id", experimentID,
 			"metric_id", m.MetricID,
@@ -445,6 +533,35 @@ func isLegacyStyle(metricType string) bool {
 		return true
 	}
 	return false
+}
+
+// flushStatus persists every recorded statusMap entry via the injected
+// status.Writer. When no writer is configured (i.e., the legacy 4-arg ctor was
+// used by existing tests), this is a no-op so behaviour stays unchanged.
+// Individual write failures are surfaced to the caller; the caller logs them
+// as non-fatal — losing a status row must not fail the whole pass.
+func (j *StandardJob) flushStatus(
+	ctx context.Context,
+	experimentID, computationDate string,
+	sm *statusMap,
+) error {
+	if j.statusWriter == nil {
+		return nil
+	}
+	for id, st := range sm.entries {
+		entry := status.Entry{
+			ExperimentID:    experimentID,
+			MetricID:        id,
+			ComputationDate: computationDate,
+			Status:          st,
+			Reason:          sm.reasonOf(id),
+			RecordedAt:      time.Now(),
+		}
+		if err := j.statusWriter.Write(ctx, entry); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // toSparkOperands converts config-layer OperandConfig values to the

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -123,6 +123,15 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 	// Flush statuses to PG after the loop (or after an early-return failure).
 	defer func() {
+		// ADR-026 #475: if Run early-returns on a non-COMPOSITE failure, any
+		// downstream COMPOSITE in `sortedMetrics` was never visited and thus
+		// has no entry in `sm` — but topo order guarantees operands run before
+		// COMPOSITEs, so the COMPOSITE *would* have been gated by `blockerFor`
+		// had we reached it. Mirror that gate here so the status table reflects
+		// SkippedUpstreamFailure rather than silently omitting the row (which
+		// M4a would interpret as "missing", not "failed-upstream").
+		markUnvisitedCompositesAsSkipped(sortedMetrics, sm)
+
 		if flushErr := j.flushStatus(ctx, experimentID, computationDate, sm); flushErr != nil {
 			slog.Error("status flush failed (non-fatal)",
 				"experiment_id", experimentID,
@@ -562,6 +571,32 @@ func (j *StandardJob) flushStatus(
 		}
 	}
 	return nil
+}
+
+// markUnvisitedCompositesAsSkipped scans the topo-ordered metric list and, for
+// any COMPOSITE whose status is unrecorded in `sm`, marks it
+// SkippedUpstreamFailure if its operands include at least one non-Completed
+// status. Called from the deferred flush so early-return paths (fail-fast on a
+// non-COMPOSITE) still surface downstream COMPOSITEs to M4a — otherwise the
+// COMPOSITE would have no row in metric_computation_status, indistinguishable
+// from a metric that was never scheduled.
+//
+// COMPOSITEs whose operands all completed (e.g., the early-return happened on
+// an unrelated metric later in topo order) are intentionally left unrecorded:
+// "not yet computed" is the right signal for M4a in that case, not "skipped".
+func markUnvisitedCompositesAsSkipped(sortedMetrics []*config.MetricConfig, sm *statusMap) {
+	for _, mPtr := range sortedMetrics {
+		if strings.ToUpper(mPtr.Type) != "COMPOSITE" {
+			continue
+		}
+		if _, recorded := sm.entries[mPtr.MetricID]; recorded {
+			// Already Completed / SkippedUpstreamFailure / SkippedCycle.
+			continue
+		}
+		if blocker, blocked := sm.blockerFor(mPtr.Operands); blocked {
+			sm.markSkippedUpstream(mPtr.MetricID, blocker)
+		}
+	}
 }
 
 // toSparkOperands converts config-layer OperandConfig values to the

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -192,6 +192,11 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 		} else {
 			rendered, err := j.renderer.RenderForType(m.Type, params)
 			if err != nil {
+				// Record the render failure in the status table so M4a can
+				// distinguish it from "metric was never scheduled". Mirrors the
+				// markFailed call on the execute-error path below. Devin
+				// observability finding on #556.
+				sm.markFailed(m.MetricID, fmt.Sprintf("render: %v", err))
 				slog.Warn("skipping metric: render error",
 					"metric_id", m.MetricID, "type", m.Type, "error", err)
 				continue
@@ -426,9 +431,23 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 		)
 	}
 
+	// Filter to metrics that actually wrote rows to delta.metric_summaries.
+	// Post-processing (daily treatment effects + QoE-engagement correlation)
+	// reads from that table — running it against skipped / cycle-excluded /
+	// failed COMPOSITE metrics would write empty or stale results to
+	// delta.daily_treatment_effects. Before #475 this was rare (render errors
+	// only); the COMPOSITE skip path makes it a normal operational outcome.
+	// Devin BUG-0002 on #556.
+	completedMetrics := make([]config.MetricConfig, 0, len(metrics))
+	for _, m := range metrics {
+		if sm.entries[m.MetricID] == status.Completed {
+			completedMetrics = append(completedMetrics, m)
+		}
+	}
+
 	// Post-processing: compute daily treatment effects for each metric.
 	if controlVariantID != "" {
-		for _, m := range metrics {
+		for _, m := range completedMetrics {
 			teParams := spark.TemplateParams{
 				ExperimentID:     exp.ExperimentID,
 				MetricID:         m.MetricID,
@@ -468,9 +487,11 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 	}
 
 	// Post-processing: compute QoE-engagement correlation for experiments with QoE metrics.
+	// Uses `completedMetrics` for the same reason as daily treatment effects above —
+	// correlations against a skipped metric read empty rows from delta.metric_summaries.
 	var qoeMetrics []config.MetricConfig
 	var engagementMetrics []config.MetricConfig
-	for _, m := range metrics {
+	for _, m := range completedMetrics {
 		if m.IsQoEMetric {
 			qoeMetrics = append(qoeMetrics, m)
 		} else if !m.IsQoEMetric && m.Type != "RATIO" {

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	"github.com/org/experimentation-platform/services/metrics/internal/status"
 )
 
-func setupTestJob(t *testing.T) (*StandardJob, *spark.MockExecutor, *querylog.MemWriter) {
+func setupTestJob(t *testing.T) (*StandardJob, *spark.MockExecutor, *querylog.MemWriter, *status.MockWriter) {
 	t.Helper()
 
 	cfgStore, err := config.LoadFromFile("../config/testdata/seed_config.json")
@@ -24,13 +25,14 @@ func setupTestJob(t *testing.T) (*StandardJob, *spark.MockExecutor, *querylog.Me
 
 	executor := spark.NewMockExecutor(500)
 	qlWriter := querylog.NewMemWriter()
+	statusWriter := status.NewMockWriter()
 
-	job := NewStandardJob(cfgStore, renderer, executor, qlWriter)
-	return job, executor, qlWriter
+	job := NewStandardJob(cfgStore, renderer, executor, qlWriter, WithStatusWriter(statusWriter))
+	return job, executor, qlWriter, statusWriter
 }
 
 func TestStandardJob_Run(t *testing.T) {
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	result, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
@@ -77,7 +79,7 @@ func TestStandardJob_Run(t *testing.T) {
 }
 
 func TestStandardJob_Run_CorrectSQLTypes(t *testing.T) {
-	job, executor, _ := setupTestJob(t)
+	job, executor, _, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
@@ -125,7 +127,7 @@ func TestStandardJob_Run_CorrectSQLTypes(t *testing.T) {
 }
 
 func TestStandardJob_Run_CupedPreExperimentWindow(t *testing.T) {
-	job, executor, _ := setupTestJob(t)
+	job, executor, _, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
@@ -158,7 +160,7 @@ func TestStandardJob_Run_CupedPreExperimentWindow(t *testing.T) {
 }
 
 func TestStandardJob_Run_NotFound(t *testing.T) {
-	job, _, _ := setupTestJob(t)
+	job, _, _, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	_, err := job.Run(ctx, "nonexistent")
@@ -166,7 +168,7 @@ func TestStandardJob_Run_NotFound(t *testing.T) {
 }
 
 func TestStandardJob_Run_DailyTreatmentEffects(t *testing.T) {
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
@@ -201,7 +203,7 @@ func TestStandardJob_Run_DailyTreatmentEffects(t *testing.T) {
 }
 
 func TestStandardJob_Run_SessionLevelMetrics(t *testing.T) {
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	// playback_qoe_test has session_level: true
@@ -230,7 +232,7 @@ func TestStandardJob_Run_SessionLevelMetrics(t *testing.T) {
 }
 
 func TestStandardJob_Run_QoEEngagementCorrelation(t *testing.T) {
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	// playback_qoe_test: ttff_mean (QoE) + rebuffer_ratio_mean (QoE), no engagement metrics
@@ -257,7 +259,7 @@ func TestStandardJob_Run_MixedQoEAndEngagement(t *testing.T) {
 	// We use homepage_recs_v2 which has 4 metrics: ctr (PROPORTION), watch_time (MEAN),
 	// stream_start (PROPORTION), rebuffer_rate (RATIO). None are QoE, so no correlation.
 	// This test verifies the "no QoE metrics" path.
-	job, _, qlWriter := setupTestJob(t)
+	job, _, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	_, err := job.Run(ctx, "e0000000-0000-0000-0000-000000000001")
@@ -273,7 +275,7 @@ func TestStandardJob_Run_MixedQoEAndEngagement(t *testing.T) {
 }
 
 func TestStandardJob_Run_PercentileMetricType(t *testing.T) {
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	// latency_percentile_test experiment uses latency_p50_ms (PERCENTILE type)
@@ -313,7 +315,7 @@ func TestStandardJob_Run_PercentileMetricType(t *testing.T) {
 }
 
 func TestStandardJob_Run_CustomMetricType(t *testing.T) {
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	// custom_metric_test experiment uses power_users_watch_time (CUSTOM type)
@@ -354,7 +356,7 @@ func TestStandardJob_Run_CustomMetricType(t *testing.T) {
 }
 
 func TestStandardJob_Run_MLRATECrossFitting(t *testing.T) {
-	job, executor, qlWriter := setupTestJob(t)
+	job, executor, qlWriter, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	// mlrate_crossfit_test (e...0008): mlrate_enabled=true, mlrate_folds=3
@@ -405,7 +407,7 @@ func TestStandardJob_Run_MLRATECrossFitting(t *testing.T) {
 }
 
 func TestStandardJob_Run_AllExperimentsWithExposureJoin(t *testing.T) {
-	job, executor, _ := setupTestJob(t)
+	job, executor, _, _ := setupTestJob(t)
 	ctx := context.Background()
 
 	// Run for search_ranking_interleave
@@ -470,13 +472,18 @@ func TestStandardJob_Run_ADR026Phase1_NewTypes(t *testing.T) {
 
 	executor := spark.NewMockExecutor(123)
 	qlWriter := querylog.NewMemWriter()
-	job := NewStandardJob(cfgStore, renderer, executor, qlWriter)
+	statusWriter := status.NewMockWriter()
+	job := NewStandardJob(cfgStore, renderer, executor, qlWriter, WithStatusWriter(statusWriter))
 
 	ctx := context.Background()
 	result, err := job.Run(ctx, "e0000000-0000-0000-0000-0000000adr26")
 	require.NoError(t, err)
-	assert.Equal(t, 4, result.MetricsComputed,
-		"all 4 metrics (3 new-type + 1 legacy) should compute primary SQL successfully")
+	// ADR-026 #475: composite_engagement is now correctly skipped because its
+	// operands (watch_time_minutes, stream_start_rate) live in a different
+	// experiment's metric list and are not part of this scheduling pass. Only
+	// the 3 metrics whose dependencies resolve will run primary SQL.
+	assert.Equal(t, 3, result.MetricsComputed,
+		"3 metrics (2 new-type with no operands + 1 legacy) compute; COMPOSITE skipped due to upstream-missing operands")
 
 	calls := executor.GetCalls()
 	require.GreaterOrEqual(t, len(calls), 3, "executor should receive >= 3 SQL calls (one per metric, plus any post-processing)")
@@ -502,15 +509,24 @@ func TestStandardJob_Run_ADR026Phase1_NewTypes(t *testing.T) {
 			"FILTERED_MEAN SQL must reference the configured value_column")
 	})
 
-	t.Run("composite SQL", func(t *testing.T) {
-		sql, ok := sqlByMetric["composite_engagement"]
-		require.True(t, ok, "COMPOSITE metric must have produced SQL")
-		assert.Contains(t, sql, "operand_rows",
-			"COMPOSITE template must produce an `operand_rows` CTE")
-		assert.Contains(t, sql, "delta.metric_summaries",
-			"COMPOSITE template must read from delta.metric_summaries")
-		assert.Contains(t, sql, "0.7", "WEIGHTED_SUM SQL must inline operand weights")
-		assert.Contains(t, sql, "0.3", "WEIGHTED_SUM SQL must inline operand weights")
+	t.Run("composite skipped (operands out of scheduling pass)", func(t *testing.T) {
+		// ADR-026 #475: COMPOSITE references operands that don't belong to this
+		// experiment's metric list, so the scheduler marks it
+		// SkippedUpstreamFailure rather than rendering against missing inputs.
+		_, ran := sqlByMetric["composite_engagement"]
+		assert.False(t, ran,
+			"COMPOSITE with out-of-pass operands must NOT produce daily_metric SQL under topo-order gating")
+
+		var composite *status.Entry
+		for i := range statusWriter.Entries {
+			if statusWriter.Entries[i].MetricID == "composite_engagement" {
+				composite = &statusWriter.Entries[i]
+				break
+			}
+		}
+		require.NotNil(t, composite, "composite_engagement must have a recorded status entry")
+		assert.Equal(t, status.SkippedUpstreamFailure, composite.Status,
+			"composite skipped because operands aren't part of this scheduling pass")
 	})
 
 	t.Run("windowed_count SQL", func(t *testing.T) {
@@ -538,7 +554,9 @@ func TestStandardJob_Run_ADR026Phase1_NewTypes(t *testing.T) {
 	}
 
 	t.Run("new types skip legacy post-processing", func(t *testing.T) {
-		newTypeIDs := []string{"mobile_avg_watch_time", "composite_engagement", "stream_starts_24h"}
+		// composite_engagement is excluded here because it is now skipped
+		// at the topo-order gate before any post-processing could run.
+		newTypeIDs := []string{"mobile_avg_watch_time", "stream_starts_24h"}
 		for _, id := range newTypeIDs {
 			assert.Empty(t, postProcByMetric[id],
 				"%s (new ADR-026 Phase 1 type) should NOT emit any session-level / lifecycle / cuped_covariate SQL", id)

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -792,3 +792,92 @@ func TestStandardJob_Run_CompositeRunsAfterOperands(t *testing.T) {
 			"%s status must be Completed (got %v)", id, entry.Status)
 	}
 }
+
+// TestStandardJob_Run_SkippedCompositeDoesNotPostProcess is the Devin BUG-0002
+// regression on #556: when a COMPOSITE is skipped (operand missing/failed,
+// cycle, etc.), the post-processing loops at standard.go:436 (daily treatment
+// effects) and standard.go:478 (QoE-engagement correlation) must NOT iterate
+// over it. Before the fix, both loops walked the unfiltered `metrics` slice
+// and rendered post-processing SQL that read from delta.metric_summaries for
+// the skipped COMPOSITE — writing empty/stale rows to
+// delta.daily_treatment_effects.
+func TestStandardJob_Run_SkippedCompositeDoesNotPostProcess(t *testing.T) {
+	// Inline fixture: a COMPOSITE whose operands are NOT in this experiment's
+	// metric list, so the topo-order gate marks it SkippedUpstreamFailure. The
+	// experiment has a control variant so the daily-treatment-effect post-pass
+	// would otherwise fire for every entry in `metrics`.
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "seed_skipped_no_post.json")
+	const fixture = `{
+		"experiments": [
+			{
+				"experiment_id": "e0000000-0000-0000-0000-00000000bb02",
+				"name": "skip_no_post",
+				"type": "STANDARD",
+				"state": "RUNNING",
+				"started_at": "2026-05-01",
+				"primary_metric_id": "session_score",
+				"secondary_metric_ids": ["engagement_index"],
+				"variants": [
+					{"variant_id": "control", "name": "Control", "traffic_fraction": 0.5, "is_control": true},
+					{"variant_id": "treatment", "name": "Treatment", "traffic_fraction": 0.5, "is_control": false}
+				]
+			}
+		],
+		"metrics": [
+			{
+				"metric_id": "session_score",
+				"name": "Session score (MEAN)",
+				"type": "MEAN",
+				"source_event_type": "session_end",
+				"value_column": "session_score"
+			},
+			{
+				"metric_id": "engagement_index",
+				"name": "Engagement (COMPOSITE, operands OUT of pass)",
+				"type": "COMPOSITE",
+				"source_event_type": "n/a",
+				"operator": "WEIGHTED_SUM",
+				"operands": [
+					{"metric_id": "watch_time_minutes", "weight": 0.6},
+					{"metric_id": "stream_start_rate", "weight": 0.4}
+				]
+			}
+		]
+	}`
+	require.NoError(t, os.WriteFile(fixturePath, []byte(fixture), 0o600))
+
+	cfgStore, err := config.LoadFromFile(fixturePath)
+	require.NoError(t, err)
+
+	renderer, err := spark.NewSQLRenderer()
+	require.NoError(t, err)
+
+	executor := spark.NewMockExecutor(500)
+	qlWriter := querylog.NewMemWriter()
+	statusWriter := status.NewMockWriter()
+
+	job := NewStandardJob(cfgStore, renderer, executor, qlWriter, WithStatusWriter(statusWriter))
+
+	_, runErr := job.Run(context.Background(), "e0000000-0000-0000-0000-00000000bb02")
+	require.NoError(t, runErr)
+
+	// The COMPOSITE must be recorded as SkippedUpstreamFailure.
+	snap := statusWriter.Snapshot()
+	byMetric := make(map[string]status.Entry, len(snap))
+	for _, e := range snap {
+		byMetric[e.MetricID] = e
+	}
+	require.Equal(t, status.SkippedUpstreamFailure, byMetric["engagement_index"].Status,
+		"COMPOSITE with out-of-pass operands must land SkippedUpstreamFailure")
+	require.Equal(t, status.Completed, byMetric["session_score"].Status,
+		"sibling metric should still complete")
+
+	// Inspect every recorded executor call. No call's SQL should reference the
+	// skipped COMPOSITE's metric_id. Daily-treatment-effect SQL has the form
+	// `... WHERE ms.metric_id = '<id>' ...` so a substring check is sufficient.
+	for _, call := range executor.GetCalls() {
+		assert.NotContainsf(t, call.SQL, "'engagement_index'",
+			"post-processing must not iterate over skipped COMPOSITE (call SQL: %s)", call.SQL)
+	}
+}

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -669,3 +669,126 @@ func TestStandardJob_Run_FailFastStillMarksDownstreamComposite(t *testing.T) {
 	assert.Contains(t, skipped.Reason, "op_a",
 		"comp_b skip reason should mention the blocking operand")
 }
+
+// TestStandardJob_Run_CompositeRunsAfterOperands is the ADR-026 #475 happy-path
+// guard for topo-order scheduling: a COMPOSITE metric whose operands are
+// independent non-COMPOSITE metrics must have its daily-metric SQL executed
+// strictly AFTER both operand queries, because composite.sql.tmpl reads from
+// delta.metric_summaries and would return NULL if scheduled before its
+// operands wrote their rows. The ordering between unrelated operands is
+// intentionally unconstrained (statusMap / topo-order do not promise stable
+// ordering for siblings).
+func TestStandardJob_Run_CompositeRunsAfterOperands(t *testing.T) {
+	// Inline fixture: three metrics on a single experiment.
+	//   session_score   -- MEAN over heartbeat events
+	//   click_rate      -- PROPORTION over click events (single source_event_type
+	//                      matches how PROPORTION is wired in seed_config.json;
+	//                      numerator/denominator fields belong to RATIO)
+	//   engagement_index -- COMPOSITE WEIGHTED_SUM(session_score*0.6 + click_rate*0.4)
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "seed_composite_happy_path.json")
+	const fixture = `{
+		"experiments": [
+			{
+				"experiment_id": "e0000000-0000-0000-0000-00000000aa01",
+				"name": "composite_happy_path",
+				"type": "STANDARD",
+				"state": "RUNNING",
+				"started_at": "2026-05-01",
+				"primary_metric_id": "engagement_index",
+				"secondary_metric_ids": ["session_score", "click_rate"],
+				"variants": [
+					{"variant_id": "control", "name": "Control", "traffic_fraction": 0.5, "is_control": true},
+					{"variant_id": "treatment", "name": "Treatment", "traffic_fraction": 0.5, "is_control": false}
+				]
+			}
+		],
+		"metrics": [
+			{
+				"metric_id": "session_score",
+				"name": "Session score (MEAN)",
+				"type": "MEAN",
+				"source_event_type": "session_end",
+				"value_column": "session_score"
+			},
+			{
+				"metric_id": "click_rate",
+				"name": "Click rate (PROPORTION)",
+				"type": "PROPORTION",
+				"source_event_type": "click"
+			},
+			{
+				"metric_id": "engagement_index",
+				"name": "Engagement index (COMPOSITE)",
+				"type": "COMPOSITE",
+				"source_event_type": "n/a",
+				"operator": "WEIGHTED_SUM",
+				"operands": [
+					{"metric_id": "session_score", "weight": 0.6},
+					{"metric_id": "click_rate", "weight": 0.4}
+				]
+			}
+		]
+	}`
+	require.NoError(t, os.WriteFile(fixturePath, []byte(fixture), 0o600))
+
+	cfgStore, err := config.LoadFromFile(fixturePath)
+	require.NoError(t, err)
+
+	renderer, err := spark.NewSQLRenderer()
+	require.NoError(t, err)
+
+	executor := spark.NewMockExecutor(500)
+	qlWriter := querylog.NewMemWriter()
+	statusWriter := status.NewMockWriter()
+
+	job := NewStandardJob(cfgStore, renderer, executor, qlWriter, WithStatusWriter(statusWriter))
+
+	_, runErr := job.Run(context.Background(), "e0000000-0000-0000-0000-00000000aa01")
+	require.NoError(t, runErr, "happy path must not surface any error")
+
+	// Locate the index of each metric's daily-metric SQL in the executor's
+	// recorded call list. Every daily-metric template (mean, proportion,
+	// composite) emits `'<metric_id>' AS metric_id` in its projection, which
+	// uniquely identifies the originating render. Daily-treatment-effect SQL
+	// also references metric IDs but uses `ms.metric_id = '...'` (qualified)
+	// so it does not collide with the literal-projection search below.
+	calls := executor.GetCalls()
+	dailyIdxOf := func(metricID string) int {
+		needle := "'" + metricID + "' AS metric_id"
+		for i, c := range calls {
+			if strings.Contains(c.SQL, needle) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	idxSession := dailyIdxOf("session_score")
+	idxClick := dailyIdxOf("click_rate")
+	idxComposite := dailyIdxOf("engagement_index")
+
+	require.NotEqual(t, -1, idxSession, "session_score daily-metric SQL must be executed")
+	require.NotEqual(t, -1, idxClick, "click_rate daily-metric SQL must be executed")
+	require.NotEqual(t, -1, idxComposite, "engagement_index COMPOSITE SQL must be executed")
+
+	// Topological invariant: both operands strictly precede the COMPOSITE.
+	// Order between session_score and click_rate is intentionally unconstrained.
+	assert.Less(t, idxSession, idxComposite,
+		"session_score must execute before engagement_index (COMPOSITE reads operand rows from delta.metric_summaries)")
+	assert.Less(t, idxClick, idxComposite,
+		"click_rate must execute before engagement_index (COMPOSITE reads operand rows from delta.metric_summaries)")
+
+	// All three metrics must be recorded as Completed in metric_computation_status.
+	snap := statusWriter.Snapshot()
+	byMetric := make(map[string]status.Entry, len(snap))
+	for _, e := range snap {
+		byMetric[e.MetricID] = e
+	}
+	for _, id := range []string{"session_score", "click_rate", "engagement_index"} {
+		entry, ok := byMetric[id]
+		require.Truef(t, ok, "%s must have a status row in the happy path", id)
+		assert.Equalf(t, status.Completed, entry.Status,
+			"%s status must be Completed (got %v)", id, entry.Status)
+	}
+}

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -2,6 +2,9 @@ package jobs
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -571,4 +574,98 @@ func TestStandardJob_Run_ADR026Phase1_NewTypes(t *testing.T) {
 			"legacy MEAN metric should produce lifecycle_metric SQL when lifecycle_stratification is enabled")
 		// Note: legacy_watch_time has no cuped_covariate_metric_id, so no cuped_covariate entry expected.
 	})
+}
+
+// TestStandardJob_Run_FailFastStillMarksDownstreamComposite is the regression
+// guard for the ADR-026 #475 fail-fast follow-up. When a non-COMPOSITE operand
+// fails, Run still early-returns the wrapped error (preserving the chaos suite
+// contract), but the deferred status flush must now also mark any downstream
+// COMPOSITE as SkippedUpstreamFailure so M4a can distinguish "failed-upstream"
+// from "never scheduled" in metric_computation_status.
+func TestStandardJob_Run_FailFastStillMarksDownstreamComposite(t *testing.T) {
+	// Build a minimal inline fixture with a non-COMPOSITE operand `op_a` and a
+	// COMPOSITE `comp_b` that depends on it. Both belong to the same experiment
+	// so topo-order schedules op_a first, comp_b second.
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "seed_failfast_composite.json")
+	const fixture = `{
+		"experiments": [
+			{
+				"experiment_id": "e0000000-0000-0000-0000-00000000ff01",
+				"name": "failfast_composite_smoke",
+				"type": "STANDARD",
+				"state": "RUNNING",
+				"started_at": "2026-05-01",
+				"primary_metric_id": "op_a",
+				"secondary_metric_ids": ["comp_b"],
+				"variants": [
+					{"variant_id": "control", "name": "Control", "traffic_fraction": 0.5, "is_control": true},
+					{"variant_id": "treatment", "name": "Treatment", "traffic_fraction": 0.5, "is_control": false}
+				]
+			}
+		],
+		"metrics": [
+			{
+				"metric_id": "op_a",
+				"name": "Operand A (MEAN)",
+				"type": "MEAN",
+				"source_event_type": "heartbeat"
+			},
+			{
+				"metric_id": "comp_b",
+				"name": "Downstream composite",
+				"type": "COMPOSITE",
+				"source_event_type": "n/a",
+				"operator": "WEIGHTED_SUM",
+				"operands": [
+					{"metric_id": "op_a", "weight": 1.0}
+				]
+			}
+		]
+	}`
+	require.NoError(t, os.WriteFile(fixturePath, []byte(fixture), 0o600))
+
+	cfgStore, err := config.LoadFromFile(fixturePath)
+	require.NoError(t, err)
+
+	renderer, err := spark.NewSQLRenderer()
+	require.NoError(t, err)
+
+	// Fail on the very first executor call so op_a (first in topo order) fails
+	// before comp_b is even reached. This is the canonical fail-fast scenario.
+	sentinel := fmt.Errorf("spark cluster unreachable")
+	executor := NewFailingExecutor(0, sentinel)
+	qlWriter := querylog.NewMemWriter()
+	statusWriter := status.NewMockWriter()
+
+	job := NewStandardJob(cfgStore, renderer, executor, qlWriter, WithStatusWriter(statusWriter))
+
+	_, runErr := job.Run(context.Background(), "e0000000-0000-0000-0000-00000000ff01")
+
+	// 1. Fail-fast contract preserved: Run returns the wrapped operand error.
+	require.Error(t, runErr)
+	assert.Contains(t, runErr.Error(), "jobs: execute metric op_a",
+		"error must identify the failing operand")
+	assert.ErrorIs(t, runErr, sentinel, "original sentinel error must remain in the wrap chain")
+
+	// 2. Status table now records BOTH the failed operand AND the downstream
+	//    COMPOSITE — the latter as SkippedUpstreamFailure so M4a can distinguish
+	//    "failed upstream" from "never scheduled".
+	snap := statusWriter.Snapshot()
+	byMetric := make(map[string]status.Entry, len(snap))
+	for _, e := range snap {
+		byMetric[e.MetricID] = e
+	}
+
+	failed, hasFailed := byMetric["op_a"]
+	require.True(t, hasFailed, "op_a must have a status row recording the failure")
+	assert.Equal(t, status.Failed, failed.Status, "op_a status must be Failed")
+
+	skipped, hasSkipped := byMetric["comp_b"]
+	require.True(t, hasSkipped,
+		"comp_b must have a status row even though Run early-returned before visiting it (ADR-026 #475)")
+	assert.Equal(t, status.SkippedUpstreamFailure, skipped.Status,
+		"comp_b status must be SkippedUpstreamFailure, not omitted")
+	assert.Contains(t, skipped.Reason, "op_a",
+		"comp_b skip reason should mention the blocking operand")
 }

--- a/services/metrics/internal/jobs/status_map.go
+++ b/services/metrics/internal/jobs/status_map.go
@@ -1,0 +1,69 @@
+package jobs
+
+import (
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	"github.com/org/experimentation-platform/services/metrics/internal/status"
+)
+
+// statusMap tracks the per-metric outcome for one scheduling pass (one experiment
+// × computation_date). It is the in-memory companion to the status.Writer that
+// flushes results to PG at the end of the pass.
+//
+// COMPOSITE metrics gate execution on operand status via blockerFor: if any
+// operand is missing or not Completed, the COMPOSITE is marked
+// SkippedUpstreamFailure without attempting render/execute.
+//
+// Not safe for concurrent use — the scheduler iterates metrics serially in
+// topological order (see TopologicalOrder in dag.go).
+type statusMap struct {
+	entries map[string]status.Status
+	reasons map[string]string
+}
+
+func newStatusMap() *statusMap {
+	return &statusMap{
+		entries: make(map[string]status.Status),
+		reasons: make(map[string]string),
+	}
+}
+
+func (s *statusMap) markCompleted(id string) {
+	s.entries[id] = status.Completed
+}
+
+func (s *statusMap) markFailed(id, reason string) {
+	s.entries[id] = status.Failed
+	s.reasons[id] = reason
+}
+
+func (s *statusMap) markSkippedUpstream(id, blocker string) {
+	s.entries[id] = status.SkippedUpstreamFailure
+	s.reasons[id] = "operand " + blocker + " did not complete"
+}
+
+func (s *statusMap) markSkippedCycle(id string) {
+	s.entries[id] = status.SkippedCycle
+	s.reasons[id] = "metric participates in a COMPOSITE cycle"
+}
+
+// blockerFor returns the first operand whose status is not Completed (or "" if
+// all operands completed). The boolean is true iff a blocker exists.
+//
+// Operands not recorded in the map (e.g., out-of-pass metrics referenced by a
+// COMPOSITE) are treated as blockers — the caller has iterated in topo order so
+// every operand within the pass will already have a recorded status by the time
+// the dependent COMPOSITE is evaluated.
+func (s *statusMap) blockerFor(operands []config.OperandConfig) (string, bool) {
+	for _, op := range operands {
+		st, ok := s.entries[op.MetricID]
+		if !ok || st != status.Completed {
+			return op.MetricID, true
+		}
+	}
+	return "", false
+}
+
+// reasonOf returns the recorded reason (or empty string if unrecorded).
+func (s *statusMap) reasonOf(id string) string {
+	return s.reasons[id]
+}

--- a/services/metrics/internal/jobs/status_map_test.go
+++ b/services/metrics/internal/jobs/status_map_test.go
@@ -1,0 +1,49 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	"github.com/org/experimentation-platform/services/metrics/internal/status"
+)
+
+func TestStatusMap_BlockerForOperands(t *testing.T) {
+	sm := newStatusMap()
+	sm.markCompleted("watch_time")
+	sm.markFailed("ctr", "spark timeout")
+
+	// engagement_score depends on watch_time (completed) + ctr (failed).
+	operands := []config.OperandConfig{
+		{MetricID: "watch_time", Weight: 1.0},
+		{MetricID: "ctr", Weight: 1.0},
+	}
+	blocker, ok := sm.blockerFor(operands)
+	if !ok {
+		t.Fatalf("expected blocker, got none")
+	}
+	if blocker != "ctr" {
+		t.Fatalf("expected blocker=ctr, got %s", blocker)
+	}
+}
+
+func TestStatusMap_NoBlockerWhenAllCompleted(t *testing.T) {
+	sm := newStatusMap()
+	sm.markCompleted("a")
+	sm.markCompleted("b")
+	_, ok := sm.blockerFor([]config.OperandConfig{{MetricID: "a"}, {MetricID: "b"}})
+	if ok {
+		t.Fatalf("expected no blocker")
+	}
+}
+
+func TestStatusMap_OperandNotYetRunIsBlocker(t *testing.T) {
+	// An operand not in the status map (e.g., out-of-pass or not yet processed) blocks the
+	// dependent. The caller must have iterated in topo order so this case = upstream not in pass.
+	sm := newStatusMap()
+	sm.markCompleted("a")
+	blocker, ok := sm.blockerFor([]config.OperandConfig{{MetricID: "a"}, {MetricID: "missing"}})
+	if !ok || blocker != "missing" {
+		t.Fatalf("expected blocker=missing, got blocker=%q ok=%v", blocker, ok)
+	}
+	_ = status.Completed // keep import
+}

--- a/services/metrics/internal/status/mock_writer.go
+++ b/services/metrics/internal/status/mock_writer.go
@@ -1,0 +1,35 @@
+package status
+
+import (
+	"context"
+	"sync"
+)
+
+// MockWriter is an in-memory Writer for unit tests.
+type MockWriter struct {
+	mu      sync.Mutex
+	Entries []Entry
+}
+
+// NewMockWriter returns an empty in-memory Writer.
+func NewMockWriter() *MockWriter {
+	return &MockWriter{Entries: nil}
+}
+
+// Write appends the entry to the in-memory log.
+func (w *MockWriter) Write(_ context.Context, entry Entry) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.Entries = append(w.Entries, entry)
+	return nil
+}
+
+// Snapshot returns a copy of the recorded entries (safe to inspect from tests
+// without racing the writer).
+func (w *MockWriter) Snapshot() []Entry {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]Entry, len(w.Entries))
+	copy(out, w.Entries)
+	return out
+}

--- a/services/metrics/internal/status/pg_writer.go
+++ b/services/metrics/internal/status/pg_writer.go
@@ -1,0 +1,39 @@
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PgWriter persists status entries to PostgreSQL via pgxpool, matching the
+// driver choice used by services/metrics/internal/querylog/writer.go.
+type PgWriter struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgWriter returns a PostgreSQL-backed status Writer.
+func NewPgWriter(pool *pgxpool.Pool) *PgWriter {
+	return &PgWriter{pool: pool}
+}
+
+// Write upserts a single status entry. Re-runs of the same
+// (experiment, metric, date) overwrite the prior outcome so the table always
+// reflects the latest scheduling pass.
+func (w *PgWriter) Write(ctx context.Context, entry Entry) error {
+	_, err := w.pool.Exec(ctx, `
+        INSERT INTO metric_computation_status
+            (experiment_id, metric_id, computation_date, status, reason, recorded_at)
+        VALUES ($1, $2, $3, $4, $5, NOW())
+        ON CONFLICT (experiment_id, metric_id, computation_date) DO UPDATE
+        SET status = EXCLUDED.status,
+            reason = EXCLUDED.reason,
+            recorded_at = NOW()
+    `, entry.ExperimentID, entry.MetricID, entry.ComputationDate, string(entry.Status), entry.Reason)
+	if err != nil {
+		return fmt.Errorf("status: write %s/%s/%s: %w",
+			entry.ExperimentID, entry.MetricID, entry.ComputationDate, err)
+	}
+	return nil
+}

--- a/services/metrics/internal/status/pg_writer_test.go
+++ b/services/metrics/internal/status/pg_writer_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package status
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPgWriter_UpsertOverwritesPrior(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://experimentation:localdev@localhost:5432/experimentation?sslmode=disable"
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	// Clean slate.
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM metric_computation_status WHERE experiment_id = 'test_exp_475'`,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewPgWriter(pool)
+
+	if err := w.Write(ctx, Entry{
+		ExperimentID:    "test_exp_475",
+		MetricID:        "m1",
+		ComputationDate: "2026-05-17",
+		Status:          Failed,
+		Reason:          "first try",
+		RecordedAt:      time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Write(ctx, Entry{
+		ExperimentID:    "test_exp_475",
+		MetricID:        "m1",
+		ComputationDate: "2026-05-17",
+		Status:          Completed,
+		Reason:          "",
+		RecordedAt:      time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var statusValue, reason string
+	err = pool.QueryRow(ctx, `
+        SELECT status, COALESCE(reason, '') FROM metric_computation_status
+        WHERE experiment_id = 'test_exp_475' AND metric_id = 'm1' AND computation_date = '2026-05-17'
+    `).Scan(&statusValue, &reason)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusValue != "completed" {
+		t.Errorf("upsert failed: status = %q want completed", statusValue)
+	}
+	if reason != "" {
+		t.Errorf("upsert failed: reason = %q want empty", reason)
+	}
+}

--- a/services/metrics/internal/status/status.go
+++ b/services/metrics/internal/status/status.go
@@ -1,0 +1,40 @@
+// Package status records the per-metric outcome of a single M3 scheduling pass
+// to PostgreSQL so M4a can distinguish "missing because not scheduled" from
+// "skipped because upstream failed" or "failed".
+//
+// See ADR-026 Phase 1 follow-up (#475) and migration 012.
+package status
+
+import (
+	"context"
+	"time"
+)
+
+// Status enumerates the four terminal outcomes a metric can land in during a
+// scheduling pass. The string values match the CHECK constraint in
+// `sql/migrations/012_metric_computation_status.sql` exactly and are part of
+// the M4a contract — do not rename without coordinating with Agent-4.
+type Status string
+
+const (
+	Completed              Status = "completed"
+	Failed                 Status = "failed"
+	SkippedUpstreamFailure Status = "skipped_upstream_failure"
+	SkippedCycle           Status = "skipped_cycle"
+)
+
+// Entry is one row of metric_computation_status.
+type Entry struct {
+	ExperimentID    string
+	MetricID        string
+	ComputationDate string // YYYY-MM-DD; matches Spark SQL templates' date format.
+	Status          Status
+	Reason          string // Free-form explanation (e.g., "operand watch_time failed: <err>").
+	RecordedAt      time.Time
+}
+
+// Writer is the interface M3's scheduler uses to flush per-metric status
+// after each pass. Implementations: PgWriter (production), MockWriter (tests).
+type Writer interface {
+	Write(ctx context.Context, entry Entry) error
+}

--- a/sql/migrations/012_metric_computation_status.sql
+++ b/sql/migrations/012_metric_computation_status.sql
@@ -1,0 +1,21 @@
+-- sql/migrations/012_metric_computation_status.sql
+-- ADR-026 Phase 1 follow-up (#475): record metric computation outcome per (experiment, metric, date)
+-- so M4a can distinguish "missing because not scheduled" from "skipped because upstream failed".
+
+CREATE TABLE IF NOT EXISTS metric_computation_status (
+    experiment_id     TEXT NOT NULL,
+    metric_id         TEXT NOT NULL,
+    computation_date  DATE NOT NULL,
+    status            TEXT NOT NULL CHECK (status IN (
+        'completed',
+        'failed',
+        'skipped_upstream_failure',
+        'skipped_cycle'
+    )),
+    reason            TEXT,
+    recorded_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (experiment_id, metric_id, computation_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_metric_computation_status_lookup
+    ON metric_computation_status (experiment_id, computation_date, status);


### PR DESCRIPTION
## Summary

- **Topological scheduling** of metrics in M3 via Kahn's algorithm (`services/metrics/internal/jobs/dag.go`). COMPOSITE metrics never run before their operand metrics have written rows to `delta.metric_summaries` for the same `computation_date`.
- **Skip semantics for upstream failures.** When a COMPOSITE's operand fails (or never ran), the COMPOSITE is marked `skipped_upstream_failure` rather than attempted — both for COMPOSITEs visited in the loop and for COMPOSITEs that would have been visited had `Run` not short-circuited on an earlier non-COMPOSITE failure (deferred `markUnvisitedCompositesAsSkipped` pass).
- **Defense-in-depth cycle detection** at scheduling time. M5 already rejects cycles at creation (#552 / `composite_cycle.rs`), but Kahn's naturally falls back to "skip the cycle, log a warning" if a malformed metric slips through — the scheduler can't loop forever.
- **New `metric_computation_status` table** (`sql/migrations/012`) records per-`(experiment_id, metric_id, computation_date)` outcomes (`completed` / `failed` / `skipped_upstream_failure` / `skipped_cycle`) so M4a can distinguish "metric is missing because it wasn't scheduled" from "metric is missing because its upstream failed."
- **Fail-fast for non-COMPOSITE errors is preserved.** The chaos suite (`chaos_test.go`) asserts on first-error-aborts-job semantics; rewriting all 110+ existing tests was out of scope for #475. The deferred-flush + `markUnvisitedCompositesAsSkipped` pattern means M4a still gets the right signal even though `Run` early-returns.

Closes #475. Companion to ADR-026 Phase 1 backend (#552) and M6 UI (#555).

## Design decisions worth flagging

| Decision | Choice | Why |
|----------|--------|-----|
| Topo-sort algorithm | **Kahn's (BFS, in-degree)** | Cycles surface naturally as non-emitted nodes; no risk of infinite recursion. M5 has the deep 3-color DFS for *explaining* cycles at creation time; M3's check is "skip and continue." |
| Failure semantics | **Fail-fast preserved for non-COMPOSITE; deferred downstream-skip for COMPOSITE** | Keeps the chaos suite intact while still satisfying the spec acceptance criterion that M4a can distinguish `skipped_upstream_failure` from `missing`. |
| Status visibility | **New `metric_computation_status` table** | Avoids touching `metric_summaries` (no M4a regression risk) and avoids overloading `querylog` (which is internal observability, not a contract surface). |
| Test seeding | **Inline `t.TempDir()` JSON fixtures** | The B1 follow-up and C1/C2/C3 use inline fixtures rather than extending `seed_adr026_phase1.json` to avoid cascading test churn — the shared seed is used by multiple existing assertions. |
| Cross-experiment COMPOSITEs | **Out of scope** (per #475) | Phase 1 assumes operand + COMPOSITE share `experiment_id` and `computation_date`. |
| Parallelism in the scheduler | **Stay sequential** | Today M3 runs metrics serially. The DAG enables future parallelism but entangling correctness review with concurrency review was deliberately deferred. |

## Files touched

| File | Change |
|------|--------|
| `services/metrics/internal/jobs/dag.go` | **NEW** — Kahn's topo sort + cycle detection |
| `services/metrics/internal/jobs/dag_test.go` | **NEW** — 4 unit tests (linear chain, nested COMPOSITE, cycle skip, operand outside pass) |
| `services/metrics/internal/jobs/status_map.go` | **NEW** — in-memory status tracking during a single `Run` |
| `services/metrics/internal/jobs/status_map_test.go` | **NEW** — 3 unit tests (blocker detection, no-blocker, operand-not-yet-run) |
| `services/metrics/internal/jobs/standard.go` | **Modified** — `Run` rewritten to iterate in topo order, gate COMPOSITEs on operand status, defer status flush + `markUnvisitedCompositesAsSkipped` to cover early-return paths |
| `services/metrics/internal/jobs/standard_test.go` | **Modified** — new `TestStandardJob_Run_CompositeRunsAfterOperands` (happy path) + `TestStandardJob_Run_FailFastStillMarksDownstreamComposite` (B1 follow-up regression test) |
| `services/metrics/internal/jobs/coverage_improvements_test.go` | **Modified** — compile-fix for new `setupTestJob` return tuple |
| `services/metrics/cmd/main.go` | **Modified** — wires `status.NewPgWriter(pool)` (with `MockWriter` fallback when `POSTGRES_URL` is unset, mirroring querylog) |
| `services/metrics/internal/status/{status,pg_writer,mock_writer,pg_writer_test}.go` | **NEW** — status enum, `*pgxpool.Pool` writer, mock writer, integration test |
| `sql/migrations/012_metric_computation_status.sql` | **NEW** — table + CHECK constraint + index |
| `services/metrics/internal/integration_test.go` | **Modified** — `TestComputeMetrics_CompositeOrdering_MultiCycle` (graceful skip if migration 012 not applied) |
| `justfile` | **Modified** — `migrate-adr026` now applies 012; new `test-adr026-m3` bundles scheduler tests |
| `docs/adrs/026-custom-metrics-layer.md` | **Modified** — status block extended |
| `CLAUDE.md` | **Modified** — Active Work line extended |
| `docs/superpowers/plans/2026-05-17-adr-026-phase-1-m3-scheduler.md` | **NEW** — the planning doc this PR executes against |

**Out of scope** (no changes): `services/metrics/internal/spark/templates/composite.sql.tmpl`, `services/metrics/internal/spark/renderer.go`, `crates/experimentation-management/`, M4a (`crates/experimentation-analysis/`), all proto schemas.

## Test plan

- [ ] `cd services && go test ./metrics/internal/jobs/ -count=1 -v` — 113 tests pass (110 preexisting + DAG/statusMap/COMPOSITE-ordering additions)
- [ ] `cd services && go test ./metrics/internal/... -count=1` — all 11 packages green
- [ ] `cd services && go vet ./metrics/...` — clean
- [ ] `just migrate-adr026` — migration 012 applies cleanly (`\d metric_computation_status` shows table + indexes)
- [ ] `just test-adr026-m3` — bundled scheduler regression suite passes (integration test gracefully skips if DB is up but migration 012 isn't applied; PASSES end-to-end once 012 is applied)
- [ ] Existing M3↔M5 / M3↔M4a contract tests (`TestM3M5*`, `TestM3M4*`) — no regression
- [ ] Manual: kill a Spark job for one operand mid-`Run` and confirm dependent COMPOSITE lands a `skipped_upstream_failure` row in `metric_computation_status`

## Migration ordering for reviewers / deployers

Migration 012 must be applied **before** any code from this branch runs against a database. Without it, the integration test gracefully skips (so CI stays green) but production COMPOSITEs would attempt status writes against a missing table and log non-fatal errors. The status flush is intentionally non-fatal: if PG is unreachable or the table is missing, the metric computation still succeeds and the error is logged but doesn't propagate to `Run`'s return value.

## Follow-ups identified during execution

- The behavior shift from fail-fast → "fail-fast + downstream-skip via deferred pass" hits the #475 spec exactly. A future cleanup could make non-COMPOSITE errors *also* collect-then-return (the original plan called for this) — would require updating `chaos_test` assertions. Not P1; file a follow-up if M4a operators report that they want sibling metrics to attempt even when an unrelated one fails.
- `PROPORTION` metric type uses `source_event_type`, not `numerator_event_type` / `denominator_event_type` (those belong to `RATIO`). The plan's example seed had this wrong — corrected in C1's inline fixture.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->