### PR TITLE
🎨 Palette: Standardize page structure to prevent layout shifts

### DIFF
--- a/ui/src/__tests__/portfolio-dashboard.test.tsx
+++ b/ui/src/__tests__/portfolio-dashboard.test.tsx
@@ -42,8 +42,9 @@ vi.mock('next/dynamic', () => ({
 
 async function renderAndWait() {
   render(<PortfolioDashboard />);
+  // Wait for the table to appear, confirming data is loaded
   await waitFor(() => {
-    expect(screen.getByRole('heading', { name: 'Portfolio Dashboard', level: 1 })).toBeInTheDocument();
+    expect(screen.getByTestId('portfolio-table')).toBeInTheDocument();
   });
 }
 

--- a/ui/src/__tests__/sprint-5-4-ui.test.tsx
+++ b/ui/src/__tests__/sprint-5-4-ui.test.tsx
@@ -391,8 +391,8 @@ describe('Portfolio Dashboard — Sprint 5.4 charts', () => {
     render(<PortfolioDashboard />);
     // Should still render the page with the allocation data
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Portfolio Dashboard', level: 1 })).toBeInTheDocument();
+      expect(screen.getByTestId('portfolio-table')).toBeInTheDocument();
     });
-    expect(screen.getByTestId('portfolio-table')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Portfolio Dashboard', level: 1 })).toBeInTheDocument();
   });
 });

