### PR TITLE
docs: streaming video sequence diagram + integration walkthrough

### DIFF
--- a/docs/design/offline_evaluation_sequence.mermaid
+++ b/docs/design/offline_evaluation_sequence.mermaid
@@ -1,0 +1,83 @@
+sequenceDiagram
+    autonumber
+    actor R as Researcher / DS
+    participant Note as Jupyter Notebook<br/>(or M6 UI)
+    participant ML as MLflow Registry
+    participant M5 as M5 Management<br/>:50055
+    participant M3 as M3 Metrics :50056<br/>(Go + Spark)
+    participant DL as Delta Lake
+    participant M4a as M4a Analysis :50053<br/>(experimentation-stats)
+    participant PG as PostgreSQL
+    participant M6 as M6 Analyst UI<br/>:3000
+    participant M4b as M4b Bandit<br/>:50054
+    participant M1 as M1 Assignment<br/>:50051
+
+    rect rgb(255, 243, 224)
+    Note over R,M5: 1. Register candidate policy + create eval job
+    R->>Note: develop candidate ranker / policy
+    Note->>ML: log_model(candidate, params, deps,<br/>training_dataset_hash)
+    ML-->>Note: { model_uri: "models:/ranker/v8", version: 3 }
+    Note->>M5: CreateOfflineEvalJob(<br/>candidate_uri,<br/>baseline_uri="models:/ranker/v7",<br/>eval_window=[T-30d, T],<br/>metrics=[engagement, watch_time, ebvs_rate],<br/>cluster_unit=user, eval_unit=session)
+    M5->>M5: validate scope, dedupe job_hash,<br/>check researcher RBAC
+    M5-->>Note: { job_id, status: QUEUED }
+    end
+
+    rect rgb(232, 245, 233)
+    Note over M5,DL: 2. Build immutable eval slice (data prep)
+    M5->>M3: BuildEvalSlice(job_id, window, eval_unit)
+    M3->>DL: query exposures × metric_events × qoe_events<br/>+ pre-period covariates (CUPED)<br/>+ cluster keys (user_id for clustered SE)
+    DL-->>M3: logged tuples<br/>(state, action, reward, π_old)
+    M3->>M3: propensity sanity:<br/>min(π_old) > floor, no degenerate ties,<br/>action space coverage
+    M3->>DL: write eval_slice/{job_id}/<br/>(immutable parquet snapshot)
+    M3->>M5: slice_ready(row_count, schema_hash,<br/>min_propensity, max_propensity)
+    end
+
+    rect rgb(225, 245, 254)
+    Note over M5,M4a: 3. Score + estimate (doubly-robust OPE — ADR-017)
+    M5->>M4a: EstimatePolicyValue(job_id,<br/>estimators=[DM, IPW, DR],<br/>variance_reduction=[CUPED, JIVE])
+    M4a->>ML: load_model(candidate_uri)
+    ML-->>M4a: model artifact<br/>(Candle / ONNX / coefficient vector)
+    M4a->>DL: read eval_slice + covariates
+    loop per logged exposure
+        M4a->>M4a: π_new(state) → action probs
+        M4a->>M4a: importance weight w = π_new / π_old<br/>(clip at τ to bound variance)
+    end
+    M4a->>M4a: Direct Method (DM):<br/>Q̂(s,a) regression on (state, action) → reward
+    M4a->>M4a: IPW: V̂_IPW = Σ w · reward / N
+    M4a->>M4a: Doubly-Robust:<br/>V̂_DR = Σ [Q̂(s, π_new(s)) + w · (reward − Q̂(s,a))] / N
+    M4a->>M4a: TC/JIVE surrogate fix<br/>(short-horizon proxy → long-horizon target)
+    M4a->>M4a: CUPED variance reduction<br/>via pre-period covariates
+    M4a->>M4a: cluster-bootstrap SEs<br/>(user-level resampling)
+    M4a->>M4a: TOST equivalence (ADR-027) vs baseline<br/>+ AVLM always-valid bounds (ADR-015)
+    M4a->>PG: write offline_eval_results<br/>(point, CI, equivalence verdict,<br/>per-segment lift, diagnostics)
+    M4a->>M5: results_ready(job_id)
+    end
+
+    rect rgb(243, 229, 245)
+    Note over M4a,M6: 4. Trustworthiness diagnostics
+    M4a->>M4a: effective sample size<br/>ESS = (Σw)² / Σw²
+    M4a->>M4a: propensity overlap<br/>(PS clipping rate, support diagnostic)
+    M4a->>M4a: covariate balance pre/post weighting
+    M4a->>M4a: cross-validate DR (estimator stability)
+    M4a->>PG: write diagnostics_card(job_id)
+    Note over M4a: If ESS < ESS_floor OR overlap < overlap_floor<br/>→ flag verdict = UNRELIABLE
+    end
+
+    rect rgb(255, 224, 230)
+    Note over R,M1: 5. Review + decision
+    M5-->>R: notify(job_id, status=READY)
+    R->>M6: open Offline Eval dashboard
+    M6->>M5: GET /offline_evals/{job_id}
+    M6->>PG: read results + diagnostics
+    M6-->>R: render lift, CI, equivalence verdict,<br/>per-segment breakouts,<br/>diagnostics health card
+    alt Promote to shadow (ADR-030)
+        R->>M5: PromoteToShadow(candidate, traffic_pct)
+        M5->>M4b: enroll arm in shadow mode<br/>(no user impact, telemetry only)
+    else Promote to live A/B
+        R->>M5: PromoteToExperiment(candidate, control)
+        M5->>M4b: enroll as new arm in policy
+        M5->>M1: create experiment config<br/>(salt, bucket allocation, guardrails)
+    else Reject / iterate
+        R->>Note: refine candidate,<br/>re-train, re-submit
+    end
+    end

--- a/docs/design/streaming_video_sequence.mermaid
+++ b/docs/design/streaming_video_sequence.mermaid
@@ -1,12 +1,16 @@
 sequenceDiagram
     autonumber
     actor U as Viewer
-    participant App as Video App<br/>(iOS / Android / Web SDK)
+    participant App as Video App<br/>(iOS / Android / Web<br/>+ Kaizen Client SDK)
+    participant Auth as Identity / Auth<br/>(customer)
+    participant BFF as Page Orchestration / BFF<br/>(customer, Kaizen Server SDK)
+    participant Recs as Recommendations<br/>(customer, Kaizen Server SDK)
+    participant Cat as Catalog / Metadata<br/>(customer)
+    participant PB as Playback Authorization<br/>(customer, Kaizen Server SDK)
+    participant CDN as Video Player + CDN
     participant M7 as M7 Flags<br/>:50057
     participant M1 as M1 Assignment<br/>:50051
-    participant Pers as Personalization<br/>(customer service)
     participant M4b as M4b Bandit<br/>:50054
-    participant Player as Video Player<br/>+ CDN
     participant M2 as M2 Ingest (Rust)<br/>:50052
     participant K as Kafka / Redpanda<br/>(7 topics)
     participant M3 as M3 Metrics<br/>(Spark + Go) :50056
@@ -15,78 +19,101 @@ sequenceDiagram
     participant M6 as M6 Analyst UI<br/>:3000
 
     rect rgb(255, 243, 224)
-    Note over U,M1: 1. App launch — flag check + experiment assignment
+    Note over U,M1: 1. Session start + page-level assignment (BFF fan-out)
     U->>App: open app
-    App->>App: ResilientProvider chain<br/>(Remote → Local WASM → static default)
-    App->>M7: EvaluateFlag(key="home_glass_ui", context)
-    M7-->>App: { enabled: true, rollout_pct: 25, reason: "TARGETING_MATCH" }
-    App->>M1: GetAssignment(experiment="home_redesign_2026q2",<br/>unit=userId, attrs={country, device, tier})
-    M1->>M1: MurmurHash3(salt ⊕ userId) → bucket ∈ [0, 10000)<br/>bucket-reuse check across overlapping experiments
-    M1-->>App: { variant: "treatment_glass_ui",<br/>exposure_id, propensity: null,<br/>arm_id: null }
-    App->>M2: ExposureEvent(exposure_id, experiment_id, variant,<br/>unit_id, attrs, ts)
-    M2->>M2: validate(proto) + Bloom-filter dedup
-    M2->>K: produce → topic "exposures"
+    App->>Auth: authenticate(credentials / refresh token)
+    Auth-->>App: { userId, account_id, plan_tier,<br/>cohort_attrs, session_token }
+
+    App->>BFF: GetPage(surface="home", userId,<br/>device, locale, app_version)
+    Note over BFF: BFF holds the Server SDK +<br/>fans out to ~dozens of services
+    BFF->>M7: EvaluateFlag("home_glass_ui_2026q2", context)
+    M7-->>BFF: { enabled: true, rollout_pct: 25 }
+    BFF->>M1: GetAssignment(experiment="home_layout_v3",<br/>unit=userId, attrs)
+    M1->>M1: MurmurHash3 + bucket-reuse check
+    M1-->>BFF: { variant: "treatment_glass_ui", exposure_id }
+    BFF->>M2: ExposureEvent (server-side, authoritative)
+    M2->>M2: proto validate + Bloom-filter dedup
+    M2->>K: produce → "exposures"
     end
 
     rect rgb(232, 245, 233)
-    Note over U,M4b: 2. Personalized rail — contextual bandit arm selection
-    App->>Pers: GetRail(userId, surface="home",<br/>row="because_you_watched")
-    Pers->>M4b: SelectArm(policy_id="rail_ranker_v3",<br/>ctx_features={genre_affinity, dwell_history, ...})
+    Note over BFF,Cat: 2. Recommendations fan-out (bandit + catalog hydration)
+    BFF->>Recs: GetRails(userId, surface="home",<br/>layout_variant, slot_budget)
+    Recs->>M4b: SelectArm(policy_id="rail_ranker_v3",<br/>ctx_features={genre_affinity,<br/>dwell_history, tod, ...})
     M4b->>M4b: LMAX single-thread core<br/>Thompson / LinUCB / Neural (Candle)
-    M4b-->>Pers: { arm_id: "ranker_v7",<br/>propensity: 0.42 (for IPW debiasing) }
-    Pers->>Pers: rank candidate titles via arm_id
-    Pers-->>App: ranked titles[]
-    App->>M2: ExposureEvent(arm_id, propensity, slot_index)
-    M2->>K: produce → topic "exposures"
+    M4b-->>Recs: { arm_id: "ranker_v7",<br/>propensity: 0.42 (for IPW) }
+    Recs->>Cat: GetTitles(candidate_ids[], locale)
+    Cat-->>Recs: hydrated title metadata<br/>(artwork, runtime, badges)
+    Recs->>Recs: rank via arm_id → build rails
+    Recs->>M2: ExposureEvent per rail<br/>(arm_id, propensity, slot_index)
+    M2->>K: produce → "exposures"
+    Recs-->>BFF: rails[] with title cards
+    BFF-->>App: assembled page<br/>(layout_variant + rails)
+    App->>U: render home screen
     end
 
     rect rgb(225, 245, 254)
