### PR TITLE
🎨 Palette: Enhance RetryableError visual cues and accessibility

### DIFF
--- a/ui/src/components/retryable-error.tsx
+++ b/ui/src/components/retryable-error.tsx
@@ -10,21 +10,37 @@ export function RetryableError({ message, onRetry, context }: RetryableErrorProp
   return (
     <div
       role="alert"
-      className="rounded-md bg-red-50 border border-red-200 p-4"
+      className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-4"
       data-testid="retryable-error"
     >
-      <h3 className="text-sm font-semibold text-red-800">
-        {context ? `Failed to load ${context}` : 'Something went wrong'}
-      </h3>
-      <p className="mt-1 text-sm text-red-700">{message}</p>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="mt-3 rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700"
-        data-testid="retry-button"
-      >
-        Retry
-      </button>
+      <div className="flex-shrink-0">
+        <svg
+          className="h-5 w-5 text-red-400"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zM9 9a1 1 0 112 0v4a1 1 0 11-2 0V9zm1-3a1 1 0 100 2 1 1 0 000-2z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-red-800">
+          {context ? `Failed to load ${context}` : 'Something went wrong'}
+        </h3>
+        <p className="mt-1 text-sm text-red-700">{message}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+          data-testid="retry-button"
+        >
+          Retry
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This PR enhances the `RetryableError` component, which is used across the experimentation platform to handle data loading failures.

### 💡 What: The UX enhancement added
- **Visual Cues:** Added a semantic error icon (exclamation-circle) next to the error message.
- **Layout Improvement:** Used a flexbox layout (`flex items-start gap-3`) to ensure the icon and text are perfectly aligned.
- **Accessibility:** Added `focus-visible:ring-2 focus-visible:ring-red-500` to the "Retry" button, ensuring it is clearly identifiable when navigated via keyboard.

### 🎯 Why: The user problem it solves
Purely text-based error messages can be easily overlooked and are less accessible for users who rely on quick visual scanning. The lack of distinct focus styles on the "Retry" button made keyboard navigation difficult in error states.

### ♿ Accessibility: Any a11y improvements made
- **Keyboard Navigation:** The "Retry" button now has a high-contrast focus ring that only appears on keyboard focus.
- **Screen Readers:** The error icon is marked with `aria-hidden="true"` to avoid redundant announcements, as the text already conveys the error.
- **Semantic HTML:** Maintained the `role="alert"` for proper screen reader announcement of the error container.

Verified with Vitest suites for Experiments, Flags, Metrics, and Monitoring. Visual verification performed via Playwright.

---
*PR created automatically by Jules for task [5955925979741476734](https://jules.google.com/task/5955925979741476734) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->