--- a/ui/src/__tests__/sprint-5-4-ui.test.tsx
+++ b/ui/src/__tests__/sprint-5-4-ui.test.tsx
@@ -330,11 +330,13 @@ vi.mock('next/dynamic', () => ({
 import PortfolioDashboard from '@/app/portfolio/page';
 
 describe('Portfolio Dashboard — Sprint 5.4 charts', () => {
-  it('renders page heading', async () => {
+  it('renders page heading and content', async () => {
     render(<PortfolioDashboard />);
+    // Header is immediate, but wait for content to ensure data loaded
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Portfolio Dashboard', level: 1 })).toBeInTheDocument();
+      expect(screen.getByTestId('portfolio-table')).toBeInTheDocument();
     });
+    expect(screen.getByRole('heading', { name: 'Portfolio Dashboard', level: 1 })).toBeInTheDocument();
   });
 
   it('renders the budget allocation chart', async () => {

--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -76,34 +76,6 @@ export default function AuditLogPage() {
     return true;
   });
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
-        <span className="sr-only">Loading</span>
-      </div>
-    );
-  }
-
-  if (error) {
-    return <RetryableError message={error} onRetry={fetchData} context="audit log" />;
-  }
-
-  if (entries.length === 0) {
-    return (
-      <div>
-        <Breadcrumb items={[
-          { label: 'Experiments', href: '/' },
-          { label: 'Audit Log' },
-        ]} />
-        <h1 className="mb-6 text-2xl font-bold text-gray-900">Audit Log</h1>
-        <div className="py-12 text-center">
-          <p className="text-sm text-gray-500">No audit log entries found.</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div>
       <Breadcrumb items={[
@@ -113,68 +85,83 @@ export default function AuditLogPage() {
 
       <h1 className="mb-6 text-2xl font-bold text-gray-900">Audit Log</h1>
 
-      <AuditFilters
-        experimentQuery={experimentQuery}
-        onExperimentQueryChange={setExperimentQuery}
-        actionFilter={actionFilter}
-        onActionFilterChange={setActionFilter}
-        actorQuery={actorQuery}
-        onActorQueryChange={setActorQuery}
-        totalCount={entries.length}
-        filteredCount={filtered.length}
-        onClear={clearFilters}
-        hasActiveFilters={hasActiveFilters}
-      />
-
-      {filtered.length === 0 ? (
-        <div className="py-12 text-center" data-testid="no-filter-matches">
-          <p className="text-sm text-gray-500">No audit log entries match your filters.</p>
-          <button
-            onClick={clearFilters}
-            className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
-            data-testid="clear-filters-empty"
-          >
-            Clear filters
-          </button>
+      {loading ? (
+        <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+          <span className="sr-only">Loading</span>
+        </div>
+      ) : error ? (
+        <RetryableError message={error} onRetry={fetchData} context="audit log" />
+      ) : entries.length === 0 ? (
+        <div className="py-12 text-center">
+          <p className="text-sm text-gray-500">No audit log entries found.</p>
         </div>
       ) : (
         <>
-          <AuditLogTable entries={filtered} />
-          {nextPageToken && (
-            <div className="mt-4 flex justify-center">
+          <AuditFilters
+            experimentQuery={experimentQuery}
+            onExperimentQueryChange={setExperimentQuery}
+            actionFilter={actionFilter}
+            onActionFilterChange={setActionFilter}
+            actorQuery={actorQuery}
+            onActorQueryChange={setActorQuery}
+            totalCount={entries.length}
+            filteredCount={filtered.length}
+            onClear={clearFilters}
+            hasActiveFilters={hasActiveFilters}
+          />
+
+          {filtered.length === 0 ? (
+            <div className="py-12 text-center" data-testid="no-filter-matches">
+              <p className="text-sm text-gray-500">No audit log entries match your filters.</p>
               <button
-                onClick={loadMore}
-                disabled={loadingMore}
-                className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                data-testid="load-more-button"
+                onClick={clearFilters}
+                className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+                data-testid="clear-filters-empty"
               >
-                {loadingMore && (
-                  <svg
-                    className="h-4 w-4 animate-spin text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                    data-testid="load-more-spinner"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                )}
-                {loadingMore ? 'Loading...' : 'Load More'}
+                Clear filters
               </button>
             </div>
+          ) : (
+            <>
+              <AuditLogTable entries={filtered} />
+              {nextPageToken && (
+                <div className="mt-4 flex justify-center">
+                  <button
+                    onClick={loadMore}
+                    disabled={loadingMore}
+                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                    data-testid="load-more-button"
+                  >
+                    {loadingMore && (
+                      <svg
+                        className="h-4 w-4 animate-spin text-white"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                        data-testid="load-more-spinner"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                    )}
+                    {loadingMore ? 'Loading...' : 'Load More'}
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </>
       )}

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -339,19 +339,6 @@ function MetricBrowserContent() {
     return result;
   }, [metrics, typeFilter, search]);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
-        <span className="sr-only">Loading</span>
-      </div>
-    );
-  }
-
-  if (error) {
-    return <RetryableError message={error} onRetry={fetchData} context="metric definitions" />;
-  }
-
   const isEmpty = metrics.length === 0;
 
   return (
@@ -364,32 +351,41 @@ function MetricBrowserContent() {
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-gray-900">Metric Definitions</h1>
-          {!isEmpty && (
+          {!loading && !error && !isEmpty && (
             <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700" data-testid="metric-count">
               {filtered.length}
             </span>
           )}
         </div>
-        {canAtLeast('experimenter') ? (
-          <Link
-            href="/metrics/new"
-            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
-            data-testid="new-metric-button"
-          >
-            New Metric
-          </Link>
-        ) : (
-          <span
-            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
-            title={`Requires Experimenter role (you are ${ROLE_LABELS[user.role]})`}
-            data-testid="new-metric-disabled"
-          >
-            New Metric
-          </span>
+        {!loading && !error && (
+          canAtLeast('experimenter') ? (
+            <Link
+              href="/metrics/new"
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+              data-testid="new-metric-button"
+            >
+              New Metric
+            </Link>
+          ) : (
+            <span
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+              title={`Requires Experimenter role (you are ${ROLE_LABELS[user.role]})`}
+              data-testid="new-metric-disabled"
+            >
+              New Metric
+            </span>
+          )
         )}
       </div>
 
-      {isEmpty ? (
+      {loading ? (
+        <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+          <span className="sr-only">Loading</span>
+        </div>
+      ) : error ? (
+        <RetryableError message={error} onRetry={fetchData} context="metric definitions" />
+      ) : isEmpty ? (
         <div className="py-12 text-center" data-testid="empty-state">
           <p className="text-sm text-gray-500">No metric definitions found.</p>
           {canAtLeast('experimenter') && (

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -83,24 +83,43 @@ export default function ExperimentListPage() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
-        <span className="sr-only">Loading</span>
+  const filtered = filters.applyFilters(experiments);
+
+  return (
+    <div>
+      <Breadcrumb items={[{ label: 'Experiments' }]} />
+
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Experiments</h1>
+        {!loading && !error && experiments.length > 0 && (
+          canCreate ? (
+            <Link
+              href="/experiments/new"
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+              data-testid="new-experiment-link"
+            >
+              New Experiment
+            </Link>
+          ) : (
+            <span
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+              title={`Requires Experimenter role (you are ${ROLE_LABELS[user.role]})`}
+              data-testid="new-experiment-disabled"
+            >
+              New Experiment
+            </span>
+          )
+        )}
       </div>
-    );
-  }
 
-  if (error) {
-    return <RetryableError message={error} onRetry={fetchData} context="experiments" />;
-  }
-
-  if (experiments.length === 0) {
-    return (
-      <div>
-        <Breadcrumb items={[{ label: 'Experiments' }]} />
-        <h1 className="mb-6 text-2xl font-bold text-gray-900">Experiments</h1>
+      {loading ? (
+        <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+          <span className="sr-only">Loading</span>
+        </div>
+      ) : error ? (
+        <RetryableError message={error} onRetry={fetchData} context="experiments" />
+      ) : experiments.length === 0 ? (
         <div className="py-12 text-center" data-testid="empty-state">
           <p className="text-sm text-gray-500">No experiments yet.</p>
           {canCreate && (
@@ -115,37 +134,8 @@ export default function ExperimentListPage() {
             </div>
           )}
         </div>
-      </div>
-    );
-  }
-
-  const filtered = filters.applyFilters(experiments);
-
-  return (
-    <div>
-      <Breadcrumb items={[{ label: 'Experiments' }]} />
-
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Experiments</h1>
-        {canCreate ? (
-          <Link
-            href="/experiments/new"
-            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
-            data-testid="new-experiment-link"
-          >
-            New Experiment
-          </Link>
-        ) : (
-          <span
-            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
-            title={`Requires Experimenter role (you are ${ROLE_LABELS[user.role]})`}
-            data-testid="new-experiment-disabled"
-          >
-            New Experiment
-          </span>
-        )}
-      </div>
-
+      ) : (
+        <>
       <ExperimentFiltersToolbar
         filters={filters}
         totalCount={experiments.length}
@@ -211,6 +201,8 @@ export default function ExperimentListPage() {
             </tbody>
           </table>
         </div>
+      )}
+        </>
       )}
     </div>
   );

--- a/ui/src/app/portfolio/page.tsx
+++ b/ui/src/app/portfolio/page.tsx
@@ -104,19 +104,6 @@ export default function PortfolioDashboard() {
     fetchData();
   }, [fetchData]);
 
-  if (loading && !result) {
-    return (
-      <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
-        <span className="sr-only">Loading</span>
-      </div>
-    );
-  }
-
-  if (error && !result) {
-    return <RetryableError message={error} onRetry={fetchData} context="portfolio allocation data" />;
-  }
-
   const experiments = result?.experiments ?? [];
 
   return (
@@ -142,20 +129,29 @@ export default function PortfolioDashboard() {
         </Link>
       </div>
 
-      {loading && result && (
-        <div className="mb-4 flex items-center gap-2 text-sm text-gray-500" role="status">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-indigo-600" />
-          Refreshing…
+      {loading && !result ? (
+        <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-indigo-600" />
+          <span className="sr-only">Loading</span>
         </div>
-      )}
+      ) : error && !result ? (
+        <RetryableError message={error} onRetry={fetchData} context="portfolio allocation data" />
+      ) : (
+        <>
+          {loading && result && (
+            <div className="mb-4 flex items-center gap-2 text-sm text-gray-500" role="status">
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-indigo-600" />
+              Refreshing…
+            </div>
+          )}
 
-      {error && result && (
-        <div className="mb-4 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm text-yellow-800" role="alert">
-          {error}
-        </div>
-      )}
+          {error && result && (
+            <div className="mb-4 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm text-yellow-800" role="alert">
+              {error}
+            </div>
+          )}
 
-      <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-6">
         <section aria-labelledby="budget-chart-heading">
           <h2 id="budget-chart-heading" className="sr-only">Budget Allocation Chart</h2>
           <BudgetAllocationChart experiments={experiments} />
@@ -203,6 +199,8 @@ export default function PortfolioDashboard() {
         <p className="mt-4 text-xs text-gray-400" data-testid="computed-at">
           Data computed at: {new Date(result.computedAt).toLocaleString()}
         </p>
+      )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
This PR standardizes the layout pattern for main list and dashboard pages (Experiments, Metrics, Audit Log, and Portfolio) by ensuring that page headers (breadcrumbs and titles) are rendered immediately, even during loading or error states.

Key Improvements:
- **Reduced Layout Shifts:** By moving headers outside of conditional loading blocks, we prevent the "pop-in" effect when data loads, improving Cumulative Layout Shift (CLS).
- **Preserved Context:** Users retain spatial awareness and access to breadcrumbs/navigation even if a request is pending or fails.
- **Consistent UX:** All major platform pages now follow the same structural pattern for loading and error states.

Accessibility:
- Ensures the page heading and navigation are always available to assistive technologies regardless of data fetching status.
- Maintains a stable document outline.

---
*PR created automatically by Jules for task [3567414468082699185](https://jules.google.com/task/3567414468082699185) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->