-    Note over U,K: 3. Playback + QoE telemetry (heartbeat sessionization)
+    Note over U,K: 3. Title detail → Playback authorization → Streaming + QoE
     U->>App: tap title
-    App->>M2: ClickEvent(title_id, slot, ts)
-    M2->>K: produce → topic "metric_events"
-    App->>Player: play(title_id, requested_bitrate)
-    Player-->>U: stream manifest + segments via CDN
+    App->>M2: ClickEvent (client SDK, includes<br/>exposure_id from BFF response)
+    M2->>K: produce → "metric_events"
+    App->>Cat: GetTitleDetail(title_id, locale)
+    Cat-->>App: detail page payload
+
+    U->>App: hit play
+    App->>PB: AuthorizePlayback(userId, title_id,<br/>device, drm_capabilities)
+    PB->>M1: GetAssignment(experiment="encoding_ladder_2026q2",<br/>unit=userId)
+    M1-->>PB: { variant: "av1_priority_ladder" }
+    PB->>PB: DRM license issuance<br/>+ entitlement check
+    PB->>M2: ExposureEvent (encoding-ladder experiment)
+    M2->>K: produce → "exposures"
+    PB-->>App: { manifest_url, license_token,<br/>playback_session_id }
+
+    App->>CDN: fetch manifest + segments
+    CDN-->>U: video stream
+
     loop every 10s while playing
-        Player->>M2: PlaybackHeartbeat(session_id,<br/>played_ms, buffered_ms,<br/>bitrate, dropped_frames)
-        M2->>M2: HeartbeatSessionizer aggregates<br/>→ derive PlaybackMetrics<br/>→ detect EBVS (exit before video start)
-        M2->>K: produce → topic "qoe_events"
+        CDN->>M2: PlaybackHeartbeat(session_id, played_ms,<br/>buffered_ms, bitrate, dropped_frames)
+        M2->>M2: HeartbeatSessionizer aggregates<br/>→ PlaybackMetrics + EBVS detection
+        M2->>K: produce → "qoe_events"
     end
-    U->>App: watch ≥ 30s threshold (engagement)
+
+    U->>App: watch ≥ 30s (engagement threshold)
     App->>M2: RewardEvent(experiment, variant, reward=1.0,<br/>arm_id, propensity)
-    M2->>K: produce → topic "reward_events"
+    M2->>K: produce → "reward_events"
     end
 
     rect rgb(255, 224, 230)
     Note over K,M4b: 4. Reward feedback loop — bandit posterior update
     K-->>M4b: consume reward_events
     M4b->>M4b: update posterior (Thompson) /<br/>features (LinUCB) /<br/>weights (Neural)
-    M4b->>M4b: persist RocksDB snapshot<br/>(crash-safe)
-    Note over M4b: New arm selections immediately reflect updated policy
+    M4b->>M4b: RocksDB snapshot (crash-safe)
+    Note over M4b: Next SelectArm call reflects updated policy
     end
 
     rect rgb(243, 229, 245)
     Note over K,M6: 5. Offline analysis + ship decision
-    K-->>M3: consume exposures, metric_events, qoe_events
-    M3->>M3: Spark SQL — daily standard metrics,<br/>hourly guardrail metrics,<br/>QoE rollups (rebuffer ratio, EBVS rate, P95 startup)
+    K-->>M3: consume exposures + metric_events + qoe_events
+    M3->>M3: Spark SQL — daily standard,<br/>hourly guardrail, QoE rollups<br/>(rebuffer ratio, EBVS rate, P95 startup)
     M3->>M3: write Delta Lake + query_log
-    M3->>M4a: signal "rollup ready" (per-experiment)
-    M4a->>M4a: CUPED variance reduction + AVLM (always-valid)<br/>TOST equivalence (ADR-027)<br/>e-values + online FDR
+    M3->>M4a: rollup_ready(experiment_id)
+    M4a->>M4a: CUPED + AVLM (ADR-015)<br/>TOST equivalence (ADR-027)<br/>e-values + online FDR (ADR-018)
     M4a->>M5: write results to PostgreSQL
     M6->>M5: GET /experiments/{id}/results
     M6-->>U: analyst dashboard rendered
     Note over M6,M5: Analyst reviews → clicks "Ship Treatment"
     M6->>M5: TransitionState(experiment, "shipped")
     M5->>M7: reconcile flag rollout → 100%
-    M5->>M1: update assignment config<br/>(disable bucket reuse for this experiment)
+    M5->>M1: assignment config update<br/>(disable bucket reuse for this experiment)
     end
 
     rect rgb(255, 235, 235)
     Note over M3,M1: Exception path — guardrail auto-pause
-    M3->>K: GuardrailBreach (rebuffer_ratio +32% vs control)<br/>→ topic "guardrail_alerts"
+    M3->>K: GuardrailBreach (rebuffer_ratio +32% vs control)<br/>→ "guardrail_alerts"
     K-->>M5: consume guardrail_alerts
     M5->>M5: state machine: ACTIVE → PAUSED
-    M5->>M1: assignment config flip — serve control to 100%
+    M5->>M1: assignment config — serve control to 100%
     M5->>M7: reconcile flag → disabled
-    M5-->>M6: emit notification banner
+    M5-->>M6: notification banner
+    Note over M5: Same code path as analyst-driven pause —<br/>no separate "auto" branch to drift
     end

--- a/docs/design/streaming_video_sequence.mermaid
+++ b/docs/design/streaming_video_sequence.mermaid
@@ -1,0 +1,92 @@
+sequenceDiagram
+    autonumber
+    actor U as Viewer
+    participant App as Video App<br/>(iOS / Android / Web SDK)
+    participant M7 as M7 Flags<br/>:50057
+    participant M1 as M1 Assignment<br/>:50051
+    participant Pers as Personalization<br/>(customer service)
+    participant M4b as M4b Bandit<br/>:50054
+    participant Player as Video Player<br/>+ CDN
+    participant M2 as M2 Ingest (Rust)<br/>:50052
+    participant K as Kafka / Redpanda<br/>(7 topics)
+    participant M3 as M3 Metrics<br/>(Spark + Go) :50056
+    participant M4a as M4a Analysis<br/>:50053
+    participant M5 as M5 Management<br/>:50055
+    participant M6 as M6 Analyst UI<br/>:3000
+
+    rect rgb(255, 243, 224)
+    Note over U,M1: 1. App launch — flag check + experiment assignment
+    U->>App: open app
+    App->>App: ResilientProvider chain<br/>(Remote → Local WASM → static default)
+    App->>M7: EvaluateFlag(key="home_glass_ui", context)
+    M7-->>App: { enabled: true, rollout_pct: 25, reason: "TARGETING_MATCH" }
+    App->>M1: GetAssignment(experiment="home_redesign_2026q2",<br/>unit=userId, attrs={country, device, tier})
+    M1->>M1: MurmurHash3(salt ⊕ userId) → bucket ∈ [0, 10000)<br/>bucket-reuse check across overlapping experiments
+    M1-->>App: { variant: "treatment_glass_ui",<br/>exposure_id, propensity: null,<br/>arm_id: null }
+    App->>M2: ExposureEvent(exposure_id, experiment_id, variant,<br/>unit_id, attrs, ts)
+    M2->>M2: validate(proto) + Bloom-filter dedup
+    M2->>K: produce → topic "exposures"
+    end
+
+    rect rgb(232, 245, 233)
+    Note over U,M4b: 2. Personalized rail — contextual bandit arm selection
+    App->>Pers: GetRail(userId, surface="home",<br/>row="because_you_watched")
+    Pers->>M4b: SelectArm(policy_id="rail_ranker_v3",<br/>ctx_features={genre_affinity, dwell_history, ...})
+    M4b->>M4b: LMAX single-thread core<br/>Thompson / LinUCB / Neural (Candle)
+    M4b-->>Pers: { arm_id: "ranker_v7",<br/>propensity: 0.42 (for IPW debiasing) }
+    Pers->>Pers: rank candidate titles via arm_id
+    Pers-->>App: ranked titles[]
+    App->>M2: ExposureEvent(arm_id, propensity, slot_index)
+    M2->>K: produce → topic "exposures"
+    end
+
+    rect rgb(225, 245, 254)
+    Note over U,K: 3. Playback + QoE telemetry (heartbeat sessionization)
+    U->>App: tap title
+    App->>M2: ClickEvent(title_id, slot, ts)
+    M2->>K: produce → topic "metric_events"
+    App->>Player: play(title_id, requested_bitrate)
+    Player-->>U: stream manifest + segments via CDN
+    loop every 10s while playing
+        Player->>M2: PlaybackHeartbeat(session_id,<br/>played_ms, buffered_ms,<br/>bitrate, dropped_frames)
+        M2->>M2: HeartbeatSessionizer aggregates<br/>→ derive PlaybackMetrics<br/>→ detect EBVS (exit before video start)
+        M2->>K: produce → topic "qoe_events"
+    end
+    U->>App: watch ≥ 30s threshold (engagement)
+    App->>M2: RewardEvent(experiment, variant, reward=1.0,<br/>arm_id, propensity)
+    M2->>K: produce → topic "reward_events"
+    end
+
+    rect rgb(255, 224, 230)
+    Note over K,M4b: 4. Reward feedback loop — bandit posterior update
+    K-->>M4b: consume reward_events
+    M4b->>M4b: update posterior (Thompson) /<br/>features (LinUCB) /<br/>weights (Neural)
+    M4b->>M4b: persist RocksDB snapshot<br/>(crash-safe)
+    Note over M4b: New arm selections immediately reflect updated policy
+    end
+
+    rect rgb(243, 229, 245)
+    Note over K,M6: 5. Offline analysis + ship decision
+    K-->>M3: consume exposures, metric_events, qoe_events
+    M3->>M3: Spark SQL — daily standard metrics,<br/>hourly guardrail metrics,<br/>QoE rollups (rebuffer ratio, EBVS rate, P95 startup)
+    M3->>M3: write Delta Lake + query_log
+    M3->>M4a: signal "rollup ready" (per-experiment)
+    M4a->>M4a: CUPED variance reduction + AVLM (always-valid)<br/>TOST equivalence (ADR-027)<br/>e-values + online FDR
+    M4a->>M5: write results to PostgreSQL
+    M6->>M5: GET /experiments/{id}/results
+    M6-->>U: analyst dashboard rendered
+    Note over M6,M5: Analyst reviews → clicks "Ship Treatment"
+    M6->>M5: TransitionState(experiment, "shipped")
+    M5->>M7: reconcile flag rollout → 100%
+    M5->>M1: update assignment config<br/>(disable bucket reuse for this experiment)
+    end
+
+    rect rgb(255, 235, 235)
+    Note over M3,M1: Exception path — guardrail auto-pause
+    M3->>K: GuardrailBreach (rebuffer_ratio +32% vs control)<br/>→ topic "guardrail_alerts"
+    K-->>M5: consume guardrail_alerts
+    M5->>M5: state machine: ACTIVE → PAUSED
+    M5->>M1: assignment config flip — serve control to 100%
+    M5->>M7: reconcile flag → disabled
+    M5-->>M6: emit notification banner
+    end

