### PR TITLE
🎨 Palette: Standardize Metrics UX and Permissions

### DIFF
--- a/ui/src/__tests__/metric-browser-permissions.test.tsx
+++ b/ui/src/__tests__/metric-browser-permissions.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__mocks__/server';
+import { describe, it, expect, vi } from 'vitest';
+import MetricBrowserPage from '@/app/metrics/page';
+import { ToastProvider } from '@/lib/toast-context';
+import { AuthProvider } from '@/lib/auth-context';
+
+const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/metrics',
+}));
+
+// Mock next/link to render an anchor tag
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe('Metric Browser Page Permission Gating', () => {
+  it('shows disabled New Metric button for viewer', async () => {
+    render(
+      <AuthProvider initialUser={{ email: 'viewer@streamco.com', role: 'viewer' }}>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Stream Start Rate')).toBeInTheDocument();
+    });
+
+    const button = screen.getByTestId('new-metric-disabled');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('title', 'Requires Experimenter role (you are Viewer)');
+  });
+
+  it('shows enabled New Metric button for experimenter', async () => {
+    render(
+      <AuthProvider initialUser={{ email: 'exp@streamco.com', role: 'experimenter' }}>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Stream Start Rate')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('new-metric-button')).toBeInTheDocument();
+  });
+
+  it('shows CTA in empty state for experimenter', async () => {
+    server.use(
+      http.post(`${MGMT_SVC}/ListMetricDefinitions`, () => {
+        return HttpResponse.json({ metrics: [], nextPageToken: '' });
+      }),
+    );
+
+    render(
+      <AuthProvider initialUser={{ email: 'exp@streamco.com', role: 'experimenter' }}>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('create-first-metric')).toBeInTheDocument();
+  });
+
+  it('does NOT show CTA in empty state for viewer', async () => {
+    server.use(
+      http.post(`${MGMT_SVC}/ListMetricDefinitions`, () => {
+        return HttpResponse.json({ metrics: [], nextPageToken: '' });
+      }),
+    );
+
+    render(
+      <AuthProvider initialUser={{ email: 'viewer@streamco.com', role: 'viewer' }}>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('create-first-metric')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -10,6 +10,8 @@ import { listMetricDefinitions } from '@/lib/api';
 import { RetryableError } from '@/components/retryable-error';
 import { CopyButton } from '@/components/copy-button';
 import { Breadcrumb } from '@/components/breadcrumb';
+import { useAuth } from '@/lib/auth-context';
+import { ROLE_LABELS } from '@/lib/auth';
 
 const SqlHighlighter = dynamic(
   () => import('@/components/sql-highlighter').then((m) => ({ default: m.SqlHighlighter })),
@@ -287,6 +289,7 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
 }
 
 function MetricBrowserContent() {
+  const { canAtLeast, user } = useAuth();
   const [metrics, setMetrics] = useState<MetricDefinition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -367,18 +370,39 @@ function MetricBrowserContent() {
             </span>
           )}
         </div>
-        <Link
-          href="/metrics/new"
-          className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
-          data-testid="new-metric-button"
-        >
-          New Metric
-        </Link>
+        {canAtLeast('experimenter') ? (
+          <Link
+            href="/metrics/new"
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+            data-testid="new-metric-button"
+          >
+            New Metric
+          </Link>
+        ) : (
+          <span
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+            title={`Requires Experimenter role (you are ${ROLE_LABELS[user.role]})`}
+            data-testid="new-metric-disabled"
+          >
+            New Metric
+          </span>
+        )}
       </div>
 
       {isEmpty ? (
         <div className="py-12 text-center" data-testid="empty-state">
           <p className="text-sm text-gray-500">No metric definitions found.</p>
+          {canAtLeast('experimenter') && (
+            <div className="mt-6">
+              <Link
+                href="/metrics/new"
+                className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+                data-testid="create-first-metric"
+              >
+                Create your first metric
+              </Link>
+            </div>
+          )}
         </div>
       ) : (
         <>


### PR DESCRIPTION
This PR standardizes the UX of the Metrics Browser page to match the patterns established in the Experiments and Feature Flags sections.

### 💡 What:
- Added permission gating to the "New Metric" button: it now appears in a disabled state with an informative tooltip ("Requires Experimenter role...") for users with insufficient permissions (e.g., Viewers).
- Enhanced the absolute empty state (when no metrics exist) by adding a "Create your first metric" Call-to-Action link for authorized users.
- Standardized button styling (`shadow-sm`, `hover:bg-indigo-500`) to match the platform's design system.

### 🎯 Why:
To provide a more cohesive and predictable user experience across the platform. Users should understand why certain actions are unavailable (permissions) and be guided on how to proceed when they encounter an empty list.

### ♿ Accessibility & UX:
- Improved discoverability of role requirements via tooltips on disabled actions.
- Provided clear next steps in empty states.
- Maintained keyboard accessibility for all new and modified elements.

### ✅ Verification:
- Created a new test suite `ui/src/__tests__/metric-browser-permissions.test.tsx` to verify gating and empty state logic.
- Ran existing metric browser tests to ensure no regressions.
- Performed visual verification using Playwright, confirming correct rendering for both 'Experimenter' and 'Viewer' roles.

---
*PR created automatically by Jules for task [7453944305605506564](https://jules.google.com/task/7453944305605506564) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->