### PR TITLE
🎨 Palette: Standardize RetryableError component

### DIFF
--- a/ui/src/components/retryable-error.tsx
+++ b/ui/src/components/retryable-error.tsx
@@ -10,21 +10,37 @@ export function RetryableError({ message, onRetry, context }: RetryableErrorProp
   return (
     <div
       role="alert"
-      className="rounded-md bg-red-50 border border-red-200 p-4"
+      className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-4"
       data-testid="retryable-error"
     >
-      <h3 className="text-sm font-semibold text-red-800">
-        {context ? `Failed to load ${context}` : 'Something went wrong'}
-      </h3>
-      <p className="mt-1 text-sm text-red-700">{message}</p>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="mt-3 rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700"
-        data-testid="retry-button"
-      >
-        Retry
-      </button>
+      <div className="flex-shrink-0 pt-0.5">
+        <svg
+          className="h-5 w-5 text-red-400"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+      <div className="flex-1 min-w-0">
+        <h3 className="text-sm font-semibold text-red-800">
+          {context ? `Failed to load ${context}` : 'Something went wrong'}
+        </h3>
+        <p className="mt-1 text-sm text-red-700">{message}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2"
+          data-testid="retry-button"
+        >
+          Retry
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
I've enhanced the `RetryableError` component to provide a better user experience when things go wrong.

### Changes Made:
- **Iconography**: Added a red exclamation icon to the error box, providing a clear visual cue that something requires attention.
- **Layout**: Switched to a flexbox layout (`flex items-start gap-3`). This ensures the icon stays aligned with the top of the message even if the error text spans multiple lines.
- **Accessibility**: Added a focus ring (`focus-visible:ring-2 focus-visible:ring-red-500`) to the "Retry" button. This is crucial for users navigating via keyboard, making it clear which element is currently focused.
- **Cleanliness**: The icon is marked as `aria-hidden="true"` so it doesn't clutter the experience for screen reader users, who already get the necessary information from the `role="alert"`.

I verified the changes by running `pnpm lint` and the relevant `vitest` suite (`chaos-resilience.test.tsx`), which uses this component extensively in its error recovery tests. All tests passed.

---
*PR created automatically by Jules for task [498440615212795677](https://jules.google.com/task/498440615212795677) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->