--- a/docs/design/streaming_video_sequence.mermaid
+++ b/docs/design/streaming_video_sequence.mermaid
@@ -37,11 +37,14 @@ sequenceDiagram
     end
 
     rect rgb(232, 245, 233)
-    Note over BFF,Cat: 2. Recommendations fan-out (bandit + catalog hydration)
+    Note over BFF,Cat: 2. Recommendations fan-out (bandit via M1 delegation + catalog hydration)
     BFF->>Recs: GetRails(userId, surface="home",<br/>layout_variant, slot_budget)
-    Recs->>M4b: SelectArm(policy_id="rail_ranker_v3",<br/>ctx_features={genre_affinity,<br/>dwell_history, tod, ...})
+    Note over Recs,M1: Recs calls M1 (not M4b directly) —<br/>M1 owns bucketing, targeting, lifecycle, timeout fallback
+    Recs->>M1: GetAssignment(experiment="rail_ranker_v3",<br/>unit=userId, policy_type=BANDIT,<br/>ctx_features={genre_affinity, dwell_history, tod, ...})
+    M1->>M4b: SelectArm (internal delegation, p99 < 15ms)
     M4b->>M4b: LMAX single-thread core<br/>Thompson / LinUCB / Neural (Candle)
-    M4b-->>Recs: { arm_id: "ranker_v7",<br/>propensity: 0.42 (for IPW) }
+    M4b-->>M1: { arm_id: "ranker_v7", propensity: 0.42 }
+    M1-->>Recs: { variant, arm_id, propensity,<br/>exposure_id } (M1 falls back on M4b timeout)
     Recs->>Cat: GetTitles(candidate_ids[], locale)
     Cat-->>Recs: hydrated title metadata<br/>(artwork, runtime, badges)
     Recs->>Recs: rank via arm_id → build rails
@@ -98,7 +101,8 @@ sequenceDiagram
     M3->>M3: write Delta Lake + query_log
     M3->>M4a: rollup_ready(experiment_id)
     M4a->>M4a: CUPED + AVLM (ADR-015)<br/>TOST equivalence (ADR-027)<br/>e-values + online FDR (ADR-018)
-    M4a->>M5: write results to PostgreSQL
+    M4a->>M4a: write results to PostgreSQL<br/>(point estimate, CI, equivalence verdict)
+    M4a->>M5: results_ready(experiment_id)
     M6->>M5: GET /experiments/{id}/results
     M6-->>U: analyst dashboard rendered
     Note over M6,M5: Analyst reviews → clicks "Ship Treatment"

--- a/docs/design/system_architecture.mermaid
+++ b/docs/design/system_architecture.mermaid
@@ -1,66 +1,155 @@
 flowchart TB
-    subgraph Clients["Client SDKs (TypeScript, Swift, Kotlin, Python, Go)"]
+    %% =========================================================
+    %% LAYER 1 — Customer-side streaming services (outside Kaizen)
+    %% =========================================================
+    subgraph L1["Customer-side Streaming Services"]
         direction LR
-        RP["RemoteProvider"]
-        LP["LocalProvider<br/>(WASM/UniFFI hash)"]
-        MP["MockProvider<br/>(unit tests)"]
+        APP["Video App<br/>iOS · Android · Web"]
+        AUTH["Identity / Auth"]
+        BFF["Page Orchestration<br/>(BFF)"]
+        REC["Recommendations"]
+        CAT["Catalog / Metadata"]
+        PB["Playback Authorization<br/>+ DRM"]
+        CDN["Video Player + CDN"]
     end
 
-    subgraph Rust["Rust Services (Cargo Workspace)"]
-        M1["<b>M1: Assignment Service</b><br/>Static, Session, Interleaving<br/>Bucket Reuse"]
-        M2R["<b>M2: Event Ingestion</b><br/>Validation, Dedup, Kafka Publish<br/>Crash-Only"]
-        M4A["<b>M4a: Analysis Engine</b><br/>Frequentist, mSPRT, GST<br/>Novelty, Interference<br/>proptest validated"]
-        M4B["<b>M4b: Bandit Policy</b><br/>Thompson, LinUCB, Neural<br/>LMAX Single-Thread Core<br/>RocksDB Snapshots"]
+    %% =========================================================
+    %% LAYER 2 — Kaizen SDKs
+    %% =========================================================
+    subgraph L2["Kaizen SDKs (sdks/)"]
+        direction LR
+        CLISDK["Client SDKs<br/>iOS (Swift) · Android (Kotlin) · Web (TS)<br/>UniFFI / WASM hash"]
+        SRVSDK["Server SDKs<br/>server-go · server-python<br/>CGo / PyO3 hash"]
     end
 
-    subgraph Go["Go Services"]
-        M2G["<b>M2: Orchestration</b><br/>SQL Query Logging"]
-        M3["<b>M3: Metric Engine</b><br/>Spark SQL, Surrogates<br/>Lifecycle, QoE, Interleaving"]
-        M5["<b>M5: Management</b><br/>CRUD, State Machine<br/>Auto-Pause Guardrails<br/>Bucket Reuse Mgmt"]
-        M7["<b>M7: Feature Flags</b><br/>Progressive Delivery<br/>CGo Hash Bridge"]
+    APP --- CLISDK
+    AUTH -. userId / cohort .- BFF
+    BFF --- SRVSDK
+    REC --- SRVSDK
+    PB --- SRVSDK
+    BFF --> REC
+    BFF --> CAT
+    REC --> CAT
+    APP --> CDN
+
+    %% =========================================================
+    %% LAYER 3 — Control plane (real-time gRPC, Rust)
+    %% =========================================================
+    subgraph L3["Control Plane (Rust gRPC services)"]
+        direction LR
+        M7["M7 Flags :50057<br/>experimentation-flags<br/>(ADR-024 — Rust port)"]
+        M1["M1 Assignment :50051<br/>experimentation-assignment<br/>MurmurHash3 · bucket reuse · interleaving"]
+        M4b["M4b Bandit :50054<br/>experimentation-bandit<br/>Thompson · LinUCB · Neural (Candle)<br/>LMAX single-thread core"]
     end
 
-    subgraph UI["TypeScript (UI Only)"]
-        M6["<b>M6: Decision Support UI</b><br/>Dashboards, View SQL<br/>Export to Notebook<br/>No Backend Computation"]
+    CLISDK -.gRPC.-> M1
+    CLISDK -.gRPC.-> M7
+    SRVSDK -->|gRPC| M1
+    SRVSDK -->|gRPC| M7
+    REC -->|gRPC| M4b
+    PB -->|gRPC| M1
+
+    %% =========================================================
+    %% LAYER 4 — Event ingestion + streaming bus
+    %% =========================================================
+    subgraph L4["Event Plane"]
+        direction LR
+        M2R["M2 Ingest (Rust) :50052<br/>experimentation-ingest<br/>proto validate · Bloom dedup<br/>HeartbeatSessionizer · EBVS"]
+        K[("Kafka / Redpanda<br/>7 topics<br/>exposures · metric_events<br/>reward_events · qoe_events<br/>guardrail_alerts<br/>model_retraining_events<br/>model_training_requests")]
+        M2G["M2 Orchestration (Go) :50058<br/>services/orchestration<br/>query log + Spark dispatch"]
     end
 
-    subgraph Infra["Infrastructure"]
-        K["Kafka Topics<br/>exposures, metric_events<br/>reward_events, qoe_events<br/>guardrail_alerts"]
-        DL["Delta Lake<br/>+ MLflow"]
-        PG["PostgreSQL<br/>Config, Results, query_log"]
-        R["Redis Cluster<br/>Feature Store"]
-        RDB["RocksDB<br/>Policy Snapshots"]
-    end
-
-    RP -->|gRPC| M1
-    LP -.->|cached config| M1
-    Clients -->|events| M2R
-
-    M1 -->|arm selection| M4B
+    APP -->|client events| M2R
+    SRVSDK -->|server exposures| M2R
+    CDN -->|heartbeats| M2R
     M2R --> K
-    K --> M3
-    K -->|rewards| M4B
-    M3 -->|metric summaries| DL
-    M3 -->|SQL| PG
-    M4A -->|reads| DL
-    M4A -->|results| PG
-    M4B --> RDB
-    M5 -->|config| M1
-    M5 -->|lifecycle| PG
-    M5 -->|auto-pause| K
-    M6 -->|reads| PG
-    M6 -->|reads| M5
-    M7 -->|CGo hash| M1
-    M3 --> R
+    K --> M2G
 
+    %% =========================================================
+    %% LAYER 5 — Analytics + ML processing
+    %% =========================================================
+    subgraph L5["Analytics & ML Plane"]
+        direction TB
+        M3["M3 Metrics :50056 (Go + Spark)<br/>services/metrics<br/>standard · guardrail · QoE rollups<br/>topo-order custom metrics (ADR-026 P1)<br/>lifecycle segmentation · interleaving"]
+        M4a["M4a Analysis :50053 (Rust)<br/>experimentation-stats<br/>CUPED · AVLM · TOST · e-values<br/>switchback · synthetic control<br/>OPE (DR + TC/JIVE) · adaptive-N · MAD"]
+        ML[("MLflow Registry<br/>Candle / ONNX artifacts")]
+    end
+
+    K --> M3
+    K -->|reward_events| M4b
+    M3 -->|rollup_ready| M4a
+    M4a <-->|load_model| ML
+    M4b <-->|policy artifacts| ML
+
+    %% =========================================================
+    %% LAYER 6 — Management + UI
+    %% =========================================================
+    subgraph L6["Management & UI"]
+        direction LR
+        M5["M5 Management :50055 (Rust)<br/>experimentation-management<br/>CRUD · state machine · RBAC<br/>guardrails · bucket reuse<br/>portfolio · adaptive-N scheduler<br/>(ADR-025 — Rust port)"]
+        M6["M6 Analyst UI :3000<br/>Next.js 14 · React 18 · Recharts · D3<br/>shadcn/ui — display only, no math"]
+    end
+
+    M5 -->|config| M1
+    M5 -->|policy| M4b
+    M5 -->|flag rollout| M7
+    M5 -->|auto-pause| K
+    M6 --> M5
+    M4a -->|results| M5
+
+    %% =========================================================
+    %% LAYER 7 — Persistence
+    %% =========================================================
+    subgraph L7["Storage"]
+        direction LR
+        DL[("Delta Lake<br/>+ query_log")]
+        PG[("PostgreSQL<br/>config · results<br/>state · ACL")]
+        RD[("Redis Cluster<br/>feature store")]
+        RDB[("RocksDB<br/>bandit snapshots")]
+    end
+
+    M3 --> DL
+    M3 --> RD
+    M4a --> PG
+    M4a --> DL
+    M5 --> PG
+    M6 -. reads .- PG
+    M4b --> RDB
+
+    %% =========================================================
+    %% LAYER 8 — Infrastructure (Pulumi + AWS Go IaC, infra/)
+    %% =========================================================
+    subgraph L8["Infrastructure — Pulumi Go IaC on AWS"]
+        direction LR
+        ECR[("ECR Repos × 9<br/>one per Kaizen service")]
+        ECS["ECS Fargate / EKS<br/>services + sidecars"]
+        OBS["Observability<br/>OpenTelemetry · Prometheus<br/>Grafana · CloudWatch"]
+        NET["Networking<br/>VPC · Subnets · NAT<br/>ALB · WAF · Route53"]
+    end
+
+    ECR -.image pull.-> ECS
+    ECS -.runs.-> L3
+    ECS -.runs.-> L4
+    ECS -.runs.-> L5
+    ECS -.runs.-> L6
+    ECS -.telemetry.-> OBS
+    NET -.ingress.-> ECS
+
+    %% =========================================================
+    %% Styling — language-coded
+    %% =========================================================
     classDef rust fill:#deb887,stroke:#8b4513,color:#000
     classDef golang fill:#7fb3d8,stroke:#2c5f8a,color:#000
     classDef ts fill:#c5e1a5,stroke:#558b2f,color:#000
     classDef infra fill:#e0e0e0,stroke:#757575,color:#000
     classDef client fill:#fff3e0,stroke:#e65100,color:#000
