### PR TITLE
feat(justfile): add prime-issue recipe + issue banner template

### DIFF
--- a/.github/issue-banner-template.md
+++ b/.github/issue-banner-template.md
@@ -1,0 +1,22 @@
+> ## 📌 Execution status (${PLAN_DATE})
+>
+> **Locked plan:** [`${PLAN_PATH}`](../tree/main/${PLAN_PATH}) — last touched on main at `${PLAN_SHA}`.
+>
+> **Branch convention:** `agent-N/feat/adr-XXX-<slug>` per CLAUDE.md. PR body must include `Closes #${ISSUE_NUM}`. Never use auto-generated worker names as branches.
+>
+> **Read the plan's Locks section first** — they are normative. If a Lock seems wrong, BLOCK and surface it via an issue comment rather than drifting. Recent precedent (PR #567): off-plan PRs that override merged Locks get rejected and waste the review investment.
+>
+> **Workflow:** invoke `superpowers:subagent-driven-development` — implementer → spec-reviewer → code-quality-reviewer per task; no parallel implementers within a single plan.
+>
+> **Hygiene gates** (per CLAUDE.md):
+> - Conventional commits (`feat(crate):`, `test(crate):`, `docs:`, `chore:`), one logical change per commit.
+> - `buf lint proto/ && buf breaking proto/ --against .git#branch=main` before any proto commit.
+> - Workspace `cargo clippy --workspace --all-features -- -D warnings` (CI-exact) before pushing.
+> - **No `git stash`** in shared worktrees (May-2026 `kind-eagle`/`witty-lion` collision incident) — use `git diff > /tmp/patch && git apply`.
+> - **No committed `gen/...` files** — they regenerate via `buf generate`.
+
+<!--
+This banner is upserted by `just prime-issue <number>`. Re-running the recipe
+rewrites the block between the EXEC-BANNER markers without disturbing the
+original spec below. To regenerate after a plan revision: `just prime-issue N`.
+-->

--- a/.github/issue-banner-template.md
+++ b/.github/issue-banner-template.md
@@ -1,6 +1,7 @@
 > ## 📌 Execution status (${PLAN_DATE})
 >
-> **Locked plan:** [`${PLAN_PATH}`](../tree/main/${PLAN_PATH}) — last touched on main at `${PLAN_SHA}`.
+> **Locked plan:** [`${PLAN_PATH}`](../../tree/main/${PLAN_PATH}) — last touched on main at `${PLAN_SHA}`.
+
 >
 > **Branch convention:** `agent-N/feat/adr-XXX-<slug>` per CLAUDE.md. PR body must include `Closes #${ISSUE_NUM}`. Never use auto-generated worker names as branches.
 >

--- a/justfile
+++ b/justfile
@@ -823,6 +823,61 @@ agent-work agent_label:
     gh issue list --label "{{agent_label}}" --state open --json number,title,milestone \
       --jq '.[] | "#\(.number)\t\(.milestone.title // "no milestone")\t\(.title)"'
 
