### PR TITLE
RFC: ADR-026 Phase 2 — M5 validator + M6 editor design lock for review (Refs #436)

### DIFF
--- a/docs/superpowers/plans/2026-05-22-adr-026-phase-2-m5-m6.md
+++ b/docs/superpowers/plans/2026-05-22-adr-026-phase-2-m5-m6.md
@@ -359,12 +359,29 @@ Each side runs the corpus through its parser and asserts (a) valid==expected_val
 
 ### Task A8: Generalize cycle detection per L3
 
-**Files:** `crates/experimentation-management/src/validators/composite_cycle.rs` (rename or move), `crates/experimentation-management/src/store.rs` (extend `MetricLookup`), `crates/experimentation-management/src/contract_test_support.rs` (in-mem impl).
+**Files:**
+- `crates/experimentation-management/src/validators/composite_cycle.rs` (rename → `cycle.rs`)
+- `crates/experimentation-management/src/validators/mod.rs` (the `MetricLookup` trait definition lives here; re-exports also live here — both must update)
+- `crates/experimentation-management/src/store.rs` (`ManagementStore`'s `impl MetricLookup` — the PG-backed production impl)
+- `crates/experimentation-management/src/contract_test_support.rs` (`MetricStore`'s `impl MetricLookup` — the in-memory wire-format contract impl)
+- `crates/experimentation-management/src/validators/composite_cycle.rs` test module (`GraphLookup` / `MockLookup` — test-only mocks that also implement the trait)
+
+**Before editing**, grep for every `impl MetricLookup` and confirm the enumeration matches (Devin PR #563 round 1 info finding — preempts the silent partial-update class of bug):
+
+```
+$ rg 'impl(.*for)?\s+MetricLookup|impl\b.*\bMetricLookup\s+for' crates/experimentation-management/
+```
+
+- [ ] **Step 0 (pre-flight, ~5 min): Verify the legacy non-COMPOSITE contract.** Step 3's match arm relies on `get_composite_operands(id)` already returning `Ok(vec![])` — not `Err(StoreError::NotFound)` — when `id` refers to a non-COMPOSITE metric stored in PG. **Devin PR #563 round 1 🚩** flagged this: the current `composite_cycle.rs::check_no_cycles` treats `NotFound` as a hard data-integrity error (an already-validated pointer is dangling), and the generalized dispatch must preserve that semantic only for "metric truly missing" cases, not for "metric exists but is leaf-type." Concretely:
+  - Open `crates/experimentation-management/src/store.rs::impl ManagementStore::get_composite_operands` and confirm: a row that exists with `type != 'COMPOSITE'` returns an empty operand list (no Postgres error path).
+  - If the PG impl is already graceful (it is, per existing COMPOSITE+MEAN-operand integration tests), Step 3's `_ => vec![]` arm matches today's behavior and the generalization is purely additive.
+  - If the PG impl raises `NotFound` for non-COMPOSITE types (regression risk), then Step 3 must instead route through `get_metric_type(current).await?` *first*, then dispatch — never call `get_composite_operands` on a known-non-COMPOSITE id. Pick whichever the audit shows.
 
 - [ ] **Step 1:** RED — extend `composite_cycle_test.rs` with mixed COMPOSITE↔METRICQL cycles:
   - COMPOSITE A → METRICQL B → MetricRef A (cycle)
   - METRICQL A → @B → @A via metricql_expression (cycle)
   - Mixed at depth 3
+  - **Regression test pinning Step 0's audit conclusion:** COMPOSITE root → MEAN operand → `Ok(())` (operand-as-leaf must not be miscategorized as a dangling pointer)
 - [ ] **Step 2:** Extend `MetricLookup`:
 
 ```rust
@@ -378,13 +395,28 @@ pub trait MetricLookup: Send + Sync {
     /// StoreError::NotFound if the metric does not exist (treated by the
     /// cycle detector as the not-yet-inserted root).
     async fn get_metricql_refs(&self, id: &str) -> Result<Vec<String>, StoreError>;
+
+    /// NEW: cheap metric-type lookup so the cycle dispatcher can pick the
+    /// right neighbor source without speculatively calling both getters.
+    /// Returns StoreError::NotFound if the metric does not exist.
+    async fn get_metric_type(&self, id: &str) -> Result<MetricType, StoreError>;
 }
 ```
+
+All four implementors enumerated above must add `get_metricql_refs` and `get_metric_type`. The in-memory mocks return values from their internal HashMap-backed graph; the PG impl issues a single small query each.
 
 - [ ] **Step 3:** GREEN — generalize `check_no_cycles` to dispatch on the *type* of each neighbor:
 
 ```rust
 // inside the DFS, when expanding neighbors of `current`:
+//
+// Legacy contract preserved (verified in Step 0): the existing
+// `check_no_cycles` treats Err(NotFound) from get_composite_operands as a
+// hard "dangling-pointer" error and Ok(vec![]) as "leaf — stop expanding."
+// The dispatcher below preserves both semantics by branching on metric
+// type FIRST, then issuing the right getter. We never call
+// get_composite_operands on a metric known to be non-COMPOSITE, which
+// removes any ambiguity between "wrong type" and "missing row."
 let neighbors = match lookup.get_metric_type(current).await? {
     MetricType::Composite => lookup.get_composite_operands(current).await?,
     MetricType::Metricql  => lookup.get_metricql_refs(current).await?,

--- a/docs/superpowers/plans/2026-05-22-adr-026-phase-2-m5-m6.md
+++ b/docs/superpowers/plans/2026-05-22-adr-026-phase-2-m5-m6.md
@@ -1,0 +1,611 @@
+# ADR-026 Phase 2: M5 MetricQL validator + M6 expression editor (#436)
+
+**Status:** Design lock — RFC for review.
+**Issue:** [#436](https://github.com/wunderkennd/kaizen-experimentation/issues/436) — P1, `sprint-5.6`, `cluster-a`, owners `agent-5` + `agent-6`.
+**Blocked by:** [#435](https://github.com/wunderkennd/kaizen-experimentation/issues/435) (Phase 2 backend — parser/compiler in M3). Backend design merged 2026-05-21 as `c9bb89c` (PR #559); execution dispatched to Multiclaude. **This plan executes only after #435 ships** — the Phase 2 grammar/AST/proto are normative inputs here.
+
+---
+
+## Summary
+
+#436 is the cross-module follow-up to #435. Once the Go MetricQL parser/compiler lives in `services/metrics/internal/metricql/`, two more things must exist before operators can actually *author* MetricQL:
+
+1. **M5 server-side validation** at metric create/update time so bad MetricQL never reaches the metric store. Without this, malformed expressions sit in the store and fail every nightly metrics pass with no observable until M3 logs.
+2. **M6 expression editor** that gives authors syntax highlighting, `@metric_ref` autocomplete, and inline diagnostics — so they discover errors in the form rather than after a deploy.
+
+Both AC sets live in #436's body verbatim. This plan resolves the eight design questions those ACs leave open, locks each answer, and breaks execution into tracer-bullet tasks.
+
+### Non-goals (v1 of #436)
+
+- **Sample-output dry-run preview.** The AC says "dry-run preview shows compiled Spark SQL + sample output (server-rendered)." Compiled SQL preview is in scope; *sample output* (executing the compiled SQL against `delta.metric_summaries` and showing rows) is deferred to a Phase 2.1 follow-up — it requires a Spark cluster connection, RBAC for arbitrary-query exposure, and a caching strategy. Phase 2 v1 ships SQL-only preview; sample output is a follow-up issue.
+- **Server-side incremental analysis.** The validator runs once per write; M6 calls it for live linting at ~500ms debounce. No long-lived "language server" process.
+- **Schema mutations.** The `metricql_expression` proto field (field 20 on `MetricDefinition`) is added by #435 and is treated here as a fixed input. This plan touches *no* proto except the new diagnostic message + the new dry-run RPC.
+- **CUSTOM metric migration.** That's #437 (Phase 3 deprecation).
+
+---
+
+## Phase 2 Contract (Locks) — binding for implementers
+
+Eight Locks freeze the cross-cutting design decisions. Each has a one-line rationale; the prose section below each restates it for review. **Locks are normative — copy verbatim, do not drift.** If a Lock seems wrong, BLOCK and escalate; the #559 review process burned seven rounds polishing the analogous backend Locks.
+
+| # | Lock | One-line answer |
+|---|---|---|
+| L1 | M5 validator implementation strategy | **Port the parser/analyzer to Rust** (matches existing `validators/` pattern; no cross-service hop on write path) |
+| L2 | M5 validator module shape | New `crates/experimentation-management/src/validators/metricql/` mod with `parser.rs`, `lexer.rs`, `ast.rs`, `analyze.rs`, `mod.rs` |
+| L3 | M5 cycle detection ownership + algorithm | M5 owns it; reuse the existing 3-color DFS from `composite_cycle.rs` seeded with refs from the parser (NOT operands) |
+| L4 | M6 editor library | **CodeMirror 6** (matches existing `sql-editor.tsx`; deviates from issue-body "Monaco" — rationale below) |
+| L5 | M6 grammar definition format | Hand-written Lezer (`@lezer/generator`) grammar from the locked EBNF; not codegen, not regex |
+| L6 | M6 autocomplete data source | Existing `ListMetricDefinitions` RPC on M5 (paged, cached client-side); no new RPC |
+| L7 | Dry-run preview RPC location + scope | New `CompileMetricqlPreview` RPC on **M3**, proxied by M5 for SDK boundary consistency; returns compiled SQL only (no sample rows in v1) |
+| L8 | Diagnostics on-wire format | New proto `MetricqlDiagnostic` message: `{severity, message, span: {start_offset, end_offset, line, column}}`, repeated in `ValidateMetricql` response |
+
+---
+
+### L1 — M5 validator implementation strategy
+
+**Decision: Port the parser/analyzer to Rust under M5.**
+
+Three candidates were considered:
+
+| Option | Pros | Cons |
+|---|---|---|
+| (a) Port parser to Rust in M5 | Matches existing `validators/` pattern; no cross-service hop on write path; diagnostics line:col native; M5 write SLA preserved | Two parser implementations to maintain (Go for compute, Rust for validation) — grammar-drift risk |
+| (b) M5 calls a new `ValidateMetricql` gRPC on M3 | Single parser source-of-truth | Cross-service call on every write; breaks the "validation lives in M5" pattern; contract test required; M3 becomes a hot-path dependency for create flows |
+| (c) Syntax-only Rust check, defer semantics to compute | Minimal Rust code | Violates AC ("validation rejects parse errors and unresolved `@metric_ref` / event references" — that's semantic, not syntactic); bad expressions silently sit in the store until first nightly pass |
+
+**(a) wins because the existing pattern is decisive.** Every M5 validator today is Rust-local: `composite_cycle.rs` (DFS), `filter_sql.rs` (FILTERED_MEAN allowlist), the meta/switchback/quasi validators in `mod.rs`. None call out to another service. Operators expect synchronous validation feedback at write time, which means Rust-local. The M5 write SLA budgets ~50ms; a cross-service gRPC + parse is easily 30–80ms p99 — eats the budget.
+
+The grammar-drift risk is real but bounded. Mitigation is **L1.x**: a shared golden corpus (`test-vectors/metricql_corpus.json`) consumed by both the Go parser (M3 `services/metrics/internal/metricql/`) and the Rust parser (M5 `crates/experimentation-management/src/validators/metricql/`). `just test-metricql-parity` verifies bit-equal AST output across both implementations on every CI run. This is the same parity pattern that enforces MurmurHash3 consistency across SDKs (`test-vectors/hash_vectors.json`).
+
+---
+
+### L2 — M5 validator module shape
+
+Mirror the locked Go module structure from #559 (`services/metrics/internal/metricql/`) so the two implementations stay reviewable side-by-side:
+
+```
+crates/experimentation-management/src/validators/metricql/
+├── mod.rs            # public entry: validate_metricql(expr, ctx) -> Result<Refs, Vec<Diagnostic>>
+├── ast.rs            # Node enum + variants mirroring Lock 2 from #559 (Aggregation, Composite, Negate, MetricRef, Literal, Ratio, etc.)
+├── lexer.rs          # Token enum + Lexer struct (mirror Lock 1 token kinds; same TokMinus / TokNumber separation)
+├── parser.rs         # Recursive-descent: parseExpression / parseComposite / parseTerm / parseUnary / parseFactor / ...
+├── analyze.rs        # Semantic analyzer: KnownMetricIDs lookup, @metric_ref resolution, percentile range checks
+└── span.rs           # Span{start, end} + line/column resolver (byte-offset → (line,col) for diagnostics)
+```
+
+The public entry is intentionally narrow:
+
+```rust
+/// Parse + semantically analyze a MetricQL expression. Returns the set of
+/// @metric_refs the expression depends on (for cycle detection upstream) on
+/// success, or a list of diagnostics (line:col + message) on failure.
+pub fn validate_metricql(
+    source: &str,
+    ctx: &ValidateContext<'_>,
+) -> Result<Vec<String>, Vec<Diagnostic>>;
+
+pub struct ValidateContext<'a> {
+    /// All metric IDs currently in the store (post-Phase 1 view). Sourced
+    /// from MetricLookup::list_metric_ids(); the caller fetches this once
+    /// before the validator runs so we don't issue a DB query per @ref.
+    pub known_metric_ids: &'a HashSet<String>,
+    /// Event types whitelisted for `from <event_type>` clauses. Phase 1
+    /// punt: regex `^[a-z_][a-z0-9_]*$` only (no catalog service yet).
+    pub event_type_re: &'a Regex,
+}
+
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub severity: Severity,  // Error | Warning (v1 emits only Error)
+    pub message: String,
+    pub span: Span,          // byte offsets + line/col
+}
+```
+
+`Vec<Diagnostic>` (not `Result<_, Diagnostic>`) because the analyzer should collect ALL errors in one pass — operators hate playing whack-a-mole. Parser errors abort the parse (single error); analyzer errors accumulate (multiple unresolved refs in one expression are common).
+
+---
+
+### L3 — M5 cycle detection: reuse the existing DFS
+
+Existing `validators/composite_cycle.rs` is a 3-color DFS over the operand graph, parameterized by a `MetricLookup` trait that returns `get_composite_operands(id) -> Vec<String>`. METRICQL has *parsed* refs, not operands. So:
+
+1. Extend `MetricLookup` with a sibling method `get_metricql_refs(id: &str) -> Result<Vec<String>, StoreError>` that:
+   - Looks up the metric's stored `metricql_expression`
+   - Parses it (calling `validate_metricql` minus the analyzer — just `parse_only`)
+   - Returns the extracted `@metric_ref` IDs
+2. Generalize `check_no_cycles` to dispatch on the metric's type when fetching neighbors:
+   - COMPOSITE → `get_composite_operands`
+   - METRICQL → `get_metricql_refs`
+3. The DFS algorithm, depth-cap, and 3-color states stay verbatim. Only the neighbor-source is generalized.
+
+**Why not split into a separate `metricql_cycle.rs`?** The graph is *one* graph — a COMPOSITE can have a METRICQL operand and vice versa. Two cycle detectors would have to coordinate and could disagree. One generalized detector keeps the algorithm honest.
+
+**Depth cap:** Same default 5 as COMPOSITE. Operators who need deeper composition rebuild via flattening or file a follow-up. (Phase 3 #437's CUSTOM-migration work may surface real-world depth distributions — revisit after that data.)
+
+---
+
+### L4 — M6 editor library: CodeMirror 6 (deviation from issue-body "Monaco")
+
+The issue body says "Monaco-based editor with MetricQL syntax highlighting." The codebase already uses **CodeMirror 6**:
+
+- `ui/src/components/metrics/sql-editor.tsx` is the Phase 1 SQL editor for FILTERED_MEAN / WINDOWED_COUNT `filter_sql` fields.
+- Its docstring states verbatim: *"For multi-line MetricQL editing (Phase 2 / #436), this component will be extended; the wrapper boundary stays the same."*
+- `ui/package.json` already bundles `@codemirror/state`, `@codemirror/view`, `@codemirror/commands`, `@codemirror/lang-sql`.
+
+Switching to Monaco would mean:
+- ~700KB+ additional JS in the bundle (Monaco's full editor is enormous)
+- Two editor libraries coexisting in M6 indefinitely (sql-editor.tsx stays for filter_sql)
+- New language-server integration (Monaco's API differs from CodeMirror's)
+- Throwing away the in-tree extension point that Phase 1 explicitly designed
+
+CodeMirror 6 supports every AC requirement natively:
+- Syntax highlighting via `@codemirror/language` + a hand-written Lezer grammar (L5)
+- Autocomplete via `@codemirror/autocomplete` (built-in completion source API)
+- Inline diagnostics via `@codemirror/lint` (returns squiggle markers + tooltips from a diagnostic source function)
+
+**The Lock is CodeMirror 6.** If the original issue author wants Monaco specifically (for the marketplace ecosystem, IntelliSense parity, or another reason), they should reopen this lock — but the burden of justification falls on Monaco given the existing pattern.
+
+---
+
+### L5 — M6 grammar: hand-written Lezer
+
+Three options:
+- (a) **Hand-written Lezer grammar** generating a JS parser via `@lezer/generator`
+- (b) **Codegen from the locked EBNF** — write a translator from the plan's EBNF to a Lezer grammar
+- (c) **Regex-based tokenization** — single-pass, no real parse tree
+
+Pick (a). The MetricQL grammar is small (~30 productions from #559 Lock 1); hand-writing the Lezer file is a one-time ~150 lines. Codegen (b) is appealing for grammar-drift resistance but the EBNF-to-Lezer translator is itself ~200 lines and adds a build step. Regex (c) can't represent precedence and would fail on `0.7 * (@a + @b)`.
+
+The Lezer grammar lives at `ui/src/components/metrics/metricql/metricql.grammar` and compiles to `metricql.js` via `lezer-generator` in the prebuild step (add to `ui/package.json` scripts).
+
+**Grammar-drift mitigation:** the same shared golden corpus from L1 (`test-vectors/metricql_corpus.json`) gets a UI parity test — `npm run test:metricql-parity` parses every fixture with the Lezer parser and asserts no syntax-error markers on valid inputs / asserts markers on invalid inputs. This is cheaper than full AST parity (Lezer outputs a syntax tree, not a typed AST) but catches the relevant failure mode.
+
+---
+
+### L6 — Autocomplete data source: existing ListMetricDefinitions
+
+Acceptance criterion: "autocomplete on `@metric_` for existing metric names."
+
+M5 already exposes `ListMetricDefinitions(experiment_id) -> Vec<MetricDefinition>` via the management gRPC service (`proto/experimentation/management/v1/management_service.proto`). The M6 metric form already calls it to populate the `operand-picker.tsx` for COMPOSITE. Reuse it — no new RPC.
+
+Client-side caching: the existing form-shell already keeps a Zustand store (or equivalent — verify in `metric-form-shell.tsx` during T12) of the list response. The MetricQL editor's completion source reads from that cache. On `@` keystroke, the completion source filters the cached list by prefix.
+
+**Edge case: just-created metric not yet in the list.** If the operator creates `watch_time` then immediately tries to author `engagement` referencing `@watch_time`, the cache may not contain `watch_time` yet (depending on optimistic-update strategy). Optimistic: insert the metric ID into the cache on successful Create response (already what the COMPOSITE form does). Confirm in T11.
+
+---
+
+### L7 — Dry-run preview RPC
+
+Acceptance criterion: "dry-run preview shows compiled Spark SQL + sample output (server-rendered)."
+
+Two halves:
+
+**Compiled SQL preview — in scope for v1.**
+New M3 RPC: `CompileMetricqlPreview(MetricqlPreviewRequest) -> MetricqlPreviewResponse`.
+
+```proto
+// proto/experimentation/metrics/v1/metrics_service.proto (M3)
+message MetricqlPreviewRequest {
+  string experiment_id = 1;
+  string metricql_expression = 2;
+  // KnownMetricIDs is derived server-side from the experiment's current
+  // metric set — the client does not pass it, to prevent autocomplete-time
+  // info leakage about other experiments' metrics.
+}
+
+message MetricqlPreviewResponse {
+  string compiled_sql = 1;
+  // Errors (if any). On success, this is empty and compiled_sql is populated.
+  repeated MetricqlDiagnostic diagnostics = 2;
+}
+```
+
+M5 *does not* re-host the parser for preview — M5's parser is for *write-time validation* (returns refs/diagnostics, not SQL). The compiled SQL is canonically M3's output. M5 proxies the preview RPC: M6 calls M5's `PreviewMetricDefinition` (a new wrapper RPC on `management_service.proto`), M5 forwards to M3, returns the response. This keeps M6's RPC surface uniform (everything via M5) and lets M5 add experiment-scoped auth without M3 needing to know about M5's RBAC.
+
+**Why expose preview at all if write-time validation already runs?** Validation answers "is this expression parseable + semantically valid?". Preview answers "what SQL does it actually produce?" — operators learn the system by inspecting the generated SQL ("ah, `@watch_time + @ctr` becomes a CTE join, not an aggregation"). This is high-value UX for the first ~50 operators authoring MetricQL.
+
+**Sample output — out of scope for v1.** Showing actual rows from `delta.metric_summaries` requires:
+- A Spark cluster connection from M3 (currently M3 schedules jobs; it doesn't run interactive queries)
+- RBAC: arbitrary expressions could enable data exfiltration (e.g., `mean(payment.value)` on a PII column the operator shouldn't see)
+- LIMIT clauses + query caching strategy
+- Timeout handling (interactive Spark queries can run for minutes)
+
+File as **#436.1 follow-up after #436 ships** with operator usage data.
+
+---
+
+### L8 — Diagnostics on-wire format
+
+New proto message reused across `ValidateMetricql` (M5) and `CompileMetricqlPreview` (M3 → M5 proxy):
+
+```proto
+// proto/experimentation/common/v1/metricql_diagnostic.proto (new file)
+message MetricqlDiagnostic {
+  enum Severity {
+    SEVERITY_UNSPECIFIED = 0;
+    SEVERITY_ERROR = 1;
+    SEVERITY_WARNING = 2;  // unused in v1 but reserved
+  }
+  Severity severity = 1;
+  string message = 2;
+  Span span = 3;
+
+  message Span {
+    int32 start_offset = 1;   // byte offset, half-open [start, end)
+    int32 end_offset = 2;
+    int32 line = 3;           // 1-based
+    int32 column = 4;         // 1-based, byte column (Unicode-naive — Phase 2 punt; revisit if needed)
+  }
+}
+```
+
+Why byte offsets + (line, col) both: the Rust parser produces byte offsets natively (the AST `Span` from #559's Lock 2); CodeMirror 6 wants byte positions for `Decoration`/`Diagnostic` ranges; humans reading log output want line/col. Send both; the resolver lives once in Rust (M5) and once in TS (`ui/src/components/metrics/metricql/diagnostics.ts`).
+
+**Single-line Unicode column:** byte column, not codepoint column. Most identifier text is ASCII; the locked grammar's IDENTIFIER regex is `[a-z_][a-z0-9_]*` (ASCII-only). String literals can contain Unicode but those are span-marked atomically — the column is for *positioning the cursor*, not for measuring "characters". Codepoint columns are a Phase 2.1 polish.
+
+---
+
+## Phase A — M5 Rust validator
+
+Files: `crates/experimentation-management/src/validators/metricql/{mod,ast,lexer,parser,analyze,span}.rs`, `crates/experimentation-management/Cargo.toml` (no new deps; reuse existing `regex`), `crates/experimentation-management/src/validators/mod.rs` (re-export), `crates/experimentation-management/src/store.rs` (extend `MetricLookup`), `crates/experimentation-management/src/grpc.rs` (wire into CreateMetricDefinition/UpdateMetricDefinition handlers), `test-vectors/metricql_corpus.json` (new), `justfile` (new `test-metricql-parity` recipe).
+
+### Task A1: Vendor the locked AST + lexer + parser from #559's Go code into Rust
+
+**Scope:** Direct mechanical port; no design judgment. Lock 1 (grammar), Lock 2 (AST), Lock 3 (proto field) from #559 are normative. Names match the Go side: `Aggregation`, `Composite`, `Negate`, `MetricRef`, `Literal`, `Ratio`, `Filter`, `Predicate`, `Window`, `Source` — Rust equivalents in `ast.rs`. `parseExpression` / `parseComposite` / `parseTerm` / `parseUnary` / `parseFactor` / `parseFilter` / `parsePredicate` / `parseValue` / `parseWindow` / `parseRatio` / `parseSource` from #559's parser methods list translate one-to-one.
+
+- [ ] **Step 1:** Define `Node` enum + variants in `ast.rs`. Use a Rust `enum Node` (tagged union — Rust has sum types unlike Go).
+
+```rust
+// ast.rs
+#[derive(Debug, Clone, PartialEq)]
+pub enum Node {
+    Aggregation(Aggregation),
+    Composite(Composite),
+    Negate(Box<Negate>),     // boxed to break recursion size
+    Ratio(Ratio),
+    MetricRef(MetricRef),
+    Literal(Literal),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Negate { pub operand: Node, pub span: Span }
+// ... rest mirror the Go types from #559 Lock 2 verbatim
+```
+
+- [ ] **Step 2:** RED — write `ast_test.rs` with the same "every variant constructible" smoke test the Go side has (`TestAST_AllNodeTypesImplementNodeInterface` analogue).
+- [ ] **Step 3:** GREEN — make it compile.
+- [ ] **Step 4:** Commit. `test(management): add MetricQL AST types (#436)`
+
+### Task A2: Lexer
+
+- [ ] **Step 1:** Token enum mirrors #559 Lock 1's token spec (`TokIdent`, `TokNumber`, `TokString`, `TokKeyword`, `TokAt`, `TokLParen`, ..., `TokMinus`, `TokStar`, `TokSlash`, comparisons). **Crucial:** `TokNumber` is unsigned (no `-` consumption) — unary minus is parsed by `parseUnary` only.
+- [ ] **Step 2:** RED — table tests for keywords, identifiers, numbers, strings, comparisons, `@metric_` identifiers (test corpus shared with Go side; see A6).
+- [ ] **Step 3:** GREEN — implement `Lexer::tokenize()`.
+- [ ] **Step 4:** Commit. `feat(management): MetricQL lexer (#436)`
+
+### Task A3: Parser
+
+- [ ] **Step 1:** RED — table tests covering each grammar production from #559 Lock 1. Use the shared corpus (A6) as the test source-of-truth.
+- [ ] **Step 2:** GREEN — recursive-descent parser, one fn per production. `parseUnary` produces a `Negate` node when it consumes `TokMinus` (the only call site that converts `-` to negation; everywhere else `-` is binary subtraction in `parseComposite`).
+- [ ] **Step 3:** Verify shadow run: pick 10 fixtures from the corpus, run them through M3's Go parser (via a temporary `parser_dump` CLI added to `services/metrics/cmd/metricql_dump`), assert the Rust AST is bit-equal modulo struct names.
+- [ ] **Step 4:** Commit. `feat(management): MetricQL recursive-descent parser (#436)`
+
+### Task A4: Semantic analyzer
+
+- [ ] **Step 1:** RED — `analyze_test.rs` cases:
+  - Unresolved `@metric_ref` → `Diagnostic{severity: Error, span: <ref token span>, message: "unknown metric: foo"}`
+  - Invalid percentile (`percentile(150)`) → diagnostic
+  - Event type fails ident regex → diagnostic
+  - Multiple errors collected in one pass (don't short-circuit)
+- [ ] **Step 2:** GREEN — implement `Analyze::analyze(ast, ctx) -> Vec<Diagnostic>`. Walk the AST; collect diagnostics; return all of them (empty Vec = success).
+- [ ] **Step 3:** Implement `extract_metric_refs(ast) -> Vec<String>` — deduplicated unordered set; identical semantics to #559's `metricql.ExtractMetricRefs` (Phase 2 backend).
+- [ ] **Step 4:** Commit. `feat(management): MetricQL semantic analyzer (#436)`
+
+### Task A5: Public entry point
+
+- [ ] **Step 1:** RED — `mod_test.rs` end-to-end cases:
+  - Valid expression → `Ok(refs)` with the expected refs
+  - Parse error → `Err(vec![Diagnostic{...}])` with span at the offending token
+  - Semantic error → `Err(vec![Diagnostic{...}])` with span at the unresolved ref
+  - Combined: parse error short-circuits (no semantic phase); semantic errors accumulate
+- [ ] **Step 2:** GREEN — implement `validate_metricql(source, ctx) -> Result<Vec<String>, Vec<Diagnostic>>`.
+- [ ] **Step 3:** Commit. `feat(management): MetricQL validate_metricql entry point (#436)`
+
+### Task A6: Shared golden corpus + parity test
+
+- [ ] **Step 1:** Write `test-vectors/metricql_corpus.json` with ~40 fixtures spanning every grammar production. Each entry has `{name, source, valid: bool, expected_refs: [...] | null, expected_error_count: int | null}`.
+
+```json
+[
+  {"name": "simple_aggregation", "source": "mean(heartbeat.value)", "valid": true, "expected_refs": []},
+  {"name": "composite_weighted", "source": "0.7 * @watch_time + 0.3 * @ctr", "valid": true, "expected_refs": ["watch_time", "ctr"]},
+  {"name": "ratio", "source": "ratio(@a, @b)", "valid": true, "expected_refs": ["a", "b"]},
+  {"name": "unary_negation", "source": "-@a + @b", "valid": true, "expected_refs": ["a", "b"]},
+  {"name": "parse_error_unclosed", "source": "mean(x", "valid": false, "expected_error_count": 1},
+  {"name": "unresolved_ref", "source": "@unknown_metric + @ctr", "valid": false, "expected_error_count": 1},
+  ...
+]
+```
+
+- [ ] **Step 2:** Write `justfile` recipe:
+
+```just
+test-metricql-parity:
+    @echo "Rust parser parity..."
+    cd crates && cargo test -p experimentation-management --test metricql_corpus_parity
+    @echo "Go parser parity..."
+    cd services && go test ./metrics/internal/metricql/ -run TestCorpusParity -v
+    @echo "✓ both parsers accept/reject the same corpus"
+```
+
+Each side runs the corpus through its parser and asserts (a) valid==expected_valid and (b) extracted refs match. If the two implementations disagree on a fixture, CI fails loudly.
+
+- [ ] **Step 3:** Commit. `test(metrics): MetricQL cross-impl parity golden corpus (#436)`
+
+### Task A7: Wire validator into CreateMetricDefinition / UpdateMetricDefinition
+
+**Files:** `crates/experimentation-management/src/grpc.rs`, `crates/experimentation-management/src/validators/mod.rs` (extend `validate_metric_definition` dispatch).
+
+- [ ] **Step 1:** RED — `grpc_test.rs` cases:
+  - CreateMetricDefinition with METRICQL type + valid expression → Ok, metric stored with `metricql_expression` populated
+  - CreateMetricDefinition with METRICQL + parse error → `Status::invalid_argument` with diagnostic details (use `.with_details()` to attach the `repeated MetricqlDiagnostic`)
+  - CreateMetricDefinition with METRICQL + cycle (creates A referencing @B, then B referencing @A) → `Status::invalid_argument`
+  - UpdateMetricDefinition with METRICQL changed → re-validation runs; cycle check against the *new* refs
+- [ ] **Step 2:** GREEN — add a METRICQL arm to `validate_metric_definition`:
+  - Call `validate_metricql(source, ctx)` to parse + analyze. On `Err(diagnostics)`, return `Status::invalid_argument` with diagnostics serialized into the response details (`Status::with_details(prost_types::Any::pack(&MetricqlDiagnosticBag{ diagnostics }))`).
+  - On `Ok(refs)`, call `check_no_cycles(metric_id, refs, lookup, depth_cap)` (the existing 3-color DFS, generalized in T7).
+- [ ] **Step 3:** Commit. `feat(management): wire MetricQL validator into Create/Update metric handlers (#436)`
+
+### Task A8: Generalize cycle detection per L3
+
+**Files:** `crates/experimentation-management/src/validators/composite_cycle.rs` (rename or move), `crates/experimentation-management/src/store.rs` (extend `MetricLookup`), `crates/experimentation-management/src/contract_test_support.rs` (in-mem impl).
+
+- [ ] **Step 1:** RED — extend `composite_cycle_test.rs` with mixed COMPOSITE↔METRICQL cycles:
+  - COMPOSITE A → METRICQL B → MetricRef A (cycle)
+  - METRICQL A → @B → @A via metricql_expression (cycle)
+  - Mixed at depth 3
+- [ ] **Step 2:** Extend `MetricLookup`:
+
+```rust
+#[tonic::async_trait]
+pub trait MetricLookup: Send + Sync {
+    // ...existing...
+    async fn exists_all_metrics(&self, metric_ids: &[&str]) -> Result<bool, StoreError>;
+    async fn get_composite_operands(&self, id: &str) -> Result<Vec<String>, StoreError>;
+
+    /// NEW: get the @metric_refs of a stored METRICQL metric. Returns
+    /// StoreError::NotFound if the metric does not exist (treated by the
+    /// cycle detector as the not-yet-inserted root).
+    async fn get_metricql_refs(&self, id: &str) -> Result<Vec<String>, StoreError>;
+}
+```
+
+- [ ] **Step 3:** GREEN — generalize `check_no_cycles` to dispatch on the *type* of each neighbor:
+
+```rust
+// inside the DFS, when expanding neighbors of `current`:
+let neighbors = match lookup.get_metric_type(current).await? {
+    MetricType::Composite => lookup.get_composite_operands(current).await?,
+    MetricType::Metricql  => lookup.get_metricql_refs(current).await?,
+    _                     => vec![],   // leaf — no graph edges
+};
+```
+
+The depth, color states, error messages stay identical.
+
+- [ ] **Step 4:** Rename `validators/composite_cycle.rs` → `validators/cycle.rs` (it's no longer COMPOSITE-specific). Update `validators/mod.rs` re-exports.
+- [ ] **Step 5:** Commit. `refactor(management): generalize cycle detection to METRICQL refs (#436)`
+
+### Task A9: ValidateMetricql RPC (for live linting from M6)
+
+M6 needs a server-side validator for live linting in the editor (debounced, ~500ms after the operator stops typing). The Create/Update handlers run validation but only at submit; live editing needs a cheaper standalone endpoint.
+
+**Files:** `proto/experimentation/management/v1/management_service.proto` (add `ValidateMetricql` RPC), `crates/experimentation-management/src/grpc.rs` (handler).
+
+- [ ] **Step 1:** Add proto:
+
+```proto
+service ManagementService {
+  // ...existing...
+  rpc ValidateMetricql(ValidateMetricqlRequest) returns (ValidateMetricqlResponse);
+}
+
+message ValidateMetricqlRequest {
+  string experiment_id = 1;       // scopes the KnownMetricIDs lookup
+  string metricql_expression = 2;
+}
+
+message ValidateMetricqlResponse {
+  repeated experimentation.common.v1.MetricqlDiagnostic diagnostics = 1;
+  repeated string referenced_metric_ids = 2;   // present on success; informational
+}
+```
+
+- [ ] **Step 2:** RED — handler test cases: valid → empty diagnostics + populated refs; parse error → 1 diagnostic; multi-error semantic case → N diagnostics, all collected.
+- [ ] **Step 3:** GREEN — handler reads the experiment's metric set, builds `ValidateContext`, calls `validate_metricql`, returns the diagnostic bag.
+- [ ] **Step 4:** `buf lint proto/ && buf breaking proto/ --against .git#branch=main`.
+- [ ] **Step 5:** Commit. `feat(management): ValidateMetricql RPC for live linting (#436)`
+
+---
+
+## Phase B — M6 expression editor
+
+Files: `ui/src/components/metrics/metricql/{editor,grammar,autocomplete,diagnostics,preview}.tsx` (new), `ui/src/components/metrics/metricql/metricql.grammar` (Lezer), `ui/src/components/metrics/metric-form-shell.tsx` (wire in METRICQL section), `ui/package.json` (add `@lezer/generator`, `@lezer/highlight`, `@codemirror/autocomplete`, `@codemirror/lint`).
+
+### Task B1: Lezer grammar
+
+- [ ] **Step 1:** Write `metricql.grammar` mirroring #559 Lock 1's EBNF. Lezer's syntax is similar to PEG; ~150 lines.
+- [ ] **Step 2:** Add prebuild step to `ui/package.json`:
+
+```json
+{
+  "scripts": {
+    "build:grammar": "lezer-generator src/components/metrics/metricql/metricql.grammar -o src/components/metrics/metricql/metricql.js",
+    "prebuild": "npm run build:grammar"
+  }
+}
+```
+
+- [ ] **Step 3:** RED — `metricql.grammar.test.ts` parses the same corpus fixtures from `test-vectors/metricql_corpus.json` and asserts no syntax-error markers on `valid: true` cases / asserts presence on `valid: false`.
+- [ ] **Step 4:** Commit. `feat(ui): MetricQL Lezer grammar (#436)`
+
+### Task B2: CodeMirror 6 editor component
+
+- [ ] **Step 1:** `ui/src/components/metrics/metricql/editor.tsx` — `MetricqlEditor` component, extends the existing `sql-editor.tsx` boundary (multi-line, configurable maxLength=4096):
+
+```tsx
+export function MetricqlEditor({
+  value, onChange, experimentId, knownMetricIds, ariaLabel, disabled
+}: MetricqlEditorProps) {
+  // CodeMirror 6 setup with: metricql language, autocomplete provider (B3),
+  // linter (B4), basic theming. Same Compartment pattern as sql-editor.tsx.
+}
+```
+
+- [ ] **Step 2:** RED — Playwright/Vitest tests for: render, value-propagation onChange, maxLength enforcement, disabled state.
+- [ ] **Step 3:** GREEN.
+- [ ] **Step 4:** Commit. `feat(ui): MetricQL CodeMirror 6 editor component (#436)`
+
+### Task B3: Autocomplete provider
+
+- [ ] **Step 1:** `ui/src/components/metrics/metricql/autocomplete.ts` — completion source reading from the form-shell's cached metric list. Trigger on `@`, filter by prefix.
+- [ ] **Step 2:** RED — Vitest cases: `@` shows all metrics; `@watch_` filters; case-insensitive; just-created metric (optimistic cache insert from L6) appears.
+- [ ] **Step 3:** GREEN.
+- [ ] **Step 4:** Commit. `feat(ui): MetricQL @metric_ autocomplete (#436)`
+
+### Task B4: Inline diagnostics (live linting)
+
+- [ ] **Step 1:** `ui/src/components/metrics/metricql/diagnostics.ts` — `linter` from `@codemirror/lint` that:
+  - Debounces 500ms on doc change
+  - Calls `ValidateMetricql` RPC on M5 (via the existing gRPC-web client used elsewhere in M6)
+  - Maps each `MetricqlDiagnostic` to a CM6 `Diagnostic{from, to, severity, message}` using `span.start_offset` / `span.end_offset`
+- [ ] **Step 2:** RED — Vitest cases:
+  - Valid expression → no markers
+  - Parse error → 1 squiggle at the right offset
+  - Multiple unresolved refs → multiple squiggles
+  - Debounce: typing 5 chars in 200ms ⇒ 1 RPC call after 500ms idle
+  - Network error (M5 unreachable) → silent (no markers, don't block editing); console warning only
+- [ ] **Step 3:** GREEN.
+- [ ] **Step 4:** Commit. `feat(ui): MetricQL inline diagnostics (live lint) (#436)`
+
+### Task B5: Compiled-SQL preview pane
+
+- [ ] **Step 1:** `ui/src/components/metrics/metricql/preview.tsx` — collapsible "Compiled SQL" pane below the editor. On valid expression (no diagnostics), calls `PreviewMetricDefinition` (M5 proxy → M3 `CompileMetricqlPreview`), renders the SQL with `@codemirror/lang-sql` syntax highlighting (read-only).
+- [ ] **Step 2:** RED — Vitest cases:
+  - Valid → SQL rendered
+  - Invalid → "Fix errors above to see compiled SQL" placeholder
+  - Network error → toast + retry button
+  - Loading state → skeleton
+- [ ] **Step 3:** GREEN.
+- [ ] **Step 4:** Commit. `feat(ui): MetricQL compiled-SQL preview pane (#436)`
+
+### Task B6: Form integration — METRICQL section
+
+- [ ] **Step 1:** `ui/src/components/metrics/metricql-section.tsx` — replaces the operand-picker / sql-editor block for METRICQL type. Composes `MetricqlEditor` (B2) + `MetricqlPreview` (B5).
+- [ ] **Step 2:** Update `metric-form-shell.tsx`: when `type === 'METRICQL'`, render `MetricqlSection`. Update `metric-type-select.tsx` to include METRICQL as an option.
+- [ ] **Step 3:** RED — Playwright E2E: open form, select METRICQL, type `0.7 * @watch_time + 0.3 * @ctr`, see compiled SQL render, submit, see metric created.
+- [ ] **Step 4:** GREEN.
+- [ ] **Step 5:** Commit. `feat(ui): METRICQL metric form section (#436)`
+
+---
+
+## Phase C — Dry-run preview RPC
+
+### Task C1: M3 `CompileMetricqlPreview` RPC
+
+**Files:** `proto/experimentation/metrics/v1/metrics_service.proto` (add RPC), `services/metrics/internal/grpc/server.go` (handler).
+
+- [ ] **Step 1:** Proto added per L7.
+- [ ] **Step 2:** RED — handler test: given a valid expression + experiment_id, returns compiled SQL matching the same compiler used at compute time (assertion: re-compile via the per-metric path and diff).
+- [ ] **Step 3:** GREEN — handler reads the experiment's metric set (for KnownMetricIDs), calls `metricql.Compile(source, ctx)`, returns `{compiled_sql, diagnostics: []}` on success or `{compiled_sql: "", diagnostics: [...]}` on parse/semantic failure.
+- [ ] **Step 4:** Commit. `feat(metrics): CompileMetricqlPreview RPC (#436)`
+
+### Task C2: M5 proxy RPC + contract test
+
+**Files:** `proto/experimentation/management/v1/management_service.proto` (add `PreviewMetricDefinition`), `crates/experimentation-management/src/grpc.rs` (handler that forwards to M3).
+
+- [ ] **Step 1:** Proto + handler — M5's `PreviewMetricDefinition` accepts the M6-friendly shape, calls M3's `CompileMetricqlPreview`, returns the response.
+- [ ] **Step 2:** **Contract test** at `crates/experimentation-management/tests/contract_preview_test.rs`: spin up an in-memory M3 mock via the existing `contract_test_support` infra, assert M5 forwards the request correctly and returns the response unmodified. (Per CLAUDE.md: "Cross-module interfaces require wire-format contract tests; the consumer agent writes the test.")
+- [ ] **Step 3:** Commit. `feat(management): PreviewMetricDefinition RPC + contract test (#436)`
+
+---
+
+## Phase D — Convergence
+
+### Task D1: Acceptance-criteria mapping
+
+Verify each #436 AC against a concrete test:
+
+| AC | Test location |
+|---|---|
+| M5: `expression` field on MetricDefinition accepts MetricQL strings | A7 grpc_test.rs::create_metricql_metric |
+| M5: validation rejects parse errors | A7 grpc_test.rs::create_metricql_parse_error |
+| M5: rejects unresolved `@metric_ref` / event references with line:col | A4 analyze_test.rs::unresolved_ref_diagnostic |
+| M5: cycle detection across the metric DAG | A8 cycle_test.rs::mixed_composite_metricql_cycle |
+| M6: editor with MetricQL syntax highlighting | B1 grammar.test.ts + B2 editor.test.tsx |
+| M6: autocomplete on `@metric_` | B3 autocomplete.test.ts |
+| M6: inline diagnostics | B4 diagnostics.test.ts |
+| M6: dry-run preview shows compiled Spark SQL | B5 preview.test.tsx + C1+C2 RPC tests |
+| M6: dry-run preview shows sample output | **Deferred** to #436.1 follow-up (L7) |
+
+### Task D2: Full-suite regression
+
+```
+cd crates && cargo test --workspace
+cd services && go test ./...
+cd ui && npm test
+just test-metricql-parity
+just test-hash    # parity gates already in repo; rerun to confirm no break
+```
+
+### Task D3: Final commit + PR
+
+`feat(metricql): M5 validator + M6 editor + dry-run preview (#436)` — push, open PR with `Closes #436`, link the parity corpus, include the AC mapping table in the body.
+
+---
+
+## Test plan summary
+
+| Phase | Test files | Count target |
+|---|---|---|
+| A (M5 Rust) | `validators/metricql/{lexer,parser,analyze,mod}_test.rs`, `grpc_test.rs`, `composite_cycle_test.rs` (extended) | ~40 unit + 8 integration |
+| A6 parity | `metricql_corpus_parity.rs` (Rust) + `metricql_corpus_test.go` (Go side, added by #435 follow-up) | 40+ corpus fixtures |
+| B (M6 TS) | `metricql/{grammar,editor,autocomplete,diagnostics,preview}.test.{ts,tsx}` | ~25 unit + 1 Playwright E2E |
+| C (Cross-service) | `services/metrics/internal/grpc/preview_test.go`, `crates/experimentation-management/tests/contract_preview_test.rs` | 1 RPC unit + 1 contract |
+
+---
+
+## Follow-ups
+
+| Item | Trigger | Owner |
+|---|---|---|
+| **#436.1** — Sample-output dry-run (execute compiled SQL against `delta.metric_summaries`, return rows) | After #436 ships + operator usage data signals demand | agent-3 + agent-5 |
+| **#436.2** — Unicode-codepoint columns in diagnostics (not byte columns) | If operators report cursor-positioning bugs with non-ASCII string literals | agent-5 |
+| **#436.3** — Editor cycle-warning *before* submit (live cycle detection in M6 using the autocomplete cache) | After #436 ships; instrument time-to-error-discovery | agent-6 |
+| **#437** — CUSTOM metric migration to MetricQL + UI deprecation warning | After #436 ships and operators have authored ≥10 MetricQL metrics | agent-3 + agent-5 + agent-6 |
+
+---
+
+## Risks + rollback
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Rust + Go parsers drift | High (grammar correctness) | A6 corpus parity test on CI; `just test-metricql-parity` blocks merge |
+| Live-lint RPC chatty | Medium (M5 CPU) | 500ms debounce + cancel-in-flight; rate-limit per-user at 4 req/s server-side |
+| CodeMirror 6 bundle bloat | Low | All deps already in bundle; new ones are `@codemirror/lang-*` family (~10KB each gzipped) |
+| Cycle check false-negative on mixed graphs | High (data integrity) | A8 explicitly tests COMPOSITE↔METRICQL mixed graphs at depth 3 |
+| Preview RPC exposes data | Medium (currently SQL-only — low; sample-output deferred — out of scope) | Compiled SQL alone has no row data; sample rows is #436.1 with RBAC design |
+
+**Rollback:** The feature is gated by the `metricql_expression` field being populated. If validation has a bug after deploy, set a temporary kill-switch via `config.MetricqlValidatorEnabled = false` in M5 config — handlers reject any create with a non-empty `metricql_expression` and the existing COMPOSITE/FILTERED_MEAN/WINDOWED_COUNT paths continue working. UI hides the METRICQL option via a feature flag (`m6.metricql.enabled`) until validation is re-enabled.
+
+---
+
+## Branch + PR conventions
+
+- Branch: `agent-5/feat/adr-026-phase-2-m5-m6` (or split: `agent-5/feat/...` for Phase A backend, `agent-6/feat/...` for Phase B UI; merged via a single integration PR or two stacked PRs at the executor's discretion).
+- Total commits: ~17 (one per Task A1–A9, B1–B6, C1–C2, D1–D3).
+- Single PR `Closes #436` once Phases A–D all pass.
+- Conventional commits: `feat(management):`, `feat(metrics):`, `feat(ui):`, `test(...)`, `refactor(...)`, `docs:`.
+
+Estimated execution time at hybrid throughput: ~12–16 agent-hours real time including the cross-impl parity build-out (slightly longer than #435 due to the proto/wire surface + Playwright E2E).


### PR DESCRIPTION
## What this is

Cross-module follow-up RFC for ADR-026 Phase 2, mirroring how #559 was reviewed and merged. Locks the design for **M5 MetricQL validator** + **M6 expression editor** so #436 can be executed once #435 (Phase 2 backend) ships.

This is **design-only — no implementation code**. The plan doc is `docs/superpowers/plans/2026-05-22-adr-026-phase-2-m5-m6.md` (611 lines, 26 fenced blocks).

## 8 design questions, 8 Locks

| # | Question | Lock |
|---|---|---|
| L1 | M5 validator strategy: port to Rust vs gRPC to M3 vs syntax-only? | **Port parser/analyzer to Rust** under `crates/experimentation-management/src/validators/metricql/`. Matches existing `validators/` pattern; no cross-service hop on write path; grammar-drift mitigated by shared golden corpus + `just test-metricql-parity` |
| L2 | M5 module shape | `mod.rs` / `ast.rs` / `lexer.rs` / `parser.rs` / `analyze.rs` / `span.rs` — mirrors #559's Go layout one-to-one for side-by-side review |
| L3 | Cycle detection ownership + algorithm | M5; reuse the existing 3-color DFS from `composite_cycle.rs`; extend `MetricLookup` with `get_metricql_refs`; dispatch on metric type when expanding DFS neighbors; rename → `cycle.rs` since it's no longer COMPOSITE-only |
| L4 | M6 editor library | **CodeMirror 6** — deviation from issue-body "Monaco". Existing `sql-editor.tsx` explicitly anticipates MetricQL as a CM6 extension; ~700KB+ bundle penalty avoided; CM6 natively supports highlighting/autocomplete/linting |
| L5 | M6 grammar format | Hand-written Lezer grammar (`@lezer/generator`), ~150 lines, compiled at prebuild |
| L6 | Autocomplete data source | Existing `ListMetricDefinitions` RPC + client-side cache; no new RPC; optimistic-cache for just-created metrics |
| L7 | Dry-run preview RPC | New `CompileMetricqlPreview` on **M3**, M5 proxies via new `PreviewMetricDefinition` (SDK-boundary consistency). Returns compiled SQL only; **sample-output rows deferred to #436.1 follow-up** (requires Spark connection + RBAC + caching) |
| L8 | Diagnostics on-wire format | New `common/v1/MetricqlDiagnostic` proto with `{severity, message, span{start_offset, end_offset, line, column}}` — shared across `ValidateMetricql` (M5) and `CompileMetricqlPreview` (M3) |

## Phase breakdown

- **Phase A** (M5 Rust): 9 tasks (A1–A9). Vendor parser; analyzer; validate_metricql entry; shared corpus + parity test; wire into Create/Update handlers; generalize cycle detection; new `ValidateMetricql` RPC for live linting.
- **Phase B** (M6 UI): 6 tasks (B1–B6). Lezer grammar; CodeMirror editor; autocomplete; live diagnostics with 500ms debounce; compiled-SQL preview pane; form integration.
- **Phase C** (cross-service): 2 tasks (C1–C2). M3 preview RPC + M5 proxy with contract test.
- **Phase D** (convergence): 3 tasks (D1–D3). AC mapping; full-suite regression; final PR.

Estimated execution: ~12–16 agent-hours; ~17 commits total.

## Notable deferrals (filed as follow-ups in the plan)

| Item | Why deferred |
|---|---|
| **#436.1** — Sample-output dry-run | Requires Spark connection from M3 + RBAC + caching; out of scope for v1 |
| **#436.2** — Unicode-codepoint columns | Byte columns work for ASCII grammar; revisit if non-ASCII string literals cause cursor bugs |
| **#436.3** — In-editor cycle warning before submit | Server-side cycle check covers correctness; UI optimization for time-to-error |

## Test strategy

Parity is the headline guard:
- `test-vectors/metricql_corpus.json` — ~40 fixtures spanning every grammar production
- Rust side: `crates/.../metricql_corpus_parity.rs`
- Go side: `services/.../metricql_corpus_test.go` (added in a #435 follow-up)
- `just test-metricql-parity` runs both and blocks merge if they disagree

Same pattern that enforces MurmurHash3 parity across SDKs via `test-vectors/hash_vectors.json`.

## Rollback

Kill-switch: `config.MetricqlValidatorEnabled = false` in M5 → handlers reject any `Create` with non-empty `metricql_expression`; UI hides the METRICQL option via `m6.metricql.enabled` flag. Existing COMPOSITE / FILTERED_MEAN / WINDOWED_COUNT paths unaffected.

## Status

**Draft RFC.** Requesting Devin review against #559's standard. Execution dispatch (subagent-driven-development or Multiclaude) deferred until:
1. #435 ships (provides the Go parser this plan ports from; provides field 20 on the proto)
2. This RFC merges (provides the Locks)

`Refs #436`