+    classDef customer fill:#f3e5f5,stroke:#6a1b9a,color:#000
+    classDef storage fill:#fff9c4,stroke:#f9a825,color:#000
 
-    class M1,M2R,M4A,M4B rust
-    class M2G,M3,M5,M7 golang
+    class M1,M2R,M4a,M4b,M7,M5 rust
+    class M2G,M3 golang
     class M6 ts
-    class K,DL,PG,R,RDB infra
-    class RP,LP,MP client
+    class K,ECR,ECS,OBS,NET,ML infra
+    class CLISDK,SRVSDK client
+    class APP,AUTH,BFF,REC,CAT,PB,CDN customer
+    class DL,PG,RD,RDB storage

--- a/docs/design/system_architecture.mermaid
+++ b/docs/design/system_architecture.mermaid
@@ -10,7 +10,7 @@ flowchart TB
         REC["Recommendations"]
         CAT["Catalog / Metadata"]
         PB["Playback Authorization<br/>+ DRM"]
-        CDN["Video Player + CDN"]
+        PLR["Video Player + CDN"]
     end
 
     %% =========================================================
@@ -30,7 +30,7 @@ flowchart TB
     BFF --> REC
     BFF --> CAT
     REC --> CAT
-    APP --> CDN
+    APP --> PLR
 
     %% =========================================================
     %% LAYER 3 — Control plane (real-time gRPC, Rust)
@@ -46,8 +46,8 @@ flowchart TB
     CLISDK -.gRPC.-> M7
     SRVSDK -->|gRPC| M1
     SRVSDK -->|gRPC| M7
-    REC -->|gRPC| M4b
     PB -->|gRPC| M1
+    M1 -.->|arm delegation<br/>p99 < 15ms<br/>internal Kaizen call| M4b
 
     %% =========================================================
     %% LAYER 4 — Event ingestion + streaming bus
@@ -61,7 +61,7 @@ flowchart TB
 
     APP -->|client events| M2R
     SRVSDK -->|server exposures| M2R
-    CDN -->|heartbeats| M2R
+    PLR -->|player heartbeats<br/>(QoE telemetry)| M2R
     M2R --> K
     K --> M2G
 
@@ -151,5 +151,5 @@ flowchart TB
     class M6 ts
     class K,ECR,ECS,OBS,NET,ML infra
     class CLISDK,SRVSDK client
-    class APP,AUTH,BFF,REC,CAT,PB,CDN customer
+    class APP,AUTH,BFF,REC,CAT,PB,PLR customer
     class DL,PG,RD,RDB storage

--- a/docs/guides/streaming-video-sequence.md
+++ b/docs/guides/streaming-video-sequence.md
@@ -1,0 +1,331 @@
+# Kaizen ↔ Streaming Video App — Sequence Walkthrough
+
+**Audience**: client engineers, server engineers, and PMs integrating Kaizen
+into an SVOD product surface (video-on-demand, live, or hybrid).
+
+**Companion diagram**: `docs/design/streaming_video_sequence.mermaid` — the
+canonical end-to-end sequence rendered as a single Mermaid file.
+
+This guide walks the same flow as the `.mermaid` source, but in narrative
+form with focused sub-diagrams per scenario. Read this when you want to
+understand *why* each hop exists; read the `.mermaid` file when you want a
+single artefact to embed in an architecture review.
+
+---
+
+## 1. Actors and ports
+
+The numbered ports below are the gRPC ports declared in `CLAUDE.md` and the
+top-level `justfile`. The customer-owned services (Video App,
+Personalization, Player/CDN) sit outside the Kaizen workspace and integrate
+through the SDKs in `sdks/` plus Kafka topics in `proto/`.
+
+| Actor                       | Owned by  | Port  | Talks via                       |
+| --------------------------- | --------- | ----- | ------------------------------- |
+| Viewer                      | n/a       | n/a   | UI                              |
+| Video App (iOS/Android/Web) | Customer  | n/a   | Kaizen SDKs (`sdks/{ios, android, web}`) |
+| Personalization service     | Customer  | n/a   | gRPC to M4b, Kafka producer     |
+| Video Player + CDN          | Customer  | n/a   | HTTP heartbeats to M2 ingest    |
+| M7 Flags                    | Agent-7   | 50057 | gRPC (ADR-024 Rust port)        |
+| M1 Assignment               | Agent-1   | 50051 | gRPC + WASM/UniFFI hash         |
+| M4b Bandit                  | Agent-4   | 50054 | gRPC, RocksDB snapshots         |
+| M2 Ingest (Rust)            | Agent-2   | 50052 | gRPC + Kafka producer           |
+| M2 Orchestration (Go)       | Agent-2   | 50058 | Kafka consumer, query logging   |
+| M3 Metrics                  | Agent-3   | 50056 | Spark SQL + Delta Lake          |
+| M4a Analysis                | Agent-4   | 50053 | Reads Delta, writes PostgreSQL  |
+| M5 Management               | Agent-5   | 50055 | gRPC, PostgreSQL, Kafka         |
+| M6 Analyst UI               | Agent-6   | 3000  | HTTP (Next.js 14)               |
+
+Kafka topics in play (created by `redpanda-init` per
+`docs/guides/streaming-integration.md`): `exposures`, `metric_events`,
+`reward_events`, `qoe_events`, `guardrail_alerts`,
+`model_retraining_events`, `model_training_requests`.
+
+---
+
+## 2. End-to-end happy path
+
+The canonical flow covers five phases plus one exception branch.
+
+1. **App launch** — flag evaluation + experiment assignment (M7, M1).
+2. **Personalized rail** — bandit arm selection through M4b.
+3. **Playback** — QoE heartbeats into the `HeartbeatSessionizer` (M2).
+4. **Reward loop** — engagement reward feeds M4b posterior update.
+5. **Offline analysis + ship** — M3 rollups, M4a inference, M5 lifecycle
+   transition, M6 dashboard.
+6. **Exception** — guardrail auto-pause triggered by M3 hourly job.
+
+See `docs/design/streaming_video_sequence.mermaid` for the rendered
+sequence. The sub-flows below zoom in on each phase.
+
+---
+
+## 3. Phase 1 — App launch (flag + assignment)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Viewer
+    participant App as Video App SDK
+    participant M7 as M7 Flags :50057
+    participant M1 as M1 Assignment :50051
+    participant M2 as M2 Ingest :50052
+    participant K as Kafka
+
+    U->>App: open app
+    App->>M7: EvaluateFlag("home_glass_ui", context)
+    M7-->>App: { enabled: true, rollout_pct: 25 }
+    Note over App: only call M1 if flag gate is open
+    App->>M1: GetAssignment(experiment, unit=userId, attrs)
+    M1->>M1: MurmurHash3 bucket + bucket-reuse check
+    M1-->>App: { variant, exposure_id }
+    App->>M2: ExposureEvent(exposure_id, experiment, variant, unit, ts)
+    M2->>K: produce → "exposures"
+```
+
+Key contracts:
+
+- **Hash parity is non-negotiable.** Web (`sdks/web`), iOS, Android, and
+  the server SDKs all use the same MurmurHash3 + salt. The
+  `test-vectors/hash_vectors.json` golden file gates every SDK release
+  (`just test-hash`).
+- **The exposure must be emitted before the user sees the treatment.** The
+  SDK fires it synchronously on the same call that returns the variant —
+  no batching, no debouncing, no "we'll send it later". Treatment effects
+  collapse if exposures are missing for users who *did* see the variant.
+- **ResilientProvider fallback.** If M1 is unreachable, the SDK falls
+  through to the LocalProvider (WASM hash + cached config) and finally to
+  static defaults (`DEFAULT_ASSIGNMENT`). See
+  `docs/design/sdk_provider.mermaid`.
+
+---
+
+## 4. Phase 2 — Personalized rail (bandit arm)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App as Video App SDK
+    participant Pers as Personalization
+    participant M4b as M4b Bandit :50054
+    participant M2 as M2 Ingest
+    participant K as Kafka
+
+    App->>Pers: GetRail(userId, surface="home")
+    Pers->>M4b: SelectArm(policy_id, ctx_features)
+    M4b->>M4b: LMAX single-thread core<br/>Thompson / LinUCB / Neural
+    M4b-->>Pers: { arm_id, propensity }
+    Pers->>Pers: rank candidate titles via arm_id
+    Pers-->>App: ranked titles
+    App->>M2: ExposureEvent(arm_id, propensity, slot_index)
+    M2->>K: produce → "exposures"
+```
+
+Why the propensity matters:
+
+- The bandit emits an **IPW (inverse-propensity-weighted) probability**
+  alongside the arm. M4a uses it for off-policy evaluation (ADR-017 —
+  TC/JIVE surrogate fix, doubly-robust OPE).
+- Without the propensity, you cannot honestly compare a new ranker to the
+  in-production one on logged data. Emit it on every exposure even if you
+  only have one arm live — it'll be `1.0` and that's a valid value.
+- Slate exposures (multi-slot rails) need a `slot_index`. Slate bandits are
+  scored as a unit, not per slot.
+
+---
+
+## 5. Phase 3 — Playback + QoE telemetry
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Viewer
+    participant App as Video App
+    participant Player as Player + CDN
+    participant M2 as M2 Ingest :50052
+    participant K as Kafka
+
+    U->>App: tap title
+    App->>M2: ClickEvent(title_id, slot, ts)
+    M2->>K: produce → "metric_events"
+    App->>Player: play(title_id)
+    Player-->>U: manifest + segments
+
+    loop every 10s while playing
+        Player->>M2: PlaybackHeartbeat(session_id,<br/>played_ms, buffered_ms,<br/>bitrate, dropped_frames)
+        M2->>M2: HeartbeatSessionizer aggregates<br/>→ derive PlaybackMetrics<br/>→ detect EBVS
+        M2->>K: produce → "qoe_events"
+    end
+
+    U->>App: watch ≥ 30s
+    App->>M2: RewardEvent(experiment, variant, reward=1.0)
+    M2->>K: produce → "reward_events"
+```
+
+What's happening server-side:
+
+- The **`HeartbeatSessionizer`** lives in `experimentation-ingest` and
+  rolls per-10s player heartbeats into a single `PlaybackMetrics` record
+  per session. Per-heartbeat rows would explode `qoe_events` cardinality;
+  the sessionizer keeps it at one row per session per ~minute window.
+- **EBVS detection** (`ebvs_detected` on `PlaybackMetrics`) marks sessions
+  that *requested* a play but never reached the first frame — usually a
+  manifest fetch failure or a CDN timeout. EBVS is a first-class guardrail
+  metric in M3. Spec: `docs/issues/ebvs-detection.md`.
+- The **30s engagement threshold** is the streaming-industry-standard
+  "play start" definition. Use whatever your product defines as
+  "engagement" — but be consistent across experiments. If you change the
+  definition mid-experiment, you'll have to throw away results.
+
+---
+
+## 6. Phase 4 — Reward feedback loop
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant K as Kafka "reward_events"
+    participant M4b as M4b Bandit :50054
+    participant RDB as RocksDB
+
+    K-->>M4b: consume reward_events
+    M4b->>M4b: update posterior (Thompson) /<br/>features (LinUCB) /<br/>weights (Neural)
+    M4b->>RDB: snapshot (crash-safe)
+    Note over M4b: Next SelectArm call reflects the update
+```
+
+The bandit's update path is **single-threaded by design** — the LMAX core
+serialises all reads and writes against a single in-memory policy state.
+This is what lets us update the posterior on every reward without locks
+while still serving thousands of `SelectArm` RPCs per second. The RocksDB
+snapshot is the durability layer for restarts; it is not on the hot path.
+
+Cold-start handling (`experimentation-bandit/src/cold_start.rs`) kicks in
+when an arm has fewer rewards than the configured floor — typically a
+forced uniform exploration phase. Configure via the bandit policy spec in
+M5, not in M4b directly.
+
+---
+
+## 7. Phase 5 — Offline analysis + ship decision
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant K as Kafka
+    participant M3 as M3 Metrics :50056
+    participant DL as Delta Lake
+    participant M4a as M4a Analysis :50053
+    participant PG as PostgreSQL
+    participant M5 as M5 Management :50055
+    participant M6 as M6 UI :3000
+    participant M1 as M1 Assignment
+    participant M7 as M7 Flags
+
+    K-->>M3: consume exposures + metric_events + qoe_events
+    M3->>M3: Spark SQL — daily standard,<br/>hourly guardrail, QoE rollups
+    M3->>DL: write rollups + query_log
+    M3->>M4a: rollup_ready(experiment_id)
+    M4a->>DL: read pre-period + treatment-period rollups
+    M4a->>M4a: CUPED + AVLM (ADR-015)<br/>e-values + FDR (ADR-018)<br/>TOST equivalence (ADR-027)
+    M4a->>PG: write results
+    M6->>M5: GET /experiments/{id}/results
+    M6->>PG: read results
+    Note over M6: Analyst reviews → clicks "Ship Treatment"
+    M6->>M5: TransitionState(experiment, "shipped")
+    M5->>M7: reconcile flag rollout → 100%
+    M5->>M1: assignment config update
+```
+
+Notes that bite people on first integration:
+
+- **M4a does all the math.** TypeScript in M6 *displays* results but never
+  computes them. This is a hard architectural rule (`CLAUDE.md` § Critical
+  Rules). If you find yourself doing a t-test in the UI, stop.
+- **CUPED requires pre-period data.** If your experiment unit has fewer
+  than ~14 days of historical metric values, CUPED won't reduce variance
+  much and M4a will fall back to unadjusted analysis. Plan accordingly
+  for new users / new content.
+- **TOST is not just for refactors.** Any time the *expected* answer is
+  "no change" — infra migration, codec swap, encoding ladder change —
+  reach for TOST (ADR-027). Standard NHST will under-power you and you
+  will ship a regression and call it a win.
+
+---
+
+## 8. Exception path — guardrail auto-pause
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M3 as M3 Metrics
+    participant K as Kafka "guardrail_alerts"
+    participant M5 as M5 Management
+    participant M1 as M1 Assignment
+    participant M7 as M7 Flags
+    participant M6 as M6 UI
+
+    M3->>M3: hourly guardrail job<br/>(rebuffer_ratio, EBVS_rate, startup_time)
+    M3->>K: GuardrailBreach(experiment, metric,<br/>delta_pct, severity)
+    K-->>M5: consume guardrail_alerts
+    M5->>M5: state machine — ACTIVE → PAUSED
+    M5->>M1: assignment config — 100% control
+    M5->>M7: reconcile flag → disabled
+    M5-->>M6: notification banner
+```
+
+The auto-pause path is intentionally **same-mechanism** as a manual pause:
+the analyst-driven `TransitionState` call and the M3-driven `GuardrailBreach`
+both hit the M5 state machine. There is no separate "auto" code path that
+can drift from the manual one.
+
+Thresholds are configured per-metric on the experiment definition in M5
+(`experimentation-management/src/validators.rs`). Severity bands map to
+either alert-only, pause, or pause-and-rollback.
+
+---
+
+## 9. Less-common flows you should know exist
+
+These are documented elsewhere; the sequence diagram above keeps them out
+of the main flow to stay readable.
+
+- **Shadow mode (ADR-030 — Proposed).** Experiment runs candidate variants
+  against production traffic but **does not change the user-visible
+  surface**. The SDK still receives a variant assignment, but the player
+  ignores it. Exposures and metrics still flow through M2/M3, and M4a
+  computes effects against the unchanged user response. Useful for
+  validating a new model on real traffic before any user impact.
+- **Holdout groups.** Permanent global control populations carved out at
+  the SDK layer and excluded from all experiment assignments. The SDK
+  short-circuits `GetAssignment` for these units and returns a sentinel
+  variant.
+- **Switchback (ADR-022).** Quasi-experimental design for marketplaces
+  with strong interference — alternating treatment windows over time
+  rather than randomising users. M3 + M4a know how to roll up and analyse
+  switchback windows; the streaming app side just needs to honour the
+  M5-driven schedule.
+- **Synthetic control (ADR-023).** Used when randomisation is not possible
+  (geo-level rollouts, regulatory carve-outs). Live in M4a; data path
+  identical to standard experiments from the SDK's perspective.
+
+---
+
+## 10. Where to look next
+
+- `docs/design/streaming_video_sequence.mermaid` — single-file sequence
+  diagram (the source of the embedded views above).
+- `docs/design/system_architecture.mermaid` — static architecture (modules
+  and storage), not flow.
+- `docs/design/data_flow.mermaid` — data-flow view (Kafka topics +
+  storage), not flow.
+- `docs/design/sdk_provider.mermaid` — SDK resilience chain
+  (Remote → Local → Default).
+- `docs/guides/streaming-integration.md` — Kafka/Redpanda wire-level
+  guide.
+- `docs/guides/integration/` — customer integration guide (draft).
+- `docs/issues/ebvs-detection.md`, `docs/issues/heartbeat-sessionization.md`
+  — specs for the QoE pieces called out in Phase 3.
+- ADRs called out above: 015 (AVLM), 017 (off-policy eval), 018 (e-values
+  + FDR), 022 (switchback), 023 (synthetic control), 027 (TOST), 030
+  (shadow mode).