+# Idempotent: re-running rewrites the <!-- EXEC-BANNER:START/END --> block
+# in place without appending. Looks for a plan file under
+# docs/superpowers/plans/ that references this issue ("Refs #N", "Closes #N",
+# or "Issue: #N"); fails with a clear error if none found.
+#
+# Run this AFTER the plan PR merges to main; the dispatch recipe `work-on`
+# reads only title+body (not comments), so the banner is how locked-plan
+# context reaches the Multiclaude worker.
+#
+# Upsert the locked-plan execution banner on a GitHub Issue.
+prime-issue issue:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ISSUE={{issue}}
+
+    PLAN=$(grep -rlE "(Refs|Closes|Issue:?)[[:space:]]*#${ISSUE}\b" docs/superpowers/plans/*.md 2>/dev/null | head -1)
+    if [ -z "$PLAN" ]; then
+        echo "✗ No plan in docs/superpowers/plans/ references #${ISSUE}" >&2
+        echo "  Plan must contain 'Refs #${ISSUE}', 'Closes #${ISSUE}', or 'Issue: #${ISSUE}'" >&2
+        exit 1
+    fi
+
+    PLAN_SHA=$(git log -1 --format=%h main -- "$PLAN" 2>/dev/null || echo "(unmerged)")
+    PLAN_DATE=$(git log -1 --format=%cs main -- "$PLAN" 2>/dev/null || date +%Y-%m-%d)
+
+    BANNER=$(sed -e "s|\${ISSUE_NUM}|${ISSUE}|g" \
+                 -e "s|\${PLAN_PATH}|${PLAN}|g" \
+                 -e "s|\${PLAN_SHA}|${PLAN_SHA}|g" \
+                 -e "s|\${PLAN_DATE}|${PLAN_DATE}|g" \
+                 .github/issue-banner-template.md)
+
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    gh issue view ${ISSUE} --json body --jq '.body' > "${TMPDIR}/current.md"
+
+    # Strip any prior <!-- EXEC-BANNER --> block plus an optional trailing
+    # "---" separator. Python one-liner because just's recipe-body parser
+    # requires consistent indentation on every line (multi-line embedded
+    # scripts that start at column 0 trip it up).
+    python3 -c 'import re,sys; t=open(sys.argv[1]).read(); t=re.sub(r"<!-- EXEC-BANNER:START -->[\s\S]*?<!-- EXEC-BANNER:END -->\n*(---\n*)?", "", t); sys.stdout.write(t.lstrip())' "${TMPDIR}/current.md" > "${TMPDIR}/stripped.md"
+
+    {
+      echo "<!-- EXEC-BANNER:START -->"
+      echo "$BANNER"
+      echo "<!-- EXEC-BANNER:END -->"
+      echo ""
+      echo "---"
+      echo ""
+      cat "${TMPDIR}/stripped.md"
+    } > "${TMPDIR}/new-body.md"
+
+    gh issue edit ${ISSUE} --body-file "${TMPDIR}/new-body.md"
+    echo "✓ Issue #${ISSUE} primed with ${PLAN} (${PLAN_SHA}, ${PLAN_DATE})"
+
 # Launch a Multiclaude worker from a GitHub Issue number
 work-on issue:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -845,8 +845,11 @@ prime-issue issue:
         exit 1
     fi
 
-    PLAN_SHA=$(git log -1 --format=%h main -- "$PLAN" 2>/dev/null || echo "(unmerged)")
-    PLAN_DATE=$(git log -1 --format=%cs main -- "$PLAN" 2>/dev/null || date +%Y-%m-%d)
+    PLAN_SHA=$(git log -1 --format=%h main -- "$PLAN" 2>/dev/null || true)
+    PLAN_SHA=${PLAN_SHA:-(unmerged)}
+    PLAN_DATE=$(git log -1 --format=%cs main -- "$PLAN" 2>/dev/null || true)
+    PLAN_DATE=${PLAN_DATE:-$(date +%Y-%m-%d)}
+
 
     BANNER=$(sed -e "s|\${ISSUE_NUM}|${ISSUE}|g" \
                  -e "s|\${PLAN_PATH}|${PLAN}|g" \


### PR DESCRIPTION
## What this is

A new `just prime-issue <N>` recipe + `.github/issue-banner-template.md` to programmatically upsert the locked-plan execution banner on any GitHub Issue.

## Why

`just work-on <N>` (the Multiclaude dispatch recipe at `justfile:817-825`) reads only the issue's **title + body** — not comments — to construct the worker prompt. Issue-comment guidance never reaches the worker. So the banner is the *only* place locked-plan context can live for it to be useful at dispatch.

Recent precedent: **PR #567** (off-plan Gemini PR) violated **Locks 1 + 4** from the merged #563 design RFC (used gRPC-to-M3 instead of in-Rust validation; used Monaco instead of CodeMirror 6). The locked-plan reference and Lock summaries were in an issue *comment* (`comment-4514647967` on #435), not the body — so the worker dispatch had no signal about the constraints.

Hand-curated banners drift; a recipe doesn't.

## How

```bash
just prime-issue 436
```

1. **Discovers the plan** by greping `docs/superpowers/plans/*.md` for `(Refs|Closes|Issue:?)\s*#436\b`
2. **Reads plan metadata** from `git log -1 --format=%h main -- $PLAN` (last-touched SHA + date)
3. **Substitutes** `${ISSUE_NUM}`, `${PLAN_PATH}`, `${PLAN_SHA}`, `${PLAN_DATE}` into `.github/issue-banner-template.md`
4. **Strips any prior banner** (regex over the `<!-- EXEC-BANNER:START -->…<!-- EXEC-BANNER:END -->` markers + optional trailing `---` separator)
5. **Rewrites** the issue body with `gh issue edit` so the banner precedes the original spec

Idempotent: re-running rewrites in place rather than appending.

## Demonstration on real issues

Both #435 and #436 have been re-primed with this recipe:

| Issue | Before | After |
|---|---|---|
| #435 | 5,221 bytes (had a pre-marker hand-authored banner — *cleaned then re-primed*) | 2,761 bytes |
| #436 | 5,036 bytes (had marker-delimited hand-authored banner with Lock-violation table) | 2,723 bytes |

The two issues now have **symmetric** body sizes — generic banner + their original spec. The Lock-specific risks (Monaco / gRPC violations etc.) intentionally **no longer live in the body** — they live in the plan docs where they belong. The banner points readers at the plan; the plan owns the specifics.

## Trade-offs

| Choice | Why |
|---|---|
| Manual `just` recipe, not GH Action | No new perms/secrets; mirrors existing `just work-on`/`just evening` patterns. GH Action on plan-PR-merge can come later if friction warrants. |
| Generic template (no per-issue risk callouts) | Issue-specific guidance lives in the plan doc's Locks section. Single source of truth. Re-priming is then safe. |
| Python one-liner for banner-stripping | `just` parses recipe bodies and requires consistent indentation on every line — multi-line embedded scripts at column 0 break the parser. One-liner sidesteps. Documented inline in the recipe. |
| Markers `<!-- EXEC-BANNER:START/END -->` | Same pattern the repo uses for `<!-- ECC:SUMMARY -->` blocks in session memory + `# Recent` blocks in `.remember/`. |

## Testing

- ✅ `just prime-issue 99999` (bogus, no plan exists) → exits 1 with `✗ No plan in docs/superpowers/plans/ references #99999` + hint
- ✅ `just prime-issue 435` → finds `2026-05-18-adr-026-phase-2-metricql.md` (sha `c9bb89c`), rewrites body
- ✅ `just prime-issue 436` → finds `2026-05-22-adr-026-phase-2-m5-m6.md` (sha `40c4b64`), rewrites body
- ✅ Idempotent: re-running `prime-issue 436` produces the same body bytes (no banner stacking)
- ✅ `just --list` parses cleanly; inline help reads "Upsert the locked-plan execution banner on a GitHub Issue."

## Future work (intentionally out of scope)

| Item | When |
|---|---|
| GitHub Action on `pull_request.merged` over `docs/superpowers/plans/**` that auto-runs `prime-issue` for referenced issues | After this recipe proves the priming UX is right |
| Plan-resident `## ⚠️ Common pitfalls` section the recipe greps + inlines under the banner | If losing per-issue risk callouts proves friction-heavy in practice |
| Issue templates at `.github/ISSUE_TEMPLATE/` that pre-reserve the EXEC-BANNER block | Complements this; not required since the recipe always rewrites |

## Files

```
.github/issue-banner-template.md   (new, 22 lines)
justfile                            (+55 lines: prime-issue recipe before work-on)
```

No proto, no Rust, no UI changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->