### PR TITLE
🎨 Palette: Refine Breadcrumb navigation with icons and focus states

### DIFF
--- a/ui/src/components/breadcrumb.tsx
+++ b/ui/src/components/breadcrumb.tsx
@@ -17,11 +17,24 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
       <ol className="flex items-center">
         {items.map((item, index) => (
           <li key={item.label} className="flex items-center">
-            {index > 0 && <span className="mx-2" aria-hidden="true">/</span>}
+            {index > 0 && (
+              <svg
+                className="mx-2 h-4 w-4 flex-shrink-0 text-gray-400"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            )}
             {item.href ? (
               <Link
                 href={item.href}
-                className="hover:text-indigo-600"
+                className="rounded-sm hover:text-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                 data-testid={index === items.length - 2 ? 'back-link' : undefined}
               >
                 {item.label}


### PR DESCRIPTION
💡 What: Refined the `Breadcrumb` component to use a Chevron icon separator and added standard accessibility focus rings to links.

🎯 Why: Plain text separators can feel dated and less intuitive. Explicit focus states are critical for keyboard navigation users to maintain spatial awareness.

♿ Accessibility:
- Added `focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2` to interactive breadcrumb links.
- Set `aria-hidden="true"` on the decorative separator icon.

📸 Verified via Playwright screenshot in `/home/jules/verification/breadcrumb_flags.png`.

---
*PR created automatically by Jules for task [18322858338088205282](https://jules.google.com/task/18322858338088205282) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->