--- a/docs/guides/streaming-video-sequence.md
+++ b/docs/guides/streaming-video-sequence.md
@@ -417,8 +417,11 @@ readable.
 
 - `docs/design/streaming_video_sequence.mermaid` — single-file sequence
   diagram (the source of the embedded views above).
+- `docs/design/offline_evaluation_sequence.mermaid` — companion sequence
+  for the offline policy-evaluation flow (researcher → MLflow → M3 slice
+  → M4a doubly-robust OPE → ship/shadow/reject decision).
 - `docs/design/system_architecture.mermaid` — static architecture
-  (modules and storage), not flow.
+  (modules, SDKs, storage, infrastructure), not flow.
 - `docs/design/data_flow.mermaid` — data-flow view (Kafka topics +
   storage), not flow.
 - `docs/design/sdk_provider.mermaid` — SDK resilience chain

--- a/docs/guides/streaming-video-sequence.md
+++ b/docs/guides/streaming-video-sequence.md
@@ -8,33 +8,46 @@ canonical end-to-end sequence rendered as a single Mermaid file.
 
 This guide walks the same flow as the `.mermaid` source, but in narrative
 form with focused sub-diagrams per scenario. Read this when you want to
-understand *why* each hop exists; read the `.mermaid` file when you want a
-single artefact to embed in an architecture review.
+understand *why* each hop exists and how Kaizen plugs into the rest of a
+streaming back-end (BFF, recommendations, catalog, playback authorization,
+DRM, CDN). Read the `.mermaid` file when you want a single artefact to
+embed in an architecture review.
 
 ---
 
 ## 1. Actors and ports
 
 The numbered ports below are the gRPC ports declared in `CLAUDE.md` and the
-top-level `justfile`. The customer-owned services (Video App,
-Personalization, Player/CDN) sit outside the Kaizen workspace and integrate
-through the SDKs in `sdks/` plus Kafka topics in `proto/`.
+top-level `justfile`. The customer-owned services (everything in the top
+half of the table) sit outside the Kaizen workspace and integrate through
+the SDKs in `sdks/` plus Kafka topics in `proto/`.
 
-| Actor                       | Owned by  | Port  | Talks via                       |
-| --------------------------- | --------- | ----- | ------------------------------- |
-| Viewer                      | n/a       | n/a   | UI                              |
-| Video App (iOS/Android/Web) | Customer  | n/a   | Kaizen SDKs (`sdks/{ios, android, web}`) |
-| Personalization service     | Customer  | n/a   | gRPC to M4b, Kafka producer     |
-| Video Player + CDN          | Customer  | n/a   | HTTP heartbeats to M2 ingest    |
-| M7 Flags                    | Agent-7   | 50057 | gRPC (ADR-024 Rust port)        |
-| M1 Assignment               | Agent-1   | 50051 | gRPC + WASM/UniFFI hash         |
-| M4b Bandit                  | Agent-4   | 50054 | gRPC, RocksDB snapshots         |
-| M2 Ingest (Rust)            | Agent-2   | 50052 | gRPC + Kafka producer           |
-| M2 Orchestration (Go)       | Agent-2   | 50058 | Kafka consumer, query logging   |
-| M3 Metrics                  | Agent-3   | 50056 | Spark SQL + Delta Lake          |
-| M4a Analysis                | Agent-4   | 50053 | Reads Delta, writes PostgreSQL  |
-| M5 Management               | Agent-5   | 50055 | gRPC, PostgreSQL, Kafka         |
-| M6 Analyst UI               | Agent-6   | 3000  | HTTP (Next.js 14)               |
+### Customer-side services (outside Kaizen)
+
+| Actor                       | Role in the streaming app                                | Kaizen integration |
+| --------------------------- | -------------------------------------------------------- | ------------------ |
+| Viewer                      | End user                                                 | n/a                |
+| Video App (iOS/Android/Web) | Client surface, render, in-app events                    | Kaizen **Client SDK** (`sdks/{ios, android, web}`) |
+| Identity / Auth             | Login, refresh, account graph, plan tier                 | None — supplies the `userId` / cohort attrs that Kaizen hashes |
+| Page Orchestration / BFF    | Assembles per-device home/detail pages from N microservices | Kaizen **Server SDK** (`sdks/server-go` or `server-python`) — calls M7 + M1 |
+| Recommendations             | Generates per-user rails, slates, search ranking         | Server SDK — calls M4b for arm selection |
+| Catalog / Metadata          | Title, episode, artwork, badges                          | None — hydrates rail/detail payloads |
+| Playback Authorization      | Entitlement check, manifest selection, DRM license       | Server SDK — calls M1 for encoding-ladder / codec experiments |
+| Video Player + CDN          | Manifest fetch, segment streaming, QoE telemetry         | Emits heartbeats directly to M2 |
+
+### Kaizen services (this repo)
+
+| Actor             | Owned by | Port  | Talks via                       |
+| ----------------- | -------- | ----- | ------------------------------- |
+| M7 Flags          | Agent-7  | 50057 | gRPC (ADR-024 Rust port)        |
+| M1 Assignment     | Agent-1  | 50051 | gRPC + WASM/UniFFI hash         |
+| M4b Bandit        | Agent-4  | 50054 | gRPC, RocksDB snapshots         |
+| M2 Ingest (Rust)  | Agent-2  | 50052 | gRPC + Kafka producer           |
+| M2 Orchestration (Go) | Agent-2 | 50058 | Kafka consumer, query logging   |
+| M3 Metrics        | Agent-3  | 50056 | Spark SQL + Delta Lake          |
+| M4a Analysis     | Agent-4  | 50053 | Reads Delta, writes PostgreSQL  |
+| M5 Management    | Agent-5  | 50055 | gRPC, PostgreSQL, Kafka         |
+| M6 Analyst UI    | Agent-6  | 3000  | HTTP (Next.js 14)               |
 
 Kafka topics in play (created by `redpanda-init` per
 `docs/guides/streaming-integration.md`): `exposures`, `metric_events`,
@@ -43,117 +56,177 @@ Kafka topics in play (created by `redpanda-init` per
 
 ---
 
-## 2. End-to-end happy path
+## 2. Where the SDK lives — client vs server
+
+A frequent first-integration confusion is "do I put the Kaizen SDK on the
+client or the server?" In an SVOD architecture with a BFF, the answer is
+**both, with different responsibilities**:
+
+| Decision type | SDK lives where | Why |
+| --- | --- | --- |
+| Page-level layout / UI variant | **Server SDK on the BFF** | BFF assembles the response; emitting the exposure server-side guarantees it lines up with what was actually returned |
+| Rail / slate ranker (bandit arm) | **Server SDK on Recommendations** | The ranker is the experiment; the rec service has the propensity |
+| Encoding ladder / codec / DRM strategy | **Server SDK on Playback Authorization** | Playback authz owns manifest selection — the experiment lives where the decision is made |
+| Client-only feature gate (e.g. new gesture, in-app debug overlay) | **Client SDK** | No server involvement needed; flag eval is local |
+| Click / engagement / playback completion events | **Client SDK** | These are client-observable behaviors; the client knows when they happen |
+
+Hash parity across SDKs (`test-vectors/hash_vectors.json`, validated by
+`just test-hash`) guarantees the **same `userId` hashes identically**
+whether the assignment is computed in Swift, Kotlin, TS, Go, or Python —
+so a user re-assigned by the BFF after a client-side cache miss lands in
+the same bucket they were already in.
+
+---
+
+## 3. End-to-end happy path
 
 The canonical flow covers five phases plus one exception branch.
 
-1. **App launch** — flag evaluation + experiment assignment (M7, M1).
-2. **Personalized rail** — bandit arm selection through M4b.
-3. **Playback** — QoE heartbeats into the `HeartbeatSessionizer` (M2).
+1. **Session start + page assembly** — Auth, then BFF fan-out to M7 + M1.
+2. **Recommendations fan-out** — BFF → Recs → M4b + Catalog.
+3. **Title detail → Playback auth → Streaming + QoE** — App → Catalog,
+   App → Playback Authorization → M1, then CDN streams while M2
+   sessionizes heartbeats.
 4. **Reward loop** — engagement reward feeds M4b posterior update.
-5. **Offline analysis + ship** — M3 rollups, M4a inference, M5 lifecycle
-   transition, M6 dashboard.
+5. **Offline analysis + ship** — M3 rollups, M4a inference, M5 lifecycle,
+   M6 dashboard.
 6. **Exception** — guardrail auto-pause triggered by M3 hourly job.
 
-See `docs/design/streaming_video_sequence.mermaid` for the rendered
+See `docs/design/streaming_video_sequence.mermaid` for the full rendered
 sequence. The sub-flows below zoom in on each phase.
 
 ---
 
-## 3. Phase 1 — App launch (flag + assignment)
-
-```mermaid
-sequenceDiagram
-    autonumber
-    actor U as Viewer
-    participant App as Video App SDK
-    participant M7 as M7 Flags :50057
-    participant M1 as M1 Assignment :50051
-    participant M2 as M2 Ingest :50052
-    participant K as Kafka
-
-    U->>App: open app
-    App->>M7: EvaluateFlag("home_glass_ui", context)
-    M7-->>App: { enabled: true, rollout_pct: 25 }
-    Note over App: only call M1 if flag gate is open
-    App->>M1: GetAssignment(experiment, unit=userId, attrs)
-    M1->>M1: MurmurHash3 bucket + bucket-reuse check
-    M1-->>App: { variant, exposure_id }
-    App->>M2: ExposureEvent(exposure_id, experiment, variant, unit, ts)
-    M2->>K: produce → "exposures"
-```
-
-Key contracts:
-
-- **Hash parity is non-negotiable.** Web (`sdks/web`), iOS, Android, and
-  the server SDKs all use the same MurmurHash3 + salt. The
-  `test-vectors/hash_vectors.json` golden file gates every SDK release
-  (`just test-hash`).
-- **The exposure must be emitted before the user sees the treatment.** The
-  SDK fires it synchronously on the same call that returns the variant —
-  no batching, no debouncing, no "we'll send it later". Treatment effects
-  collapse if exposures are missing for users who *did* see the variant.
-- **ResilientProvider fallback.** If M1 is unreachable, the SDK falls
-  through to the LocalProvider (WASM hash + cached config) and finally to
-  static defaults (`DEFAULT_ASSIGNMENT`). See
-  `docs/design/sdk_provider.mermaid`.
-
----
-
-## 4. Phase 2 — Personalized rail (bandit arm)
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant App as Video App SDK
-    participant Pers as Personalization
-    participant M4b as M4b Bandit :50054
-    participant M2 as M2 Ingest
-    participant K as Kafka
-
-    App->>Pers: GetRail(userId, surface="home")
-    Pers->>M4b: SelectArm(policy_id, ctx_features)
-    M4b->>M4b: LMAX single-thread core<br/>Thompson / LinUCB / Neural
-    M4b-->>Pers: { arm_id, propensity }
-    Pers->>Pers: rank candidate titles via arm_id
-    Pers-->>App: ranked titles
-    App->>M2: ExposureEvent(arm_id, propensity, slot_index)
-    M2->>K: produce → "exposures"
-```
-
-Why the propensity matters:
-
-- The bandit emits an **IPW (inverse-propensity-weighted) probability**
-  alongside the arm. M4a uses it for off-policy evaluation (ADR-017 —
-  TC/JIVE surrogate fix, doubly-robust OPE).
-- Without the propensity, you cannot honestly compare a new ranker to the
-  in-production one on logged data. Emit it on every exposure even if you
-  only have one arm live — it'll be `1.0` and that's a valid value.
-- Slate exposures (multi-slot rails) need a `slot_index`. Slate bandits are
-  scored as a unit, not per slot.
-
----
-
-## 5. Phase 3 — Playback + QoE telemetry
+## 4. Phase 1 — Session start + page-level assignment
 
 ```mermaid
 sequenceDiagram
     autonumber
     actor U as Viewer
     participant App as Video App
-    participant Player as Player + CDN
+    participant Auth as Identity / Auth
+    participant BFF as Page Orchestration / BFF
+    participant M7 as M7 Flags :50057
+    participant M1 as M1 Assignment :50051
+    participant M2 as M2 Ingest :50052
+    participant K as Kafka
+
+    U->>App: open app
+    App->>Auth: authenticate(creds / refresh token)
+    Auth-->>App: { userId, plan_tier, cohort_attrs }
+    App->>BFF: GetPage(surface="home", userId, device, locale)
+    BFF->>M7: EvaluateFlag("home_glass_ui_2026q2", context)
+    M7-->>BFF: { enabled, rollout_pct, reason }
+    BFF->>M1: GetAssignment(experiment, unit=userId, attrs)
+    M1-->>BFF: { variant, exposure_id }
+    BFF->>M2: ExposureEvent (server-side, authoritative)
+    M2->>K: produce → "exposures"
+    Note over BFF: BFF returns page payload after<br/>both calls resolve (or fall back)
+```
+
+Key contracts:
+
+- **Server-side exposures are authoritative.** Whichever service makes
+  the variant decision emits the `ExposureEvent`. The BFF knows
+  definitively that the user got the variant in the response — the
+  client might receive bytes and then crash before render.
+- **Identity is upstream of Kaizen.** Kaizen never authenticates anyone;
+  it consumes `userId` + cohort attrs and hashes them. If you don't have
+  a stable identity, that's a problem for `experimentation-hash`, not
+  for `experimentation-assignment`.
+- **Hash parity is non-negotiable.** Web (`sdks/web`), iOS, Android, and
+  the server SDKs all use the same MurmurHash3 + salt. The
+  `test-vectors/hash_vectors.json` golden file gates every SDK release.
+- **ResilientProvider fallback.** If M1 is unreachable from the BFF, the
+  server SDK falls through to the LocalProvider (WASM/CGo hash + cached
+  config) and finally to static defaults (`DEFAULT_ASSIGNMENT`). See
+  `docs/design/sdk_provider.mermaid`.
+
+---
+
+## 5. Phase 2 — Recommendations fan-out (bandit + catalog)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant BFF as BFF
+    participant Recs as Recommendations
+    participant M4b as M4b Bandit :50054
+    participant Cat as Catalog
+    participant M2 as M2 Ingest
+    participant K as Kafka
+    participant App as Video App
+
+    BFF->>Recs: GetRails(userId, surface, layout_variant)
+    Recs->>M4b: SelectArm(policy_id, ctx_features)
+    M4b->>M4b: LMAX core — Thompson / LinUCB / Neural
+    M4b-->>Recs: { arm_id, propensity }
+    Recs->>Cat: GetTitles(candidate_ids[], locale)
+    Cat-->>Recs: hydrated metadata
+    Recs->>Recs: rank via arm_id → build rails
+    Recs->>M2: ExposureEvent per rail (arm_id, propensity)
+    M2->>K: produce → "exposures"
+    Recs-->>BFF: rails[] with title cards
+    BFF-->>App: assembled page
+```
+
+Why each hop matters:
+
+- **The bandit lives behind the recommendations service, not the BFF.**
+  Different surfaces (home, search, detail-page-rails, end-of-episode)
+  have different rankers and different bandit policies. Recs is where
+  that catalog of policies lives.
+- **Propensity is the cost of being honest later.** The bandit emits an
+  **IPW (inverse-propensity-weighted) probability** alongside the arm.
+  M4a uses it for off-policy evaluation (ADR-017 — TC/JIVE surrogate
+  fix, doubly-robust OPE). Without the propensity, you cannot compare
+  a new ranker to the in-production one on logged data. Emit it on
+  every exposure even if you only have one arm live — it'll be `1.0`
+  and that's a valid value.
+- **Catalog hydration is *not* a Kaizen concern.** The recs service
+  pulls metadata from your existing catalog system; Kaizen never holds
+  title metadata. This is intentional — the catalog ship cycle is
+  different from the experimentation ship cycle.
+- **Slate exposures (multi-slot rails) need a `slot_index`.** Slate
+  bandits are scored as a unit, not per slot.
+
+---
+
+## 6. Phase 3 — Title detail → Playback authorization → Streaming + QoE
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Viewer
+    participant App as Video App
+    participant Cat as Catalog
+    participant PB as Playback Authorization
+    participant M1 as M1 Assignment :50051
+    participant CDN as Video Player + CDN
     participant M2 as M2 Ingest :50052
     participant K as Kafka
 
     U->>App: tap title
-    App->>M2: ClickEvent(title_id, slot, ts)
+    App->>M2: ClickEvent (client SDK)
     M2->>K: produce → "metric_events"
-    App->>Player: play(title_id)
-    Player-->>U: manifest + segments
+    App->>Cat: GetTitleDetail(title_id)
+    Cat-->>App: detail payload
+
+    U->>App: hit play
+    App->>PB: AuthorizePlayback(userId, title_id, device, drm_caps)
+    PB->>M1: GetAssignment(experiment="encoding_ladder_2026q2", unit=userId)
+    M1-->>PB: { variant: "av1_priority_ladder" }
+    PB->>PB: DRM license + entitlement check
+    PB->>M2: ExposureEvent (encoding-ladder experiment)
+    M2->>K: produce → "exposures"
+    PB-->>App: { manifest_url, license_token, session_id }
+
+    App->>CDN: fetch manifest + segments
+    CDN-->>U: video stream
 
     loop every 10s while playing
-        Player->>M2: PlaybackHeartbeat(session_id,<br/>played_ms, buffered_ms,<br/>bitrate, dropped_frames)
-        M2->>M2: HeartbeatSessionizer aggregates<br/>→ derive PlaybackMetrics<br/>→ detect EBVS
+        CDN->>M2: PlaybackHeartbeat(session_id, played_ms,<br/>buffered_ms, bitrate, dropped_frames)
+        M2->>M2: HeartbeatSessionizer →<br/>PlaybackMetrics + EBVS detection
         M2->>K: produce → "qoe_events"
     end
 
@@ -162,24 +235,35 @@ sequenceDiagram
     M2->>K: produce → "reward_events"
 ```
 
-What's happening server-side:
+What's happening here:
 
-- The **`HeartbeatSessionizer`** lives in `experimentation-ingest` and
-  rolls per-10s player heartbeats into a single `PlaybackMetrics` record
-  per session. Per-heartbeat rows would explode `qoe_events` cardinality;
-  the sessionizer keeps it at one row per session per ~minute window.
-- **EBVS detection** (`ebvs_detected` on `PlaybackMetrics`) marks sessions
-  that *requested* a play but never reached the first frame — usually a
-  manifest fetch failure or a CDN timeout. EBVS is a first-class guardrail
-  metric in M3. Spec: `docs/issues/ebvs-detection.md`.
-- The **30s engagement threshold** is the streaming-industry-standard
+- **Playback Authorization is its own experiment surface.** Encoding
+  ladder, codec priority (AV1 vs HEVC vs H.264), per-tier bitrate caps,
+  CDN selection — all of these are experiments that live inside the
+  playback authz service. They have nothing to do with home page
+  layout, and they should be in their own M1 experiments with their own
+  guardrails (rebuffer ratio, startup time).
+- **The HeartbeatSessionizer** lives in `experimentation-ingest` and
+  rolls per-10s player heartbeats into a single `PlaybackMetrics`
+  record per session. Per-heartbeat rows would explode `qoe_events`
+  cardinality; the sessionizer keeps it at one row per session per
+  ~minute window.
+- **EBVS detection** (`ebvs_detected` on `PlaybackMetrics`) marks
+  sessions that *requested* a play but never reached the first frame —
+  usually a manifest fetch failure or a CDN timeout. EBVS is a
+  first-class guardrail metric in M3. Spec:
+  `docs/issues/ebvs-detection.md`.
+- **The 30s engagement threshold** is the streaming-industry-standard
   "play start" definition. Use whatever your product defines as
-  "engagement" — but be consistent across experiments. If you change the
-  definition mid-experiment, you'll have to throw away results.
+  "engagement" — but be consistent across experiments. If you change
+  the definition mid-experiment, throw away the results.
+- **DRM is not Kaizen's problem.** License issuance, key rotation,
+  device attestation — all of that lives in the playback authz service.
+  Kaizen just records *which encoding variant* was authorized.
 
 ---
 
-## 6. Phase 4 — Reward feedback loop
+## 7. Phase 4 — Reward feedback loop
 
 ```mermaid
 sequenceDiagram
@@ -194,20 +278,21 @@ sequenceDiagram
     Note over M4b: Next SelectArm call reflects the update
 ```
 
-The bandit's update path is **single-threaded by design** — the LMAX core
-serialises all reads and writes against a single in-memory policy state.
-This is what lets us update the posterior on every reward without locks
-while still serving thousands of `SelectArm` RPCs per second. The RocksDB
-snapshot is the durability layer for restarts; it is not on the hot path.
+The bandit's update path is **single-threaded by design** — the LMAX
+core serialises all reads and writes against a single in-memory policy
+state. This is what lets us update the posterior on every reward without
+locks while still serving thousands of `SelectArm` RPCs per second. The
+RocksDB snapshot is the durability layer for restarts; it is not on the
+hot path.
 
 Cold-start handling (`experimentation-bandit/src/cold_start.rs`) kicks in
 when an arm has fewer rewards than the configured floor — typically a
-forced uniform exploration phase. Configure via the bandit policy spec in
-M5, not in M4b directly.
+forced uniform exploration phase. Configure via the bandit policy spec
+in M5, not in M4b directly.
 
 ---
 
-## 7. Phase 5 — Offline analysis + ship decision
+## 8. Phase 5 — Offline analysis + ship decision
 
 ```mermaid
 sequenceDiagram
@@ -239,21 +324,26 @@ sequenceDiagram
 
 Notes that bite people on first integration:
 
-- **M4a does all the math.** TypeScript in M6 *displays* results but never
-  computes them. This is a hard architectural rule (`CLAUDE.md` § Critical
-  Rules). If you find yourself doing a t-test in the UI, stop.
+- **M4a does all the math.** TypeScript in M6 *displays* results but
+  never computes them. This is a hard architectural rule (`CLAUDE.md` §
+  Critical Rules). If you find yourself doing a t-test in the UI, stop.
 - **CUPED requires pre-period data.** If your experiment unit has fewer
-  than ~14 days of historical metric values, CUPED won't reduce variance
-  much and M4a will fall back to unadjusted analysis. Plan accordingly
-  for new users / new content.
+  than ~14 days of historical metric values, CUPED won't reduce
+  variance much and M4a will fall back to unadjusted analysis. Plan
+  accordingly for new users / new content.
 - **TOST is not just for refactors.** Any time the *expected* answer is
-  "no change" — infra migration, codec swap, encoding ladder change —
-  reach for TOST (ADR-027). Standard NHST will under-power you and you
-  will ship a regression and call it a win.
+  "no change" — infra migration, codec swap, encoding ladder change,
+  CDN switch — reach for TOST (ADR-027). Standard NHST will under-power
+  you and you will ship a regression and call it a win.
+- **The ship action is not a redeploy.** When M5 transitions an
+  experiment to `shipped`, it reconciles to M7 (flag → 100%) and M1
+  (assignment config). The customer-side services keep using the same
+  flag-eval and assignment APIs — they just always get the treatment
+  arm now.
 
 ---
 
-## 8. Exception path — guardrail auto-pause
+## 9. Exception path — guardrail auto-pause
 
 ```mermaid
 sequenceDiagram
@@ -274,49 +364,61 @@ sequenceDiagram
     M5-->>M6: notification banner
 ```
 
-The auto-pause path is intentionally **same-mechanism** as a manual pause:
-the analyst-driven `TransitionState` call and the M3-driven `GuardrailBreach`
-both hit the M5 state machine. There is no separate "auto" code path that
-can drift from the manual one.
+The auto-pause path is intentionally **same-mechanism** as a manual
+pause: the analyst-driven `TransitionState` call and the M3-driven
+`GuardrailBreach` both hit the M5 state machine. There is no separate
+"auto" code path that can drift from the manual one.
 
 Thresholds are configured per-metric on the experiment definition in M5
 (`experimentation-management/src/validators.rs`). Severity bands map to
 either alert-only, pause, or pause-and-rollback.
 
+For streaming-specific guardrails, the standard set is:
+- **Rebuffer ratio** (target: < 0.5%, alert at +20%, pause at +30%)
+- **EBVS rate** (target: < 2%, alert at +15%, pause at +25%)
+- **P95 startup time** (target: < 2s, alert at +500ms, pause at +1s)
+- **Crash rate** (alert at +10%, pause at +25%)
+
 ---
 
-## 9. Less-common flows you should know exist
+## 10. Less-common flows you should know exist
 
-These are documented elsewhere; the sequence diagram above keeps them out
-of the main flow to stay readable.
+These are documented elsewhere; the main sequence keeps them out to stay
+readable.
 
-- **Shadow mode (ADR-030 — Proposed).** Experiment runs candidate variants
-  against production traffic but **does not change the user-visible
-  surface**. The SDK still receives a variant assignment, but the player
-  ignores it. Exposures and metrics still flow through M2/M3, and M4a
-  computes effects against the unchanged user response. Useful for
-  validating a new model on real traffic before any user impact.
-- **Holdout groups.** Permanent global control populations carved out at
-  the SDK layer and excluded from all experiment assignments. The SDK
-  short-circuits `GetAssignment` for these units and returns a sentinel
-  variant.
+- **Shadow mode (ADR-030 — Proposed).** Experiment runs candidate
+  variants against production traffic but **does not change the
+  user-visible surface**. The BFF or Recs service still receives a
+  variant assignment, but the response uses the control variant.
+  Exposures and metrics still flow through M2/M3, and M4a computes
+  effects against the unchanged user response. Useful for validating a
+  new model on real traffic before any user impact.
+- **Holdout groups.** Permanent global control populations carved out
+  at the server SDK layer (BFF, Recs, Playback) and excluded from all
+  experiment assignments. The SDK short-circuits `GetAssignment` for
+  these units and returns a sentinel variant.
 - **Switchback (ADR-022).** Quasi-experimental design for marketplaces
   with strong interference — alternating treatment windows over time
-  rather than randomising users. M3 + M4a know how to roll up and analyse
-  switchback windows; the streaming app side just needs to honour the
-  M5-driven schedule.
-- **Synthetic control (ADR-023).** Used when randomisation is not possible
-  (geo-level rollouts, regulatory carve-outs). Live in M4a; data path
-  identical to standard experiments from the SDK's perspective.
+  rather than randomising users. Useful for delivery-side experiments
+  (CDN selection, regional encoder pools) where users share the same
+  underlying resource pool.
+- **Synthetic control (ADR-023).** Used when randomisation is not
+  possible (geo-level rollouts, regulatory carve-outs, content-region
+  experiments). Live in M4a; data path identical from the SDK's
+  perspective.
+- **Cross-modal calibration (ADR-029 — Proposed).** Cluster G —
+  Personalization Orchestration. Relevant when a single ranker scores
+  heterogeneous slates (video + manga + commerce) — the
+  `experimentation-calibration` crate provides a unified NEV scale.
 
 ---
 
-## 10. Where to look next
+## 11. Where to look next
 
 - `docs/design/streaming_video_sequence.mermaid` — single-file sequence
   diagram (the source of the embedded views above).
-- `docs/design/system_architecture.mermaid` — static architecture (modules
-  and storage), not flow.
+- `docs/design/system_architecture.mermaid` — static architecture
+  (modules and storage), not flow.
 - `docs/design/data_flow.mermaid` — data-flow view (Kafka topics +
   storage), not flow.
 - `docs/design/sdk_provider.mermaid` — SDK resilience chain
@@ -324,8 +426,10 @@ of the main flow to stay readable.
 - `docs/guides/streaming-integration.md` — Kafka/Redpanda wire-level
   guide.
 - `docs/guides/integration/` — customer integration guide (draft).
-- `docs/issues/ebvs-detection.md`, `docs/issues/heartbeat-sessionization.md`
-  — specs for the QoE pieces called out in Phase 3.
-- ADRs called out above: 015 (AVLM), 017 (off-policy eval), 018 (e-values
-  + FDR), 022 (switchback), 023 (synthetic control), 027 (TOST), 030
-  (shadow mode).
+- `docs/issues/ebvs-detection.md`,
+  `docs/issues/heartbeat-sessionization.md` — specs for the QoE pieces
+  called out in Phase 3.
+- ADRs called out above: 015 (AVLM), 017 (off-policy eval), 018
+  (e-values + FDR), 022 (switchback), 023 (synthetic control), 024 (M7
+  Rust port), 027 (TOST), 029 (cross-modal calibration), 030 (shadow
+  mode).

--- a/docs/guides/streaming-video-sequence.md
+++ b/docs/guides/streaming-video-sequence.md
@@ -30,7 +30,7 @@ the SDKs in `sdks/` plus Kafka topics in `proto/`.
 | Video App (iOS/Android/Web) | Client surface, render, in-app events                    | Kaizen **Client SDK** (`sdks/{ios, android, web}`) |
 | Identity / Auth             | Login, refresh, account graph, plan tier                 | None — supplies the `userId` / cohort attrs that Kaizen hashes |
 | Page Orchestration / BFF    | Assembles per-device home/detail pages from N microservices | Kaizen **Server SDK** (`sdks/server-go` or `server-python`) — calls M7 + M1 |
-| Recommendations             | Generates per-user rails, slates, search ranking         | Server SDK — calls M4b for arm selection |
+| Recommendations             | Generates per-user rails, slates, search ranking         | Server SDK — calls M1 with policy_type=BANDIT; M1 internally delegates to M4b |
 | Catalog / Metadata          | Title, episode, artwork, badges                          | None — hydrates rail/detail payloads |
 | Playback Authorization      | Entitlement check, manifest selection, DRM license       | Server SDK — calls M1 for encoding-ladder / codec experiments |
 | Video Player + CDN          | Manifest fetch, segment streaming, QoE telemetry         | Emits heartbeats directly to M2 |
@@ -65,7 +65,7 @@ client or the server?" In an SVOD architecture with a BFF, the answer is
 | Decision type | SDK lives where | Why |
 | --- | --- | --- |
 | Page-level layout / UI variant | **Server SDK on the BFF** | BFF assembles the response; emitting the exposure server-side guarantees it lines up with what was actually returned |
-| Rail / slate ranker (bandit arm) | **Server SDK on Recommendations** | The ranker is the experiment; the rec service has the propensity |
+| Rail / slate ranker (bandit arm) | **Server SDK on Recommendations** (calling M1, which delegates to M4b) | The ranker is the experiment; Recs is the caller. M4b is internal and only reachable through M1. |
 | Encoding ladder / codec / DRM strategy | **Server SDK on Playback Authorization** | Playback authz owns manifest selection — the experiment lives where the decision is made |
 | Client-only feature gate (e.g. new gesture, in-app debug overlay) | **Client SDK** | No server involvement needed; flag eval is local |
 | Click / engagement / playback completion events | **Client SDK** | These are client-observable behaviors; the client knows when they happen |
@@ -83,7 +83,7 @@ the same bucket they were already in.
 The canonical flow covers five phases plus one exception branch.
 
 1. **Session start + page assembly** — Auth, then BFF fan-out to M7 + M1.
-2. **Recommendations fan-out** — BFF → Recs → M4b + Catalog.
+2. **Recommendations fan-out** — BFF → Recs → M1 (→ M4b internally) + Catalog.
 3. **Title detail → Playback auth → Streaming + QoE** — App → Catalog,
    App → Playback Authorization → M1, then CDN streams while M2
    sessionizes heartbeats.
@@ -151,6 +151,7 @@ sequenceDiagram
     autonumber
     participant BFF as BFF
     participant Recs as Recommendations
+    participant M1 as M1 Assignment :50051
     participant M4b as M4b Bandit :50054
     participant Cat as Catalog
     participant M2 as M2 Ingest
@@ -158,9 +159,11 @@ sequenceDiagram
     participant App as Video App
 
     BFF->>Recs: GetRails(userId, surface, layout_variant)
-    Recs->>M4b: SelectArm(policy_id, ctx_features)
+    Recs->>M1: GetAssignment(experiment, policy_type=BANDIT, ctx_features)
+    M1->>M4b: SelectArm (internal delegation)
     M4b->>M4b: LMAX core — Thompson / LinUCB / Neural
-    M4b-->>Recs: { arm_id, propensity }
+    M4b-->>M1: { arm_id, propensity }
+    M1-->>Recs: { variant, arm_id, propensity, exposure_id }
     Recs->>Cat: GetTitles(candidate_ids[], locale)
     Cat-->>Recs: hydrated metadata
     Recs->>Recs: rank via arm_id → build rails
@@ -172,10 +175,19 @@ sequenceDiagram
 
 Why each hop matters:
 
-- **The bandit lives behind the recommendations service, not the BFF.**
-  Different surfaces (home, search, detail-page-rails, end-of-episode)
-  have different rankers and different bandit policies. Recs is where
-  that catalog of policies lives.
+- **Recs calls M1, not M4b directly.** M4b's `BanditPolicyService` is an
+  **internal** Kaizen service — the proto comment says so explicitly
+  (`proto/experimentation/bandit/v1/bandit_service.proto`: "Called by M1
+  Assignment Service"). The Server SDKs do not expose an M4b client.
+  Routing through `M1.GetAssignment` is what gives bandit experiments
+  the same bucketing, targeting, lifecycle gating, and timeout fallback
+  that static experiments get. M1 internally delegates to M4b via a
+  low-latency gRPC call (p99 < 15ms) — see
+  `crates/experimentation-assignment/src/bandit_client.rs`.
+- **Different surfaces, different bandit policies.** Home, search,
+  detail-page-rails, end-of-episode — each surface has its own ranker
+  and policy. The policy registry lives in M4b; M5 owns the lifecycle
+  binding from experiment → policy.
 - **Propensity is the cost of being honest later.** The bandit emits an
   **IPW (inverse-propensity-weighted) probability** alongside the arm.
   M4a uses it for off-policy evaluation (ADR-017 — TC/JIVE surrogate


### PR DESCRIPTION
## Summary

Documents how Kaizen interfaces with a streaming video application as a single, traceable sequence — from app launch through playback QoE, reward feedback, and ship decision, plus a guardrail auto-pause exception path.

- **`docs/design/streaming_video_sequence.mermaid`** — single-file `sequenceDiagram` covering all 12 actors (Viewer, Video App SDK, M7 Flags, M1 Assignment, Personalization, M4b Bandit, Player+CDN, M2 Ingest, Kafka, M3 Metrics, M4a Analysis, M5 Management, M6 UI). Color-banded by phase to match the existing `data_flow.mermaid` / `system_architecture.mermaid` style in `docs/design/`.
- **`docs/guides/streaming-video-sequence.md`** — narrative companion with focused sub-diagrams per phase, ports/owners table, and pointers to the ADRs governing each step (015 AVLM, 017 off-policy eval, 018 e-values, 022 switchback, 023 synthetic control, 024 M7 Rust port, 027 TOST, 030 shadow mode).

## What's covered

| Phase | Modules | Notes |
| --- | --- | --- |
| 1. App launch | M7 → M1 → M2 | Flag-gated assignment, hash-parity contract, exposure-before-render rule |
| 2. Personalized rail | M4b → Personalization → M2 | Bandit arm selection, IPW propensity capture |
| 3. Playback + QoE | Player → M2 (`HeartbeatSessionizer`) | EBVS detection, 10s heartbeat aggregation, 30s engagement reward |
| 4. Reward loop | Kafka → M4b → RocksDB | LMAX single-thread core, crash-safe snapshots |
| 5. Analysis + ship | M3 → M4a → M5 → M6 | CUPED+AVLM, TOST, M5 state machine, M1/M7 reconciliation |
| 6. Auto-pause | M3 → Kafka → M5 | Same state-machine path as manual pause (no drift) |

## Why now

There are several architecture diagrams in `docs/design/` (system, data-flow, SDK provider, state machine) but no end-to-end *temporal* view. New integrators and PMs ask "what calls what, in what order" — this fills that gap, in a media-domain (SVOD/streaming) framing that matches the platform's primary use case.

## Test plan

- [ ] Mermaid renders in GitHub PR preview (rect/loop/end blocks balanced; 12 participants declared)
- [ ] All port numbers match `CLAUDE.md` (50051–50058, 3000)
- [ ] All Kafka topic names match `docs/guides/streaming-integration.md` (`exposures`, `metric_events`, `reward_events`, `qoe_events`, `guardrail_alerts`)
- [ ] All referenced ADRs exist in `docs/adrs/` (015, 017, 018, 022, 023, 024, 027, 030)
- [ ] No code or schema changes; pure docs

Docs-only — no CI risk beyond markdown/mermaid lint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6VxWyt5YU4B89PS37ajGT)_