### PR TITLE
feat: enable live MetricQL linting on metric-creation form (Closes #571)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ gh issue view 42 --json body -q '.body' | multiclaude worker create "$(cat -)"
 | Module runbooks | `docs/runbooks/m4a-analysis.md`, `docs/runbooks/m4b-policy.md` |
 | Infra runbook (adding a Cloud Run service) | `docs/runbooks/gcp-compute-services.md` (registry pattern at `infra/pkg/gcp/services/`, established by #542 / PR #546) |
 | Operator runbook (creating M5 custom metrics) | `docs/runbooks/m5-metric-definitions.md` (Tier 1 types FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT; #434) |
+| Operator runbook (ADR-026 Phase 3 migration) | `docs/runbooks/adr-026-phase-3-migration.md` (scan + translate + shadow + apply workflow for legacy CUSTOM metrics; #437) |
 | Work tracking | GitHub Issues (Milestones = Sprints, Issues = Tasks) |
 | Claude Code settings | `.claude/settings.json` |
 | PR triage subagent | `.claude/agents/pr-triage.md` |

--- a/crates/experimentation-management/src/bin/custom_migrator.rs
+++ b/crates/experimentation-management/src/bin/custom_migrator.rs
@@ -7,8 +7,8 @@
 //! |-------------|---------------|----------------------------------------------------------|
 //! | `scan`      | Implemented   | Fetch all CUSTOM metrics from M5; write to JSON.         |
 //! | `translate` | Implemented   | Classify + translate scan output; write proposals JSON.  |
-//! | `shadow`    | Stub (Phase B)| Schedule shadow computations on M3; poll for 7d results. |
-//! | `apply`     | Stub (Phase C)| Apply APPROVED proposals via `M5::MigrateMetricDefinition`. |
+//! | `shadow`    | Implemented   | Schedule shadow computations on M3; poll until APPROVED. |
+//! | `apply`     | Implemented   | Apply APPROVED proposals via `M5::MigrateMetricDefinition`. |
 //!
 //! ## Migration workflow
 //!
@@ -19,25 +19,36 @@
 //! # Step 2 — classify + translate; review proposals.json and proposals.md.
 //! custom_migrator translate --report scan.json --output proposals.json --markdown proposals.md
 //!
-//! # Step 3 — (Phase B) schedule M3 shadow computations and poll for 7 days.
-//! custom_migrator shadow --proposals proposals.json --m3-addr http://localhost:50056
+//! # Step 3 — schedule M3 shadow computations and poll until APPROVED / budget exhausts.
+//! custom_migrator shadow --proposals proposals.json --m3-addr http://localhost:50056 \
+//!     --duration 7d --output shadow.json
 //!
-//! # Step 4 — (Phase C) apply APPROVED proposals after operator review.
-//! custom_migrator apply --proposals proposals.json --shadow-results shadow.json --confirm
+//! # Step 4a — preview the migrations without mutating M5.
+//! custom_migrator apply --shadow-results shadow.json --m5-addr http://localhost:50055 --dry-run
+//!
+//! # Step 4b — apply the APPROVED proposals after operator review.
+//! custom_migrator apply --shadow-results shadow.json --m5-addr http://localhost:50055 \
+//!     --operator alice@example.com --confirm
 //! ```
 
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use tracing::info;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
 
-use experimentation_management::migration::cli::translate_subcommand;
-use experimentation_proto::experimentation::common::v1::MetricType;
+use experimentation_management::migration::cli::{json_to_metric_definition, translate_subcommand};
+use experimentation_proto::experimentation::common::v1::{MetricDefinition, MetricType};
 use experimentation_proto::experimentation::management::v1::{
     experiment_management_service_client::ExperimentManagementServiceClient,
-    ListMetricDefinitionsRequest,
+    ListMetricDefinitionsRequest, MigrateMetricDefinitionRequest,
+};
+use experimentation_proto::experimentation::metrics::v1::{
+    metric_computation_service_client::MetricComputationServiceClient,
+    GetShadowResultsRequest, PromoteShadowResultRequest, ScheduleShadowComputationRequest,
 };
 
 // ---------------------------------------------------------------------------
@@ -95,9 +106,26 @@ enum Cmd {
         markdown: Option<PathBuf>,
     },
 
-    /// Schedule M3 shadow computations and poll for 7 days of results.
+    /// Schedule M3 shadow computations and poll until APPROVED / REJECTED.
     ///
-    /// **NOT YET IMPLEMENTED — requires ADR-026 Phase B (M3 shadow-run RPCs).**
+    /// Reads the proposals JSON produced by `translate`, filters to Tier 1
+    /// (FILTERED_MEAN / COMPOSITE / WINDOWED_COUNT) and Tier 2 (METRICQL)
+    /// entries, and for each one:
+    ///
+    ///   1. Calls M3 `ScheduleShadowComputation` with the candidate metric.
+    ///   2. Polls `PromoteShadowResult` on a cadence (default 60s, overridable
+    ///      via `CUSTOM_MIGRATOR_POLL_INTERVAL_SECS`) until the run reaches a
+    ///      terminal state (APPROVED / REJECTED) or `--duration` exhausts.
+    ///   3. Snapshots `days_within_tolerance` / `total_days` from
+    ///      `GetShadowResults` for the audit trail.
+    ///
+    /// The 7-consecutive-days-within-tolerance gate is enforced by M3 inside
+    /// `PromoteShadowResult` (see PR #580); the migrator does not double-check.
+    ///
+    /// Tier 3 entries are non-translatable and are not shadow-run.
+    ///
+    /// Writes the per-proposal outcomes as `ShadowOutput` JSON to `--output`,
+    /// which is the direct input to the `apply` subcommand.
     Shadow {
         /// Path to the proposals JSON produced by `custom_migrator translate`.
         #[arg(long)]
@@ -107,30 +135,73 @@ enum Cmd {
         #[arg(long)]
         m3_addr: String,
 
-        /// How long to poll for shadow results before giving up (e.g. "7d", "168h").
+        /// How long to poll for shadow results before giving up (e.g. "7d", "168h",
+        /// "30m", "60s"). Cannot be zero.
         #[arg(long, default_value = "7d")]
         duration: String,
+
+        /// Output path for the shadow-outcome JSON consumed by `apply`
+        /// (default: shadow.json).
+        #[arg(long, default_value = "shadow.json")]
+        output: PathBuf,
     },
 
     /// Apply APPROVED migration proposals to M5.
     ///
-    /// **NOT YET IMPLEMENTED — requires ADR-026 Phase C (M5 MigrateMetricDefinition RPC).**
+    /// Reads the `ShadowOutput` JSON produced by `custom_migrator shadow`,
+    /// filters to outcomes with `status == APPROVED` and a non-empty
+    /// `result_id`, and for each surviving outcome calls M5's
+    /// `MigrateMetricDefinition` RPC (ADR-026 Phase 3 — Lock L7 two-step apply).
+    ///
+    /// Operator workflow:
+    ///
+    ///   1. `--dry-run` first — prints the planned migrations as a table
+    ///      and exits 0 without mutating M5.
+    ///   2. `--confirm --operator <name>` — sequentially applies each
+    ///      APPROVED outcome via `MigrateMetricDefinition`. Per-outcome
+    ///      failures DO NOT abort the run (apply-as-much-as-possible)
+    ///      but DO drive the final exit code to 1.
+    ///
+    /// `--dry-run` and `--confirm` are mutually exclusive (one must be set).
+    ///
+    /// Exit codes: `0` (all OK / nothing to apply), `1` (at least one
+    /// migration failed), `2` (fatal — couldn't read input or connect to M5).
     Apply {
         /// Path to the proposals JSON produced by `custom_migrator translate`.
+        /// Kept for cross-reference / audit; the binding input is `--shadow-results`.
         #[arg(long)]
-        proposals: PathBuf,
+        proposals: Option<PathBuf>,
 
-        /// Path to the shadow-results JSON produced by `custom_migrator shadow`.
+        /// Path to the `ShadowOutput` JSON produced by `custom_migrator shadow`.
+        /// APPROVED outcomes here drive the migrations applied to M5.
         #[arg(long)]
         shadow_results: PathBuf,
 
-        /// Print what would be applied without making any changes.
+        /// gRPC address of the M5 management service (e.g. "http://localhost:50055").
+        #[arg(long)]
+        m5_addr: String,
+
+        /// Operator identifier written to M5's `metric_migrations` audit row
+        /// (e.g. user email or service id). REQUIRED when `--confirm` is set;
+        /// optional for `--dry-run`.
+        #[arg(long)]
+        operator: Option<String>,
+
+        /// Print the planned migrations as a table and exit without mutating M5.
+        /// Mutually exclusive with --confirm.
         #[arg(long, group = "mode")]
         dry_run: bool,
 
-        /// Actually apply the APPROVED proposals. Mutually exclusive with --dry-run.
+        /// Actually apply the APPROVED migrations. Requires --operator.
+        /// Mutually exclusive with --dry-run.
         #[arg(long, group = "mode")]
         confirm: bool,
+
+        /// Optional path for a sidecar audit JSON (`ApplyOutput`) capturing
+        /// per-outcome results. Defaults to `<shadow_results>.apply.json`
+        /// in `--confirm` mode; suppressed in `--dry-run` mode.
+        #[arg(long)]
+        output: Option<PathBuf>,
     },
 }
 
@@ -149,22 +220,70 @@ async fn main() {
 
     let cli = Cli::parse();
 
-    let result = match cli.cmd {
-        Cmd::Scan { m5_addr, output, page_size } => scan(&m5_addr, &output, page_size).await,
+    let exit_code = match cli.cmd {
+        Cmd::Scan { m5_addr, output, page_size } => {
+            run_or_log(scan(&m5_addr, &output, page_size).await)
+        }
         Cmd::Translate { report, output, markdown } => {
-            translate(&report, &output, markdown.as_deref()).await
+            run_or_log(translate(&report, &output, markdown.as_deref()).await)
         }
-        Cmd::Shadow { proposals, m3_addr, duration } => {
-            shadow_stub(&proposals, &m3_addr, &duration)
+        Cmd::Shadow { proposals, m3_addr, duration, output } => {
+            // The shadow subcommand owns its own exit-code semantics
+            // (0 = any APPROVED, 1 = none APPROVED, 2 = fatal). See
+            // `shadow_subcommand` for the contract.
+            match shadow_subcommand(&proposals, &m3_addr, &duration, &output).await {
+                Ok(code) => code,
+                Err(e) => {
+                    tracing::error!(error = %e, "{:#}", e);
+                    2
+                }
+            }
         }
-        Cmd::Apply { proposals, shadow_results, dry_run, confirm } => {
-            apply_stub(&proposals, &shadow_results, dry_run, confirm)
+        Cmd::Apply {
+            proposals,
+            shadow_results,
+            m5_addr,
+            operator,
+            dry_run,
+            confirm,
+            output,
+        } => {
+            // The apply subcommand owns its exit-code semantics (0 OK / 1
+            // per-outcome failures / 2 fatal). See `apply_subcommand` for
+            // the contract.
+            match apply_subcommand(
+                proposals.as_deref(),
+                &shadow_results,
+                &m5_addr,
+                operator.as_deref(),
+                dry_run,
+                confirm,
+                output.as_deref(),
+            )
+            .await
+            {
+                Ok(code) => code,
+                Err(e) => {
+                    tracing::error!(error = %e, "{:#}", e);
+                    2
+                }
+            }
         }
     };
 
-    if let Err(e) = result {
-        tracing::error!(error = %e, "{:#}", e);
-        std::process::exit(1);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+}
+
+/// Map a `Result<()>` to a process exit code, logging on failure.
+fn run_or_log(result: Result<()>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(e) => {
+            tracing::error!(error = %e, "{:#}", e);
+            1
+        }
     }
 }
 
@@ -338,62 +457,2420 @@ async fn translate(
 }
 
 // ---------------------------------------------------------------------------
-// shadow — stub (Phase B implements)
+// shadow — orchestrates M3 ScheduleShadowComputation / PromoteShadowResult
+// ---------------------------------------------------------------------------
+//
+// Locked-plan binding: L3 (Equivalence verification). The 7-consecutive-days
+// gate is enforced by M3 inside PromoteShadowResult (PR #580) — the migrator's
+// only job is to drive the schedule → poll → promote workflow and snapshot the
+// outcomes into the JSON that the apply subcommand (T3) consumes.
+
+/// Default polling interval between successive PromoteShadowResult calls.
+///
+/// Overridable via the `CUSTOM_MIGRATOR_POLL_INTERVAL_SECS` env var so
+/// integration tests can run with a sub-second cadence. The variable parses
+/// as a non-zero u64 number of seconds; invalid values fall back to the default
+/// with a warning.
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Environment variable that overrides `DEFAULT_POLL_INTERVAL`. Tests set this
+/// to a small value (e.g. "1") so the polling loop ticks quickly.
+const POLL_INTERVAL_ENV: &str = "CUSTOM_MIGRATOR_POLL_INTERVAL_SECS";
+
+/// Migrator-side status that means `ScheduleShadowComputation` itself failed
+/// (network / NotFound / etc.). Distinct from M3-side statuses (PENDING /
+/// RUNNING / APPROVED / REJECTED / FAILED) which are reported verbatim.
+const STATUS_SCHEDULING_FAILED: &str = "SCHEDULING_FAILED";
+
+// ---------------------------------------------------------------------------
+// ShadowOutput JSON shape — T3's apply subcommand consumes this directly
 // ---------------------------------------------------------------------------
 
-fn shadow_stub(proposals: &Path, m3_addr: &str, duration: &str) -> Result<()> {
-    eprintln!("ERROR: shadow-run not yet implemented in this release.");
-    eprintln!();
-    eprintln!(
-        "  proposals : {}",
-        proposals.display()
-    );
-    eprintln!("  m3-addr   : {m3_addr}");
-    eprintln!("  duration  : {duration}");
-    eprintln!();
-    eprintln!(
-        "Requires ADR-026 Phase 3 Task B \
-         (M3 ScheduleShadowComputation / GetShadowResults RPCs)."
-    );
-    eprintln!(
-        "See docs/adrs/026-custom-metrics-layer.md §Phase-B and \
-         the active plan in docs/superpowers/plans/."
-    );
-    std::process::exit(2);
+/// One outcome record per Tier-1/Tier-2 proposal that was shadow-run.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ShadowOutcome {
+    /// ID of the original CUSTOM metric being migrated.
+    pub original_metric_id: String,
+    /// `shadow_id` assigned by M3 (UUID). Empty when scheduling itself failed.
+    pub shadow_id: String,
+    /// `result_id` from `PromoteShadowResult` — non-empty only when status is
+    /// `APPROVED`. T3's apply subcommand feeds this into
+    /// `MigrateMetricDefinitionRequest.shadow_run_result_id`.
+    pub result_id: String,
+    /// Terminal status. One of: `APPROVED`, `REJECTED`, `PENDING`, `FAILED`
+    /// (M3-side), `SCHEDULING_FAILED` (migrator-side).
+    pub status: String,
+    /// Human-readable explanation. From `PromoteShadowResult.reason` for
+    /// M3-side statuses, or the migrator's own error message for
+    /// `SCHEDULING_FAILED` / budget-exhaust.
+    pub reason: String,
+    /// Snapshot of M3's `days_within_tolerance` at the time of the final
+    /// poll. Diagnostic only; the L3 gate is enforced by M3.
+    pub days_within_tolerance: i32,
+    /// Snapshot of M3's `total_days` at the time of the final poll.
+    pub total_days: i32,
+    /// The candidate `MetricDefinition` being shadowed, encoded via
+    /// `migration::report::metric_to_json` for round-trip with
+    /// `migration::cli::json_to_metric_definition`. Echoed here so the
+    /// `apply` subcommand does not have to re-load `proposals.json`.
+    pub candidate_metric: serde_json::Value,
+}
+
+/// Top-level shape of the shadow-output JSON file.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ShadowOutput {
+    /// RFC 3339 timestamp captured before the first scheduling call.
+    pub schedule_started_at: String,
+    /// RFC 3339 timestamp captured after writing the last outcome.
+    pub schedule_completed_at: String,
+    /// One entry per Tier-1/Tier-2 proposal. Tier-3 proposals from
+    /// `proposals.json` are skipped (logged at WARN) and absent here.
+    pub outcomes: Vec<ShadowOutcome>,
 }
 
 // ---------------------------------------------------------------------------
-// apply — stub (Phase C implements)
+// Shadow subcommand entry point
 // ---------------------------------------------------------------------------
 
-fn apply_stub(
-    proposals: &Path,
-    shadow_results: &Path,
+/// Run the shadow workflow against M3. Returns the process exit code:
+///
+///   * `0` — at least one outcome is APPROVED.
+///   * `1` — no APPROVED outcomes (all REJECTED / PENDING / FAILED /
+///     SCHEDULING_FAILED, or no Tier-1/Tier-2 proposals to run).
+///   * `2` — fatal error before writing the output (couldn't read proposals,
+///     couldn't connect to M3, etc.). Surface via `Err` so `main()` can log.
+async fn shadow_subcommand(
+    proposals_path: &Path,
+    m3_addr: &str,
+    duration_str: &str,
+    output_path: &Path,
+) -> Result<i32> {
+    info!(
+        proposals = %proposals_path.display(),
+        m3_addr,
+        duration = duration_str,
+        output = %output_path.display(),
+        "starting shadow-run workflow"
+    );
+
+    let budget = parse_duration(duration_str)
+        .with_context(|| format!("parsing --duration '{duration_str}'"))?;
+    let poll_interval = poll_interval_from_env();
+
+    // 1. Read proposals.json (produced by translate_subcommand).
+    let raw = std::fs::read_to_string(proposals_path)
+        .with_context(|| format!("reading proposals JSON from {}", proposals_path.display()))?;
+    let proposals_json: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing proposals JSON from {}", proposals_path.display()))?;
+
+    // 2. Filter to Tier 1 / Tier 2 (Tier 3 logged + skipped).
+    let candidates = extract_shadow_candidates(&proposals_json)?;
+    let total_candidates = candidates.len();
+    info!(total = total_candidates, "candidates to shadow-run");
+
+    if total_candidates == 0 {
+        warn!("no Tier-1/Tier-2 proposals found; writing empty ShadowOutput");
+    }
+
+    // 3. Connect to M3.
+    let mut client = MetricComputationServiceClient::connect(m3_addr.to_string())
+        .await
+        .with_context(|| format!("connecting to M3 at {m3_addr}"))?;
+
+    let schedule_started_at = rfc3339_now();
+    let mut outcomes = Vec::with_capacity(total_candidates);
+
+    // 4. Sequentially shadow each candidate. Operator-driven cadence is fine.
+    for cand in candidates {
+        let outcome = run_one_shadow(&mut client, cand, budget, poll_interval).await;
+        outcomes.push(outcome);
+    }
+
+    let schedule_completed_at = rfc3339_now();
+
+    // 5. Write the shadow output.
+    let out = ShadowOutput {
+        schedule_started_at,
+        schedule_completed_at,
+        outcomes,
+    };
+    let json = serde_json::to_string_pretty(&out)
+        .context("serializing ShadowOutput to JSON")?;
+    std::fs::write(output_path, json)
+        .with_context(|| format!("writing ShadowOutput to {}", output_path.display()))?;
+
+    // 6. Log a one-line summary per outcome and compute exit code.
+    let approved = log_summary(&out.outcomes);
+    info!(
+        total = out.outcomes.len(),
+        approved,
+        output = %output_path.display(),
+        "shadow-run complete"
+    );
+
+    // L3 contract: 0 if any APPROVED, 1 otherwise.
+    Ok(if approved > 0 { 0 } else { 1 })
+}
+
+// ---------------------------------------------------------------------------
+// Candidate extraction (proposals.json → Vec<ShadowCandidate>)
+// ---------------------------------------------------------------------------
+
+/// One Tier-1/Tier-2 proposal lined up for shadow-run.
+struct ShadowCandidate {
+    original_metric_id: String,
+    tier: String,
+    /// The proto MetricDefinition reconstructed from `proposals.json`.
+    candidate_metric: MetricDefinition,
+    /// The raw JSON encoding of the candidate (echoed into `ShadowOutcome`
+    /// without an extra serialization round-trip).
+    candidate_json: serde_json::Value,
+}
+
+/// Pull every Tier-1/Tier-2 entry out of `proposals.json` and reconstruct the
+/// candidate `MetricDefinition`. Tier-3 entries are logged at WARN and dropped.
+///
+/// `proposals.json` shape: `{"summary": {...}, "entries": [{ "original_metric_id",
+/// "tier", "reason", "proposal", "parse_error" }]}` (see
+/// `migration::report::render_json`).
+fn extract_shadow_candidates(value: &serde_json::Value) -> Result<Vec<ShadowCandidate>> {
+    let entries = value
+        .get("entries")
+        .and_then(|v| v.as_array())
+        .context("proposals JSON missing required `entries` array")?;
+
+    let mut candidates = Vec::new();
+    for entry in entries {
+        let original_metric_id = entry
+            .get("original_metric_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let tier = entry
+            .get("tier")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        if !is_shadow_eligible_tier(&tier) {
+            warn!(
+                original_metric_id = %original_metric_id,
+                tier = %tier,
+                "skipping non-Tier-1/Tier-2 proposal (Tier 3 stays CUSTOM)"
+            );
+            continue;
+        }
+
+        let proposal = entry
+            .get("proposal")
+            .filter(|v| !v.is_null())
+            .with_context(|| {
+                format!(
+                    "proposal field missing for {} (tier {})",
+                    original_metric_id, tier
+                )
+            })?;
+
+        let candidate_metric = json_to_metric_definition(proposal).with_context(|| {
+            format!("decoding candidate MetricDefinition for {}", original_metric_id)
+        })?;
+
+        candidates.push(ShadowCandidate {
+            original_metric_id,
+            tier,
+            candidate_metric,
+            candidate_json: proposal.clone(),
+        });
+    }
+    Ok(candidates)
+}
+
+/// Tier name from `proposals.json`. Tier 1 = FILTERED_MEAN / COMPOSITE /
+/// WINDOWED_COUNT, Tier 2 = METRICQL. Tier 3 = untranslatable.
+fn is_shadow_eligible_tier(tier: &str) -> bool {
+    matches!(
+        tier,
+        "tier1_filtered_mean"
+            | "tier1_composite"
+            | "tier1_windowed_count"
+            | "tier2_metricql"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Single-proposal shadow loop
+// ---------------------------------------------------------------------------
+
+/// Drive `ScheduleShadowComputation` → poll `PromoteShadowResult` → snapshot
+/// `GetShadowResults` for one candidate. Bounded by `budget` (wall-clock).
+async fn run_one_shadow(
+    client: &mut MetricComputationServiceClient<tonic::transport::Channel>,
+    cand: ShadowCandidate,
+    budget: Duration,
+    poll_interval: Duration,
+) -> ShadowOutcome {
+    let ShadowCandidate {
+        original_metric_id,
+        tier,
+        candidate_metric,
+        candidate_json,
+    } = cand;
+    info!(
+        original_metric_id = %original_metric_id,
+        tier = %tier,
+        "scheduling shadow computation"
+    );
+
+    // (a) ScheduleShadowComputation — capture shadow_id or fail this outcome.
+    let shadow_id = match client
+        .schedule_shadow_computation(ScheduleShadowComputationRequest {
+            original_metric_id: original_metric_id.clone(),
+            candidate_metric: Some(candidate_metric),
+        })
+        .await
+    {
+        Ok(resp) => resp.into_inner().shadow_id,
+        Err(status) => {
+            warn!(
+                original_metric_id = %original_metric_id,
+                code = ?status.code(),
+                message = %status.message(),
+                "ScheduleShadowComputation failed"
+            );
+            return ShadowOutcome {
+                original_metric_id,
+                shadow_id: String::new(),
+                result_id: String::new(),
+                status: STATUS_SCHEDULING_FAILED.to_string(),
+                reason: format!(
+                    "ScheduleShadowComputation failed ({:?}): {}",
+                    status.code(),
+                    status.message()
+                ),
+                days_within_tolerance: 0,
+                total_days: 0,
+                candidate_metric: candidate_json,
+            };
+        }
+    };
+
+    info!(
+        original_metric_id = %original_metric_id,
+        shadow_id = %shadow_id,
+        "shadow scheduled; polling for terminal status"
+    );
+
+    // (b) Poll PromoteShadowResult until terminal or budget exhausted.
+    let started = Instant::now();
+    let (status, result_id, reason) = poll_until_terminal(
+        client,
+        &shadow_id,
+        budget,
+        poll_interval,
+        started,
+    )
+    .await;
+
+    // (c) Snapshot diagnostic counters from GetShadowResults at the end.
+    let (days_within_tolerance, total_days) =
+        snapshot_progress(client, &shadow_id).await;
+
+    info!(
+        original_metric_id = %original_metric_id,
+        shadow_id = %shadow_id,
+        status = %status,
+        days_within_tolerance,
+        total_days,
+        "shadow run finished"
+    );
+
+    ShadowOutcome {
+        original_metric_id,
+        shadow_id,
+        result_id,
+        status,
+        reason,
+        days_within_tolerance,
+        total_days,
+        candidate_metric: candidate_json,
+    }
+}
+
+/// Call `PromoteShadowResult` on a cadence until M3 returns APPROVED /
+/// REJECTED or the wall-clock budget exhausts. Returns `(status, result_id,
+/// reason)`.
+///
+/// `PENDING` means "M3 has not yet collected 7 days of within-tolerance data";
+/// we just wait. `result_id` is empty unless `status == APPROVED`.
+async fn poll_until_terminal(
+    client: &mut MetricComputationServiceClient<tonic::transport::Channel>,
+    shadow_id: &str,
+    budget: Duration,
+    poll_interval: Duration,
+    started: Instant,
+) -> (String, String, String) {
+    loop {
+        match client
+            .promote_shadow_result(PromoteShadowResultRequest {
+                shadow_id: shadow_id.to_string(),
+            })
+            .await
+        {
+            Ok(resp) => {
+                let inner = resp.into_inner();
+                match inner.status.as_str() {
+                    "APPROVED" => {
+                        return (inner.status, inner.result_id, inner.reason);
+                    }
+                    "REJECTED" => {
+                        return (inner.status, String::new(), inner.reason);
+                    }
+                    "PENDING" => {
+                        // Fall through to sleep.
+                    }
+                    other => {
+                        // Unexpected M3-side status (FAILED, RUNNING leaking,
+                        // etc.) — surface verbatim and stop polling.
+                        return (
+                            other.to_string(),
+                            String::new(),
+                            inner.reason,
+                        );
+                    }
+                }
+            }
+            Err(status) => {
+                warn!(
+                    shadow_id,
+                    code = ?status.code(),
+                    message = %status.message(),
+                    "PromoteShadowResult returned an error; will retry until budget exhausts"
+                );
+            }
+        }
+
+        if started.elapsed() >= budget {
+            return (
+                "PENDING".to_string(),
+                String::new(),
+                format!(
+                    "budget exhausted before APPROVED/REJECTED ({}s of {}s elapsed)",
+                    started.elapsed().as_secs(),
+                    budget.as_secs(),
+                ),
+            );
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+/// Snapshot `days_within_tolerance` / `total_days` from `GetShadowResults`
+/// for the audit trail. Non-fatal — returns zeros on error.
+async fn snapshot_progress(
+    client: &mut MetricComputationServiceClient<tonic::transport::Channel>,
+    shadow_id: &str,
+) -> (i32, i32) {
+    match client
+        .get_shadow_results(GetShadowResultsRequest {
+            shadow_id: shadow_id.to_string(),
+        })
+        .await
+    {
+        Ok(resp) => {
+            let inner = resp.into_inner();
+            (inner.days_within_tolerance, inner.total_days)
+        }
+        Err(status) => {
+            warn!(
+                shadow_id,
+                code = ?status.code(),
+                message = %status.message(),
+                "GetShadowResults snapshot failed; using zeros"
+            );
+            (0, 0)
+        }
+    }
+}
+
+/// Log a one-line summary per outcome and return the count of APPROVED.
+fn log_summary(outcomes: &[ShadowOutcome]) -> usize {
+    let mut approved = 0usize;
+    for o in outcomes {
+        info!(
+            original_metric_id = %o.original_metric_id,
+            status = %o.status,
+            days_within_tolerance = o.days_within_tolerance,
+            total_days = o.total_days,
+            reason = %o.reason,
+            "outcome"
+        );
+        if o.status == "APPROVED" {
+            approved += 1;
+        }
+    }
+    approved
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: duration parsing, env override, RFC3339 timestamps
+// ---------------------------------------------------------------------------
+
+/// Parse a duration like "7d", "168h", "30m", or "60s" into a `Duration`.
+/// Returns an error for empty input, zero-magnitude values, or unrecognized
+/// suffixes. Intentionally narrow: this is an operator-facing CLI flag with
+/// a documented set of units, not a general-purpose parser.
+fn parse_duration(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        anyhow::bail!("empty duration");
+    }
+    let (num, unit) = s.split_at(
+        s.find(|c: char| !c.is_ascii_digit())
+            .with_context(|| format!("duration '{s}' has no unit suffix"))?,
+    );
+    let n: u64 = num
+        .parse()
+        .with_context(|| format!("invalid duration magnitude '{num}'"))?;
+    if n == 0 {
+        anyhow::bail!("duration must be > 0");
+    }
+    let secs = match unit {
+        "s" => n,
+        "m" => n.checked_mul(60).context("duration overflow")?,
+        "h" => n.checked_mul(3_600).context("duration overflow")?,
+        "d" => n.checked_mul(86_400).context("duration overflow")?,
+        other => anyhow::bail!(
+            "unrecognized duration unit '{other}' (expected one of s, m, h, d)"
+        ),
+    };
+    Ok(Duration::from_secs(secs))
+}
+
+/// Read the poll interval from `CUSTOM_MIGRATOR_POLL_INTERVAL_SECS`, falling
+/// back to `DEFAULT_POLL_INTERVAL`. Invalid / zero values are warned and
+/// replaced with the default.
+fn poll_interval_from_env() -> Duration {
+    match std::env::var(POLL_INTERVAL_ENV) {
+        Ok(s) => match s.parse::<u64>() {
+            Ok(n) if n > 0 => Duration::from_secs(n),
+            _ => {
+                warn!(
+                    env = POLL_INTERVAL_ENV,
+                    value = %s,
+                    "invalid value; using default poll interval"
+                );
+                DEFAULT_POLL_INTERVAL
+            }
+        },
+        Err(_) => DEFAULT_POLL_INTERVAL,
+    }
+}
+
+/// Current wall-clock time, formatted as RFC 3339. Used purely for audit
+/// metadata in `ShadowOutput`. `chrono` is already a workspace dep.
+fn rfc3339_now() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+// ---------------------------------------------------------------------------
+// apply — Lock L7 two-step apply (ADR-026 Phase 3 / #437)
+// ---------------------------------------------------------------------------
+//
+// Reads the ShadowOutput JSON produced by `shadow`, filters to APPROVED
+// outcomes, and calls M5's MigrateMetricDefinition for each one (added in
+// commit c259513). The handler re-validates the APPROVED state with M3
+// internally; we never bypass that gate.
+//
+// `--dry-run` prints a tabular plan without touching M5; `--confirm`
+// (paired with `--operator`) actually mutates and exits non-zero on any
+// per-outcome failure.
+
+/// One outcome record per APPROVED shadow result that the apply subcommand
+/// attempted to migrate. Written to the sidecar `ApplyOutput` JSON for the
+/// audit trail referenced by the operator runbook.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ApplyOutcome {
+    /// ID of the original CUSTOM metric being migrated.
+    pub original_metric_id: String,
+    /// ID of the replacement metric (echoed from
+    /// `MigrateMetricDefinitionResponse.new_metric_id`). Empty on failure.
+    pub new_metric_id: String,
+    /// `shadow_run_result_id` fed into MigrateMetricDefinition. Copied from
+    /// the input `ShadowOutcome.result_id` regardless of success.
+    pub shadow_run_result_id: String,
+    /// `metric_migrations.migration_id` returned by M5 on success. Empty on
+    /// failure.
+    pub migration_id: String,
+    /// RFC 3339 server-side timestamp from `MigrateMetricDefinitionResponse.
+    /// applied_at`. Empty on failure.
+    pub applied_at: String,
+    /// `OK` on success; otherwise the canonical tonic Code as a string
+    /// (`INVALID_ARGUMENT`, `FAILED_PRECONDITION`, `UNAVAILABLE`, ...).
+    pub status: String,
+    /// On success: empty. On failure: the verbatim Status message from M5.
+    pub error: String,
+}
+
+/// Top-level audit-JSON written next to the input shadow results in
+/// `--confirm` mode. Captures the operator, when the apply ran, and one row
+/// per APPROVED outcome that was attempted.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ApplyOutput {
+    /// RFC 3339 timestamp captured before the first MigrateMetricDefinition call.
+    pub apply_started_at: String,
+    /// RFC 3339 timestamp captured after the last outcome was processed.
+    pub apply_completed_at: String,
+    /// Operator identifier (from `--operator`) recorded for the audit trail.
+    pub operator: String,
+    /// Path to the input `--shadow-results` file (for cross-reference).
+    pub shadow_results_path: String,
+    /// One entry per APPROVED outcome that was attempted.
+    pub outcomes: Vec<ApplyOutcome>,
+    /// Convenience aggregates so a downstream consumer doesn't have to scan
+    /// the `outcomes` array. `total_attempted == succeeded + failed`.
+    pub total_attempted: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+}
+
+/// Run the apply workflow. Returns the process exit code:
+///
+///   * `0` — every APPROVED outcome was applied successfully (or there were
+///     no APPROVED outcomes to apply; this is treated as a no-op, not an
+///     error, since operators may run apply prophylactically).
+///   * `1` — at least one per-outcome MigrateMetricDefinition call failed.
+///     Successful migrations are still committed; the audit JSON captures
+///     which ones succeeded and which didn't.
+///   * `2` — fatal (couldn't read input JSON, couldn't connect to M5,
+///     --confirm without --operator). Surface via `Err` so `main()` logs.
+async fn apply_subcommand(
+    proposals_path: Option<&Path>,
+    shadow_results_path: &Path,
+    m5_addr: &str,
+    operator: Option<&str>,
     dry_run: bool,
     confirm: bool,
-) -> Result<()> {
-    eprintln!("ERROR: apply not yet implemented in this release.");
-    eprintln!();
-    eprintln!("  proposals      : {}", proposals.display());
-    eprintln!("  shadow-results : {}", shadow_results.display());
-    eprintln!("  --dry-run      : {dry_run}");
-    eprintln!("  --confirm      : {confirm}");
-    eprintln!();
-    eprintln!(
-        "Requires ADR-026 Phase 3 Task C \
-         (M5 MigrateMetricDefinition RPC + APPROVED approval gate)."
+    output_path: Option<&Path>,
+) -> Result<i32> {
+    info!(
+        proposals = ?proposals_path.map(|p| p.display().to_string()),
+        shadow_results = %shadow_results_path.display(),
+        m5_addr,
+        dry_run,
+        confirm,
+        "starting apply workflow"
     );
-    eprintln!(
-        "See docs/adrs/026-custom-metrics-layer.md §Phase-C and \
-         the active plan in docs/superpowers/plans/."
+
+    // (0) clap's group="mode" already enforces mutual exclusion; require one.
+    if !dry_run && !confirm {
+        anyhow::bail!(
+            "one of --dry-run or --confirm is required \
+             (--dry-run previews, --confirm mutates)"
+        );
+    }
+
+    // (0b) --confirm requires --operator. Without an operator the audit row
+    // would be ambiguous; refuse before opening any RPC channel.
+    if confirm && operator.map(str::trim).unwrap_or("").is_empty() {
+        anyhow::bail!(
+            "--operator is required when --confirm is set \
+             (the operator identifier is written to M5's metric_migrations \
+             audit row; refusing to apply with an empty operator)"
+        );
+    }
+
+    // (1) Read the ShadowOutput JSON.
+    let raw = std::fs::read_to_string(shadow_results_path).with_context(|| {
+        format!(
+            "reading shadow results JSON from {}",
+            shadow_results_path.display()
+        )
+    })?;
+    let shadow: ShadowOutput = serde_json::from_str(&raw).with_context(|| {
+        format!(
+            "parsing shadow results JSON from {}",
+            shadow_results_path.display()
+        )
+    })?;
+    info!(
+        total_outcomes = shadow.outcomes.len(),
+        "loaded ShadowOutput"
     );
-    eprintln!();
-    eprintln!(
-        "SAFETY NOTE: The apply subcommand is intentionally gated behind Phase C \
-         to ensure M5 performs a full re-validation (MetricLookup-backed cycle \
-         detection + store write) before any CUSTOM metric is irreversibly migrated. \
-         Never apply proposals with ad-hoc scripts; wait for Phase C."
+
+    // (2) Filter to APPROVED outcomes with a non-empty result_id, logging
+    // each skip by its status so the operator can see why everything that
+    // didn't run was excluded.
+    let (approved, skipped) = partition_outcomes(&shadow.outcomes);
+    log_skipped_outcomes(&skipped);
+
+    // (3) Short-circuit: nothing to apply is not an error.
+    if approved.is_empty() {
+        warn!(
+            "no APPROVED outcomes to apply (skipped={}); exiting 0",
+            skipped.len()
+        );
+        println!(
+            "No APPROVED outcomes to apply in {} (skipped {} non-APPROVED).",
+            shadow_results_path.display(),
+            skipped.len()
+        );
+        return Ok(0);
+    }
+
+    // (4) --dry-run: print plan and exit. Never connect to M5.
+    if dry_run {
+        print_dry_run_plan(&approved);
+        return Ok(0);
+    }
+
+    // (5) --confirm: connect to M5 and apply each APPROVED outcome.
+    let operator_str = operator
+        .expect("operator required for --confirm; checked above")
+        .trim()
+        .to_string();
+
+    let mut client = ExperimentManagementServiceClient::connect(m5_addr.to_string())
+        .await
+        .with_context(|| format!("connecting to M5 at {m5_addr}"))?;
+
+    let apply_started_at = rfc3339_now();
+    let mut outcomes: Vec<ApplyOutcome> = Vec::with_capacity(approved.len());
+    let mut succeeded: usize = 0;
+    let mut failed: usize = 0;
+
+    // Apply-as-much-as-possible: per-outcome failures don't abort the run
+    // (operators want partial progress to land), but DO drive exit code 1
+    // at the end so CI / wrappers can detect incomplete applies.
+    for cand in &approved {
+        let outcome = apply_one(&mut client, cand, &operator_str).await;
+        if outcome.status == "OK" {
+            succeeded += 1;
+            info!(
+                original_metric_id = %outcome.original_metric_id,
+                new_metric_id = %outcome.new_metric_id,
+                migration_id = %outcome.migration_id,
+                applied_at = %outcome.applied_at,
+                "migration applied"
+            );
+        } else {
+            failed += 1;
+            warn!(
+                original_metric_id = %outcome.original_metric_id,
+                shadow_run_result_id = %outcome.shadow_run_result_id,
+                status = %outcome.status,
+                error = %outcome.error,
+                "migration failed"
+            );
+        }
+        outcomes.push(outcome);
+    }
+
+    let apply_completed_at = rfc3339_now();
+
+    // (6) Write the sidecar audit JSON. Default to <shadow>.apply.json so
+    // operators don't have to remember to pass --output.
+    let audit_path = output_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| default_audit_path(shadow_results_path));
+    let total_attempted = outcomes.len();
+    let audit = ApplyOutput {
+        apply_started_at,
+        apply_completed_at,
+        operator: operator_str,
+        shadow_results_path: shadow_results_path.display().to_string(),
+        outcomes,
+        total_attempted,
+        succeeded,
+        failed,
+    };
+    let audit_json = serde_json::to_string_pretty(&audit)
+        .context("serializing ApplyOutput audit JSON")?;
+    std::fs::write(&audit_path, audit_json).with_context(|| {
+        format!("writing ApplyOutput audit JSON to {}", audit_path.display())
+    })?;
+
+    // (7) One-line summary and exit code.
+    println!(
+        "Applied {}/{} APPROVED outcomes ({} failed). Audit JSON: {}",
+        succeeded, total_attempted, failed, audit_path.display()
     );
-    std::process::exit(2);
+    info!(
+        succeeded,
+        failed,
+        total_attempted,
+        audit = %audit_path.display(),
+        "apply complete"
+    );
+
+    Ok(if failed > 0 { 1 } else { 0 })
 }
 
+/// Partition outcomes into `(approved, skipped)`. `approved` keeps only the
+/// outcomes that are safe to apply: `status == APPROVED` AND non-empty
+/// `result_id` (an APPROVED status without a result_id is malformed input —
+/// the shadow workflow only populates result_id on APPROVED, but defending
+/// here closes the gap if a hand-edited file ever shows up).
+fn partition_outcomes(
+    outcomes: &[ShadowOutcome],
+) -> (Vec<ShadowOutcome>, Vec<ShadowOutcome>) {
+    let mut approved = Vec::new();
+    let mut skipped = Vec::new();
+    for o in outcomes {
+        if o.status == "APPROVED" && !o.result_id.is_empty() {
+            approved.push(o.clone());
+        } else {
+            skipped.push(o.clone());
+        }
+    }
+    (approved, skipped)
+}
+
+/// Log each skipped outcome at WARN with its status, so the operator can
+/// see what was excluded and why without having to grep the input JSON.
+fn log_skipped_outcomes(skipped: &[ShadowOutcome]) {
+    for o in skipped {
+        if o.status == "APPROVED" {
+            // APPROVED but empty result_id — input malformed; flag loudly.
+            warn!(
+                original_metric_id = %o.original_metric_id,
+                "skipping outcome: APPROVED status but empty result_id (malformed input)"
+            );
+        } else {
+            info!(
+                original_metric_id = %o.original_metric_id,
+                status = %o.status,
+                reason = %o.reason,
+                "skipping non-APPROVED outcome"
+            );
+        }
+    }
+}
+
+/// Print the planned migrations as a simple pipe-separated table. Operators
+/// run `--dry-run` first; the output is meant to be human-skimmable, not
+/// machine-parseable (the sidecar JSON is the machine-readable artifact).
+fn print_dry_run_plan(approved: &[ShadowOutcome]) {
+    println!("DRY RUN — would apply {} APPROVED migration(s):", approved.len());
+    println!(
+        "  {:<32} | {:<32} | {:<14} | {:<36} | {:<6}",
+        "old_metric_id", "new_metric_id", "type", "shadow_run_result_id", "days"
+    );
+    println!(
+        "  {:-<32}-+-{:-<32}-+-{:-<14}-+-{:-<36}-+-{:-<6}",
+        "", "", "", "", ""
+    );
+    for o in approved {
+        let new_id = o
+            .candidate_metric
+            .get("metric_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let type_label = describe_candidate_type(&o.candidate_metric);
+        let days = if o.total_days > 0 {
+            format!("{}/{}", o.days_within_tolerance, o.total_days)
+        } else {
+            "-".to_string()
+        };
+        println!(
+            "  {:<32} | {:<32} | {:<14} | {:<36} | {:<6}",
+            o.original_metric_id, new_id, type_label, o.result_id, days
+        );
+    }
+    println!();
+    println!("DRY RUN — no migrations applied. Re-run with --confirm --operator <name> to apply.");
+}
+
+/// Human-readable label for the candidate metric's type, derived from the
+/// echoed `candidate_metric` JSON (which is in `migration::report::metric_to_json`
+/// shape — keys are `filtered_mean` / `composite` / `windowed_count` /
+/// `metricql_expression` / `custom_sql`).
+fn describe_candidate_type(candidate: &serde_json::Value) -> String {
+    if candidate.get("filtered_mean").is_some() {
+        return "FILTERED_MEAN".to_string();
+    }
+    if candidate.get("composite").is_some() {
+        return "COMPOSITE".to_string();
+    }
+    if candidate.get("windowed_count").is_some() {
+        return "WINDOWED_COUNT".to_string();
+    }
+    if candidate
+        .get("metricql_expression")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+    {
+        return "METRICQL".to_string();
+    }
+    // Fall back to the numeric `type` field if it's present and recognised.
+    match candidate.get("type").and_then(|v| v.as_i64()) {
+        Some(1) => "MEAN".to_string(),
+        Some(2) => "RATIO".to_string(),
+        Some(3) => "PROPORTION".to_string(),
+        Some(4) => "COUNT".to_string(),
+        Some(5) => "RATE".to_string(),
+        Some(6) => "CUSTOM".to_string(),
+        Some(other) => format!("type={other}"),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Apply one APPROVED outcome via `MigrateMetricDefinition`. Returns an
+/// `ApplyOutcome` capturing success or failure verbatim — never panics, so
+/// the outer loop can continue with the next outcome.
+async fn apply_one(
+    client: &mut ExperimentManagementServiceClient<tonic::transport::Channel>,
+    outcome: &ShadowOutcome,
+    operator: &str,
+) -> ApplyOutcome {
+    // (a) Re-decode the candidate MetricDefinition from the echoed JSON. We
+    // intentionally use the same helper as the shadow subcommand
+    // (`json_to_metric_definition`) so this round-trips with the JSON shape
+    // written by `metric_to_json`. A decode failure here is a malformed
+    // ShadowOutput input — we surface it as InvalidArgument-style failure
+    // for this outcome rather than aborting the whole apply run.
+    let new_metric = match json_to_metric_definition(&outcome.candidate_metric) {
+        Ok(m) => m,
+        Err(e) => {
+            return ApplyOutcome {
+                original_metric_id: outcome.original_metric_id.clone(),
+                new_metric_id: String::new(),
+                shadow_run_result_id: outcome.result_id.clone(),
+                migration_id: String::new(),
+                applied_at: String::new(),
+                status: "INVALID_INPUT".to_string(),
+                error: format!("decoding candidate_metric: {e:#}"),
+            };
+        }
+    };
+
+    // (b) Build and send the request.
+    let req = MigrateMetricDefinitionRequest {
+        old_metric_id: outcome.original_metric_id.clone(),
+        new_metric: Some(new_metric),
+        shadow_run_result_id: outcome.result_id.clone(),
+        operator: operator.to_string(),
+    };
+
+    match client.migrate_metric_definition(req).await {
+        Ok(resp) => {
+            let inner = resp.into_inner();
+            ApplyOutcome {
+                original_metric_id: outcome.original_metric_id.clone(),
+                new_metric_id: inner.new_metric_id,
+                shadow_run_result_id: outcome.result_id.clone(),
+                migration_id: inner.migration_id,
+                applied_at: inner.applied_at,
+                status: "OK".to_string(),
+                error: String::new(),
+            }
+        }
+        Err(status) => ApplyOutcome {
+            original_metric_id: outcome.original_metric_id.clone(),
+            new_metric_id: String::new(),
+            shadow_run_result_id: outcome.result_id.clone(),
+            migration_id: String::new(),
+            applied_at: String::new(),
+            status: format!("{:?}", status.code()).to_uppercase(),
+            error: status.message().to_string(),
+        },
+    }
+}
+
+/// Default sidecar audit path: `<shadow>.apply.json`. Mirrors the convention
+/// `<shadow>.apply.json` referenced in the operator runbook.
+fn default_audit_path(shadow_results_path: &Path) -> PathBuf {
+    let mut s = shadow_results_path.as_os_str().to_owned();
+    s.push(".apply.json");
+    PathBuf::from(s)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::Mutex;
+
+    use tokio::net::TcpListener;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::Server;
+    use tonic::{Code, Request, Response, Status};
+
+    use experimentation_proto::experimentation::metrics::v1::{
+        metric_computation_service_server::{
+            MetricComputationService, MetricComputationServiceServer,
+        },
+        CompileMetricqlPreviewRequest, CompileMetricqlPreviewResponse,
+        ComputeGuardrailMetricsRequest, ComputeMetricsRequest, ComputeMetricsResponse,
+        ExportNotebookRequest, ExportNotebookResponse, GetQueryLogRequest, GetQueryLogResponse,
+        GetShadowResultsResponse, PromoteShadowResultResponse,
+        ScheduleShadowComputationResponse,
+    };
+
+    // -----------------------------------------------------------------------
+    // Pure-function unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_duration_accepts_seconds_minutes_hours_days() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7_200));
+        assert_eq!(parse_duration("7d").unwrap(), Duration::from_secs(604_800));
+    }
+
+    #[test]
+    fn parse_duration_rejects_empty_zero_and_unknown_units() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("0s").is_err(), "zero must be rejected");
+        assert!(parse_duration("0d").is_err());
+        assert!(parse_duration("10x").is_err(), "unknown unit must be rejected");
+        assert!(parse_duration("abc").is_err(), "non-numeric prefix must fail");
+        assert!(parse_duration("10").is_err(), "missing unit suffix must fail");
+    }
+
+    #[test]
+    fn is_shadow_eligible_tier_accepts_tier1_and_tier2_only() {
+        assert!(is_shadow_eligible_tier("tier1_filtered_mean"));
+        assert!(is_shadow_eligible_tier("tier1_composite"));
+        assert!(is_shadow_eligible_tier("tier1_windowed_count"));
+        assert!(is_shadow_eligible_tier("tier2_metricql"));
+        assert!(!is_shadow_eligible_tier("tier3_untranslatable"));
+        assert!(!is_shadow_eligible_tier(""));
+        assert!(!is_shadow_eligible_tier("tier1_bogus"));
+    }
+
+    #[test]
+    fn log_summary_counts_only_approved() {
+        let outcomes = vec![
+            outcome("a", "APPROVED"),
+            outcome("b", "REJECTED"),
+            outcome("c", "PENDING"),
+            outcome("d", "APPROVED"),
+            outcome("e", "SCHEDULING_FAILED"),
+        ];
+        assert_eq!(log_summary(&outcomes), 2);
+    }
+
+    #[test]
+    fn extract_shadow_candidates_filters_tier3_and_preserves_proposals() {
+        let proposals_json = serde_json::json!({
+            "summary": { "total": 3 },
+            "entries": [
+                proposal_entry("m_fm", "tier1_filtered_mean", true),
+                proposal_entry("m_t3", "tier3_untranslatable", false),
+                proposal_entry("m_mql", "tier2_metricql", true),
+            ]
+        });
+
+        let candidates = extract_shadow_candidates(&proposals_json).unwrap();
+        let ids: Vec<&str> = candidates
+            .iter()
+            .map(|c| c.original_metric_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["m_fm", "m_mql"], "tier3 must be filtered out");
+
+        // candidate_json should be the same shape as the proposals' "proposal"
+        // field (so apply can re-decode with json_to_metric_definition).
+        let first = &candidates[0];
+        assert_eq!(
+            first.candidate_json.get("metric_id").and_then(|v| v.as_str()),
+            Some("m_fm")
+        );
+        // candidate_metric is the decoded proto MetricDefinition.
+        assert_eq!(first.candidate_metric.metric_id, "m_fm");
+    }
+
+    #[test]
+    fn extract_shadow_candidates_errors_on_missing_proposal_for_tier1() {
+        // Tier 1 entry with a null proposal would be malformed input; surface
+        // an error rather than silently dropping it.
+        let proposals_json = serde_json::json!({
+            "entries": [{
+                "original_metric_id": "broken",
+                "tier": "tier1_filtered_mean",
+                "reason": "x",
+                "proposal": null,
+                "parse_error": null
+            }]
+        });
+        assert!(extract_shadow_candidates(&proposals_json).is_err());
+    }
+
+    #[test]
+    fn extract_shadow_candidates_errors_on_missing_entries_array() {
+        let proposals_json = serde_json::json!({ "summary": { "total": 0 } });
+        assert!(extract_shadow_candidates(&proposals_json).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock M3 — programmable Schedule / Promote / GetResults responses
+    // -----------------------------------------------------------------------
+
+    /// Sequence of `PromoteShadowResultResponse` payloads to return per call,
+    /// keyed by shadow_id. Each Vec is consumed front-to-back; the final
+    /// element repeats if calls exceed the vec length (useful for PENDING
+    /// budget-exhaust). If a shadow_id has no entry, the mock returns
+    /// `PENDING` indefinitely.
+    type PromoteScript = HashMap<String, Vec<PromoteShadowResultResponse>>;
+
+    /// Per-shadow_id `GetShadowResults` snapshot used by `snapshot_progress`.
+    type GetResultsMap = HashMap<String, GetShadowResultsResponse>;
+
+    /// Behavior knob for `ScheduleShadowComputation`. The "next id" counter
+    /// hands out deterministic shadow_ids `s-1`, `s-2`, ... unless the test
+    /// has injected a forced-error code for a specific call number (1-based).
+    #[derive(Default)]
+    struct ScheduleBehavior {
+        /// Map from call ordinal (1-based) → tonic error code to return.
+        force_errors: HashMap<u32, (Code, String)>,
+        next_id: u32,
+    }
+
+    struct MockM3 {
+        schedule: Mutex<ScheduleBehavior>,
+        promote: Mutex<PromoteScript>,
+        get_results: Mutex<GetResultsMap>,
+        promote_call_count: Mutex<HashMap<String, u32>>,
+    }
+
+    #[tonic::async_trait]
+    impl MetricComputationService for MockM3 {
+        async fn schedule_shadow_computation(
+            &self,
+            req: Request<ScheduleShadowComputationRequest>,
+        ) -> Result<Response<ScheduleShadowComputationResponse>, Status> {
+            let mut sb = self.schedule.lock().unwrap();
+            sb.next_id += 1;
+            let call_num = sb.next_id;
+            if let Some((code, msg)) = sb.force_errors.remove(&call_num) {
+                return Err(Status::new(code, msg));
+            }
+            let _ = req.into_inner(); // intentionally ignore body in tests
+            let shadow_id = format!("s-{}", call_num);
+            Ok(Response::new(ScheduleShadowComputationResponse { shadow_id }))
+        }
+
+        async fn promote_shadow_result(
+            &self,
+            req: Request<PromoteShadowResultRequest>,
+        ) -> Result<Response<PromoteShadowResultResponse>, Status> {
+            let inner = req.into_inner();
+            let id = inner.shadow_id.clone();
+            let mut count = self.promote_call_count.lock().unwrap();
+            *count.entry(id.clone()).or_insert(0) += 1;
+            drop(count);
+
+            let mut script = self.promote.lock().unwrap();
+            if let Some(seq) = script.get_mut(&id) {
+                let resp = if seq.len() > 1 {
+                    seq.remove(0)
+                } else if let Some(last) = seq.first() {
+                    last.clone()
+                } else {
+                    pending_response("no script entries")
+                };
+                return Ok(Response::new(resp));
+            }
+            // Default: PENDING forever.
+            Ok(Response::new(pending_response("no script for this id")))
+        }
+
+        async fn get_shadow_results(
+            &self,
+            req: Request<GetShadowResultsRequest>,
+        ) -> Result<Response<GetShadowResultsResponse>, Status> {
+            let inner = req.into_inner();
+            let map = self.get_results.lock().unwrap();
+            if let Some(snapshot) = map.get(&inner.shadow_id) {
+                Ok(Response::new(snapshot.clone()))
+            } else {
+                Ok(Response::new(GetShadowResultsResponse {
+                    shadow_id: inner.shadow_id,
+                    status: "PENDING".into(),
+                    rows: vec![],
+                    days_within_tolerance: 0,
+                    total_days: 0,
+                }))
+            }
+        }
+
+        // ---- Stubs for the rest of the trait surface ----
+        // These mock-impl stubs live inside `#[cfg(test)] mod tests` and
+        // satisfy `MetricComputationService` so the test can mock just the
+        // shadow-run RPCs exercised by `apply`. The stub-marker CI check
+        // (scripts/check_stub_markers.py) is filename-based and can't see
+        // inside a `#[cfg(test)]` block; one `// stub-allow:` per method
+        // is the documented escape hatch.
+        async fn compute_metrics(
+            &self,
+            _req: Request<ComputeMetricsRequest>,
+        ) -> Result<Response<ComputeMetricsResponse>, Status> {
+            // stub-allow: tracked-in #437 (test-mock for MetricComputationService trait surface)
+            Err(Status::unimplemented("stub"))
+        }
+        async fn compute_guardrail_metrics(
+            &self,
+            _req: Request<ComputeGuardrailMetricsRequest>,
+        ) -> Result<Response<ComputeMetricsResponse>, Status> {
+            // stub-allow: tracked-in #437 (test-mock for MetricComputationService trait surface)
+            Err(Status::unimplemented("stub"))
+        }
+        async fn export_notebook(
+            &self,
+            _req: Request<ExportNotebookRequest>,
+        ) -> Result<Response<ExportNotebookResponse>, Status> {
+            // stub-allow: tracked-in #437 (test-mock for MetricComputationService trait surface)
+            Err(Status::unimplemented("stub"))
+        }
+        async fn get_query_log(
+            &self,
+            _req: Request<GetQueryLogRequest>,
+        ) -> Result<Response<GetQueryLogResponse>, Status> {
+            // stub-allow: tracked-in #437 (test-mock for MetricComputationService trait surface)
+            Err(Status::unimplemented("stub"))
+        }
+        async fn compile_metricql_preview(
+            &self,
+            _req: Request<CompileMetricqlPreviewRequest>,
+        ) -> Result<Response<CompileMetricqlPreviewResponse>, Status> {
+            // stub-allow: tracked-in #437 (test-mock for MetricComputationService trait surface)
+            Err(Status::unimplemented("stub"))
+        }
+    }
+
+    fn pending_response(reason: &str) -> PromoteShadowResultResponse {
+        PromoteShadowResultResponse {
+            result_id: String::new(),
+            status: "PENDING".into(),
+            reason: reason.into(),
+        }
+    }
+
+    /// Spawn a mock M3 listening on a random port. Returns the bound address
+    /// and a handle to the mock for test-side script mutation.
+    async fn spawn_mock_m3(mock: MockM3) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(MetricComputationServiceServer::new(mock))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .ok();
+        });
+        tokio::task::yield_now().await;
+        addr
+    }
+
+    // -----------------------------------------------------------------------
+    // Workflow tests with mock M3
+    // -----------------------------------------------------------------------
+
+    /// Build a proposals.json `Value` with one Tier-1 entry per id.
+    fn build_proposals(ids_and_tiers: &[(&str, &str)]) -> serde_json::Value {
+        let entries: Vec<serde_json::Value> = ids_and_tiers
+            .iter()
+            .map(|(id, tier)| {
+                proposal_entry(id, tier, !tier.starts_with("tier3_"))
+            })
+            .collect();
+        serde_json::json!({
+            "summary": { "total": entries.len() },
+            "entries": entries,
+        })
+    }
+
+    /// Construct a proposals.json entry with a minimal proposal payload that
+    /// `json_to_metric_definition` can decode. For Tier-3 entries
+    /// `with_proposal=false` drops the proposal field (matches real shape).
+    fn proposal_entry(
+        metric_id: &str,
+        tier: &str,
+        with_proposal: bool,
+    ) -> serde_json::Value {
+        if with_proposal {
+            serde_json::json!({
+                "original_metric_id": metric_id,
+                "tier": tier,
+                "reason": format!("test reason for {}", metric_id),
+                "proposal": {
+                    "metric_id": metric_id,
+                    "name": format!("{} name", metric_id),
+                    "type": 1
+                },
+                "parse_error": null,
+            })
+        } else {
+            serde_json::json!({
+                "original_metric_id": metric_id,
+                "tier": tier,
+                "reason": "tier3 reason",
+                "proposal": null,
+                "parse_error": "parse failed",
+            })
+        }
+    }
+
+    fn outcome(id: &str, status: &str) -> ShadowOutcome {
+        ShadowOutcome {
+            original_metric_id: id.to_string(),
+            shadow_id: format!("s-{}", id),
+            result_id: String::new(),
+            status: status.to_string(),
+            reason: String::new(),
+            days_within_tolerance: 0,
+            total_days: 0,
+            candidate_metric: serde_json::json!({}),
+        }
+    }
+
+    /// Build mock M3 state and a single proposals.json file in a temp dir.
+    async fn setup_workflow(
+        mock: MockM3,
+        proposals_value: serde_json::Value,
+    ) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf, String) {
+        let addr = spawn_mock_m3(mock).await;
+        let dir = tempfile::TempDir::new().unwrap();
+        let proposals_path = dir.path().join("proposals.json");
+        std::fs::write(
+            &proposals_path,
+            serde_json::to_string_pretty(&proposals_value).unwrap(),
+        )
+        .unwrap();
+        let output_path = dir.path().join("shadow.json");
+        (
+            dir,
+            proposals_path,
+            output_path,
+            format!("http://{addr}"),
+        )
+    }
+
+    /// Read+parse the shadow output file from disk.
+    fn read_shadow_output(path: &std::path::Path) -> ShadowOutput {
+        let raw = std::fs::read_to_string(path).unwrap();
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    /// Ensure the shadow workflow polls every second instead of every minute
+    /// so PENDING budgets drain in test time.
+    ///
+    /// Because environment variables are process-global, simultaneous tests
+    /// would race. We use a `OnceLock` to set the var exactly once for the
+    /// whole test binary — every test in this module then observes the same
+    /// (small) poll interval. This is safe because no test in this module
+    /// needs a *different* poll cadence.
+    fn ensure_fast_polling() {
+        use std::sync::OnceLock;
+        static INIT: OnceLock<()> = OnceLock::new();
+        INIT.get_or_init(|| {
+            // SAFETY: set_var happens before any thread reads
+            // POLL_INTERVAL_ENV (poll_interval_from_env is only invoked
+            // inside shadow_subcommand, which test bodies call after this).
+            std::env::set_var(POLL_INTERVAL_ENV, "1");
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn happy_path_two_proposals_both_approved() {
+        ensure_fast_polling();
+
+        let mut promote = PromoteScript::new();
+        promote.insert(
+            "s-1".to_string(),
+            vec![PromoteShadowResultResponse {
+                result_id: "s-1".into(),
+                status: "APPROVED".into(),
+                reason: String::new(),
+            }],
+        );
+        promote.insert(
+            "s-2".to_string(),
+            vec![PromoteShadowResultResponse {
+                result_id: "s-2".into(),
+                status: "APPROVED".into(),
+                reason: String::new(),
+            }],
+        );
+
+        let mut get_results = GetResultsMap::new();
+        get_results.insert(
+            "s-1".to_string(),
+            GetShadowResultsResponse {
+                shadow_id: "s-1".into(),
+                status: "APPROVED".into(),
+                rows: vec![],
+                days_within_tolerance: 7,
+                total_days: 7,
+            },
+        );
+        get_results.insert(
+            "s-2".to_string(),
+            GetShadowResultsResponse {
+                shadow_id: "s-2".into(),
+                status: "APPROVED".into(),
+                rows: vec![],
+                days_within_tolerance: 7,
+                total_days: 7,
+            },
+        );
+
+        let mock = MockM3 {
+            schedule: Mutex::new(ScheduleBehavior::default()),
+            promote: Mutex::new(promote),
+            get_results: Mutex::new(get_results),
+            promote_call_count: Mutex::new(HashMap::new()),
+        };
+
+        let proposals = build_proposals(&[
+            ("m_a", "tier1_filtered_mean"),
+            ("m_b", "tier2_metricql"),
+        ]);
+        let (_dir, proposals_path, output_path, m3_url) =
+            setup_workflow(mock, proposals).await;
+
+        let exit_code = shadow_subcommand(&proposals_path, &m3_url, "30s", &output_path)
+            .await
+            .unwrap();
+        assert_eq!(exit_code, 0, "any APPROVED should yield exit code 0");
+
+        let out = read_shadow_output(&output_path);
+        assert_eq!(out.outcomes.len(), 2);
+        for o in &out.outcomes {
+            assert_eq!(o.status, "APPROVED");
+            assert!(!o.result_id.is_empty(), "APPROVED outcomes must carry result_id");
+            assert_eq!(o.days_within_tolerance, 7);
+            assert_eq!(o.total_days, 7);
+        }
+        // candidate_metric round-trips back to a MetricDefinition without panic.
+        for o in &out.outcomes {
+            let m = json_to_metric_definition(&o.candidate_metric).unwrap();
+            assert_eq!(m.metric_id, o.original_metric_id);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejected_outcome_propagates_reason_and_empty_result_id() {
+        ensure_fast_polling();
+
+        let mut promote = PromoteScript::new();
+        promote.insert(
+            "s-1".to_string(),
+            vec![PromoteShadowResultResponse {
+                result_id: String::new(),
+                status: "REJECTED".into(),
+                reason: "diff_abs exceeded tolerance on day 4".into(),
+            }],
+        );
+
+        let mock = MockM3 {
+            schedule: Mutex::new(ScheduleBehavior::default()),
+            promote: Mutex::new(promote),
+            get_results: Mutex::new(GetResultsMap::new()),
+            promote_call_count: Mutex::new(HashMap::new()),
+        };
+
+        let proposals = build_proposals(&[("m_x", "tier1_composite")]);
+        let (_dir, proposals_path, output_path, m3_url) =
+            setup_workflow(mock, proposals).await;
+
+        let exit_code = shadow_subcommand(&proposals_path, &m3_url, "10s", &output_path)
+            .await
+            .unwrap();
+        assert_eq!(exit_code, 1, "no APPROVED => exit 1");
+
+        let out = read_shadow_output(&output_path);
+        assert_eq!(out.outcomes.len(), 1);
+        let o = &out.outcomes[0];
+        assert_eq!(o.status, "REJECTED");
+        assert!(o.result_id.is_empty(), "REJECTED must not carry result_id");
+        assert!(
+            o.reason.contains("diff_abs"),
+            "rejection reason should propagate; got: {}",
+            o.reason
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pending_outcome_when_budget_exhausts() {
+        ensure_fast_polling();
+
+        // No script entry => mock returns PENDING forever.
+        let mock = MockM3 {
+            schedule: Mutex::new(ScheduleBehavior::default()),
+            promote: Mutex::new(PromoteScript::new()),
+            get_results: Mutex::new(GetResultsMap::new()),
+            promote_call_count: Mutex::new(HashMap::new()),
+        };
+
+        let proposals = build_proposals(&[("m_p", "tier1_filtered_mean")]);
+        let (_dir, proposals_path, output_path, m3_url) =
+            setup_workflow(mock, proposals).await;
+
+        // Budget = 2s, poll cadence = 1s. Budget exhausts after a couple of
+        // polls.
+        let exit_code = shadow_subcommand(&proposals_path, &m3_url, "2s", &output_path)
+            .await
+            .unwrap();
+        assert_eq!(exit_code, 1, "no APPROVED => exit 1");
+
+        let out = read_shadow_output(&output_path);
+        assert_eq!(out.outcomes.len(), 1);
+        let o = &out.outcomes[0];
+        assert_eq!(o.status, "PENDING");
+        assert!(o.result_id.is_empty());
+        assert!(
+            o.reason.to_lowercase().contains("budget"),
+            "reason should mention budget; got: {}",
+            o.reason
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn scheduling_failure_is_recorded_but_does_not_abort_remaining_proposals() {
+        ensure_fast_polling();
+
+        // First Schedule call fails; second succeeds and is APPROVED.
+        let mut schedule_behavior = ScheduleBehavior::default();
+        schedule_behavior.force_errors.insert(
+            1,
+            (Code::Unavailable, "M3 ECONNREFUSED simulated".into()),
+        );
+
+        let mut promote = PromoteScript::new();
+        // The second Schedule call hands out shadow_id "s-2" (next_id=2).
+        promote.insert(
+            "s-2".to_string(),
+            vec![PromoteShadowResultResponse {
+                result_id: "s-2".into(),
+                status: "APPROVED".into(),
+                reason: String::new(),
+            }],
+        );
+
+        let mock = MockM3 {
+            schedule: Mutex::new(schedule_behavior),
+            promote: Mutex::new(promote),
+            get_results: Mutex::new(GetResultsMap::new()),
+            promote_call_count: Mutex::new(HashMap::new()),
+        };
+
+        let proposals = build_proposals(&[
+            ("m_fail", "tier1_filtered_mean"),
+            ("m_ok", "tier2_metricql"),
+        ]);
+        let (_dir, proposals_path, output_path, m3_url) =
+            setup_workflow(mock, proposals).await;
+
+        let exit_code = shadow_subcommand(&proposals_path, &m3_url, "10s", &output_path)
+            .await
+            .unwrap();
+        assert_eq!(exit_code, 0, "second proposal APPROVED => exit 0");
+
+        let out = read_shadow_output(&output_path);
+        assert_eq!(out.outcomes.len(), 2);
+
+        let failed = out.outcomes.iter().find(|o| o.original_metric_id == "m_fail").unwrap();
+        assert_eq!(failed.status, STATUS_SCHEDULING_FAILED);
+        assert!(failed.shadow_id.is_empty(), "no shadow_id when scheduling failed");
+        assert!(failed.result_id.is_empty());
+        assert!(
+            failed.reason.contains("ScheduleShadowComputation failed"),
+            "scheduling-failed reason should mention the RPC; got: {}",
+            failed.reason
+        );
+
+        let ok = out.outcomes.iter().find(|o| o.original_metric_id == "m_ok").unwrap();
+        assert_eq!(ok.status, "APPROVED");
+        assert_eq!(ok.result_id, "s-2");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tier3_proposals_are_skipped_with_warning() {
+        ensure_fast_polling();
+
+        // Only the Tier-1 entry gets a script entry; Tier-3 is dropped before
+        // any RPC call.
+        let mut promote = PromoteScript::new();
+        promote.insert(
+            "s-1".to_string(),
+            vec![PromoteShadowResultResponse {
+                result_id: "s-1".into(),
+                status: "APPROVED".into(),
+                reason: String::new(),
+            }],
+        );
+
+        let mock = MockM3 {
+            schedule: Mutex::new(ScheduleBehavior::default()),
+            promote: Mutex::new(promote),
+            get_results: Mutex::new(GetResultsMap::new()),
+            promote_call_count: Mutex::new(HashMap::new()),
+        };
+
+        let proposals = build_proposals(&[
+            ("m_keep", "tier1_filtered_mean"),
+            ("m_skip", "tier3_untranslatable"),
+        ]);
+        let (_dir, proposals_path, output_path, m3_url) =
+            setup_workflow(mock, proposals).await;
+
+        let exit_code = shadow_subcommand(&proposals_path, &m3_url, "10s", &output_path)
+            .await
+            .unwrap();
+        assert_eq!(exit_code, 0);
+
+        let out = read_shadow_output(&output_path);
+        assert_eq!(out.outcomes.len(), 1, "tier3 entry must not appear in outcomes");
+        let o = &out.outcomes[0];
+        assert_eq!(o.original_metric_id, "m_keep");
+        assert_eq!(o.status, "APPROVED");
+        // No outcome references the skipped id.
+        assert!(out
+            .outcomes
+            .iter()
+            .all(|o| o.original_metric_id != "m_skip"));
+    }
+
+    // -----------------------------------------------------------------------
+    // apply — pure-function unit tests
+    // -----------------------------------------------------------------------
+
+    fn approved_outcome(id: &str, result_id: &str) -> ShadowOutcome {
+        ShadowOutcome {
+            original_metric_id: id.to_string(),
+            shadow_id: format!("s-{}", id),
+            result_id: result_id.to_string(),
+            status: "APPROVED".to_string(),
+            reason: String::new(),
+            days_within_tolerance: 7,
+            total_days: 7,
+            // Minimal candidate_metric that round-trips through
+            // `json_to_metric_definition` — same shape `proposal_entry` uses.
+            candidate_metric: serde_json::json!({
+                "metric_id": format!("{}_v2", id),
+                "name": format!("{} v2", id),
+                "type": 1,
+            }),
+        }
+    }
+
+    #[test]
+    fn partition_outcomes_keeps_only_approved_with_result_id() {
+        let outcomes = vec![
+            approved_outcome("a", "uuid-a"),
+            outcome("b", "REJECTED"),
+            outcome("c", "PENDING"),
+            outcome("d", "SCHEDULING_FAILED"),
+            // APPROVED with empty result_id is malformed — must be skipped.
+            {
+                let mut o = approved_outcome("malformed", "");
+                o.result_id = String::new();
+                o
+            },
+        ];
+        let (approved, skipped) = partition_outcomes(&outcomes);
+        assert_eq!(approved.len(), 1, "only the valid APPROVED outcome survives");
+        assert_eq!(approved[0].original_metric_id, "a");
+        assert_eq!(skipped.len(), 4, "everything else is skipped");
+    }
+
+    #[test]
+    fn describe_candidate_type_handles_tier1_and_tier2() {
+        assert_eq!(
+            describe_candidate_type(&serde_json::json!({"filtered_mean": {}})),
+            "FILTERED_MEAN"
+        );
+        assert_eq!(
+            describe_candidate_type(&serde_json::json!({"composite": {}})),
+            "COMPOSITE"
+        );
+        assert_eq!(
+            describe_candidate_type(&serde_json::json!({"windowed_count": {}})),
+            "WINDOWED_COUNT"
+        );
+        assert_eq!(
+            describe_candidate_type(
+                &serde_json::json!({"metricql_expression": "mean(x.v)"})
+            ),
+            "METRICQL"
+        );
+        // Empty metricql_expression should NOT count as METRICQL — fall
+        // through to numeric `type`.
+        assert_eq!(
+            describe_candidate_type(
+                &serde_json::json!({"metricql_expression": "", "type": 1})
+            ),
+            "MEAN"
+        );
+        assert_eq!(
+            describe_candidate_type(&serde_json::json!({})),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn default_audit_path_appends_apply_json_suffix() {
+        assert_eq!(
+            default_audit_path(Path::new("shadow.json")),
+            PathBuf::from("shadow.json.apply.json")
+        );
+        assert_eq!(
+            default_audit_path(Path::new("/tmp/run-42/shadow.json")),
+            PathBuf::from("/tmp/run-42/shadow.json.apply.json")
+        );
+    }
+
+    #[test]
+    fn cli_rejects_dry_run_and_confirm_together() {
+        // clap's group="mode" enforces this at parse time. We verify by
+        // calling try_parse_from with both flags and asserting an error.
+        // (Cli doesn't derive Debug, so we match on `is_err` + render manually.)
+        let result = Cli::try_parse_from([
+            "custom_migrator",
+            "apply",
+            "--shadow-results", "/tmp/s.json",
+            "--m5-addr", "http://localhost:50055",
+            "--dry-run",
+            "--confirm",
+        ]);
+        let err = match result {
+            Ok(_) => panic!("--dry-run and --confirm must be mutually exclusive"),
+            Err(e) => e,
+        };
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("cannot be used with") || rendered.contains("mutually exclusive"),
+            "error should mention mutual exclusion; got: {rendered}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock M5 — programmable MigrateMetricDefinition responses
+    // -----------------------------------------------------------------------
+    //
+    // The mock implements the full `ExperimentManagementService` trait so it
+    // can back a real tonic server, but only `migrate_metric_definition`
+    // returns useful responses. The other 26 RPCs panic via `unimplemented`
+    // (we never call them from the apply path; any unexpected call is a
+    // test bug we want to surface loudly).
+
+    /// Programmed result for one MigrateMetricDefinition call. Tests push a
+    /// sequence into `MockM5.migrate_script`; the mock pops front-to-back.
+    /// If the script empties before a call, the mock returns `Code::Internal`
+    /// with a "no script entries" message — preserves the test's intent
+    /// (don't silently fall through to a meaningless Ok).
+    enum MigrateResult {
+        Ok {
+            new_metric_id: String,
+            migration_id: String,
+            applied_at: String,
+        },
+        Err(Code, String),
+    }
+
+    struct MockM5 {
+        migrate_script: Mutex<Vec<MigrateResult>>,
+        migrate_calls: Mutex<Vec<MigrateMetricDefinitionRequest>>,
+    }
+
+    impl MockM5 {
+        fn new(script: Vec<MigrateResult>) -> Self {
+            Self {
+                migrate_script: Mutex::new(script),
+                migrate_calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl experimentation_proto::experimentation::management::v1::experiment_management_service_server::ExperimentManagementService
+        for MockM5
+    {
+        async fn migrate_metric_definition(
+            &self,
+            request: Request<MigrateMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::MigrateMetricDefinitionResponse>, Status>
+        {
+            let req = request.into_inner();
+            self.migrate_calls.lock().unwrap().push(req.clone());
+            let mut script = self.migrate_script.lock().unwrap();
+            if script.is_empty() {
+                return Err(Status::new(
+                    Code::Internal,
+                    "MockM5 migrate_script exhausted",
+                ));
+            }
+            match script.remove(0) {
+                MigrateResult::Ok {
+                    new_metric_id,
+                    migration_id,
+                    applied_at,
+                } => Ok(Response::new(
+                    experimentation_proto::experimentation::management::v1::MigrateMetricDefinitionResponse {
+                        new_metric_id,
+                        migration_id,
+                        applied_at,
+                    },
+                )),
+                MigrateResult::Err(code, msg) => Err(Status::new(code, msg)),
+            }
+        }
+
+        // ---- Stubs for the rest of the trait surface ----
+        // We never call these from the apply workflow; any unexpected call
+        // is a test-design bug. `unimplemented!` panics with a clear message,
+        // which will fail the test loudly rather than silently returning
+        // bogus data.
+
+        async fn create_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::CreateExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: create_experiment")
+        }
+        async fn get_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::GetExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: get_experiment")
+        }
+        async fn update_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::UpdateExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: update_experiment")
+        }
+        async fn list_experiments(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::ListExperimentsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ListExperimentsResponse>, Status> {
+            unimplemented!("MockM5 stub: list_experiments")
+        }
+        async fn start_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::StartExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: start_experiment")
+        }
+        async fn conclude_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::ConcludeExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: conclude_experiment")
+        }
+        async fn archive_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::ArchiveExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: archive_experiment")
+        }
+        async fn pause_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::PauseExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: pause_experiment")
+        }
+        async fn resume_experiment(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::ResumeExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            unimplemented!("MockM5 stub: resume_experiment")
+        }
+        async fn create_metric_definition(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::CreateMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::MetricDefinition>, Status> {
+            unimplemented!("MockM5 stub: create_metric_definition")
+        }
+        async fn get_metric_definition(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::GetMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::MetricDefinition>, Status> {
+            unimplemented!("MockM5 stub: get_metric_definition")
+        }
+        async fn list_metric_definitions(
+            &self,
+            _r: Request<ListMetricDefinitionsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ListMetricDefinitionsResponse>, Status> {
+            unimplemented!("MockM5 stub: list_metric_definitions")
+        }
+        async fn create_layer(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::CreateLayerRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Layer>, Status> {
+            unimplemented!("MockM5 stub: create_layer")
+        }
+        async fn get_layer(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::GetLayerRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Layer>, Status> {
+            unimplemented!("MockM5 stub: get_layer")
+        }
+        async fn get_layer_allocations(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::GetLayerAllocationsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::GetLayerAllocationsResponse>, Status> {
+            unimplemented!("MockM5 stub: get_layer_allocations")
+        }
+        async fn create_targeting_rule(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::CreateTargetingRuleRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::TargetingRule>, Status> {
+            unimplemented!("MockM5 stub: create_targeting_rule")
+        }
+        async fn create_surrogate_model(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::CreateSurrogateModelRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::SurrogateModelConfig>, Status> {
+            unimplemented!("MockM5 stub: create_surrogate_model")
+        }
+        async fn list_surrogate_models(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::ListSurrogateModelsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ListSurrogateModelsResponse>, Status> {
+            unimplemented!("MockM5 stub: list_surrogate_models")
+        }
+        async fn get_surrogate_calibration(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::GetSurrogateCalibrationRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::SurrogateModelConfig>, Status> {
+            unimplemented!("MockM5 stub: get_surrogate_calibration")
+        }
+        async fn trigger_surrogate_recalibration(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::TriggerSurrogateRecalibrationRequest>,
+        ) -> Result<Response<()>, Status> {
+            unimplemented!("MockM5 stub: trigger_surrogate_recalibration")
+        }
+        type StreamConfigUpdatesStream = std::pin::Pin<
+            Box<
+                dyn tokio_stream::Stream<
+                        Item = Result<
+                            experimentation_proto::experimentation::management::v1::ConfigUpdateEvent,
+                            Status,
+                        >,
+                    > + Send,
+            >,
+        >;
+        async fn stream_config_updates(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::StreamConfigUpdatesRequest>,
+        ) -> Result<Response<Self::StreamConfigUpdatesStream>, Status> {
+            unimplemented!("MockM5 stub: stream_config_updates")
+        }
+        async fn get_portfolio_allocation(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::GetPortfolioAllocationRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::GetPortfolioAllocationResponse>, Status> {
+            unimplemented!("MockM5 stub: get_portfolio_allocation")
+        }
+        async fn validate_metricql(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::ValidateMetricqlRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ValidateMetricqlResponse>, Status> {
+            unimplemented!("MockM5 stub: validate_metricql")
+        }
+        async fn preview_metric_definition(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::PreviewMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::PreviewMetricDefinitionResponse>, Status> {
+            unimplemented!("MockM5 stub: preview_metric_definition")
+        }
+    }
+
+    /// Spawn a mock M5 server. Returns the bound address and an Arc handle
+    /// to the mock so tests can inspect the recorded calls.
+    async fn spawn_mock_m5(mock: MockM5) -> (SocketAddr, std::sync::Arc<MockM5>) {
+        use experimentation_proto::experimentation::management::v1::experiment_management_service_server::ExperimentManagementServiceServer;
+        let arc = std::sync::Arc::new(mock);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // tonic's generated server takes ownership; clone via Arc indirection.
+        let server_handle = ArcMockM5(arc.clone());
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(ExperimentManagementServiceServer::new(server_handle))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .ok();
+        });
+        tokio::task::yield_now().await;
+        (addr, arc)
+    }
+
+    /// Thin newtype wrapper so we can implement the service trait on an
+    /// `Arc<MockM5>` (tonic's generated `*ServiceServer::new` needs an owned
+    /// `impl Service`).
+    struct ArcMockM5(std::sync::Arc<MockM5>);
+
+    #[tonic::async_trait]
+    impl experimentation_proto::experimentation::management::v1::experiment_management_service_server::ExperimentManagementService
+        for ArcMockM5
+    {
+        async fn migrate_metric_definition(
+            &self,
+            request: Request<MigrateMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::MigrateMetricDefinitionResponse>, Status> {
+            self.0.migrate_metric_definition(request).await
+        }
+        async fn create_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::CreateExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.create_experiment(r).await
+        }
+        async fn get_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::GetExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.get_experiment(r).await
+        }
+        async fn update_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::UpdateExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.update_experiment(r).await
+        }
+        async fn list_experiments(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::ListExperimentsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ListExperimentsResponse>, Status> {
+            self.0.list_experiments(r).await
+        }
+        async fn start_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::StartExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.start_experiment(r).await
+        }
+        async fn conclude_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::ConcludeExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.conclude_experiment(r).await
+        }
+        async fn archive_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::ArchiveExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.archive_experiment(r).await
+        }
+        async fn pause_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::PauseExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.pause_experiment(r).await
+        }
+        async fn resume_experiment(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::ResumeExperimentRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Experiment>, Status> {
+            self.0.resume_experiment(r).await
+        }
+        async fn create_metric_definition(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::CreateMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::MetricDefinition>, Status> {
+            self.0.create_metric_definition(r).await
+        }
+        async fn get_metric_definition(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::GetMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::MetricDefinition>, Status> {
+            self.0.get_metric_definition(r).await
+        }
+        async fn list_metric_definitions(
+            &self,
+            r: Request<ListMetricDefinitionsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ListMetricDefinitionsResponse>, Status> {
+            self.0.list_metric_definitions(r).await
+        }
+        async fn create_layer(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::CreateLayerRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Layer>, Status> {
+            self.0.create_layer(r).await
+        }
+        async fn get_layer(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::GetLayerRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::Layer>, Status> {
+            self.0.get_layer(r).await
+        }
+        async fn get_layer_allocations(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::GetLayerAllocationsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::GetLayerAllocationsResponse>, Status> {
+            self.0.get_layer_allocations(r).await
+        }
+        async fn create_targeting_rule(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::CreateTargetingRuleRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::TargetingRule>, Status> {
+            self.0.create_targeting_rule(r).await
+        }
+        async fn create_surrogate_model(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::CreateSurrogateModelRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::SurrogateModelConfig>, Status> {
+            self.0.create_surrogate_model(r).await
+        }
+        async fn list_surrogate_models(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::ListSurrogateModelsRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ListSurrogateModelsResponse>, Status> {
+            self.0.list_surrogate_models(r).await
+        }
+        async fn get_surrogate_calibration(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::GetSurrogateCalibrationRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::common::v1::SurrogateModelConfig>, Status> {
+            self.0.get_surrogate_calibration(r).await
+        }
+        async fn trigger_surrogate_recalibration(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::TriggerSurrogateRecalibrationRequest>,
+        ) -> Result<Response<()>, Status> {
+            self.0.trigger_surrogate_recalibration(r).await
+        }
+        type StreamConfigUpdatesStream = std::pin::Pin<
+            Box<
+                dyn tokio_stream::Stream<
+                        Item = Result<
+                            experimentation_proto::experimentation::management::v1::ConfigUpdateEvent,
+                            Status,
+                        >,
+                    > + Send,
+            >,
+        >;
+        async fn stream_config_updates(
+            &self,
+            _r: Request<experimentation_proto::experimentation::management::v1::StreamConfigUpdatesRequest>,
+        ) -> Result<Response<Self::StreamConfigUpdatesStream>, Status> {
+            unimplemented!("ArcMockM5: stream_config_updates")
+        }
+        async fn get_portfolio_allocation(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::GetPortfolioAllocationRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::GetPortfolioAllocationResponse>, Status> {
+            self.0.get_portfolio_allocation(r).await
+        }
+        async fn validate_metricql(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::ValidateMetricqlRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::ValidateMetricqlResponse>, Status> {
+            self.0.validate_metricql(r).await
+        }
+        async fn preview_metric_definition(
+            &self,
+            r: Request<experimentation_proto::experimentation::management::v1::PreviewMetricDefinitionRequest>,
+        ) -> Result<Response<experimentation_proto::experimentation::management::v1::PreviewMetricDefinitionResponse>, Status> {
+            self.0.preview_metric_definition(r).await
+        }
+    }
+
+    /// Write a `ShadowOutput` JSON to a temp dir and return the paths.
+    fn write_shadow_output_to_disk(
+        outcomes: Vec<ShadowOutcome>,
+    ) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("shadow.json");
+        let out = ShadowOutput {
+            schedule_started_at: "2026-01-01T00:00:00Z".into(),
+            schedule_completed_at: "2026-01-01T01:00:00Z".into(),
+            outcomes,
+        };
+        std::fs::write(&path, serde_json::to_string_pretty(&out).unwrap()).unwrap();
+        (dir, path)
+    }
+
+    // -----------------------------------------------------------------------
+    // Workflow tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn apply_dry_run_prints_plan_and_makes_no_rpc_calls() {
+        // 1 APPROVED + 1 REJECTED. dry_run must not call M5.
+        let outcomes = vec![
+            approved_outcome("m_a", "result-1"),
+            outcome("m_r", "REJECTED"),
+        ];
+        let (_dir, shadow_path) = write_shadow_output_to_disk(outcomes);
+
+        // Mock with an empty script — if dry_run calls migrate, it would
+        // get back "exhausted" and the call would still be recorded.
+        let mock = MockM5::new(vec![]);
+        let (addr, arc) = spawn_mock_m5(mock).await;
+
+        let exit_code = apply_subcommand(
+            None,
+            &shadow_path,
+            &format!("http://{addr}"),
+            None,
+            true,  // dry_run
+            false, // confirm
+            None,
+        )
+        .await
+        .expect("dry_run should never return Err");
+
+        assert_eq!(exit_code, 0, "dry_run exits 0");
+        assert_eq!(
+            arc.migrate_calls.lock().unwrap().len(),
+            0,
+            "dry_run must not call MigrateMetricDefinition"
+        );
+        // No sidecar audit file in dry_run mode.
+        assert!(
+            !default_audit_path(&shadow_path).exists(),
+            "dry_run must not write the audit sidecar"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn apply_confirm_applies_all_approved_outcomes() {
+        let outcomes = vec![
+            approved_outcome("m_a", "result-1"),
+            approved_outcome("m_b", "result-2"),
+            outcome("m_skip", "REJECTED"),
+        ];
+        let (_dir, shadow_path) = write_shadow_output_to_disk(outcomes);
+
+        let script = vec![
+            MigrateResult::Ok {
+                new_metric_id: "m_a_v2".into(),
+                migration_id: "mig-1".into(),
+                applied_at: "2026-01-01T01:00:00Z".into(),
+            },
+            MigrateResult::Ok {
+                new_metric_id: "m_b_v2".into(),
+                migration_id: "mig-2".into(),
+                applied_at: "2026-01-01T01:00:01Z".into(),
+            },
+        ];
+        let mock = MockM5::new(script);
+        let (addr, arc) = spawn_mock_m5(mock).await;
+
+        let exit_code = apply_subcommand(
+            None,
+            &shadow_path,
+            &format!("http://{addr}"),
+            Some("test@example.com"),
+            false, // dry_run
+            true,  // confirm
+            None,
+        )
+        .await
+        .expect("apply_subcommand returns Ok with code 0 on success");
+
+        assert_eq!(exit_code, 0, "all APPROVED outcomes succeeded => exit 0");
+        let calls = arc.migrate_calls.lock().unwrap();
+        assert_eq!(calls.len(), 2, "must call migrate exactly twice");
+        // Verify the request fields: operator, shadow_run_result_id, old/new ids.
+        assert_eq!(calls[0].operator, "test@example.com");
+        assert_eq!(calls[0].old_metric_id, "m_a");
+        assert_eq!(calls[0].shadow_run_result_id, "result-1");
+        assert_eq!(
+            calls[0].new_metric.as_ref().map(|m| m.metric_id.as_str()),
+            Some("m_a_v2")
+        );
+        assert_eq!(calls[1].old_metric_id, "m_b");
+        assert_eq!(calls[1].shadow_run_result_id, "result-2");
+
+        // Audit JSON written to the default path with both outcomes recorded.
+        let audit_path = default_audit_path(&shadow_path);
+        let audit_raw = std::fs::read_to_string(&audit_path).unwrap();
+        let audit: ApplyOutput = serde_json::from_str(&audit_raw).unwrap();
+        assert_eq!(audit.total_attempted, 2);
+        assert_eq!(audit.succeeded, 2);
+        assert_eq!(audit.failed, 0);
+        assert_eq!(audit.operator, "test@example.com");
+        assert!(audit.outcomes.iter().all(|o| o.status == "OK"));
+        assert_eq!(audit.outcomes[0].new_metric_id, "m_a_v2");
+        assert_eq!(audit.outcomes[0].migration_id, "mig-1");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn apply_confirm_continues_on_partial_failure_and_exits_nonzero() {
+        let outcomes = vec![
+            approved_outcome("m_ok", "result-1"),
+            approved_outcome("m_fail", "result-2"),
+        ];
+        let (_dir, shadow_path) = write_shadow_output_to_disk(outcomes);
+
+        let script = vec![
+            MigrateResult::Ok {
+                new_metric_id: "m_ok_v2".into(),
+                migration_id: "mig-1".into(),
+                applied_at: "2026-01-01T01:00:00Z".into(),
+            },
+            MigrateResult::Err(
+                Code::FailedPrecondition,
+                "shadow run result must be APPROVED but is REJECTED".into(),
+            ),
+        ];
+        let mock = MockM5::new(script);
+        let (addr, arc) = spawn_mock_m5(mock).await;
+
+        let exit_code = apply_subcommand(
+            None,
+            &shadow_path,
+            &format!("http://{addr}"),
+            Some("test@example.com"),
+            false,
+            true,
+            None,
+        )
+        .await
+        .expect("partial failure should not raise — exit code carries the result");
+
+        assert_eq!(exit_code, 1, "any per-outcome failure => exit 1");
+        let calls = arc.migrate_calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            2,
+            "second outcome must still be attempted (apply-as-much-as-possible)"
+        );
+
+        let audit_path = default_audit_path(&shadow_path);
+        let audit: ApplyOutput =
+            serde_json::from_str(&std::fs::read_to_string(&audit_path).unwrap()).unwrap();
+        assert_eq!(audit.total_attempted, 2);
+        assert_eq!(audit.succeeded, 1);
+        assert_eq!(audit.failed, 1);
+        let ok = audit.outcomes.iter().find(|o| o.status == "OK").unwrap();
+        assert_eq!(ok.original_metric_id, "m_ok");
+        let bad = audit.outcomes.iter().find(|o| o.status != "OK").unwrap();
+        assert_eq!(bad.original_metric_id, "m_fail");
+        assert_eq!(bad.status, "FAILEDPRECONDITION");
+        assert!(
+            bad.error.contains("REJECTED"),
+            "error message propagated: {}",
+            bad.error
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn apply_confirm_without_operator_fails_before_any_rpc() {
+        let outcomes = vec![approved_outcome("m_a", "result-1")];
+        let (_dir, shadow_path) = write_shadow_output_to_disk(outcomes);
+
+        let mock = MockM5::new(vec![]);
+        let (addr, arc) = spawn_mock_m5(mock).await;
+
+        let result = apply_subcommand(
+            None,
+            &shadow_path,
+            &format!("http://{addr}"),
+            None, // no operator
+            false,
+            true, // confirm
+            None,
+        )
+        .await;
+
+        let err = result.expect_err("must reject --confirm without --operator");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("operator"),
+            "error must mention --operator; got: {msg}"
+        );
+        assert_eq!(
+            arc.migrate_calls.lock().unwrap().len(),
+            0,
+            "must not call M5 when --operator is missing"
+        );
+        // Also: empty/whitespace --operator string is rejected.
+        let result_ws = apply_subcommand(
+            None,
+            &shadow_path,
+            &format!("http://{addr}"),
+            Some("   "),
+            false,
+            true,
+            None,
+        )
+        .await;
+        assert!(result_ws.is_err(), "whitespace-only operator must be rejected");
+        assert_eq!(arc.migrate_calls.lock().unwrap().len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn apply_with_no_approved_outcomes_is_a_noop_exit_zero() {
+        let outcomes = vec![
+            outcome("a", "REJECTED"),
+            outcome("b", "PENDING"),
+            outcome("c", "SCHEDULING_FAILED"),
+        ];
+        let (_dir, shadow_path) = write_shadow_output_to_disk(outcomes);
+
+        let mock = MockM5::new(vec![]);
+        let (addr, arc) = spawn_mock_m5(mock).await;
+
+        let exit_code = apply_subcommand(
+            None,
+            &shadow_path,
+            &format!("http://{addr}"),
+            Some("test@example.com"),
+            false,
+            true, // confirm
+            None,
+        )
+        .await
+        .expect("no APPROVED is not an error");
+
+        assert_eq!(exit_code, 0, "no APPROVED => exit 0 (no-op)");
+        assert_eq!(
+            arc.migrate_calls.lock().unwrap().len(),
+            0,
+            "no RPC calls when nothing to apply"
+        );
+        // Also: no audit file should be written when there's nothing to apply.
+        assert!(
+            !default_audit_path(&shadow_path).exists(),
+            "no audit file when no APPROVED outcomes"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn apply_confirm_with_custom_output_path_writes_audit_there() {
+        // Spot-check that --output overrides the default <shadow>.apply.json.
+        let outcomes = vec![approved_outcome("m_a", "result-1")];
+        let (dir, shadow_path) = write_shadow_output_to_disk(outcomes);
+
+        let script = vec![MigrateResult::Ok {
+            new_metric_id: "m_a_v2".into(),
+            migration_id: "mig-1".into(),
+            applied_at: "2026-01-01T01:00:00Z".into(),
+        }];
+        let mock = MockM5::new(script);
+        let (addr, _arc) = spawn_mock_m5(mock).await;
+
+        let custom_audit = dir.path().join("audit.json");
+        let exit_code = apply_subcommand(
+            None,
+            &shadow_path,
+            &format!("http://{addr}"),
+            Some("test@example.com"),
+            false,
+            true,
+            Some(&custom_audit),
+        )
+        .await
+        .unwrap();
+        assert_eq!(exit_code, 0);
+        assert!(custom_audit.exists(), "audit JSON at the --output path");
+        assert!(
+            !default_audit_path(&shadow_path).exists(),
+            "default audit path must be empty when --output is set"
+        );
+    }
+}

--- a/crates/experimentation-management/src/contract_test_support.rs
+++ b/crates/experimentation-management/src/contract_test_support.rs
@@ -24,7 +24,8 @@ use experimentation_proto::experimentation::management::v1::{
     GetLayerAllocationsRequest, GetLayerAllocationsResponse, GetLayerRequest,
     GetMetricDefinitionRequest, GetSurrogateCalibrationRequest, ListExperimentsRequest,
     ListExperimentsResponse, ListMetricDefinitionsRequest, ListMetricDefinitionsResponse,
-    ListSurrogateModelsRequest, ListSurrogateModelsResponse, PauseExperimentRequest,
+    ListSurrogateModelsRequest, ListSurrogateModelsResponse,
+    MigrateMetricDefinitionRequest, MigrateMetricDefinitionResponse, PauseExperimentRequest,
     PreviewMetricDefinitionRequest, PreviewMetricDefinitionResponse,
     ResumeExperimentRequest, StartExperimentRequest, StreamConfigUpdatesRequest,
     GetPortfolioAllocationRequest, GetPortfolioAllocationResponse,
@@ -567,6 +568,21 @@ impl ExperimentManagementService for ManagementServiceHandler {
             metrics,
             next_page_token: String::new(),
         }))
+    }
+
+    async fn migrate_metric_definition(
+        &self,
+        _request: Request<MigrateMetricDefinitionRequest>,
+    ) -> Result<Response<MigrateMetricDefinitionResponse>, Status> {
+        // The in-memory contract-test handler doesn't carry the M3 shadow
+        // gate or the atomic-transaction store. MigrateMetricDefinition is
+        // exercised end-to-end via the PG-backed e2e suite in
+        // tests/metric_migration_e2e_test.rs and unit-tested via the
+        // production handler in src/grpc.rs.
+        Err(Status::unimplemented(
+            "MigrateMetricDefinition is not implemented in the in-memory contract-test handler; \
+             use the production handler in src/grpc.rs (PG-backed) for end-to-end testing.",
+        ))
     }
 
     async fn create_layer(

--- a/crates/experimentation-management/src/contract_test_support.rs
+++ b/crates/experimentation-management/src/contract_test_support.rs
@@ -708,9 +708,11 @@ impl ExperimentManagementService for ManagementServiceHandler {
         request: Request<ValidateMetricqlRequest>,
     ) -> Result<Response<ValidateMetricqlResponse>, Status> {
         let req = request.into_inner();
-        if req.experiment_id.trim().is_empty() {
-            return Err(Status::invalid_argument("experiment_id is required"));
-        }
+        // In-memory stub: empty experiment_id is accepted (matches
+        // grpc.rs::validate_metricql contract — ADR-026 Phase 2 follow-up #571).
+        // Existence checks against the global catalog are exercised by the
+        // integration test (`tests/validate_metricql_global_scope_test.rs`), not
+        // this stub, which only asserts wire-format behavior.
         // Contract test stub: delegate to the validator directly (no DB needed).
         use crate::validators::metricql::{validate_metricql as vm, ValidateContext};
         if req.metricql_expression.trim().is_empty() {

--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -53,7 +53,7 @@ use experimentation_proto::experimentation::metrics::v1::{
 };
 
 use crate::bucket_reuse;
-use crate::store::{ExperimentRow, ManagementStore, MetricFilter, StoreError, VariantRow};
+use crate::store::{ExperimentRow, ManagementStore, StoreError, VariantRow};
 use crate::validators;
 
 // Broadcast channel capacity. Slow subscribers will see RecvError::Lagged.
@@ -1616,15 +1616,20 @@ impl ExperimentManagementService for ManagementServiceHandler {
         // and an experiment-scoped catalog lookup belongs in a later sub-task.
         let global_set: Option<HashSet<String>> = if req.experiment_id.trim().is_empty() {
             debug!("validate_metricql: empty experiment_id, loading global metric catalog");
-            let rows = self
+            // `list_metric_ids` runs `SELECT metric_id FROM metric_definitions`
+            // rather than `list_metrics(MetricFilter::default())`'s 18-column
+            // SELECT — this handler runs on every ~500ms lint cycle and the
+            // wider query was deserialising large JSON / SQL text blobs that
+            // get immediately discarded. (Devin PR #595 🟡 perf finding.)
+            let ids = self
                 .state
                 .store
-                .list_metrics(MetricFilter::default())
+                .list_metric_ids()
                 .await
                 .map_err(|err| {
                     Status::internal(format!("failed to load global metric catalog: {err}"))
                 })?;
-            Some(rows.into_iter().map(|r| r.metric_id).collect())
+            Some(ids.into_iter().collect())
         } else {
             None
         };

--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -52,7 +52,7 @@ use experimentation_proto::experimentation::metrics::v1::{
 };
 
 use crate::bucket_reuse;
-use crate::store::{ExperimentRow, ManagementStore, StoreError, VariantRow};
+use crate::store::{ExperimentRow, ManagementStore, MetricFilter, StoreError, VariantRow};
 use crate::validators;
 
 // Broadcast channel capacity. Slow subscribers will see RecvError::Lagged.
@@ -1588,11 +1588,8 @@ impl ExperimentManagementService for ManagementServiceHandler {
     ) -> Result<Response<ValidateMetricqlResponse>, Status> {
         let req = request.into_inner();
 
-        if req.experiment_id.trim().is_empty() {
-            return Err(Status::invalid_argument("experiment_id is required"));
-        }
-
         // Per plan L8: empty expression returns one diagnostic, not an RPC error.
+        // (Empty `experiment_id` is now valid — see global-scope branch below.)
         if req.metricql_expression.trim().is_empty() {
             return Ok(Response::new(ValidateMetricqlResponse {
                 diagnostics: vec![ProtoMetricqlDiagnostic {
@@ -1609,10 +1606,30 @@ impl ExperimentManagementService for ManagementServiceHandler {
             }));
         }
 
-        // Pass None for known_metric_ids — existence checks are enforced at
-        // write time (CreateMetricDefinition). The live-lint path only needs to
-        // catch parse/semantic structural errors during interactive editing.
-        let ctx = validators::metricql::ValidateContext { known_metric_ids: None };
+        // ADR-026 Phase 2 follow-up (#571): empty `experiment_id` is the global
+        // scope used by the metric-creation form (which has no experiment
+        // context). Build `known_metric_ids` from the full metric_definitions
+        // table so the live-lint surface can flag unresolved @refs even before
+        // an experiment exists. The per-experiment path stays `None` for now —
+        // existence checks already run at write-time on CreateMetricDefinition,
+        // and an experiment-scoped catalog lookup belongs in a later sub-task.
+        let global_set: Option<std::collections::HashSet<String>> =
+            if req.experiment_id.trim().is_empty() {
+                let rows = self
+                    .state
+                    .store
+                    .list_metrics(MetricFilter::default())
+                    .await
+                    .map_err(|err| {
+                        Status::internal(format!("failed to load global metric catalog: {err}"))
+                    })?;
+                Some(rows.into_iter().map(|r| r.metric_id).collect())
+            } else {
+                None
+            };
+        let ctx = validators::metricql::ValidateContext {
+            known_metric_ids: global_set.as_ref(),
+        };
 
         let response =
             match validators::metricql::validate_metricql(&req.metricql_expression, &ctx) {

--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -39,7 +39,8 @@ use experimentation_proto::experimentation::management::v1::{
     GetMetricDefinitionRequest, GetPortfolioAllocationRequest, GetPortfolioAllocationResponse,
     GetSurrogateCalibrationRequest, ListExperimentsRequest, ListExperimentsResponse,
     ListMetricDefinitionsRequest, ListMetricDefinitionsResponse, ListSurrogateModelsRequest,
-    ListSurrogateModelsResponse, PauseExperimentRequest,
+    ListSurrogateModelsResponse, MigrateMetricDefinitionRequest,
+    MigrateMetricDefinitionResponse, PauseExperimentRequest,
     PortfolioStats as ProtoPortfolioStats, PreviewMetricDefinitionRequest,
     PreviewMetricDefinitionResponse, ResumeExperimentRequest, StartExperimentRequest,
     StreamConfigUpdatesRequest, TriggerSurrogateRecalibrationRequest, UpdateExperimentRequest,
@@ -47,7 +48,7 @@ use experimentation_proto::experimentation::management::v1::{
 };
 use experimentation_proto::experimentation::metrics::v1::{
     metric_computation_service_client::MetricComputationServiceClient,
-    CompileMetricqlPreviewRequest,
+    CompileMetricqlPreviewRequest, GetShadowResultsRequest,
 };
 
 use crate::bucket_reuse;
@@ -139,6 +140,13 @@ pub struct ManagementServiceHandler {
 impl ManagementServiceHandler {
     pub fn new(state: SharedState) -> Self {
         Self { state }
+    }
+
+    /// Accessor for the underlying store. Currently used by e2e tests that
+    /// need to assert against rows the handler wrote (e.g., the
+    /// `metric_migrations` audit row written by MigrateMetricDefinition).
+    pub fn store(&self) -> &Arc<ManagementStore> {
+        &self.state.store
     }
 }
 
@@ -1165,6 +1173,179 @@ impl ExperimentManagementService for ManagementServiceHandler {
         Ok(Response::new(ListMetricDefinitionsResponse {
             metrics,
             next_page_token: String::new(),
+        }))
+    }
+
+    // ---------------------------------------------------------------------------
+    // MigrateMetricDefinition (ADR-026 Phase 3 / #437)
+    // ---------------------------------------------------------------------------
+    //
+    // Lock L7 two-step apply contract: operators call this from
+    // `custom_migrator apply` once a candidate's shadow run has been APPROVED
+    // by M3. The handler enforces preconditions in a deliberate order so
+    // callers get the most helpful error first:
+    //
+    //   1. (b) new_metric.type != CUSTOM           → InvalidArgument
+    //   2. (c) new_metric.metric_id != old_metric_id → InvalidArgument
+    //   3. (a) old_metric_id exists AND is CUSTOM   → InvalidArgument
+    //   4. (e) validate_metric_definition(new)      → InvalidArgument
+    //   5. (d) M3 shadow status == APPROVED        → FailedPrecondition
+    //
+    // Cheap proto-field checks (1, 2) run first so we never burn DB or RPC
+    // round trips on obvious operator mistakes. Cross-service checks (3, 5)
+    // run after local validation (4) so we never call M3 on a request that
+    // would have failed anyway.
+    //
+    // On success a single atomic transaction (see `ManagementStore::migrate_metric`)
+    // inserts the new metric_definitions row + the metric_migrations audit
+    // row. Unique-constraint violations on either side surface as AlreadyExists.
+    async fn migrate_metric_definition(
+        &self,
+        request: Request<MigrateMetricDefinitionRequest>,
+    ) -> Result<Response<MigrateMetricDefinitionResponse>, Status> {
+        let req = request.into_inner();
+        let old_metric_id = req.old_metric_id.trim();
+        let shadow_run_result_id = req.shadow_run_result_id.trim();
+        let operator = req.operator.trim();
+        let new_metric = req
+            .new_metric
+            .ok_or_else(|| Status::invalid_argument("new_metric is required"))?;
+
+        if old_metric_id.is_empty() {
+            return Err(Status::invalid_argument("old_metric_id is required"));
+        }
+        if shadow_run_result_id.is_empty() {
+            return Err(Status::invalid_argument("shadow_run_result_id is required"));
+        }
+        if operator.is_empty() {
+            return Err(Status::invalid_argument("operator is required"));
+        }
+
+        // Parse shadow_run_result_id as a UUID up front, with the rest of the
+        // request-shape validations. A malformed UUID is a caller bug, not a
+        // missing shadow run; surfacing it as InvalidArgument here avoids
+        // burning an M3 round trip and avoids the misleading
+        // FailedPrecondition("shadow_run_result_id not found in M3") that the
+        // mock M3 (and probably the real one) would otherwise return.
+        let shadow_uuid = Uuid::parse_str(shadow_run_result_id).map_err(|e| {
+            Status::invalid_argument(format!(
+                "shadow_run_result_id is not a valid UUID: {shadow_run_result_id} ({e})"
+            ))
+        })?;
+
+        // (b) The new metric MUST NOT be CUSTOM. Migration is exactly the act
+        // of leaving CUSTOM behind; allowing CUSTOM → CUSTOM would defeat the
+        // whole purpose of the Phase 3 deprecation track.
+        if new_metric.r#type() == MetricType::Custom {
+            return Err(Status::invalid_argument(
+                "new metric must not be CUSTOM (migrate to FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT, or METRICQL)",
+            ));
+        }
+
+        // (c) The new metric_id MUST differ from the old. Allowing same-id
+        // would be an in-place mutation, which Phase 3 explicitly forbids
+        // (L7: "Never destructive in-place").
+        if new_metric.metric_id.trim() == old_metric_id {
+            return Err(Status::invalid_argument(
+                "new metric_id must differ from old_metric_id (in-place migration is forbidden)",
+            ));
+        }
+
+        // (a) The old metric MUST exist AND its type MUST be CUSTOM. We use
+        // get_metric_type because the cycle-detection lookup already exposes
+        // it cheaply (single-column SELECT). NotFound + non-CUSTOM both map
+        // to InvalidArgument so the operator gets a clear actionable error
+        // distinct from a missing-new-metric or shadow-not-approved error.
+        match self.state.store.get_metric_type(old_metric_id).await {
+            Ok(MetricType::Custom) => {}
+            Ok(other) => {
+                return Err(Status::invalid_argument(format!(
+                    "old metric must be CUSTOM but is {:?}: {old_metric_id}",
+                    other
+                )));
+            }
+            Err(StoreError::NotFound(_)) => {
+                return Err(Status::invalid_argument(format!(
+                    "old metric does not exist: {old_metric_id}"
+                )));
+            }
+            Err(e) => return Err(store_err_to_status(e)),
+        }
+
+        // (e) Re-run the standard CreateMetricDefinition validator on the
+        // replacement. This catches MetricQL parse errors, COMPOSITE cycles,
+        // FILTERED_MEAN value_column violations, etc. Same code path as
+        // Create — the migration RPC never bypasses validation.
+        validators::validate_metric_definition(&new_metric, self.state.store.as_ref())
+            .await
+            .map_err(|boxed| *boxed)?;
+
+        // (d) The shadow run identified by shadow_run_result_id MUST be
+        // APPROVED. PromoteShadowResult returns result_id == shadow_id of the
+        // promoted run, so we look it up via GetShadowResults. The L7
+        // two-step gate hinges on this check: a candidate that has not been
+        // approved by M3's 7-day rolling differ can never reach M5's write
+        // path. Network errors from M3 surface as Unavailable (the operator
+        // can retry); non-APPROVED status surfaces as FailedPrecondition
+        // (different error class: caller did not prepare correctly).
+        let mut metrics_client = self.state.metrics_client.clone();
+        let shadow_resp = metrics_client
+            .get_shadow_results(Request::new(GetShadowResultsRequest {
+                shadow_id: shadow_run_result_id.to_string(),
+            }))
+            .await
+            .map_err(|status| {
+                // Propagate the actual code if it's already Unavailable / NotFound,
+                // otherwise wrap as Unavailable since M5 cannot proceed without
+                // M3's verdict.
+                match status.code() {
+                    tonic::Code::NotFound => Status::failed_precondition(format!(
+                        "shadow_run_result_id not found in M3: {shadow_run_result_id}"
+                    )),
+                    tonic::Code::Unavailable => Status::unavailable(format!(
+                        "M3 unavailable while verifying shadow run: {}",
+                        status.message()
+                    )),
+                    _ => Status::unavailable(format!(
+                        "M3 GetShadowResults failed: {}",
+                        status.message()
+                    )),
+                }
+            })?
+            .into_inner();
+
+        if shadow_resp.status != "APPROVED" {
+            return Err(Status::failed_precondition(format!(
+                "shadow run result must be APPROVED but is {}: {}",
+                shadow_resp.status, shadow_run_result_id
+            )));
+        }
+
+        // All preconditions cleared: single atomic transaction inserts the
+        // new metric + audit row. The old CUSTOM row is left in place per
+        // L7 (non-destructive). shadow_uuid was already parsed at the
+        // request-shape stage above.
+        let (new_row, migration_id, applied_at) = self
+            .state
+            .store
+            .migrate_metric(&new_metric, old_metric_id, shadow_uuid, operator)
+            .await
+            .map_err(store_err_to_status)?;
+
+        info!(
+            target: "m5.migration",
+            old_metric_id = %old_metric_id,
+            new_metric_id = %new_row.metric_id,
+            shadow_run_result_id = %shadow_run_result_id,
+            operator = %operator,
+            migration_id = %migration_id,
+            "migrated CUSTOM metric definition"
+        );
+
+        Ok(Response::new(MigrateMetricDefinitionResponse {
+            new_metric_id: new_row.metric_id,
+            migration_id: migration_id.to_string(),
+            applied_at: applied_at.to_rfc3339(),
         }))
     }
 

--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -2026,6 +2026,48 @@ mod tests {
         assert!(!diags.is_empty());
     }
 
+    // ── Global-scope known_metric_ids (#571 safety-net) ──────────────────────
+    // The real RPC-level test lives in
+    // `tests/validate_metricql_global_scope_test.rs` and is DATABASE_URL-gated.
+    // These two pure-Rust tests prove the validator-layer contract used by the
+    // empty-experiment_id branch of `validate_metricql`, so the contract
+    // doesn't regress in CI environments without Postgres.
+
+    #[test]
+    fn global_scope_empty_catalog_flags_unknown_ref_with_position() {
+        // Simulates the empty-experiment_id branch with an empty global
+        // catalog: `Some(&empty)` triggers existence checks and an unresolved
+        // @ref must come back with a 1-indexed line:col via internal_to_proto_diag.
+        use std::collections::HashSet;
+        let empty: HashSet<String> = HashSet::new();
+        let ctx = ValidateContext { known_metric_ids: Some(&empty) };
+        let src = "@watch_time + 0";
+        let diags = validators::metricql::validate_metricql(src, &ctx).unwrap_err();
+        assert_eq!(diags.len(), 1, "expected one unresolved-ref diagnostic, got: {diags:?}");
+        let proto = internal_to_proto_diag(diags.into_iter().next().unwrap(), src);
+        assert!(
+            proto.message.contains("@watch_time"),
+            "diagnostic must reference the unresolved id; got: {}",
+            proto.message
+        );
+        let span = proto.span.expect("span must be present");
+        assert!(span.line >= 1, "line must be 1-indexed; got {}", span.line);
+        assert!(span.column >= 1, "column must be 1-indexed; got {}", span.column);
+    }
+
+    #[test]
+    fn global_scope_with_known_id_validates_clean() {
+        // Simulates the empty-experiment_id branch with a catalog containing
+        // `watch_time`: the same expression as above must validate cleanly.
+        use std::collections::HashSet;
+        let mut catalog: HashSet<String> = HashSet::new();
+        catalog.insert("watch_time".to_string());
+        let ctx = ValidateContext { known_metric_ids: Some(&catalog) };
+        let refs = validators::metricql::validate_metricql("@watch_time + 0", &ctx)
+            .expect("expression with known @ref must validate");
+        assert_eq!(refs, vec!["watch_time"]);
+    }
+
     #[test]
     fn multiline_expression_error_attributed_to_line2() {
         // "mean(heartbeat.value)\nand wrong" — the "and" part will parse/fail

--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -11,13 +11,14 @@
 //! On connect, the server first back-fills all currently RUNNING/PAUSED
 //! experiments (so M1 can recover after restart), then streams live updates.
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use experimentation_proto::experimentation::common::v1::{
@@ -1613,20 +1614,20 @@ impl ExperimentManagementService for ManagementServiceHandler {
         // an experiment exists. The per-experiment path stays `None` for now —
         // existence checks already run at write-time on CreateMetricDefinition,
         // and an experiment-scoped catalog lookup belongs in a later sub-task.
-        let global_set: Option<std::collections::HashSet<String>> =
-            if req.experiment_id.trim().is_empty() {
-                let rows = self
-                    .state
-                    .store
-                    .list_metrics(MetricFilter::default())
-                    .await
-                    .map_err(|err| {
-                        Status::internal(format!("failed to load global metric catalog: {err}"))
-                    })?;
-                Some(rows.into_iter().map(|r| r.metric_id).collect())
-            } else {
-                None
-            };
+        let global_set: Option<HashSet<String>> = if req.experiment_id.trim().is_empty() {
+            debug!("validate_metricql: empty experiment_id, loading global metric catalog");
+            let rows = self
+                .state
+                .store
+                .list_metrics(MetricFilter::default())
+                .await
+                .map_err(|err| {
+                    Status::internal(format!("failed to load global metric catalog: {err}"))
+                })?;
+            Some(rows.into_iter().map(|r| r.metric_id).collect())
+        } else {
+            None
+        };
         let ctx = validators::metricql::ValidateContext {
             known_metric_ids: global_set.as_ref(),
         };

--- a/crates/experimentation-management/src/migration/cli.rs
+++ b/crates/experimentation-management/src/migration/cli.rs
@@ -197,7 +197,11 @@ pub struct TierCounts {
 ///
 /// Only the fields that the scan serializes are read; everything else stays at
 /// proto3 defaults. `custom_sql` is the field the classifier reads.
-fn json_to_metric_definition(v: &Value) -> Result<MetricDefinition> {
+///
+/// `pub` so the `custom_migrator` binary's `shadow` subcommand can reuse the
+/// same JSON shape when reading candidates back out of `proposals.json`
+/// (T2 round-trip closer for `metric_to_json`).
+pub fn json_to_metric_definition(v: &Value) -> Result<MetricDefinition> {
     use experimentation_proto::experimentation::common::v1::{
         metric_definition::TypeConfig, CompositeConfig, CompositeOperand, FilteredMeanConfig,
         WindowedCountConfig,

--- a/crates/experimentation-management/src/store.rs
+++ b/crates/experimentation-management/src/store.rs
@@ -1216,6 +1216,24 @@ impl ManagementStore {
         Ok(rows.into_iter().map(MetricRow::from).collect())
     }
 
+    /// List just the `metric_id` column from `metric_definitions`. Used by
+    /// `validate_metricql`'s global-scope path (#571) which only needs a
+    /// `HashSet<String>` of ids to validate `@metric_ref` resolution and
+    /// runs on every ~500ms lint cycle. `list_metrics()` fetches all 18
+    /// columns including potentially large `custom_sql` / `type_config` /
+    /// `metricql_expression` text blobs — overkill for a global-scope
+    /// existence check. No filter argument: the global catalog is always
+    /// all-rows by definition. (Devin PR #595 🟡 perf finding.)
+    pub async fn list_metric_ids(&self) -> Result<Vec<String>, StoreError> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT metric_id FROM metric_definitions ORDER BY metric_id",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(StoreError::Db)?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     /// True if a metric with the given id exists.
     pub async fn exists_metric(&self, metric_id: &str) -> Result<bool, StoreError> {
         let row: (bool,) = sqlx::query_as(

--- a/crates/experimentation-management/src/store.rs
+++ b/crates/experimentation-management/src/store.rs
@@ -439,6 +439,46 @@ fn metric_type_config_from_json(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Metric migration audit-row domain type (ADR-026 Phase 3 / #437)
+// ---------------------------------------------------------------------------
+
+/// One row from `metric_migrations`. Written by `migrate_metric` and read
+/// back by `get_metric_migration_by_id` (used by the e2e test to verify the
+/// audit columns are bound correctly).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetricMigrationRow {
+    pub migration_id: Uuid,
+    pub old_metric_id: String,
+    pub new_metric_id: String,
+    pub shadow_run_result_id: Uuid,
+    pub operator: String,
+    pub applied_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow, Debug, Clone)]
+struct MetricMigrationRowSql {
+    migration_id: Uuid,
+    old_metric_id: String,
+    new_metric_id: String,
+    shadow_run_result_id: Uuid,
+    operator: String,
+    applied_at: DateTime<Utc>,
+}
+
+impl From<MetricMigrationRowSql> for MetricMigrationRow {
+    fn from(r: MetricMigrationRowSql) -> Self {
+        MetricMigrationRow {
+            migration_id: r.migration_id,
+            old_metric_id: r.old_metric_id,
+            new_metric_id: r.new_metric_id,
+            shadow_run_result_id: r.shadow_run_result_id,
+            operator: r.operator,
+            applied_at: r.applied_at,
+        }
+    }
+}
+
 impl MetricRow {
     /// Round-trip a stored row back into the proto `MetricDefinition`. Mirrors
     /// the inverse of `create_metric`'s serialisation: flat columns map to
@@ -962,6 +1002,156 @@ impl ManagementStore {
         })?;
 
         Ok(MetricRow::from(row))
+    }
+
+    /// Atomic CUSTOM-metric migration (ADR-026 Phase 3 / #437).
+    ///
+    /// Inserts a new `metric_definitions` row for the replacement metric AND
+    /// an audit row in `metric_migrations` linking old to new, with the
+    /// shadow result id and operator, in a single transaction. Either both
+    /// inserts succeed or both roll back. The old CUSTOM row in
+    /// `metric_definitions` is NOT touched — per ADR-026 Phase 3, the
+    /// original stays for read-compat and audit.
+    ///
+    /// Error mapping:
+    ///
+    /// - `StoreError::AlreadyExists("old metric already migrated")` on
+    ///   unique-constraint violation against `uq_metric_migrations_old`.
+    /// - `StoreError::AlreadyExists("new metric_id already exists: <id>")` on
+    ///   unique-constraint violation against the `metric_definitions` PK.
+    /// - `StoreError::Db` for any other database error.
+    ///
+    /// Returns the `(new_metric_row, migration_id, applied_at)` triple from
+    /// the inserted rows. Caller maps these into the gRPC response.
+    pub async fn migrate_metric(
+        &self,
+        new_metric: &MetricDefinition,
+        old_metric_id: &str,
+        shadow_run_result_id: Uuid,
+        operator: &str,
+    ) -> Result<(MetricRow, Uuid, DateTime<Utc>), StoreError> {
+        let type_config_json = build_metric_type_config(new_metric);
+
+        let mut tx = self.pool.begin().await.map_err(StoreError::Db)?;
+
+        // 1. Insert the new metric_definitions row.
+        let new_row: MetricRowSql = sqlx::query_as(
+            r#"INSERT INTO metric_definitions (
+                   metric_id, name, description, type,
+                   source_event_type, numerator_event_type, denominator_event_type,
+                   percentile, custom_sql,
+                   lower_is_better, is_qoe_metric,
+                   cuped_covariate_metric_id, minimum_detectable_effect,
+                   stakeholder, aggregation_level, type_config, metricql_expression
+               ) VALUES (
+                   $1, $2, $3, $4,
+                   $5, $6, $7,
+                   $8, $9,
+                   $10, $11,
+                   $12, $13,
+                   $14, $15, $16, $17
+               )
+               RETURNING
+                   metric_id, name, description, type,
+                   source_event_type, numerator_event_type, denominator_event_type,
+                   percentile, custom_sql,
+                   lower_is_better, is_qoe_metric,
+                   cuped_covariate_metric_id, minimum_detectable_effect,
+                   stakeholder, aggregation_level, type_config, metricql_expression, created_at"#,
+        )
+        .bind(&new_metric.metric_id)
+        .bind(&new_metric.name)
+        .bind(opt_str(&new_metric.description))
+        .bind(metric_type_to_sql(new_metric.r#type()))
+        .bind(opt_str(&new_metric.source_event_type))
+        .bind(opt_str(&new_metric.numerator_event_type))
+        .bind(opt_str(&new_metric.denominator_event_type))
+        .bind(opt_pos_f64(new_metric.percentile))
+        .bind(opt_str(&new_metric.custom_sql))
+        .bind(new_metric.lower_is_better)
+        .bind(new_metric.is_qoe_metric)
+        .bind(opt_str(&new_metric.cuped_covariate_metric_id))
+        .bind(opt_pos_f64(new_metric.minimum_detectable_effect))
+        .bind(stakeholder_to_sql(new_metric.stakeholder()))
+        .bind(aggregation_level_to_sql(new_metric.aggregation_level()))
+        .bind(type_config_json.map(sqlx::types::Json))
+        .bind(opt_str(&new_metric.metricql_expression))
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("unique") || msg.contains("duplicate") {
+                StoreError::AlreadyExists(format!(
+                    "new metric_id already exists: {}",
+                    new_metric.metric_id
+                ))
+            } else {
+                StoreError::Db(e)
+            }
+        })?;
+
+        // 2. Insert the audit row into metric_migrations.
+        // We RETURNING migration_id + applied_at because both are DB-defaulted
+        // (gen_random_uuid() and NOW() respectively).
+        let audit_row: (Uuid, DateTime<Utc>) = sqlx::query_as(
+            r#"INSERT INTO metric_migrations
+                   (old_metric_id, new_metric_id, shadow_run_result_id, operator)
+               VALUES ($1, $2, $3, $4)
+               RETURNING migration_id, applied_at"#,
+        )
+        .bind(old_metric_id)
+        .bind(&new_metric.metric_id)
+        .bind(shadow_run_result_id)
+        .bind(operator)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| {
+            let msg = e.to_string();
+            // uq_metric_migrations_old → "old metric already migrated".
+            // Other unique violations (none expected on this row) → generic.
+            if (msg.contains("unique") || msg.contains("duplicate"))
+                && msg.contains("uq_metric_migrations_old")
+            {
+                StoreError::AlreadyExists(format!(
+                    "old metric already migrated: {old_metric_id}"
+                ))
+            } else if msg.contains("unique") || msg.contains("duplicate") {
+                StoreError::AlreadyExists(format!(
+                    "migration audit-row collision for old metric: {old_metric_id}"
+                ))
+            } else {
+                StoreError::Db(e)
+            }
+        })?;
+
+        tx.commit().await.map_err(StoreError::Db)?;
+
+        Ok((MetricRow::from(new_row), audit_row.0, audit_row.1))
+    }
+
+    /// Fetch a single `metric_migrations` audit row by `migration_id`.
+    ///
+    /// Used by the Phase 3 e2e suite to verify that the columns written by
+    /// `migrate_metric` (old_metric_id, new_metric_id, shadow_run_result_id,
+    /// operator) are bound to the right inputs. Returns `StoreError::NotFound`
+    /// if no row matches.
+    pub async fn get_metric_migration_by_id(
+        &self,
+        migration_id: Uuid,
+    ) -> Result<MetricMigrationRow, StoreError> {
+        let row: Option<MetricMigrationRowSql> = sqlx::query_as(
+            r#"SELECT migration_id, old_metric_id, new_metric_id,
+                       shadow_run_result_id, operator, applied_at
+               FROM metric_migrations
+               WHERE migration_id = $1"#,
+        )
+        .bind(migration_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(StoreError::Db)?;
+
+        row.map(MetricMigrationRow::from)
+            .ok_or_else(|| StoreError::NotFound(migration_id.to_string()))
     }
 
     /// Fetch a single metric definition by `metric_id`.

--- a/crates/experimentation-management/tests/metric_migration_e2e_test.rs
+++ b/crates/experimentation-management/tests/metric_migration_e2e_test.rs
@@ -1,0 +1,824 @@
+//! ADR-026 Phase 3 / Task T1 end-to-end test for MigrateMetricDefinition.
+//!
+//! Exercises the L7 two-step apply contract: a CUSTOM (raw-SQL) metric is
+//! created in the M5 store, an APPROVED shadow result is reported by a mock
+//! M3, and the migrate RPC writes the replacement metric + audit row in a
+//! single atomic transaction.
+//!
+//! Covers (per locked plan §T1):
+//!
+//!   happy:   CUSTOM original + valid METRICQL replacement + APPROVED shadow
+//!            → both rows created + response returns new_metric_id + migration_id
+//!   error 1: original isn't CUSTOM                    → InvalidArgument
+//!   error 2: new is CUSTOM                            → InvalidArgument
+//!   error 3: same metric_id                           → InvalidArgument
+//!   error 4: shadow not APPROVED (REJECTED status)    → FailedPrecondition
+//!   error 5: validate_metric_definition fails (bad MetricQL) → InvalidArgument
+//!   error 6: duplicate old_metric_id (second attempt) → AlreadyExists
+//!   error 7: duplicate new_metric_id                  → AlreadyExists
+//!
+//! Also asserts the precondition-check ordering (b → c → a → e → d) by
+//! constructing requests that would fail multiple checks and confirming the
+//! handler reports the most-helpful (earliest) failure.
+//!
+//! ## Running this suite
+//!
+//! Like the Phase 1 e2e suite, these tests are PG-gated on `DATABASE_URL`
+//! and skip quietly when it is unset.
+//!
+//! ```sh
+//! just db-reset && just migrate
+//! export DATABASE_URL=postgres://postgres:postgres@localhost:5432/kaizen_dev
+//! cargo test -p experimentation-management --test metric_migration_e2e_test
+//! ```
+//!
+//! Without `DATABASE_URL`, every test prints a skip message and returns Ok,
+//! so the binary still passes in environments without a database. CI runs
+//! the real assertions against a managed Postgres.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server;
+use tonic::{Code, Request, Response, Status};
+use uuid::Uuid;
+
+use experimentation_proto::experimentation::common::v1::{
+    MetricAggregationLevel, MetricDefinition, MetricStakeholder, MetricType,
+};
+use experimentation_proto::experimentation::management::v1::{
+    experiment_management_service_server::ExperimentManagementService,
+    CreateMetricDefinitionRequest, GetMetricDefinitionRequest, MigrateMetricDefinitionRequest,
+};
+use experimentation_proto::experimentation::metrics::v1::{
+    metric_computation_service_client::MetricComputationServiceClient,
+    metric_computation_service_server::{MetricComputationService, MetricComputationServiceServer},
+    CompileMetricqlPreviewRequest, CompileMetricqlPreviewResponse,
+    ComputeGuardrailMetricsRequest, ComputeMetricsRequest, ComputeMetricsResponse,
+    ExportNotebookRequest, ExportNotebookResponse, GetQueryLogRequest, GetQueryLogResponse,
+    GetShadowResultsRequest, GetShadowResultsResponse, PromoteShadowResultRequest,
+    PromoteShadowResultResponse, ScheduleShadowComputationRequest,
+    ScheduleShadowComputationResponse,
+};
+
+use experimentation_management::grpc::{ManagementServiceHandler, SharedState};
+use experimentation_management::store::ManagementStore;
+
+// ---------------------------------------------------------------------------
+// Mock M3 — driven by a per-shadow-id status map
+// ---------------------------------------------------------------------------
+
+/// Map from shadow_id (UUID string) to the status string M3 should return
+/// for `GetShadowResults`. Tests preload entries to control whether a given
+/// migrate call's shadow_run_result_id resolves to APPROVED / REJECTED / etc.
+type ShadowStatusMap = Arc<Mutex<std::collections::HashMap<String, String>>>;
+
+struct MockM3 {
+    shadow_status: ShadowStatusMap,
+}
+
+#[tonic::async_trait]
+impl MetricComputationService for MockM3 {
+    async fn get_shadow_results(
+        &self,
+        req: Request<GetShadowResultsRequest>,
+    ) -> Result<Response<GetShadowResultsResponse>, Status> {
+        let inner = req.into_inner();
+        let map = self.shadow_status.lock().unwrap();
+        match map.get(&inner.shadow_id) {
+            Some(status) => Ok(Response::new(GetShadowResultsResponse {
+                shadow_id: inner.shadow_id,
+                status: status.clone(),
+                rows: vec![],
+                days_within_tolerance: 0,
+                total_days: 0,
+            })),
+            None => Err(Status::not_found(format!(
+                "shadow_id not registered with mock M3: {}",
+                inner.shadow_id
+            ))),
+        }
+    }
+
+    // Stub remaining RPCs to satisfy the trait bound.
+    async fn compute_metrics(
+        &self,
+        _req: Request<ComputeMetricsRequest>,
+    ) -> Result<Response<ComputeMetricsResponse>, Status> {
+        Err(Status::unimplemented("stub"))
+    }
+
+    async fn compute_guardrail_metrics(
+        &self,
+        _req: Request<ComputeGuardrailMetricsRequest>,
+    ) -> Result<Response<ComputeMetricsResponse>, Status> {
+        Err(Status::unimplemented("stub"))
+    }
+
+    async fn export_notebook(
+        &self,
+        _req: Request<ExportNotebookRequest>,
+    ) -> Result<Response<ExportNotebookResponse>, Status> {
+        Err(Status::unimplemented("stub"))
+    }
+
+    async fn get_query_log(
+        &self,
+        _req: Request<GetQueryLogRequest>,
+    ) -> Result<Response<GetQueryLogResponse>, Status> {
+        Err(Status::unimplemented("stub"))
+    }
+
+    async fn compile_metricql_preview(
+        &self,
+        _req: Request<CompileMetricqlPreviewRequest>,
+    ) -> Result<Response<CompileMetricqlPreviewResponse>, Status> {
+        Err(Status::unimplemented("stub"))
+    }
+
+    async fn schedule_shadow_computation(
+        &self,
+        _req: Request<ScheduleShadowComputationRequest>,
+    ) -> Result<Response<ScheduleShadowComputationResponse>, Status> {
+        Err(Status::unimplemented("stub"))
+    }
+
+    async fn promote_shadow_result(
+        &self,
+        _req: Request<PromoteShadowResultRequest>,
+    ) -> Result<Response<PromoteShadowResultResponse>, Status> {
+        Err(Status::unimplemented("stub"))
+    }
+}
+
+async fn spawn_mock_m3() -> (SocketAddr, ShadowStatusMap) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let shadow_status: ShadowStatusMap =
+        Arc::new(Mutex::new(std::collections::HashMap::new()));
+    let mock = MockM3 {
+        shadow_status: shadow_status.clone(),
+    };
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(MetricComputationServiceServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+    tokio::task::yield_now().await;
+    (addr, shadow_status)
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Build a real (PG-backed) gRPC handler whose M3 client points at the
+/// caller-supplied mock. Returns `None` if no Postgres is reachable.
+async fn try_handler(m3_addr: SocketAddr) -> Option<ManagementServiceHandler> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    match ManagementStore::connect(&url).await {
+        Ok(store) => {
+            let endpoint =
+                tonic::transport::Endpoint::from_shared(format!("http://{m3_addr}"))
+                    .expect("valid M3 endpoint");
+            let channel = endpoint.connect_lazy();
+            let client = MetricComputationServiceClient::new(channel);
+            let state = SharedState::new_with_channel(store, client);
+            Some(ManagementServiceHandler::new(state))
+        }
+        Err(e) => {
+            eprintln!("skip: could not connect to DATABASE_URL: {e}");
+            None
+        }
+    }
+}
+
+/// Process-unique id (timestamp + monotonic counter). Avoids cross-test
+/// collisions even when the suite is run repeatedly against a persistent DB.
+fn unique_id(prefix: &str) -> String {
+    static CTR: AtomicU64 = AtomicU64::new(1);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("e2e_mig_{prefix}_{ts}_{n}")
+}
+
+fn custom_metric(id: &str) -> MetricDefinition {
+    MetricDefinition {
+        metric_id: id.to_string(),
+        name: format!("custom {id}"),
+        description: "migration e2e original".into(),
+        r#type: MetricType::Custom as i32,
+        source_event_type: "video_play".into(),
+        custom_sql: "SELECT COUNT(*) FROM video_play".into(),
+        stakeholder: MetricStakeholder::User as i32,
+        aggregation_level: MetricAggregationLevel::User as i32,
+        ..Default::default()
+    }
+}
+
+fn mean_metric(id: &str) -> MetricDefinition {
+    MetricDefinition {
+        metric_id: id.to_string(),
+        name: format!("mean {id}"),
+        r#type: MetricType::Mean as i32,
+        source_event_type: "video_play".into(),
+        stakeholder: MetricStakeholder::User as i32,
+        aggregation_level: MetricAggregationLevel::User as i32,
+        ..Default::default()
+    }
+}
+
+/// METRICQL replacement that doesn't reference any other metrics (so the
+/// validator's existence check is vacuously satisfied). The expression
+/// `mean(heartbeat.value)` parses + analyses cleanly under the Phase 2
+/// MetricQL grammar.
+fn metricql_replacement(id: &str) -> MetricDefinition {
+    MetricDefinition {
+        metric_id: id.to_string(),
+        name: format!("metricql {id}"),
+        description: "migration e2e replacement".into(),
+        r#type: MetricType::Metricql as i32,
+        stakeholder: MetricStakeholder::User as i32,
+        aggregation_level: MetricAggregationLevel::User as i32,
+        metricql_expression: "mean(heartbeat.value)".into(),
+        ..Default::default()
+    }
+}
+
+/// METRICQL with a parse error — used to exercise (e) validator failure.
+fn metricql_bad(id: &str) -> MetricDefinition {
+    MetricDefinition {
+        metric_id: id.to_string(),
+        name: format!("bad metricql {id}"),
+        r#type: MetricType::Metricql as i32,
+        stakeholder: MetricStakeholder::User as i32,
+        aggregation_level: MetricAggregationLevel::User as i32,
+        // Unterminated string literal — guaranteed parse error.
+        metricql_expression: "'unterminated".into(),
+        ..Default::default()
+    }
+}
+
+/// Helper to create a CUSTOM metric directly through the handler's
+/// `create_metric_definition` (so the row uses the production code path).
+async fn seed_custom(handler: &ManagementServiceHandler, id: &str) {
+    handler
+        .create_metric_definition(Request::new(CreateMetricDefinitionRequest {
+            metric: Some(custom_metric(id)),
+        }))
+        .await
+        .expect("seed CUSTOM metric ok");
+}
+
+/// Helper to create a MEAN metric (non-CUSTOM, used in the "old isn't CUSTOM"
+/// case).
+async fn seed_mean(handler: &ManagementServiceHandler, id: &str) {
+    handler
+        .create_metric_definition(Request::new(CreateMetricDefinitionRequest {
+            metric: Some(mean_metric(id)),
+        }))
+        .await
+        .expect("seed MEAN metric ok");
+}
+
+/// Register a fresh shadow_id with the given status on the mock M3.
+/// Returns the shadow_id as a string for use in MigrateMetricDefinitionRequest.
+fn register_shadow(shadow_status: &ShadowStatusMap, status: &str) -> String {
+    let id = Uuid::new_v4().to_string();
+    shadow_status
+        .lock()
+        .unwrap()
+        .insert(id.clone(), status.to_string());
+    id
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn happy_path_custom_to_metricql_with_approved_shadow() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let old_id = unique_id("happy_old");
+    let new_id = unique_id("happy_new");
+    seed_custom(&handler, &old_id).await;
+
+    let shadow_id = register_shadow(&shadow_status, "APPROVED");
+
+    let resp = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id.clone(),
+            new_metric: Some(metricql_replacement(&new_id)),
+            shadow_run_result_id: shadow_id.clone(),
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect("happy-path migrate ok")
+        .into_inner();
+
+    assert_eq!(resp.new_metric_id, new_id, "echoes new metric_id");
+    assert!(!resp.migration_id.is_empty(), "migration_id populated");
+    let migration_uuid =
+        Uuid::parse_str(&resp.migration_id).expect("migration_id is a valid UUID");
+    assert!(
+        !resp.applied_at.is_empty(),
+        "applied_at populated (RFC 3339): {}",
+        resp.applied_at
+    );
+    // RFC 3339 always has a 'T' separator between date and time.
+    assert!(
+        resp.applied_at.contains('T'),
+        "applied_at looks RFC 3339: {}",
+        resp.applied_at
+    );
+
+    // I1: read back the NEW metric definition to confirm it actually landed
+    // in the DB. The gRPC response alone doesn't prove anything was persisted.
+    let stored_new = handler
+        .get_metric_definition(Request::new(GetMetricDefinitionRequest {
+            metric_id: new_id.clone(),
+        }))
+        .await
+        .expect("new metric is retrievable")
+        .into_inner();
+    assert_eq!(stored_new.r#type(), MetricType::Metricql);
+    assert_eq!(stored_new.metricql_expression, "mean(heartbeat.value)");
+
+    // I1: read back the OLD CUSTOM metric to confirm L7's "never destructive
+    // in-place" guarantee — the original row stays put with type=CUSTOM even
+    // after migration.
+    let stored_old = handler
+        .get_metric_definition(Request::new(GetMetricDefinitionRequest {
+            metric_id: old_id.clone(),
+        }))
+        .await
+        .expect("old CUSTOM row preserved per L7")
+        .into_inner();
+    assert_eq!(stored_old.r#type(), MetricType::Custom);
+
+    // I1: read back the metric_migrations audit row to confirm every column
+    // got bound to the right input (catches accidental argument swaps in the
+    // INSERT). Use the handler's store directly via the new
+    // get_metric_migration_by_id lookup.
+    let shadow_uuid = Uuid::parse_str(&shadow_id).expect("shadow_id is a valid UUID");
+    let audit = handler
+        .store()
+        .get_metric_migration_by_id(migration_uuid)
+        .await
+        .expect("audit row is retrievable");
+    assert_eq!(audit.migration_id, migration_uuid, "migration_id roundtrip");
+    assert_eq!(audit.old_metric_id, old_id, "audit.old_metric_id");
+    assert_eq!(audit.new_metric_id, new_id, "audit.new_metric_id");
+    assert_eq!(
+        audit.shadow_run_result_id, shadow_uuid,
+        "audit.shadow_run_result_id"
+    );
+    assert_eq!(audit.operator, "alice@example.com", "audit.operator");
+}
+
+#[tokio::test]
+async fn old_is_not_custom_returns_invalid_argument() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    // Seed a MEAN (not CUSTOM) metric — precondition (a) must reject it.
+    let old_id = unique_id("not_custom");
+    let new_id = unique_id("repl");
+    seed_mean(&handler, &old_id).await;
+
+    let shadow_id = register_shadow(&shadow_status, "APPROVED");
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id.clone(),
+            new_metric: Some(metricql_replacement(&new_id)),
+            shadow_run_result_id: shadow_id,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject non-CUSTOM old metric");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("CUSTOM"),
+        "message must mention CUSTOM, got: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn new_is_custom_returns_invalid_argument() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let old_id = unique_id("old");
+    let new_id = unique_id("new_custom");
+    seed_custom(&handler, &old_id).await;
+
+    // No need to actually seed the shadow — (b) short-circuits before M3.
+    let shadow_id = register_shadow(&shadow_status, "APPROVED");
+
+    let mut replacement = custom_metric(&new_id);
+    // Distinguish the description so a future bug that wrote it would show
+    // up clearly.
+    replacement.description = "should be rejected".into();
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id,
+            new_metric: Some(replacement),
+            shadow_run_result_id: shadow_id,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject CUSTOM replacement");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("CUSTOM"),
+        "message must mention CUSTOM, got: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn same_metric_id_returns_invalid_argument() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let id = unique_id("same_id");
+    seed_custom(&handler, &id).await;
+    let shadow_id = register_shadow(&shadow_status, "APPROVED");
+
+    // Construct a METRICQL replacement that reuses the old id.
+    let mut replacement = metricql_replacement(&id);
+    replacement.metric_id = id.clone();
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: id.clone(),
+            new_metric: Some(replacement),
+            shadow_run_result_id: shadow_id,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject same metric_id");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("differ"),
+        "message must mention 'differ', got: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn shadow_not_approved_returns_failed_precondition() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let old_id = unique_id("rejected_old");
+    let new_id = unique_id("rejected_new");
+    seed_custom(&handler, &old_id).await;
+    let shadow_id = register_shadow(&shadow_status, "REJECTED");
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id.clone(),
+            new_metric: Some(metricql_replacement(&new_id)),
+            shadow_run_result_id: shadow_id,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject non-APPROVED shadow");
+
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert!(
+        err.message().contains("APPROVED"),
+        "message must mention APPROVED, got: {}",
+        err.message()
+    );
+    assert!(
+        err.message().contains("REJECTED"),
+        "message must include actual status, got: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn validator_failure_returns_invalid_argument() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let old_id = unique_id("bad_repl_old");
+    let new_id = unique_id("bad_repl_new");
+    seed_custom(&handler, &old_id).await;
+    let shadow_id = register_shadow(&shadow_status, "APPROVED");
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id,
+            new_metric: Some(metricql_bad(&new_id)),
+            shadow_run_result_id: shadow_id,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject invalid MetricQL");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    // The MetricQL parser reports a string-literal diagnostic for an
+    // unterminated quote — we don't assert the exact wording (it ships from
+    // the validator crate), only that some diagnostic-shaped message is
+    // surfaced.
+    assert!(
+        !err.message().is_empty(),
+        "validator must populate an error message"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_old_metric_id_returns_already_exists() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let old_id = unique_id("dup_old");
+    let new_id_1 = unique_id("dup_new1");
+    let new_id_2 = unique_id("dup_new2");
+    seed_custom(&handler, &old_id).await;
+    let shadow_id_1 = register_shadow(&shadow_status, "APPROVED");
+    let shadow_id_2 = register_shadow(&shadow_status, "APPROVED");
+
+    // First migration succeeds.
+    handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id.clone(),
+            new_metric: Some(metricql_replacement(&new_id_1)),
+            shadow_run_result_id: shadow_id_1,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect("first migrate ok");
+
+    // Second migration of the SAME old_metric_id with a different new_id
+    // must hit the uq_metric_migrations_old constraint.
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id.clone(),
+            new_metric: Some(metricql_replacement(&new_id_2)),
+            shadow_run_result_id: shadow_id_2,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("second migrate must fail");
+
+    assert_eq!(err.code(), Code::AlreadyExists);
+    assert!(
+        err.message().contains("already migrated") || err.message().contains(&old_id),
+        "message must indicate already-migrated, got: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn duplicate_new_metric_id_returns_already_exists() {
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    // Set up two CUSTOM metrics + a shared replacement id. First migrate
+    // takes the new id; second must fail on metric_definitions PK collision.
+    let old_id_1 = unique_id("dup_n_old1");
+    let old_id_2 = unique_id("dup_n_old2");
+    let shared_new_id = unique_id("dup_n_shared");
+    seed_custom(&handler, &old_id_1).await;
+    seed_custom(&handler, &old_id_2).await;
+    let shadow_id_1 = register_shadow(&shadow_status, "APPROVED");
+    let shadow_id_2 = register_shadow(&shadow_status, "APPROVED");
+
+    handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id_1,
+            new_metric: Some(metricql_replacement(&shared_new_id)),
+            shadow_run_result_id: shadow_id_1,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect("first migrate (taking the new id) ok");
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id_2,
+            new_metric: Some(metricql_replacement(&shared_new_id)),
+            shadow_run_result_id: shadow_id_2,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("second migrate must fail on new-id PK collision");
+
+    assert_eq!(err.code(), Code::AlreadyExists);
+    assert!(
+        err.message().contains("already exists")
+            || err.message().contains(&shared_new_id),
+        "message must indicate already-exists, got: {}",
+        err.message()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Precondition-order tests
+// ---------------------------------------------------------------------------
+//
+// The handler must check preconditions in the order b → c → a → e → d so
+// callers always get the most-helpful (earliest) failure. We assert this by
+// constructing requests that would fail multiple checks and confirming the
+// reported error matches the EARLIEST precondition.
+
+#[tokio::test]
+async fn precondition_order_b_beats_c() {
+    // new=CUSTOM (b fails) AND same metric_id (c would also fail).
+    // Expected: InvalidArgument with "CUSTOM" — (b) fires first.
+    let (m3_addr, _shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let id = unique_id("ord_bc");
+    let mut replacement = custom_metric(&id);
+    replacement.metric_id = id.clone();
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: id.clone(),
+            new_metric: Some(replacement),
+            shadow_run_result_id: Uuid::new_v4().to_string(),
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must fail on (b)");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("CUSTOM"),
+        "(b) must fire before (c); message: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn precondition_order_c_beats_a() {
+    // new.metric_id == old (c fails) AND old does not exist (a would also fail).
+    // Expected: InvalidArgument with "differ" — (c) fires first.
+    let (m3_addr, _shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let nonexistent_id = unique_id("ord_ca_nonexistent");
+    let mut replacement = metricql_replacement(&nonexistent_id);
+    replacement.metric_id = nonexistent_id.clone();
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: nonexistent_id.clone(),
+            new_metric: Some(replacement),
+            shadow_run_result_id: Uuid::new_v4().to_string(),
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must fail on (c)");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("differ"),
+        "(c) must fire before (a); message: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn precondition_order_e_beats_d() {
+    // Bad MetricQL (e fails) AND shadow is REJECTED (d would also fail).
+    // Expected: InvalidArgument from the validator — (e) fires before (d).
+    let (m3_addr, shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let old_id = unique_id("ord_ed_old");
+    let new_id = unique_id("ord_ed_new");
+    seed_custom(&handler, &old_id).await;
+    let shadow_id = register_shadow(&shadow_status, "REJECTED");
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id,
+            new_metric: Some(metricql_bad(&new_id)),
+            shadow_run_result_id: shadow_id,
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must fail on (e)");
+
+    // (e) → InvalidArgument; (d) would be → FailedPrecondition.
+    assert_eq!(
+        err.code(),
+        Code::InvalidArgument,
+        "(e) must fire before (d); got code {:?}",
+        err.code()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Request-shape tests (run without DB; cheap edge cases)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_old_metric_id_returns_invalid_argument() {
+    let (m3_addr, _shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let new_id = unique_id("empty_old_new");
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: "".into(),
+            new_metric: Some(metricql_replacement(&new_id)),
+            shadow_run_result_id: Uuid::new_v4().to_string(),
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject empty old_metric_id");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("old_metric_id"),
+        "message must mention old_metric_id, got: {}",
+        err.message()
+    );
+}
+
+#[tokio::test]
+async fn missing_new_metric_returns_invalid_argument() {
+    let (m3_addr, _shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: "foo".into(),
+            new_metric: None,
+            shadow_run_result_id: Uuid::new_v4().to_string(),
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject missing new_metric");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("new_metric"),
+        "message must mention new_metric, got: {}",
+        err.message()
+    );
+}
+
+// I2: a malformed shadow_run_result_id is a caller bug, not a missing shadow
+// run. The handler must surface it as InvalidArgument from the request-shape
+// stage — BEFORE the M3 GetShadowResults RPC — so callers don't get the
+// misleading FailedPrecondition("shadow_run_result_id not found in M3") that
+// the original ordering produced (the mock M3, and likely the real one,
+// returns NotFound for a UUID it doesn't know about).
+#[tokio::test]
+async fn malformed_shadow_uuid_returns_invalid_argument() {
+    let (m3_addr, _shadow_status) = spawn_mock_m3().await;
+    let Some(handler) = try_handler(m3_addr).await else { return };
+
+    let old_id = unique_id("malformed_uuid_old");
+    let new_id = unique_id("malformed_uuid_new");
+    // We deliberately do NOT seed old_id and do NOT register a shadow result:
+    // a request-shape rejection must fire before either DB or M3 is consulted.
+    // (If the UUID parse moved back behind the M3 call, this test would fail
+    //  with FailedPrecondition / Unavailable instead of InvalidArgument.)
+    let err = handler
+        .migrate_metric_definition(Request::new(MigrateMetricDefinitionRequest {
+            old_metric_id: old_id,
+            new_metric: Some(metricql_replacement(&new_id)),
+            shadow_run_result_id: "not-a-uuid".into(),
+            operator: "alice@example.com".into(),
+        }))
+        .await
+        .expect_err("must reject malformed shadow_run_result_id");
+
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(
+        err.message().contains("shadow_run_result_id"),
+        "message must mention shadow_run_result_id, got: {}",
+        err.message()
+    );
+    assert!(
+        err.message().contains("UUID"),
+        "message must mention UUID, got: {}",
+        err.message()
+    );
+}

--- a/crates/experimentation-management/tests/validate_metricql_global_scope_test.rs
+++ b/crates/experimentation-management/tests/validate_metricql_global_scope_test.rs
@@ -17,9 +17,10 @@
 //! cargo test -p experimentation-management --test validate_metricql_global_scope_test
 //! ```
 //!
-//! A pure-Rust safety-net unit test for the same contract lives in
+//! Pure-Rust safety-net unit tests for the same contract live in
 //! `crates/experimentation-management/src/grpc.rs` (`mod tests`); see
-//! `empty_experiment_id_no_longer_returns_invalid_argument`.
+//! `global_scope_empty_catalog_flags_unknown_ref_with_position` and
+//! `global_scope_with_known_id_validates_clean`.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -108,7 +109,7 @@ async fn empty_experiment_id_with_known_metric_returns_valid() {
     let response = handler
         .validate_metricql(Request::new(ValidateMetricqlRequest {
             experiment_id: String::new(),
-            metricql_expression: expression.clone(),
+            metricql_expression: expression,
         }))
         .await
         .expect("validate_metricql must accept empty experiment_id")
@@ -121,7 +122,7 @@ async fn empty_experiment_id_with_known_metric_returns_valid() {
     );
     assert_eq!(
         response.referenced_metric_ids,
-        vec![metric_id.clone()],
+        vec![metric_id],
         "referenced_metric_ids must surface the resolved @ref"
     );
 }
@@ -143,7 +144,7 @@ async fn empty_experiment_id_with_unknown_metric_returns_diagnostic() {
     let response = handler
         .validate_metricql(Request::new(ValidateMetricqlRequest {
             experiment_id: String::new(),
-            metricql_expression: expression.clone(),
+            metricql_expression: expression,
         }))
         .await
         .expect("validate_metricql must accept empty experiment_id")

--- a/crates/experimentation-management/tests/validate_metricql_global_scope_test.rs
+++ b/crates/experimentation-management/tests/validate_metricql_global_scope_test.rs
@@ -1,0 +1,189 @@
+//! ADR-026 Phase 2 follow-up (#571 Task 1) — global-scope `ValidateMetricql`.
+//!
+//! These tests exercise the live-lint path used by the M6 metric-creation form,
+//! which has no experiment context yet. When `experiment_id` is empty the M5
+//! handler must build its `known_metric_ids` set from the global
+//! `metric_definitions` table (via `ManagementStore::list_metrics(default)`),
+//! NOT reject the request with `INVALID_ARGUMENT`.
+//!
+//! ## Running this suite
+//!
+//! Mirrors `metric_definition_e2e_test.rs`: gated on `DATABASE_URL`, skips
+//! quietly when unset.
+//!
+//! ```sh
+//! just db-reset && just migrate
+//! export DATABASE_URL=postgres://postgres:postgres@localhost:5432/kaizen_dev
+//! cargo test -p experimentation-management --test validate_metricql_global_scope_test
+//! ```
+//!
+//! A pure-Rust safety-net unit test for the same contract lives in
+//! `crates/experimentation-management/src/grpc.rs` (`mod tests`); see
+//! `empty_experiment_id_no_longer_returns_invalid_argument`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tonic::Request;
+
+use experimentation_management::grpc::{ManagementServiceHandler, SharedState};
+use experimentation_management::store::ManagementStore;
+use experimentation_proto::experimentation::common::v1::{
+    MetricAggregationLevel, MetricDefinition, MetricStakeholder, MetricType,
+};
+use experimentation_proto::experimentation::management::v1::{
+    experiment_management_service_server::ExperimentManagementService,
+    CreateMetricDefinitionRequest, ValidateMetricqlRequest,
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirror metric_definition_e2e_test.rs)
+// ---------------------------------------------------------------------------
+
+async fn try_handler() -> Option<ManagementServiceHandler> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    match ManagementStore::connect(&url).await {
+        Ok(store) => {
+            let state = SharedState::new(store);
+            Some(ManagementServiceHandler::new(state))
+        }
+        Err(e) => {
+            eprintln!("skip: could not connect to DATABASE_URL: {e}");
+            None
+        }
+    }
+}
+
+/// Process-unique id with a stable prefix so the same metric can be looked up
+/// across the two test cases via the global catalog.
+fn unique_id(prefix: &str) -> String {
+    static CTR: AtomicU64 = AtomicU64::new(1);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("e2e_{prefix}_{ts}_{n}")
+}
+
+/// A MEAN metric that will be inserted into `metric_definitions` so the
+/// global-scope path of `validate_metricql` can find it.
+fn mean_metric(id: &str) -> MetricDefinition {
+    MetricDefinition {
+        metric_id: id.to_string(),
+        name: format!("mean {id}"),
+        r#type: MetricType::Mean as i32,
+        source_event_type: "video_play".into(),
+        stakeholder: MetricStakeholder::User as i32,
+        aggregation_level: MetricAggregationLevel::User as i32,
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — empty experiment_id + known metric → valid
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_experiment_id_with_known_metric_returns_valid() {
+    let Some(handler) = try_handler().await else {
+        return;
+    };
+
+    // Create a metric in the global catalog (no experiment scope).
+    let metric_id = unique_id("watch_time");
+    handler
+        .create_metric_definition(Request::new(CreateMetricDefinitionRequest {
+            metric: Some(mean_metric(&metric_id)),
+        }))
+        .await
+        .expect("create_metric_definition ok");
+
+    // Live-lint path: empty experiment_id, expression references the new metric.
+    // We deliberately wrap @id in an arithmetic Composite (`@id + 0`) because the
+    // analyzer rejects a *bare* @ref at root as semantically nonsensical for a
+    // metric definition; the live-lint surface we care about is the existence
+    // check inside a composite expression, which is exactly what the
+    // metric-creation form will type.
+    let expression = format!("@{metric_id} + 0");
+    let response = handler
+        .validate_metricql(Request::new(ValidateMetricqlRequest {
+            experiment_id: String::new(),
+            metricql_expression: expression.clone(),
+        }))
+        .await
+        .expect("validate_metricql must accept empty experiment_id")
+        .into_inner();
+
+    assert!(
+        response.diagnostics.is_empty(),
+        "expected no diagnostics for known global metric, got: {:?}",
+        response.diagnostics
+    );
+    assert_eq!(
+        response.referenced_metric_ids,
+        vec![metric_id.clone()],
+        "referenced_metric_ids must surface the resolved @ref"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — empty experiment_id + unknown metric → diagnostic with line:col
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_experiment_id_with_unknown_metric_returns_diagnostic() {
+    let Some(handler) = try_handler().await else {
+        return;
+    };
+
+    // A metric_id that we deliberately do NOT insert. Process-unique so any
+    // residual seed data in a shared DB cannot satisfy it.
+    let unknown_id = unique_id("never_created");
+    let expression = format!("@{unknown_id} + 0");
+    let response = handler
+        .validate_metricql(Request::new(ValidateMetricqlRequest {
+            experiment_id: String::new(),
+            metricql_expression: expression.clone(),
+        }))
+        .await
+        .expect("validate_metricql must accept empty experiment_id")
+        .into_inner();
+
+    assert_eq!(
+        response.diagnostics.len(),
+        1,
+        "expected exactly one diagnostic for an unknown global metric, got: {:?}",
+        response.diagnostics
+    );
+
+    let diag = &response.diagnostics[0];
+    let lower = diag.message.to_lowercase();
+    assert!(
+        lower.contains("unknown") || lower.contains("unresolved") || lower.contains("not found"),
+        "diagnostic must flag the unresolved ref; got message: {:?}",
+        diag.message
+    );
+    assert!(
+        diag.message.contains(&unknown_id),
+        "diagnostic message must mention the unknown metric id {unknown_id}; got: {:?}",
+        diag.message
+    );
+
+    let span = diag.span.as_ref().expect("diagnostic must carry a span");
+    assert!(
+        span.line >= 1,
+        "diagnostic line must be 1-indexed; got line={}",
+        span.line
+    );
+    assert!(
+        span.column >= 1,
+        "diagnostic column must be 1-indexed; got column={}",
+        span.column
+    );
+
+    assert!(
+        response.referenced_metric_ids.is_empty(),
+        "referenced_metric_ids must be empty when diagnostics fire; got: {:?}",
+        response.referenced_metric_ids
+    );
+}

--- a/crates/experimentation-management/tests/validate_metricql_global_scope_test.rs
+++ b/crates/experimentation-management/tests/validate_metricql_global_scope_test.rs
@@ -3,8 +3,11 @@
 //! These tests exercise the live-lint path used by the M6 metric-creation form,
 //! which has no experiment context yet. When `experiment_id` is empty the M5
 //! handler must build its `known_metric_ids` set from the global
-//! `metric_definitions` table (via `ManagementStore::list_metrics(default)`),
-//! NOT reject the request with `INVALID_ARGUMENT`.
+//! `metric_definitions` table (via `ManagementStore::list_metric_ids()` — a
+//! lightweight `SELECT metric_id` introduced in response to Devin PR #595 🟡
+//! perf finding; the wider `list_metrics()` was deserialising 18 columns
+//! including large JSON/SQL blobs on every ~500ms lint cycle), NOT reject
+//! the request with `INVALID_ARGUMENT`.
 //!
 //! ## Running this suite
 //!

--- a/docs/runbooks/adr-026-phase-3-migration.md
+++ b/docs/runbooks/adr-026-phase-3-migration.md
@@ -1,0 +1,381 @@
+# ADR-026 Phase 3 — CUSTOM Metric Migration Runbook
+
+## What this runbook covers
+
+ADR-026 Phase 3 retires legacy `METRIC_TYPE_CUSTOM` metrics in favour of the
+Phase 1 structured types (`FILTERED_MEAN`, `COMPOSITE`, `WINDOWED_COUNT`) and
+the Phase 2 MetricQL expression language. This runbook is for operators
+driving that migration against a real org's metrics: scan the inventory,
+translate eligible CUSTOMs, shadow-run the candidates against M3 until
+row-level equivalence is established, and apply the migrations atomically
+through M5. Survey is operational guidance, not a prerequisite (Lock L8) —
+you may run survey + translate ad-hoc; the migration tool's pattern library
+is conservative-by-default, so anything that cannot be auto-translated is
+surfaced as a Tier 3 entry for human review.
+
+## Workflow at a glance
+
+```
+scan  →  translate  →  (distribute proposals to owners)  →  shadow (7+ days)
+                                                              ↓
+                                                       apply --dry-run
+                                                              ↓
+                                                       apply --confirm
+```
+
+| Step | Input | Output | Guarantees |
+|------|-------|--------|------------|
+| `scan` | M5 gRPC URL | `scan.json` (raw `MetricDefinition`s, `type = CUSTOM`) | Read-only; pages through `ListMetricDefinitions` until exhaustion |
+| `translate` | `scan.json` | `proposals.json` + `summary.md` | AST-based; only patterns that round-trip 100% are auto-classified Tier 1/2 |
+| `shadow` | `proposals.json`, M3 gRPC URL | `shadow.json` | M3 enforces 7 consecutive days within tolerance before approving |
+| `apply --dry-run` | `shadow.json` | stdout table | No M5 writes |
+| `apply --confirm` | `shadow.json` | M5 mutations + audit sidecar | Atomic txn per migration; old CUSTOM row preserved |
+
+---
+
+## Prerequisites
+
+| Requirement | Why |
+|-------------|-----|
+| M5 (`experimentation-management`) reachable at a known gRPC URL | `scan` and `apply` both call M5 RPCs (`ListMetricDefinitions`, `MigrateMetricDefinition`) |
+| M3 (metrics service) reachable at a known gRPC URL | `shadow` schedules + polls via `ScheduleShadowComputation`, `PromoteShadowResult`, `GetShadowResults` |
+| `custom_migrator` binary built or available via `cargo run` | All four subcommands live in this binary; build with `cargo build --release -p experimentation-management --bin custom_migrator` or set `$CUSTOM_MIGRATOR_BIN` to a prebuilt path |
+| Operator identity (email or service-account id) | Required for `apply --confirm --operator <id>`; written into the `metric_migrations.operator` audit column |
+| Read access to the relevant org's metric definitions | Whoever the M5 caller authenticates as needs to be able to list / read the CUSTOM rows being migrated |
+| `jq` (recommended, optional) | The `survey.sh` wrapper uses `jq` for its closing summary; otherwise counts display as `?` |
+
+ADR-026 Phase 3 ships migration `016_adr026_phase3_metric_migrations.sql`
+(the `metric_migrations` audit table). Ensure migrations 001–016 are
+applied against the M5 PostgreSQL database before running `apply --confirm`.
+
+---
+
+## Step 1 — Scan + translate (the survey)
+
+### What it does
+
+`custom_migrator scan` calls `M5::ListMetricDefinitions(type = CUSTOM)` and
+serialises every returned `MetricDefinition` into a JSON array.
+
+`custom_migrator translate` reads that array and, per metric, runs the AST
+classifier. Each metric resolves to one of five outcomes (each is a tier of
+the classification enum in
+`crates/experimentation-management/src/migration/classifier.rs`):
+
+| Tier | Meaning | Apply-eligible? |
+|------|---------|-----------------|
+| `tier1_filtered_mean` | Auto-translatable to `FILTERED_MEAN` | Yes |
+| `tier1_composite` | Auto-translatable to `COMPOSITE` | Yes |
+| `tier1_windowed_count` | Auto-translatable to `WINDOWED_COUNT` | Yes |
+| `tier2_metricql` | Auto-translatable to a MetricQL expression | Yes |
+| `tier3_untranslatable` | Not auto-translatable; needs human design | No |
+
+The translator round-trips every proposal through
+`validate_metric_definition` before emission (Lock L1) so the classifier
+never produces semantically-invalid output.
+
+### How to run
+
+**Quick path (recommended)** — uses the `survey.sh` wrapper, which calls
+both subcommands and prints a one-line tier breakdown at the end:
+
+```bash
+./scripts/migration-phase3/survey.sh \
+    --m5-addr http://localhost:50055 \
+    --output-dir ./migration-phase3-output \
+    --org acme
+```
+
+The wrapper writes:
+
+- `./migration-phase3-output/acme-scan.json` — raw `MetricDefinition` list
+- `./migration-phase3-output/acme-proposals.json` — proposals (input for `shadow`)
+- `./migration-phase3-output/acme-summary.md` — Markdown summary for review
+
+Run `./scripts/migration-phase3/survey.sh --help` for the full flag list and
+environment variables.
+
+**Direct invocation** — drives `custom_migrator` yourself:
+
+```bash
+custom_migrator scan \
+    --m5-addr http://localhost:50055 \
+    --output ./scan.json
+
+custom_migrator translate \
+    --report ./scan.json \
+    --output ./proposals.json \
+    --markdown ./summary.md
+```
+
+### What to do with the output
+
+- Send `summary.md` to the metric owners — it groups proposals by tier and
+  lists each metric's `original_metric_id`, the destination type, and the
+  human-readable reason from the classifier.
+- Collect go / no-go answers per proposal. Tier 3 entries always require a
+  follow-up — they are not shadow-runnable in their current form and need
+  the metric owner to decide whether to redesign as a structured / MetricQL
+  metric or leave it on CUSTOM until further notice.
+- `proposals.json` (machine-readable) is the binding input for the
+  `shadow` subcommand. Trim any owner-rejected proposals out of the file
+  before proceeding (or carry them through and rely on the operator review
+  at `apply --dry-run` to filter them out — both work, the former is
+  cleaner).
+
+---
+
+## Step 2 — Shadow run
+
+### What it does
+
+`custom_migrator shadow` reads the proposals JSON, filters to Tier 1 + Tier
+2 (Tier 3 is skipped with a warning), and for each surviving proposal:
+
+1. Calls `M3::ScheduleShadowComputation(original_metric_id, candidate_metric)`.
+2. Polls `M3::PromoteShadowResult` on a cadence (default 60s, override via
+   `CUSTOM_MIGRATOR_POLL_INTERVAL_SECS`) until terminal status or
+   `--duration` exhausts.
+3. Snapshots `days_within_tolerance` / `total_days` from
+   `M3::GetShadowResults` for the audit trail.
+
+M3 owns the 7-consecutive-days-within-tolerance gate (PR #580, Lock L3) —
+`PromoteShadowResult` will not return `APPROVED` until a run accumulates 7
+clean days. The migrator does not double-check the gate; it trusts M3's
+verdict.
+
+### How to run
+
+```bash
+custom_migrator shadow \
+    --proposals ./proposals.json \
+    --m3-addr http://localhost:50056 \
+    --duration 14d \
+    --output ./shadow.json
+```
+
+### Why 14d, not 7d
+
+7 days is the minimum M3 will accept. In practice, a (metric, experiment,
+variant, day) tuple with no data on either side does not count toward the
+7. Budget extra days for partial-data windows so a real-world run reaches
+APPROVED inside the polling budget instead of expiring at `PENDING`.
+
+### Outcome statuses
+
+The shadow output is a `ShadowOutput` JSON with one entry per proposal.
+The `status` field is one of:
+
+| Status | Meaning | Operator action |
+|--------|---------|-----------------|
+| `APPROVED` | 7+ consecutive days within tolerance; M3 returned an APPROVED `result_id` | Carry into `apply` |
+| `REJECTED` | At least one (experiment, variant, day) tuple failed the tolerance check | Investigate via `GetShadowResults`; do NOT re-run blindly |
+| `PENDING` | `--duration` exhausted before terminal status | Re-run with longer `--duration`; check M3 health |
+| `SCHEDULING_FAILED` | `ScheduleShadowComputation` rejected the candidate (validator failure, M3 unreachable, etc.) | Read the error reason; fix the proposal or M3, then re-run |
+| `FAILED` | A transient infra error during polling | Re-run; check M3 + network |
+
+### When to repeat
+
+- `PENDING` with budget exhausted → re-run with longer `--duration`, or
+  verify the original metric is actually computing during the shadow
+  window (no data = no progress).
+- `REJECTED` → DO NOT re-run blindly. Pull the per-tuple diff rows via
+  `M3::GetShadowResults(shadow_run_id)` and inspect `diff_abs` / `diff_rel`
+  / `within_tolerance`. The classifier may have produced a semantically
+  correct but numerically different proposal (e.g., off-by-one boundary on
+  a windowed count); the metric owner needs to either accept the drift or
+  redesign the candidate.
+
+---
+
+## Step 3 — Apply
+
+Apply is a two-step process by design (Lock L7): always dry-run first,
+then confirm.
+
+### Dry-run
+
+```bash
+custom_migrator apply \
+    --shadow-results ./shadow.json \
+    --m5-addr http://localhost:50055 \
+    --dry-run
+```
+
+Prints the planned migrations as a table to stdout. Filters automatically
+to `status == APPROVED` and a non-empty `result_id`. No M5 mutations.
+
+### Confirm
+
+```bash
+custom_migrator apply \
+    --shadow-results ./shadow.json \
+    --m5-addr http://localhost:50055 \
+    --confirm \
+    --operator alice@example.com
+```
+
+`--operator` is required when `--confirm` is set; it lands in the
+`metric_migrations.operator` audit column as plain text.
+
+### What apply guarantees (Lock L7)
+
+- **Old CUSTOM row preserved.** Apply is forward-only and NEVER destructive
+  in place. The original `metric_definitions` row stays queryable; new
+  experiments simply reference the new `metric_id`.
+- **Single atomic transaction per migration.** The new `metric_definitions`
+  row and the corresponding `metric_migrations` audit row commit together
+  inside one PostgreSQL transaction. A crash mid-transaction rolls back
+  both — no partial state.
+- **Apply-as-much-as-possible.** Per-outcome failures do NOT abort the run;
+  the migrator records them and continues with the next outcome. The
+  process exits with code `1` if any outcome failed, `0` if all succeeded
+  or there was nothing to apply.
+
+### Audit trail
+
+Every successful migration writes a row to `metric_migrations` (audit
+table from migration `016_adr026_phase3_metric_migrations.sql`). The row
+includes the operator string, both metric IDs, the M3 `shadow_run_result_id`
+that was promoted, and the wall-clock timestamp.
+
+The migrator also writes a sidecar `ApplyOutput` JSON for each `--confirm`
+run. By default this lands next to the shadow-results file with an
+`.apply.json` suffix (e.g. `shadow.json` → `shadow.json.apply.json`); pass
+`--output <path>` to override. Dry-run mode does not emit a sidecar.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | All APPROVED outcomes applied successfully, or there was nothing to apply |
+| `1`  | At least one outcome failed; sidecar audit lists the per-outcome status |
+| `2`  | Fatal — could not read input file, could not connect to M5, mutually-exclusive flags violated, etc. |
+
+---
+
+## Step 4 — Rollback
+
+Apply is **forward-only by design.** There is no `custom_migrator rollback`
+subcommand. Per Lock L7, apply is never destructive in place: the old
+CUSTOM row is preserved at all times.
+
+### To "undo" a migration
+
+1. Pause or end any experiments that reference the new `metric_id`.
+2. Edit those experiments to point back at the original CUSTOM
+   `metric_id` (still present in `metric_definitions`).
+3. Optionally delete the new `metric_definitions` row via direct DB
+   access — leave the `metric_migrations` audit row in place as history.
+
+### Why no automated rollback
+
+A migrated metric may already be the basis of post-migration experiment
+analysis. An automated rollback that flipped the new row out from under
+those experiments would silently invalidate every analysis already
+computed against it. Rollback requires operator judgment about which
+downstream consumers are affected and how to communicate the change; the
+tool deliberately does not attempt that judgment.
+
+---
+
+## Acceptance-criteria mapping (F1)
+
+The following table maps each #437 acceptance criterion to the test or
+file where it is enforced.
+
+| #437 AC | Test / file location | Notes |
+|---------|----------------------|-------|
+| Migration tool: scan + classify + report | Classifier unit tests in `crates/experimentation-management/src/migration/classifier.rs` (15 `#[test]`s in `mod tests`); Tier 1 / Tier 2 builders in `migration/tier1.rs` + `migration/tier2.rs`; report rendering in `migration/report.rs` (`mod tests`); corpus parity in `crates/experimentation-management/tests/custom_corpus_parity.rs` against `test-vectors/custom_migration_corpus.json` | Phase A (#577) |
+| Shadow-run with row-level equivalence | Differ unit tests in `services/metrics/internal/shadow/differ_test.go` (19 `func Test*`); promote-gate in `services/metrics/internal/shadow/promote_test.go`; shadow handler in `services/metrics/internal/handler/shadow_handler_test.go` (15 `func Test*`); runner integration in `services/metrics/internal/jobs/shadow_runner_test.go` (14 `func Test*`) | Phase B (#580) |
+| M5 `CreateMetric` for CUSTOM emits deprecation warning | `crates/experimentation-management/tests/metric_deprecation_e2e_test.rs::create_custom_emits_deprecation_header` (plus the negative-case companions `create_mean_does_not_emit_deprecation_header` and `create_filtered_mean_does_not_emit_deprecation_header`); handler at `crates/experimentation-management/src/grpc.rs` (search for `"x-kaizen-deprecation"`) | Phase C (#578) |
+| M5 `UpdateMetric` warns on change-to-CUSTOM | _Not applicable — `UpdateMetricDefinition` RPC does not exist; metrics are immutable by design (see ADR-026 § "Implementation status" and the `m5-metric-definitions.md` runbook). The deprecation surface is owned entirely by `CreateMetricDefinition` (row above)._ | Phase C (#578) |
+| M6 CUSTOM labeled "Deprecated" | `ui/src/components/metrics/metric-type-select.test.tsx` (5 tests covering the deprecated label in the option list, the warning icon when CUSTOM is selected, the negative case for non-CUSTOM types, and the onChange callback) | Phase D (#578) |
+| M6 deprecation toast on create-page mount | `ui/src/__tests__/metric-custom-deprecation-toast.test.tsx` (3 `describe` blocks: `shouldShowCustomDeprecationToast`, `DEPRECATION_TOAST_MESSAGE`, and `NewMetricPage deprecation toast`); helper at `ui/src/lib/metric-deprecation.ts` | Phase D (#578) |
+| Migration guide doc | `docs/runbooks/adr-026-phase-3-migration.md` (this file) | This PR (#437) |
+| Hide CUSTOM from form after sunset (4 weeks) | _Deferred — the M6 feature flag `m6.metric_type.custom.hidden` (L6 Phase 3.B) is documented as a follow-up. The Phase D label + toast tests above are the shipped subset; the flag-toggle hide is queued for the post-sunset PR once telemetry confirms zero new CUSTOMs for 2 consecutive weeks._ | Phase D follow-up |
+| **`MigrateMetricDefinition` RPC + `metric_migrations` audit table** | `crates/experimentation-management/tests/metric_migration_e2e_test.rs` (14 `#[tokio::test]`s — happy path, the four L7 precondition gates, atomic-transaction rollback, unique-constraint conflicts, precondition ordering); migration `sql/migrations/016_adr026_phase3_metric_migrations.sql`; handler at `crates/experimentation-management/src/grpc.rs::migrate_metric_definition` | This PR (T1, c259513) |
+| **`custom_migrator shadow` subcommand** | `crates/experimentation-management/src/bin/custom_migrator.rs` `mod tests` shadow group (5 `#[tokio::test]`s: `happy_path_two_proposals_both_approved`, `rejected_outcome_propagates_reason_and_empty_result_id`, `pending_outcome_when_budget_exhausts`, `scheduling_failure_is_recorded_but_does_not_abort_remaining_proposals`, `tier3_proposals_are_skipped_with_warning`) plus 7 sync helpers (`parse_duration_*`, `is_shadow_eligible_tier_*`, `log_summary_counts_only_approved`, `extract_shadow_candidates_*`) | This PR (T2, bea93e6) |
+| **`custom_migrator apply` subcommand** | `crates/experimentation-management/src/bin/custom_migrator.rs` `mod tests` apply group (6 `#[tokio::test]`s: `apply_dry_run_prints_plan_and_makes_no_rpc_calls`, `apply_confirm_applies_all_approved_outcomes`, `apply_confirm_continues_on_partial_failure_and_exits_nonzero`, `apply_confirm_without_operator_fails_before_any_rpc`, `apply_with_no_approved_outcomes_is_a_noop_exit_zero`, `apply_confirm_with_custom_output_path_writes_audit_there`) plus 4 sync helpers (`partition_outcomes_*`, `describe_candidate_type_*`, `default_audit_path_*`, `cli_rejects_dry_run_and_confirm_together`) | This PR (T3, 4855514) |
+
+---
+
+## Troubleshooting
+
+### Shadow REJECTED — what does the diff look like
+
+Read the per-tuple rows via M3's `GetShadowResults(shadow_run_id)`. Each
+row carries `diff_abs`, `diff_rel`, and `within_tolerance`. Group by
+(experiment, variant, day) and look at the rows where `within_tolerance =
+false`:
+
+- If the absolute diffs cluster near zero but `within_tolerance` is still
+  false, the tolerance is tight (e.g., proportion metrics tolerate
+  zero difference); confirm the metric type matches the proposal.
+- If `diff_abs` is large and clusters by day, suspect a windowing
+  off-by-one (a common Tier 1 windowed_count failure mode).
+- If a single tuple has a huge diff and the rest are clean, there may be
+  a data-quality issue with the underlying events on that day; check
+  whether the original CUSTOM query was silently filtering nulls.
+
+### Shadow PENDING with budget exhausted
+
+The migrator polled for `--duration` without M3 reaching APPROVED /
+REJECTED. Common causes:
+
+- M3 hasn't accumulated 7 days of clean data yet. Re-run with longer
+  `--duration` (e.g., `21d`).
+- The original CUSTOM metric is not actually computing during the shadow
+  window — no data on the "left" side means no progress. Check the
+  original metric's recent computation status in M3.
+- M3 polling fell behind. Inspect M3 logs for shadow scheduler stalls.
+
+### `apply --confirm` returns `AlreadyExists`
+
+The unique constraint `uq_metric_migrations_old` rejects a second
+migration of the same `original_metric_id`. The metric has already been
+migrated; query the existing `metric_migrations` row to see when and by
+whom:
+
+```sql
+SELECT migration_id, operator, applied_at, new_metric_id
+FROM metric_migrations
+WHERE old_metric_id = '<id>';
+```
+
+If the previous migration was wrong, follow "Step 4 — Rollback" above
+before authoring a new migration to a different `new_metric_id`.
+
+### `apply --confirm` returns `FailedPrecondition`
+
+The M5 handler re-validates the `shadow_run_result_id` with M3 at apply
+time (Lock L7 precondition (d)). If M3 has since invalidated the result
+(typically because the underlying metric SQL has changed since the shadow
+was approved), the handler rejects the apply with `FailedPrecondition`.
+Re-run `custom_migrator shadow` against the current proposal to obtain a
+fresh `result_id`.
+
+### Operator made a typo in `--operator`
+
+The `metric_migrations.operator` column is plain text and immutable; the
+audit row records exactly what was passed. There is no in-band correction.
+Use the `migration_id` from the sidecar `ApplyOutput` JSON in any
+subsequent communications, and consider adding a follow-up audit note in
+your team's ticket tracker rather than mutating the row.
+
+---
+
+## References
+
+- ADR-026: `docs/adrs/026-custom-metrics-layer.md`
+- Locked plan: `docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md`
+- M5 Custom Metric Definitions (Phase 1 operator runbook): `docs/runbooks/m5-metric-definitions.md`
+- M3 Analysis runbook: `docs/runbooks/m4a-analysis.md`
+- Migration tool entry point: `crates/experimentation-management/src/bin/custom_migrator.rs`
+- Migration classifier: `crates/experimentation-management/src/migration/classifier.rs`
+- M5 `MigrateMetricDefinition` handler: `crates/experimentation-management/src/grpc.rs` (search for `migrate_metric_definition`)
+- M3 shadow scheduler: `services/metrics/internal/shadow/` (Go) + `services/metrics/internal/handler/shadow_handler.go`
+- Audit migration: `sql/migrations/016_adr026_phase3_metric_migrations.sql`
+- Corpus fixtures: `test-vectors/custom_migration_corpus.json`
+- Survey wrapper: `scripts/migration-phase3/survey.sh`
+- Issues: `#437` (this work), `#577` (Phase A), `#578` (Phase C / D), `#580` (Phase B)

--- a/docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md
+++ b/docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md
@@ -39,6 +39,51 @@ Eight Locks freeze the cross-cutting design decisions. **Locks are normative —
 
 ---
 
+## Cross-phase artifacts
+
+Every artifact named in a Lock body, in a stub help-text, in a per-phase task list, or in the convergence runbook that crosses a phase boundary MUST appear in this table. Spec reviewers grep this table when reviewing each phase PR; missing rows are a blocker.
+
+This section was **retrofitted in the convergence (F) PR** per `docs/superpowers/templates/locked-plan-template.md` (introduced by #591), which itself was authored in response to the exact gap that caused #437 to close administratively after #580 merged: `MigrateMetricDefinition` was named in Phase A's `apply` stub help text and in L7's prose, but no phase explicitly owned producing it. The table below is the discoverable contract that would have prevented that.
+
+| Artifact | Producer phase / task | Consumer phase / task | Lock # | Status |
+|---|---|---|---|---|
+| `experimentation-management` Cargo dep `sqlparser = "0.50"` | Phase A / A1 | Phase A / A2 (translator) | L1 | verified — landed in #577 |
+| `crates/experimentation-management/src/migration/{classifier,tier1,tier2,report}.rs` (AST translator) | Phase A / A2 | Phase A / A3 (`translate` subcommand), Phase F runbook | L1, L4 | verified — landed in #577 |
+| `crates/experimentation-management/src/bin/custom_migrator.rs` (`scan` + `translate`) | Phase A / A3 | Phase E1 (survey.sh), Phase E2 (per-org proposals) | L2 | verified — landed in #577 |
+| `test-vectors/custom_migration_corpus.json` (30+ corpus fixtures) | Phase A / A2 | Phase A `custom_corpus_parity.rs`, Phase F `just test-metricql-parity`-style gate | L4 | verified — landed in #577 |
+| Migration `sql/migrations/015_adr026_phase3_metric_shadow_runs.sql` (`metric_shadow_runs` + `metric_shadow_run_results` tables) | Phase B / B1 | Phase B / B2 (computation), Phase B / B3 (differ), Phase F `MigrateMetricDefinition` precondition (d) | L3 | verified — landed in #580 |
+| M3 RPC `ScheduleShadowComputation` | Phase B / B1 | Phase F `custom_migrator shadow` subcommand | L3 | verified — landed in #580 |
+| M3 RPC `GetShadowResults` (incl. `days_within_tolerance` / `total_days`) | Phase B / B1 | Phase F `custom_migrator shadow` poller, Phase F `MigrateMetricDefinition` precondition (d) | L3 | verified — landed in #580 |
+| M3 RPC `PromoteShadowResult` (`result_id == shadow_id` of promoted run) | Phase B / B1 | Phase F `custom_migrator shadow` (writes `result_id` into `ShadowOutcome`), Phase F `MigrateMetricDefinition.shadow_run_result_id` (M5 calls back into M3 to re-verify APPROVED at apply time) | L3, L7 | verified — landed in #580 |
+| Shadow computation in `services/metrics/internal/jobs/standard.go` `Run` loop | Phase B / B2 | Phase B / B3 (differ runs against its output) | L3 | verified — landed in #580 |
+| `services/metrics/internal/shadow/differ.go` (per-tuple `within_tolerance` evaluation) | Phase B / B3 | Phase B / B1 `PromoteShadowResult` (consumes the aggregated `metric_shadow_run_results`) | L3 | verified — landed in #580 |
+| M5 deprecation trailer `x-kaizen-deprecation` (Rust) | Phase C / C1 | Phase D / D2 (M6 Connect-Web interceptor surfaces it as toast) | L5 | verified — landed in #578 |
+| M5 deprecation telemetry counter `m5.metric_definition.custom.created` | Phase C / C1 | Phase F operator visibility into "are new CUSTOMs still being created?" (drives L6 4-week sunset decision) | L5, L6 | verified — landed in #578 |
+| Go-variant M5 deprecation trailer parity | Phase C / C2 | Phase D / D2 (same M6 interceptor handles both servers) | L5 | verified — landed in #578 |
+| Proto RPC `MigrateMetricDefinition` on `experimentation.management.v1.ManagementService` | **Phase F (convergence) / T1** — was originally scoped to Phase C / C3 but not produced on the C/D PR | Phase F `custom_migrator apply` subcommand, runbook | L7 | verified — landed in this PR (commit `c259513`) |
+| Migration `sql/migrations/016_adr026_phase3_metric_migrations.sql` (`metric_migrations` audit table; `UNIQUE(old_metric_id)` enforces no-double-migration) | **Phase F / T1** — was originally scoped to Phase C / C3 ("Migration 014 already added the metric_migrations table" — but no phase produced it) | Phase F `MigrateMetricDefinition` handler, Phase F runbook rollback section, future `MigrationsList` RPC if added | L7 | verified — landed in this PR (commit `c259513`) |
+| M3-side verification path: M5 calls `GetShadowResults(shadow_id=shadow_run_result_id)` from `MigrateMetricDefinition` to re-confirm APPROVED at apply time | Phase F / T1 | Phase F `custom_migrator apply` (transitively, via the M5 RPC) | L7 | verified — landed in this PR (commit `c259513`) |
+| Go-variant M5 `MigrateMetricDefinition` stub returning `Unimplemented` | Phase C / C4 (per locked plan) — verify whether this shipped in #578 or remains a follow-up | Phase F runbook (operator must use the Rust M5 binary, not the Go variant, for `apply`) | L7 | verified — Rust side complete; Go variant stub status tracked as follow-up (Go variant of M5 is being deprecated per ADR-025; not a blocker for #437) |
+| Phase F `custom_migrator shadow` subcommand (real impl replacing Phase A stub) | Phase F / T2 | Phase F `custom_migrator apply` consumes its `ShadowOutput` JSON | L3 | verified — landed in this PR (commit `bea93e6`) |
+| `ShadowOutput` / `ShadowOutcome` JSON contract (fields: `original_metric_id`, `shadow_id`, `result_id`, `status`, `reason`, `days_within_tolerance`, `total_days`, `candidate_metric`) | Phase F / T2 | Phase F / T3 (`apply` consumes it directly), Phase F runbook (operator-readable artifact) | L3, L7 | verified — landed in this PR (commit `bea93e6`) |
+| Phase F `custom_migrator apply` subcommand (real impl replacing Phase A stub) | Phase F / T3 | Operator (runs the binary); Phase F runbook references it | L7 | verified — landed in this PR (commit `4855514`) |
+| `ApplyOutput` sidecar JSON (per-outcome `status`/`new_metric_id`/`migration_id`/`applied_at` plus aggregate counters) | Phase F / T3 | Operator audit trail; runbook references it; Phase F `metric_migrations` table is the durable record | L7 | verified — landed in this PR (commit `4855514`) |
+| `scripts/migration-phase3/survey.sh` (bash wrapper over `scan + translate`) | Phase F / T4 (Phase E1 in locked plan numbering) | Operators running per-org surveys; runbook documents invocation | L8 | verified — landed in this PR (commit `e308d08`) |
+| `docs/runbooks/adr-026-phase-3-migration.md` (operator runbook) | Phase F / T4 | Operators (workflow + troubleshooting + rollback); F1 AC mapping table inside the runbook is the audit grid for #437's acceptance criteria | L7, L8 | verified — landed in this PR (commit `e308d08`) |
+| F1 acceptance-criteria mapping (`#437 AC → test/file location`) — embedded in the runbook | Phase F / T5 | Final-PR reviewer; future audits | — | verified — landed in this PR (commit `e308d08`, as a section inside the runbook) |
+| M6 CUSTOM relabel `"Custom SQL (deprecated)"` + warning icon | Phase D / D1 | M6 users; runbook references the operator-facing UI signal | L5, L6 | verified — landed in #578 |
+| M6 Connect-Web interceptor surfacing `x-kaizen-deprecation` as toast + persistent banner | Phase D / D2 | M6 users; runbook troubleshooting section | L5 | verified — landed in #578 |
+| M6 feature flag `m6.metric_type.custom.hidden` + `ui/src/lib/flags.ts` (gates Phase 3.B "hide from create form") | Phase D / D3 (per locked plan) | Phase 3.B sunset (4 weeks after Phase D ships + zero new CUSTOMs telemetry confirms it's safe) | L6 | **deferred — Phase 3.B follow-up.** Not produced in #578 (D1+D2 only); not produced in this PR. Tracked as the L6 (3.B) phase that's intentionally separated from the convergence PR per the locked plan's "Three-phase rollout" language. F1 row marks this `_deferred_` honestly. |
+
+**Authoring rules (per `docs/superpowers/templates/locked-plan-template.md`):**
+
+1. **Producer is always upstream.** No cycles in this table — verified by inspection.
+2. **No "implicit" artifacts.** Every Lock body and every cross-phase reference in a stub help-text has a row.
+3. **The convergence (F) phase verifies every row reaches `verified`.** The one exception is the M6 sunset flag row, which is explicitly `_deferred_` per Lock L6's phased rollout — the row is here so the deferral is visible from a single grep rather than hidden in a closed issue.
+4. **Stub-marker comments in code must reference a row.** Both stubs in `custom_migrator.rs` that pointed at L7 (`apply`) and L3 (`shadow`) are now real implementations — the stub-marker debt the locked plan inherited is closed.
+
+---
+
 ### L1 — Translator approach: AST-based, not regex
 
 **Decision: parse CUSTOM SQL with `sqlparser-rs` (Spark dialect), pattern-match the resulting AST against translation rules.**

--- a/proto/experimentation/management/v1/management_service.proto
+++ b/proto/experimentation/management/v1/management_service.proto
@@ -216,7 +216,9 @@ message PreviewMetricDefinitionResponse {
 // against the experiment's metric catalog. No side effects; safe to call
 // at the editor's debounce cadence (~500ms per keystroke pause).
 message ValidateMetricqlRequest {
-  // Scopes the known-metric-ids lookup. Required.
+  // Scopes the known-metric-ids lookup. Empty string = global scope:
+  // the validator builds known_metric_ids from the full metric_definitions
+  // table. Set to a specific experiment id to scope to that experiment.
   string experiment_id = 1;
   // The MetricQL source text to validate. Empty source returns one
   // diagnostic "empty expression".

--- a/proto/experimentation/management/v1/management_service.proto
+++ b/proto/experimentation/management/v1/management_service.proto
@@ -38,6 +38,27 @@ service ExperimentManagementService {
   rpc GetMetricDefinition(GetMetricDefinitionRequest) returns (experimentation.common.v1.MetricDefinition);
   rpc ListMetricDefinitions(ListMetricDefinitionsRequest) returns (ListMetricDefinitionsResponse);
 
+  // MigrateMetricDefinition (ADR-026 Phase 3 / #437) — Lock L7 two-step
+  // apply contract. Operators call this from `custom_migrator apply` once
+  // a candidate's shadow run has been APPROVED by M3.
+  //
+  // The handler enforces (in this order):
+  //   1. new_metric.type != CUSTOM (InvalidArgument).
+  //   2. new_metric.metric_id != old_metric_id (InvalidArgument).
+  //   3. old_metric_id exists AND its type is CUSTOM (InvalidArgument).
+  //   4. validate_metric_definition(new_metric) passes — same validator
+  //      used by CreateMetricDefinition (InvalidArgument).
+  //   5. shadow_run_result_id resolves to an APPROVED row via M3's
+  //      GetShadowResults (FailedPrecondition if not APPROVED; Unavailable
+  //      if M3 itself errors).
+  //
+  // On success, a single atomic transaction inserts the new metric into
+  // metric_definitions and an audit row into metric_migrations. On any
+  // unique-constraint collision the call returns AlreadyExists. The old
+  // CUSTOM row is NOT deleted — it remains for read-compat / audit per
+  // ADR-026 Phase 3 non-goals.
+  rpc MigrateMetricDefinition(MigrateMetricDefinitionRequest) returns (MigrateMetricDefinitionResponse);
+
   // Layer management.
   rpc CreateLayer(CreateLayerRequest) returns (experimentation.common.v1.Layer);
   rpc GetLayer(GetLayerRequest) returns (experimentation.common.v1.Layer);
@@ -135,6 +156,38 @@ message ListMetricDefinitionsRequest {
 message ListMetricDefinitionsResponse {
   repeated experimentation.common.v1.MetricDefinition metrics = 1;
   string next_page_token = 2;
+}
+
+// --- MigrateMetricDefinition (ADR-026 Phase 3 / #437) ---
+
+// MigrateMetricDefinition — Lock L7 two-step apply contract. Migrates a
+// CUSTOM (raw-SQL) metric to a structured / MetricQL replacement once its
+// shadow run has been APPROVED by M3. See the rpc comment in
+// ExperimentManagementService above for the full precondition order.
+message MigrateMetricDefinitionRequest {
+  // The CUSTOM metric being deprecated. MUST exist + MUST have type=CUSTOM.
+  string old_metric_id = 1;
+  // The replacement metric definition. MUST NOT have type=CUSTOM.
+  // MUST have metric_id != old_metric_id.
+  experimentation.common.v1.MetricDefinition new_metric = 2;
+  // The result_id returned by M3's PromoteShadowResult (which equals the
+  // shadow_id of the promoted run — see metrics_service.proto). M5 verifies
+  // via M3's GetShadowResults RPC that this resolves to an APPROVED
+  // metric_shadow_runs row before creating the new metric. Encodes the
+  // L7 two-step gate.
+  string shadow_run_result_id = 3;
+  // Operator identifier for the audit log (e.g., user email or service id).
+  string operator = 4;
+}
+
+message MigrateMetricDefinitionResponse {
+  // The metric_id of the newly-created replacement metric (echo of
+  // request.new_metric.metric_id).
+  string new_metric_id = 1;
+  // The migration_id of the audit-log row in metric_migrations.
+  string migration_id = 2;
+  // RFC 3339 timestamp the migration was committed (server time).
+  string applied_at = 3;
 }
 
 // --- PreviewMetricDefinition (ADR-026 Phase 2 / #436) ---

--- a/scripts/check_stub_markers.py
+++ b/scripts/check_stub_markers.py
@@ -87,6 +87,7 @@ EXCLUDE_FRAGMENTS = (
     "/graphify-out/",
 )
 EXCLUDE_SUFFIXES = (
+    # Canonical test-file conventions (per language).
     "_test.rs",
     "_test.go",
     "_test.py",
@@ -96,6 +97,25 @@ EXCLUDE_SUFFIXES = (
     ".spec.ts",
     ".spec.tsx",
     ".spec.js",
+    # Test-helper modules. Rust convention: a feature's test support lives
+    # in `<feature>_test_support.rs` or bare `test_support.rs` next to
+    # `lib.rs` (e.g. `crates/experimentation-management/src/contract_test_support.rs`).
+    # Same pattern for `_test_helpers`, `_test_utils`, `_test_fixtures`, and
+    # for the Go / TS equivalents. These files contain mock impls of trait /
+    # interface surfaces; stub markers in them are scaffolding, not work.
+    "test_support.rs",
+    "test_support.go",
+    "test_helpers.rs",
+    "test_helpers.go",
+    "test_helpers.ts",
+    "test_helpers.tsx",
+    "test_utils.rs",
+    "test_utils.go",
+    "test_utils.ts",
+    "test_utils.tsx",
+    "test_fixtures.rs",
+    "test_fixtures.go",
+    "test_fixtures.ts",
 )
 
 # Context window (lines above the marker) in which an allow comment must

--- a/scripts/migration-phase3/survey.sh
+++ b/scripts/migration-phase3/survey.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# =============================================================================
+# survey.sh — ADR-026 Phase 3 CUSTOM-metric inventory (#437)
+# =============================================================================
+#
+# Thin wrapper around `custom_migrator scan + translate`. Calls M5 to enumerate
+# every CUSTOM-typed MetricDefinition, then classifies + translates them into a
+# proposals JSON + a human-readable Markdown summary. Output paths are
+# org-keyed when `--org` is set so operators can fan out across multiple orgs
+# without overwriting each other's artifacts.
+#
+# Survey is operational guidance, not a prerequisite (Lock L8). The migration
+# tool's pattern library is conservative-by-default; anything not auto-classified
+# falls through to Tier 3 and is surfaced as a non-translatable proposal.
+#
+# Usage:
+#   ./scripts/migration-phase3/survey.sh --m5-addr http://localhost:50055
+#   ./scripts/migration-phase3/survey.sh --m5-addr http://m5.example:50055 \
+#       --output-dir ./out --org acme
+#
+# See docs/runbooks/adr-026-phase-3-migration.md for the full workflow.
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via env or flags).
+# ---------------------------------------------------------------------------
+DEFAULT_M5_ADDR="${CUSTOM_MIGRATOR_M5_ADDR:-http://localhost:50055}"
+DEFAULT_OUTPUT_DIR="./migration-phase3-output/$(date +%Y-%m-%d)"
+DEFAULT_BIN="${CUSTOM_MIGRATOR_BIN:-}"   # empty = use `cargo run`
+
+# Colors (only when stdout is a tty).
+if [[ -t 1 ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[1;33m'
+    BLUE=$'\033[0;34m'
+    NC=$'\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+_log()  { echo "${BLUE}[survey]${NC} $*"; }
+_ok()   { echo "${GREEN}[  OK  ]${NC} $*"; }
+_warn() { echo "${YELLOW}[ WARN ]${NC} $*" >&2; }
+_fail() { echo "${RED}[ FAIL ]${NC} $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Usage / --help
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'EOF'
+survey.sh — ADR-026 Phase 3 CUSTOM-metric inventory (#437)
+
+Wraps `custom_migrator scan` and `custom_migrator translate` against an M5
+instance to produce, for each CUSTOM metric on the server:
+
+    <prefix>scan.json        — raw MetricDefinition list returned by M5
+    <prefix>proposals.json   — machine-readable proposals (input for shadow)
+    <prefix>summary.md       — human-readable Markdown for operator review
+
+The script does NOT shadow-run or apply anything; it produces artifacts for
+the migration owners to review. See the runbook for the full workflow.
+
+USAGE
+  survey.sh [OPTIONS]
+
+OPTIONS
+  --m5-addr <url>       M5 gRPC address (e.g. http://localhost:50055)
+                        Default: $CUSTOM_MIGRATOR_M5_ADDR or
+                                 http://localhost:50055
+  --output-dir <path>   Directory to write artifacts into
+                        Default: ./migration-phase3-output/<YYYY-MM-DD>
+  --org <name>          Optional org tag. When set, outputs are prefixed:
+                          <org>-scan.json
+                          <org>-proposals.json
+                          <org>-summary.md
+                        When omitted, just scan.json / proposals.json /
+                        summary.md.
+  --binary <path>       Path to a prebuilt custom_migrator binary. When set,
+                        the script invokes it directly instead of going
+                        through `cargo run`. Useful in CI / container envs
+                        where Cargo isn't installed.
+                        Default: $CUSTOM_MIGRATOR_BIN (empty = use cargo run)
+  --force               Permit running against a non-empty output directory.
+                        Without this, the script refuses to clobber artifacts
+                        from a previous run on the same day.
+  -h, --help            Print this message and exit 0.
+
+ENVIRONMENT
+  CUSTOM_MIGRATOR_M5_ADDR    Same as --m5-addr.
+  CUSTOM_MIGRATOR_BIN        Same as --binary.
+
+WORKFLOW DRIVEN BY THIS SCRIPT
+  1. Verify required tools are on PATH (cargo, unless --binary is set).
+  2. Create the output directory.
+  3. Run: custom_migrator scan      --m5-addr ... --output <prefix>scan.json
+  4. Run: custom_migrator translate --report  <prefix>scan.json \
+                                    --output  <prefix>proposals.json \
+                                    --markdown <prefix>summary.md
+  5. Print a one-line summary: counts of CUSTOMs found, by tier.
+
+EXIT CODES
+  0   Success.
+  1   Any sub-command failed (scan or translate).
+  2   Bad CLI args / missing prerequisites.
+
+EXAMPLES
+  # Local dev — defaults to ./migration-phase3-output/<today>/
+  ./scripts/migration-phase3/survey.sh --m5-addr http://localhost:50055
+
+  # Per-org run with prebuilt binary
+  ./scripts/migration-phase3/survey.sh \
+      --m5-addr http://m5.example:50055 \
+      --output-dir /tmp/survey \
+      --org acme \
+      --binary /opt/kaizen/bin/custom_migrator
+
+  # Re-run for the same day, overwriting yesterday's artifacts
+  ./scripts/migration-phase3/survey.sh --m5-addr http://localhost:50055 --force
+
+SEE ALSO
+  docs/runbooks/adr-026-phase-3-migration.md
+  crates/experimentation-management/src/bin/custom_migrator.rs
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# CLI parsing.
+# ---------------------------------------------------------------------------
+M5_ADDR="$DEFAULT_M5_ADDR"
+OUTPUT_DIR="$DEFAULT_OUTPUT_DIR"
+ORG=""
+BIN="$DEFAULT_BIN"
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --m5-addr)
+            [[ $# -lt 2 ]] && { _fail "--m5-addr requires a URL"; exit 2; }
+            M5_ADDR="$2"; shift 2 ;;
+        --output-dir)
+            [[ $# -lt 2 ]] && { _fail "--output-dir requires a path"; exit 2; }
+            OUTPUT_DIR="$2"; shift 2 ;;
+        --org)
+            [[ $# -lt 2 ]] && { _fail "--org requires a name"; exit 2; }
+            ORG="$2"; shift 2 ;;
+        --binary)
+            [[ $# -lt 2 ]] && { _fail "--binary requires a path"; exit 2; }
+            BIN="$2"; shift 2 ;;
+        --force)
+            FORCE=1; shift ;;
+        -h|--help)
+            usage; exit 0 ;;
+        --)
+            shift; break ;;
+        -*)
+            _fail "unknown option: $1"
+            echo "Run with --help for usage." >&2
+            exit 2 ;;
+        *)
+            _fail "unexpected positional arg: $1"
+            echo "Run with --help for usage." >&2
+            exit 2 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Prerequisites.
+# ---------------------------------------------------------------------------
+if [[ -n "$BIN" ]]; then
+    if [[ ! -x "$BIN" ]]; then
+        _fail "--binary path is not executable: $BIN"
+        exit 2
+    fi
+else
+    if ! command -v cargo >/dev/null 2>&1; then
+        _fail "cargo not on PATH and --binary not set; cannot invoke custom_migrator"
+        exit 2
+    fi
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    _warn "jq not on PATH; the closing summary will be approximate (counts may show as '?')"
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve output paths.
+# ---------------------------------------------------------------------------
+mkdir -p "$OUTPUT_DIR"
+
+# Safety belt: refuse to clobber non-empty existing dir unless --force.
+if [[ $FORCE -ne 1 ]]; then
+    # `find -mindepth 1` lists anything in the directory; if non-empty, bail.
+    if [[ -n "$(find "$OUTPUT_DIR" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+        _fail "output directory not empty: $OUTPUT_DIR"
+        echo "Pass --force to overwrite existing artifacts." >&2
+        exit 2
+    fi
+fi
+
+PREFIX=""
+if [[ -n "$ORG" ]]; then
+    # Sanitize org for filenames: allow alphanumeric, dash, underscore.
+    if [[ ! "$ORG" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        _fail "--org must match [A-Za-z0-9_-]+ (got: $ORG)"
+        exit 2
+    fi
+    PREFIX="${ORG}-"
+fi
+
+SCAN_OUT="${OUTPUT_DIR}/${PREFIX}scan.json"
+PROPOSALS_OUT="${OUTPUT_DIR}/${PREFIX}proposals.json"
+SUMMARY_OUT="${OUTPUT_DIR}/${PREFIX}summary.md"
+
+# ---------------------------------------------------------------------------
+# Build the migrator invocation prefix.
+# ---------------------------------------------------------------------------
+if [[ -n "$BIN" ]]; then
+    MIGRATOR_CMD=("$BIN")
+else
+    # `cargo run` invocation. The `--quiet` keeps log lines from polluting
+    # operator stdout; tracing inside the tool still emits its own output.
+    MIGRATOR_CMD=(cargo run --quiet --release \
+        -p experimentation-management \
+        --bin custom_migrator --)
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1 — scan.
+# ---------------------------------------------------------------------------
+_log "scanning M5 at $M5_ADDR..."
+_log "  output: $SCAN_OUT"
+
+if ! "${MIGRATOR_CMD[@]}" scan \
+        --m5-addr "$M5_ADDR" \
+        --output "$SCAN_OUT"; then
+    _fail "scan failed; M5 unreachable or returned an error"
+    exit 1
+fi
+_ok "scan complete"
+
+# ---------------------------------------------------------------------------
+# Step 2 — translate.
+# ---------------------------------------------------------------------------
+_log "translating proposals..."
+_log "  proposals: $PROPOSALS_OUT"
+_log "  summary:   $SUMMARY_OUT"
+
+if ! "${MIGRATOR_CMD[@]}" translate \
+        --report "$SCAN_OUT" \
+        --output "$PROPOSALS_OUT" \
+        --markdown "$SUMMARY_OUT"; then
+    _fail "translate failed; check $SCAN_OUT for malformed input"
+    exit 1
+fi
+_ok "translate complete"
+
+# ---------------------------------------------------------------------------
+# Step 3 — one-line summary.
+#
+# `proposals.json` is `{ "summary": {...}, "entries": [...] }` (see
+# crates/experimentation-management/src/migration/report.rs::render_json).
+# The `summary` block has explicit per-tier counters so we read those rather
+# than re-counting entries.
+# ---------------------------------------------------------------------------
+TOTAL="?" TIER1="?" TIER2="?" TIER3="?"
+if command -v jq >/dev/null 2>&1; then
+    if [[ -f "$PROPOSALS_OUT" ]]; then
+        TOTAL=$(jq '.summary.total' < "$PROPOSALS_OUT" 2>/dev/null || echo "?")
+        TIER1=$(jq '.summary.tier1_filtered_mean + .summary.tier1_composite + .summary.tier1_windowed_count' \
+                    < "$PROPOSALS_OUT" 2>/dev/null || echo "?")
+        TIER2=$(jq '.summary.tier2_metricql' < "$PROPOSALS_OUT" 2>/dev/null || echo "?")
+        TIER3=$(jq '.summary.tier3_untranslatable' < "$PROPOSALS_OUT" 2>/dev/null || echo "?")
+    fi
+fi
+
+echo
+_ok "${OUTPUT_DIR}: ${TOTAL} CUSTOMs found, ${TIER1} Tier-1, ${TIER2} Tier-2, ${TIER3} Tier-3"
+_log "next: distribute ${SUMMARY_OUT} to metric owners for review"
+_log "      then shadow-run via: custom_migrator shadow --proposals ${PROPOSALS_OUT} ..."
+_log "      see docs/runbooks/adr-026-phase-3-migration.md"

--- a/services/management/internal/handlers/migration_stubs.go
+++ b/services/management/internal/handlers/migration_stubs.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	mgmtv1 "github.com/org/experimentation/gen/go/experimentation/management/v1"
+)
+
+// MigrateMetricDefinition is part of the ADR-026 Phase 3 (#437) convergence
+// surface (Lock L7 — two-step apply with shadow-run validation). Per ADR-025,
+// the canonical M5 implementation is the Rust crate
+// `experimentation-management`, which owns the full migration handler
+// including the M3 shadow-run-result validation and the atomic
+// `metric_migrations` write. The Go variant of M5 is retained-until-
+// deprecation and does NOT reimplement this endpoint; this stub exists
+// solely so `*ExperimentService` satisfies the regenerated
+// `managementv1connect.ExperimentManagementServiceHandler` interface for
+// `go vet` / `go build`. Any caller hitting the Go service for migration
+// receives `Unimplemented` with a clear pointer to the Rust path.
+//
+// Mirrors the pattern in `metricql_stubs.go`; reuses
+// `errUnimplementedInGoVariant` from that file.
+func (s *ExperimentService) MigrateMetricDefinition(
+	ctx context.Context,
+	req *connect.Request[mgmtv1.MigrateMetricDefinitionRequest],
+) (*connect.Response[mgmtv1.MigrateMetricDefinitionResponse], error) {
+	return nil, connect.NewError(
+		connect.CodeUnimplemented,
+		errUnimplementedInGoVariant("MigrateMetricDefinition"),
+	)
+}

--- a/sql/migrations/016_adr026_phase3_metric_migrations.sql
+++ b/sql/migrations/016_adr026_phase3_metric_migrations.sql
@@ -1,0 +1,86 @@
+-- ADR-026 Phase 3 (#437): metric migration audit log.
+--
+-- Background
+-- ----------
+-- ADR-026 Phase 3 introduces a two-step apply contract (Lock L7) for migrating
+-- CUSTOM (raw-SQL) metric definitions to a structured / MetricQL replacement
+-- once their shadow run has been APPROVED by M3. The migration tool
+-- ("custom_migrator") generates per-metric JSON proposals; the operator applies
+-- them via M5's MigrateMetricDefinition RPC. That RPC creates the new metric
+-- AND writes a soft-link record into the table introduced here.
+--
+-- Schema overview
+-- ---------------
+-- One row per applied migration. The old CUSTOM metric STAYS in
+-- metric_definitions (audit + read-compat per ADR-026 Phase 3 non-goals), so
+-- queries that need the historical SQL can still find it. This table is the
+-- soft-link that says "metric X has been migrated; metric Y is the
+-- replacement; the migration was authorised by shadow run Z".
+--
+-- Relationship to other migrations
+-- ---------------------------------
+--   Migration 011 (ADR-026 Phase 1): added FILTERED_MEAN / COMPOSITE /
+--     WINDOWED_COUNT to metric_definitions.
+--   Migration 013 (ADR-026 Phase 2): added metricql_expression to
+--     metric_definitions.
+--   Migration 015 (ADR-026 Phase 3 — shadow pipeline): added
+--     metric_shadow_runs + metric_shadow_run_results.
+--   This migration (016) adds the audit log MigrateMetricDefinition writes
+--     after a successful APPROVED-gated apply. It does NOT touch
+--     metric_definitions; the new structured metric goes in via the normal
+--     INSERT path.
+--
+-- Rationale notes
+-- ---------------
+-- * uq_metric_migrations_old prevents double-migration of a single CUSTOM.
+--   One row per old_metric_id; rollback (e.g., reverting a bad migration) is
+--   a manual ops operation — delete the row in metric_migrations + the new
+--   metric in metric_definitions. We deliberately do not automate this:
+--   ADR-026 Phase 3 commits to non-destructive migration only.
+--
+-- * No FK on old_metric_id because the old CUSTOM row stays in
+--   metric_definitions and is never deleted by this RPC. A FK would also
+--   gate rollback (couldn't drop the old metric without first dropping the
+--   migration record) which is the wrong default for an audit table.
+--
+-- * No FK on shadow_run_result_id because M3's metric_shadow_runs lives in
+--   the M3-owned database. Cross-service FKs are an anti-pattern in this
+--   stack (Lock L3); the gate is enforced at the M5 handler boundary by
+--   calling M3's GetShadowResults RPC and verifying status == APPROVED.
+--
+-- * FK on new_metric_id with ON DELETE RESTRICT is safe: the new metric
+--   row is created in the same transaction as this audit row, so the row
+--   exists by the time we link to it. The RESTRICT ensures an operator
+--   cannot drop the new metric without first reckoning with this audit row.
+--
+-- Replayability
+-- -------------
+-- All DDL uses CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS so
+-- this migration is safely re-runnable on dev databases that have been
+-- partially seeded (matches the style of migrations 011, 013, and 015).
+
+-- ============================================================
+-- Table: metric_migrations
+-- ============================================================
+-- One row per applied migration of a CUSTOM metric to a structured /
+-- MetricQL replacement. Written atomically with the new metric_definitions
+-- row by MigrateMetricDefinition.
+CREATE TABLE IF NOT EXISTS metric_migrations (
+    migration_id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    old_metric_id        TEXT        NOT NULL,
+    new_metric_id        TEXT        NOT NULL,
+    shadow_run_result_id UUID        NOT NULL,
+    operator             TEXT        NOT NULL,
+    applied_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_metric_migrations_new
+        FOREIGN KEY (new_metric_id) REFERENCES metric_definitions(metric_id) ON DELETE RESTRICT,
+    CONSTRAINT uq_metric_migrations_old UNIQUE (old_metric_id)
+);
+
+-- ============================================================
+-- Index: applied_at (btree)
+-- ============================================================
+-- Operators reading the audit log usually do so by recency ("show me the
+-- last 20 migrations"). A btree on applied_at makes that query cheap.
+CREATE INDEX IF NOT EXISTS idx_metric_migrations_applied_at
+    ON metric_migrations (applied_at);

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.2
+        version: 6.20.2
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
       '@codemirror/lang-sql':
         specifier: ^6.10.0
         version: 6.10.0
+      '@codemirror/lint':
+        specifier: ^6.9.6
+        version: 6.9.6
       '@codemirror/state':
         specifier: ^6.6.0
         version: 6.6.0
@@ -42,6 +48,15 @@ importers:
         specifier: ^2.12.0
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@lezer/generator':
+        specifier: ^1.8.0
+        version: 1.8.0
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
+      '@lezer/lr':
+        specifier: ^1.4.10
+        version: 1.4.10
       '@tailwindcss/postcss':
         specifier: ^4.2.1
         version: 4.2.2
@@ -140,6 +155,9 @@ packages:
 
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.6':
+    resolution: {integrity: sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==}
 
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
@@ -438,6 +456,10 @@ packages:
 
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/generator@1.8.0':
+    resolution: {integrity: sha512-/SF4EDWowPqV1jOgoGSGTIFsE7Ezdr7ZYxyihl5eMKVO5tlnpIhFcDavgm1hHY5GEonoOAEnJ0CU0x+tvuAuUg==}
+    hasBin: true
 
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
@@ -2950,6 +2972,12 @@ snapshots:
       '@lezer/lr': 1.4.10
       style-mod: 4.1.3
 
+  '@codemirror/lint@6.9.6':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
   '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
@@ -3173,6 +3201,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@lezer/common@1.5.2': {}
+
+  '@lezer/generator@1.8.0':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/lr': 1.4.10
 
   '@lezer/highlight@1.2.3':
     dependencies:

--- a/ui/src/__tests__/flag-pages.test.tsx
+++ b/ui/src/__tests__/flag-pages.test.tsx
@@ -127,15 +127,16 @@ describe('Flag List Page', () => {
     expect(screen.queryByText('dark_mode_rollout')).not.toBeInTheDocument();
   });
 
-  it('shows no-filter-matches when search has no results', async () => {
+  it('shows no-filter-matches when filters have no results', async () => {
     await renderAndWait();
     const user = userEvent.setup();
 
     await user.type(screen.getByTestId('flag-search'), 'zzzznonexistent');
     expect(screen.getByTestId('no-filter-matches')).toBeInTheDocument();
+    expect(screen.getByText('No flags match your filters.')).toBeInTheDocument();
   });
 
-  it('clears search when "Clear filters" button in empty state is clicked', async () => {
+  it('clears filters when "Clear filters" button in empty state is clicked', async () => {
     await renderAndWait();
     const user = userEvent.setup();
 
@@ -151,7 +152,7 @@ describe('Flag List Page', () => {
     expect(screen.getByTestId('flag-count')).toHaveTextContent('4');
   });
 
-  it('clears search when "Clear filters" button in toolbar is clicked', async () => {
+  it('clears filters when "Clear filters" button in toolbar is clicked', async () => {
     await renderAndWait();
     const user = userEvent.setup();
 
@@ -163,6 +164,31 @@ describe('Flag List Page', () => {
 
     expect(screen.getByTestId('flag-search')).toHaveValue('');
     expect(screen.getByTestId('flag-count')).toHaveTextContent('4');
+  });
+
+  it('filters flags by type', async () => {
+    await renderAndWait();
+    const user = userEvent.setup();
+
+    const typeFilter = screen.getByTestId('type-filter');
+    await user.selectOptions(typeFilter, 'JSON');
+
+    expect(screen.getByText('player_config_override')).toBeInTheDocument();
+    expect(screen.queryByText('dark_mode_rollout')).not.toBeInTheDocument();
+    expect(screen.getByTestId('flag-count')).toHaveTextContent('1');
+
+    await user.selectOptions(typeFilter, ''); // All types
+    expect(screen.getByTestId('flag-count')).toHaveTextContent('4');
+  });
+
+  it('searches flags by ID', async () => {
+    await renderAndWait();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByTestId('flag-search'), 'flag-bool-rollout');
+    expect(screen.getByText('dark_mode_rollout')).toBeInTheDocument();
+    expect(screen.queryByText('checkout_flow_variant')).not.toBeInTheDocument();
+    expect(screen.getByTestId('flag-count')).toHaveTextContent('1');
   });
 
   it('renders correct type badge colors', async () => {

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -17,14 +17,24 @@ const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   JSON: 'bg-orange-100 text-orange-800',
 };
 
+const ALL_FLAG_TYPES: FlagType[] = ['BOOLEAN', 'STRING', 'NUMERIC', 'JSON'];
+
 function FlagListContent() {
   const { canAtLeast, user } = useAuth();
   const [flags, setFlags] = useState<Flag[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState<FlagType | ''>('');
   const inputRef = useRef<HTMLInputElement>(null);
   useSearchShortcut(inputRef);
+
+  const hasActiveFilters = search !== '' || typeFilter !== '';
+
+  const clearFilters = useCallback(() => {
+    setSearch('');
+    setTypeFilter('');
+  }, []);
 
   const fetchData = useCallback(() => {
     setLoading(true);
@@ -44,14 +54,21 @@ function FlagListContent() {
   useEffect(() => { fetchData(); }, [fetchData]);
 
   const filtered = useMemo(() => {
-    if (!search) return flags;
-    const q = search.toLowerCase();
-    return flags.filter(
-      (f) =>
-        f.name.toLowerCase().includes(q) ||
-        f.description.toLowerCase().includes(q),
-    );
-  }, [flags, search]);
+    let result = flags;
+    if (typeFilter) {
+      result = result.filter((f) => f.type === typeFilter);
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (f) =>
+          f.name.toLowerCase().includes(q) ||
+          f.description.toLowerCase().includes(q) ||
+          f.flagId.toLowerCase().includes(q),
+      );
+    }
+    return result;
+  }, [flags, typeFilter, search]);
 
   return (
     <div>
@@ -127,7 +144,7 @@ function FlagListContent() {
           <input
             ref={inputRef}
             type="text"
-            placeholder="Search by name or description..."
+            placeholder="Search by name, ID, or description..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-10 text-sm shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
@@ -140,9 +157,21 @@ function FlagListContent() {
             </span>
           </div>
         </div>
-        {search && (
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value as FlagType | '')}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          data-testid="type-filter"
+          aria-label="Filter by flag type"
+        >
+          <option value="">All Types</option>
+          {ALL_FLAG_TYPES.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        {hasActiveFilters && (
           <button
-            onClick={() => setSearch('')}
+            onClick={clearFilters}
             className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
             data-testid="clear-filters-toolbar"
           >
@@ -153,9 +182,9 @@ function FlagListContent() {
 
           {filtered.length === 0 ? (
             <div className="py-12 text-center" data-testid="no-filter-matches">
-              <p className="text-sm text-gray-500">No flags match your search.</p>
+              <p className="text-sm text-gray-500">No flags match your filters.</p>
               <button
-                onClick={() => setSearch('')}
+                onClick={clearFilters}
                 className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
                 data-testid="clear-filters-empty"
               >

--- a/ui/src/app/metrics/new/page.tsx
+++ b/ui/src/app/metrics/new/page.tsx
@@ -182,16 +182,6 @@ function isFormValid(state: MetricFormState): boolean {
   }
 }
 
-/**
- * Experiment ID is not available on the metric creation form (a metric is not
- * yet bound to an experiment at creation time). The MetricQL validator (B4)
- * and preview RPC (B5/C2) accept an empty string — the server resolves
- * @metric_ref existence from the global metric catalog, not per-experiment.
- * A follow-up spec can thread a real experimentId here once the form-shell
- * supports experiment context.
- */
-const METRICQL_FORM_EXPERIMENT_ID = '';
-
 export default function NewMetricPage() {
   const router = useRouter();
   const { addToast } = useToast();
@@ -304,10 +294,16 @@ export default function NewMetricPage() {
               />
             )}
             {state.type === 'METRICQL' && (
+              // experimentId is intentionally omitted — a metric is not yet
+              // bound to an experiment at creation time. The B4 linter forwards
+              // an empty experiment_id to M5's ValidateMetricql, which treats
+              // empty as global scope and builds the known-metric set from the
+              // full catalog (Issue #571). Live diagnostics activate as the
+              // operator types.
               <MetricqlSection
                 value={state.metricqlExpression}
                 onChange={(next) => dispatch({ type: 'SET_METRICQL_EXPRESSION', value: next })}
-                experimentId={METRICQL_FORM_EXPERIMENT_ID}
+                experimentId={null}
                 knownMetricIds={knownMetricIds}
                 disabled={state.submitting}
               />

--- a/ui/src/components/metrics/metricql-section.test.tsx
+++ b/ui/src/components/metrics/metricql-section.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MetricqlSection } from './metricql-section';
 
 // ---------------------------------------------------------------------------
@@ -213,5 +213,97 @@ describe('MetricqlSection', () => {
     await screen.findByTestId('metricql-editor');
     // The helper text includes "@metric_id" in a <code> element.
     expect(screen.getByText('@metric_id')).toBeInTheDocument();
+  });
+
+  // ─── Global-scope live-lint (Issue #571 Task 2) ────────────────────────────
+  //
+  // The metric-creation form renders MetricqlSection with experimentId={null}
+  // because a metric is not yet bound to an experiment at creation time.
+  // The linter must still activate and forward an empty experiment_id to M5's
+  // ValidateMetricql RPC, which builds the known-metric set from the global
+  // catalog (Task 1 of #571). These tests mirror the new-metric form's call
+  // shape and verify the squiggle path is wired end-to-end.
+
+  test('linter activates and surfaces diagnostics when experimentId is null', async () => {
+    const { validateMetricql } = await import('@/lib/api');
+    const mocked = vi.mocked(validateMetricql);
+    mocked.mockResolvedValueOnce({
+      diagnostics: [{
+        severity: 1,
+        message: 'unresolved metric: @unknown_metric',
+        span: { startOffset: 0, endOffset: 15, line: 1, column: 1 },
+      }],
+      referencedMetricIds: [],
+    });
+
+    render(
+      <MetricqlSection
+        value="@unknown_metric"
+        onChange={() => {}}
+        experimentId={null}
+        knownMetricIds={[]}
+      />,
+    );
+
+    await screen.findByTestId('metricql-editor');
+
+    // The CM6 linter has a 500ms `delay` debounce. Wait for the RPC to fire.
+    await waitFor(
+      () => {
+        expect(mocked).toHaveBeenCalled();
+      },
+      { timeout: 3000 },
+    );
+
+    // Verify the empty wire signal that M5 interprets as global scope.
+    expect(mocked).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: '@unknown_metric' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    // After the response resolves, CM6 paints lint markers into the DOM as
+    // `.cm-lintRange` (with severity-specific subclass `.cm-lintRange-error`).
+    // This is the squiggle assertion.
+    await waitFor(
+      () => {
+        const editor = screen.getByTestId('metricql-editor');
+        const lintRange = editor.querySelector('.cm-lintRange-error');
+        expect(lintRange).not.toBeNull();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  test('linter activates when experimentId prop is omitted entirely', async () => {
+    // Omitting the prop (vs. passing null) exercises the `undefined` codepath
+    // through the optional `experimentId?: string | null` type.
+    const { validateMetricql } = await import('@/lib/api');
+    const mocked = vi.mocked(validateMetricql);
+    mocked.mockResolvedValueOnce({
+      diagnostics: [],
+      referencedMetricIds: [],
+    });
+
+    render(
+      <MetricqlSection
+        value="@another"
+        onChange={() => {}}
+        knownMetricIds={[]}
+      />,
+    );
+
+    await screen.findByTestId('metricql-editor');
+
+    await waitFor(
+      () => {
+        expect(mocked).toHaveBeenCalled();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(mocked).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: '@another' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });

--- a/ui/src/components/metrics/metricql-section.test.tsx
+++ b/ui/src/components/metrics/metricql-section.test.tsx
@@ -272,6 +272,12 @@ describe('MetricqlSection', () => {
       },
       { timeout: 3000 },
     );
+
+    // MetricqlSection normalises `experimentId ?? ''` for MetricqlPreview
+    // (which requires a non-nullable string). Verify the preview stub
+    // receives the empty wire signal, mirroring the linter's RPC wire shape.
+    const previewToggle = screen.getByTestId('metricql-preview-toggle');
+    expect(previewToggle.getAttribute('data-experiment-id')).toBe('');
   });
 
   test('linter activates when experimentId prop is omitted entirely', async () => {

--- a/ui/src/components/metrics/metricql-section.tsx
+++ b/ui/src/components/metrics/metricql-section.tsx
@@ -18,8 +18,15 @@ export interface MetricqlSectionProps {
   /** The current MetricQL expression value (drives the form's metricqlExpression field). */
   value: string;
   onChange: (next: string) => void;
-  /** Experiment ID for the validator (B4) + preview (B5/C2) RPCs. */
-  experimentId: string;
+  /**
+   * Experiment ID for the validator (B4) + preview (B5/C2) RPCs.
+   *
+   * Omit (or pass `null` / `undefined`) when the section is rendered outside an
+   * experiment binding — e.g. the metric creation form. M5's ValidateMetricql
+   * handler treats an empty experiment_id as global scope and builds the known
+   * metric set from the full catalog (Issue #571 Task 1).
+   */
+  experimentId?: string | null;
   /**
    * Known metric IDs from the form's cached ListMetricDefinitions response.
    * Powers the @-autocomplete (B3). Optimistic cache updates (just-created
@@ -69,7 +76,9 @@ export function MetricqlSection({
       </div>
 
       <MetricqlPreview
-        experimentId={experimentId}
+        // Normalise null/undefined → '' so the preview RPC matches the wire
+        // format (M5 treats empty experiment_id as global scope, Issue #571).
+        experimentId={experimentId ?? ''}
         metricqlExpression={value}
         hasErrors={hasObviousErrors}
         className="mt-2"

--- a/ui/src/components/metrics/metricql/diagnostics.test.ts
+++ b/ui/src/components/metrics/metricql/diagnostics.test.ts
@@ -184,6 +184,48 @@ describe('metricqlLintSource', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Global-scope normalisation (Issue #571 Task 2)
+  //
+  // The metric-creation form has no experimentId. M5's ValidateMetricql handler
+  // now treats an empty experiment_id string as global scope (Task 1 of #571).
+  // The linter accepts string | null | undefined and normalises to '' at the
+  // RPC boundary so the wire format stays a plain string matching the proto.
+  // -------------------------------------------------------------------------
+
+  test('normalises null experimentId to empty string at the RPC boundary', async () => {
+    const validate = mockValidate(okResponse());
+    const source = metricqlLintSource({ experimentId: null, validateFn: validate });
+
+    await source(makeView('mean(@ctr)'));
+    expect(validate).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: 'mean(@ctr)' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  test('normalises undefined experimentId to empty string at the RPC boundary', async () => {
+    const validate = mockValidate(okResponse());
+    const source = metricqlLintSource({ experimentId: undefined, validateFn: validate });
+
+    await source(makeView('mean(@ctr)'));
+    expect(validate).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: 'mean(@ctr)' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  test('passes empty-string experimentId through unchanged', async () => {
+    const validate = mockValidate(okResponse());
+    const source = metricqlLintSource({ experimentId: '', validateFn: validate });
+
+    await source(makeView('mean(@ctr)'));
+    expect(validate).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: 'mean(@ctr)' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
   // AbortController — cancel-in-flight
   // -------------------------------------------------------------------------
 

--- a/ui/src/components/metrics/metricql/diagnostics.ts
+++ b/ui/src/components/metrics/metricql/diagnostics.ts
@@ -30,11 +30,22 @@ export type { ValidateMetricqlRpcResponse };
 
 export interface MetricqlLinterOptions {
   /**
-   * Experiment ID passed to the ValidateMetricql RPC. Required.
+   * Experiment ID passed to the ValidateMetricql RPC.
+   *
+   * Empty / null / undefined all mean "global scope" — Issue #571 Task 1 taught
+   * the M5 ValidateMetricql handler to build the known-metric set from the full
+   * metric_definitions table (instead of an experiment's bound metrics) when
+   * the request's experiment_id is empty. This lets the metric-creation form,
+   * which has no experimentId yet, register the linter and receive live
+   * diagnostics as the operator types.
+   *
    * Captured at mount; if the experimentId prop changes, the editor is
    * remounted by the parent form (B6) so this capture is always fresh.
+   *
+   * Normalised to `''` at the RPC boundary so the wire format stays a plain
+   * string (matches `ValidateMetricqlRequest.experiment_id: string` in proto).
    */
-  experimentId: string;
+  experimentId: string | null | undefined;
 
   /**
    * Injected validate function — defaults to the real API client.
@@ -77,6 +88,10 @@ export interface MetricqlLinterOptions {
 export function metricqlLintSource(opts: MetricqlLinterOptions) {
   const timeoutMs = opts.timeoutMs ?? 2000;
   const validate = opts.validateFn ?? validateMetricql;
+  // Normalise null / undefined to '' at construction time so every RPC call
+  // sees the same wire-format string (matches proto). M5 treats '' as the
+  // global-scope signal (Issue #571 Task 1).
+  const experimentIdWire = opts.experimentId ?? '';
 
   // Mutable state shared across lint invocations for this editor instance.
   let currentController: AbortController | null = null;
@@ -103,7 +118,7 @@ export function metricqlLintSource(opts: MetricqlLinterOptions) {
 
     try {
       const response = await validate(
-        { experimentId: opts.experimentId, metricqlExpression: source },
+        { experimentId: experimentIdWire, metricqlExpression: source },
         { signal: ctl.signal },
       );
       clearTimeout(timer);
@@ -178,9 +193,12 @@ export function metricqlLintSource(opts: MetricqlLinterOptions) {
  *
  * Usage (inside the MetricqlEditor mount-once useEffect):
  *
- *   if (experimentId) {
- *     extensions.push(metricqlLinter({ experimentId, debounceMs: 500, timeoutMs: 2000 }));
- *   }
+ *   extensions.push(metricqlLinter({ experimentId, debounceMs: 500, timeoutMs: 2000 }));
+ *
+ * Registered unconditionally — when experimentId is null / undefined / '' the
+ * linter forwards an empty experiment_id to ValidateMetricql, which M5 treats
+ * as global scope (Issue #571). This means standalone usage (e.g. the metric
+ * creation form) still surfaces inline diagnostics.
  *
  * The `delay` option on `linter()` is the debounce — CM6 fires the source
  * function only after `debounceMs` ms of idle, so we don't need a separate

--- a/ui/src/components/metrics/metricql/editor.test.tsx
+++ b/ui/src/components/metrics/metricql/editor.test.tsx
@@ -286,7 +286,7 @@ describe('MetricqlEditor', () => {
   // so the editor must register the linter unconditionally and forward the
   // raw value (null / undefined / '') through to the RPC boundary.
 
-  test('linter_fires_when_experimentId_is_undefined_global_scope', async () => {
+  test('linter fires when experimentId is undefined (global-scope path)', async () => {
     const { validateMetricql } = await import('@/lib/api');
     const mocked = vi.mocked(validateMetricql);
     mocked.mockResolvedValueOnce({
@@ -330,7 +330,7 @@ describe('MetricqlEditor', () => {
     );
   });
 
-  test('linter_fires_when_experimentId_is_null_global_scope', async () => {
+  test('linter fires when experimentId is null (global-scope path)', async () => {
     const { validateMetricql } = await import('@/lib/api');
     const mocked = vi.mocked(validateMetricql);
     mocked.mockResolvedValueOnce({

--- a/ui/src/components/metrics/metricql/editor.test.tsx
+++ b/ui/src/components/metrics/metricql/editor.test.tsx
@@ -19,6 +19,12 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act, waitFor } from '@testing-library/react';
 import { MetricqlEditor } from './editor';
 
+// Mock the API client so the linter (B4) does not hit the network.
+// Tests that need a specific response override the mock per-test via mockResolvedValueOnce.
+vi.mock('@/lib/api', () => ({
+  validateMetricql: vi.fn().mockResolvedValue({ diagnostics: [], referencedMetricIds: [] }),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -47,8 +53,12 @@ function getEditorView(container: HTMLElement) {
 // ---------------------------------------------------------------------------
 
 describe('MetricqlEditor', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     // Reset DOM between tests — RTL cleanup handles this but be explicit.
+    // Also clear API mock call history so linter-RPC assertions don't see
+    // calls from prior tests in this file.
+    const { validateMetricql } = await import('@/lib/api');
+    vi.mocked(validateMetricql).mockClear();
   });
 
   // ─── Render ──────────────────────────────────────────────────────────────
@@ -264,5 +274,98 @@ describe('MetricqlEditor', () => {
         />,
       ),
     ).not.toThrow();
+  });
+
+  // ─── Live-lint registration on global-scope (Issue #571 Task 2) ──────────
+  //
+  // The metric-creation form has no experimentId at creation time.  Previously
+  // the editor short-circuited and skipped registering the linter when
+  // experimentId was falsy, which meant operators got NO inline diagnostics
+  // while authoring a brand-new metric.  M5's ValidateMetricql handler now
+  // treats an empty experiment_id as the global-scope signal (Task 1 of #571),
+  // so the editor must register the linter unconditionally and forward the
+  // raw value (null / undefined / '') through to the RPC boundary.
+
+  test('linter_fires_when_experimentId_is_undefined_global_scope', async () => {
+    const { validateMetricql } = await import('@/lib/api');
+    const mocked = vi.mocked(validateMetricql);
+    mocked.mockResolvedValueOnce({
+      diagnostics: [{
+        severity: 1,
+        message: 'unresolved metric: @unknown_metric',
+        span: { startOffset: 0, endOffset: 15, line: 1, column: 1 },
+      }],
+      referencedMetricIds: [],
+    });
+
+    render(
+      <MetricqlEditor
+        value="@unknown_metric"
+        onChange={() => {}}
+        ariaLabel="MetricQL expression"
+        experimentId={undefined}
+      />,
+    );
+
+    const wrapper = screen.getByTestId('metricql-editor');
+    await waitFor(() => {
+      expect(wrapper.querySelector('.cm-editor')).not.toBeNull();
+    });
+
+    // The linter is registered unconditionally and CM6's `delay: 500` debounce
+    // schedules the source fn on doc init.  Wait for the validateMetricql RPC
+    // to be invoked — that proves the linter is active.  The RPC must receive
+    // experimentId='' (the normalised wire value for global scope) regardless
+    // of whether the caller passed null, undefined, or ''.
+    await waitFor(
+      () => {
+        expect(mocked).toHaveBeenCalled();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(mocked).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: '@unknown_metric' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  test('linter_fires_when_experimentId_is_null_global_scope', async () => {
+    const { validateMetricql } = await import('@/lib/api');
+    const mocked = vi.mocked(validateMetricql);
+    mocked.mockResolvedValueOnce({
+      diagnostics: [{
+        severity: 1,
+        message: 'unresolved metric: @missing',
+        span: { startOffset: 0, endOffset: 8, line: 1, column: 1 },
+      }],
+      referencedMetricIds: [],
+    });
+
+    render(
+      <MetricqlEditor
+        value="@missing"
+        onChange={() => {}}
+        ariaLabel="MetricQL expression"
+        experimentId={null}
+      />,
+    );
+
+    const wrapper = screen.getByTestId('metricql-editor');
+    await waitFor(() => {
+      expect(wrapper.querySelector('.cm-editor')).not.toBeNull();
+    });
+
+    await waitFor(
+      () => {
+        expect(mocked).toHaveBeenCalled();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(mocked).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: '@missing' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });

--- a/ui/src/components/metrics/metricql/editor.tsx
+++ b/ui/src/components/metrics/metricql/editor.tsx
@@ -45,9 +45,12 @@ export interface MetricqlEditorProps {
   disabled?: boolean;
   /**
    * Experiment ID for the autocomplete provider (B3) and lint provider (B4).
-   * Received but unused in B2; included so B6 can pass it through without API churn.
+   * `null` / `undefined` / `''` all mean "global scope" — the M5 ValidateMetricql
+   * handler builds the known-metric set from the full metric_definitions catalog
+   * when the request's experiment_id is empty (Issue #571 Task 1). This lets
+   * the metric-creation form (which has no experimentId yet) get live diagnostics.
    */
-  experimentId?: string;
+  experimentId?: string | null;
   /**
    * Known metric IDs for autocomplete (B3).
    * Received but unused in B2; included so B6 can pass it through without API churn.
@@ -83,7 +86,9 @@ export function MetricqlEditor({
   // experimentId is captured at mount for the linter. If B6 changes the
   // experimentId, it will remount the editor (key prop change), so this ref
   // is always fresh within a mount lifetime.
-  const experimentIdRef = useRef(experimentId);
+  // Type allows null/undefined to flow through — the linter normalises to ''
+  // at the RPC boundary (see diagnostics.ts), which M5 treats as global scope.
+  const experimentIdRef = useRef<string | null | undefined>(experimentId);
   useEffect(() => {
     experimentIdRef.current = experimentId;
   }, [experimentId]);
@@ -105,17 +110,17 @@ export function MetricqlEditor({
         // B3: @metric_ref autocomplete. Always included; when knownMetricIds
         // is not provided the ref starts empty and the menu simply never opens.
         metricqlAutocomplete({ getKnownMetricIds: () => knownMetricIdsRef.current }),
-        // B4: inline MetricQL diagnostics. Only active when an experimentId is
-        // provided — the ValidateMetricql RPC requires one to resolve @metric_ref
-        // references in context. When absent, no linter is registered and the
-        // editor renders without error underlines (safe for standalone usage).
-        ...(experimentIdRef.current
-          ? [metricqlLinter({
-              experimentId: experimentIdRef.current,
-              debounceMs: 500,
-              timeoutMs: 2000,
-            })]
-          : []),
+        // B4: inline MetricQL diagnostics. Registered unconditionally — the
+        // linter forwards experimentId (which may be null / undefined / '')
+        // straight to ValidateMetricql, and M5 treats an empty experiment_id
+        // as global scope, building the known-metric set from the full catalog
+        // (Issue #571). This means the metric-creation form (no experimentId
+        // bound yet) still gets live diagnostics as the operator types.
+        metricqlLinter({
+          experimentId: experimentIdRef.current,
+          debounceMs: 500,
+          timeoutMs: 2000,
+        }),
         EditorState.transactionFilter.of((tr) => {
           // Multi-line is ALLOWED (unlike sql-editor.tsx).
           // Reject only transactions that would exceed maxLength.


### PR DESCRIPTION
## Summary

ADR-026 Phase 2 follow-up — enables live MetricQL linting on the metric-creation form. Closes #571.

Before this PR, the linter was wired correctly in isolation (#570 shipped the full Lezer grammar / 500ms debounce / AbortController / 2s timeout / `ValidateMetricql` RPC stack), but it never fired on `/metrics/new` because the editor gated registration on `experimentIdRef.current` being truthy, and the creation form passed `''` (the metric isn't bound to an experiment yet at creation time).

This PR makes `experiment_id` semantically optional across the stack — empty string / null / undefined all mean **"global scope: use the full `metric_definitions` catalog"** — so the creation form can register the linter unconditionally and the operator gets squiggle feedback as they type.

## Acceptance criteria (verbatim from #571)

- [x] **M6 editor accepts `experimentId?: string | null` (optional) and registers the linter unconditionally on `metric-form-shell` mount.**
  → `ui/src/components/metrics/metricql/editor.tsx` (relaxed type at line 53; unconditional `metricqlLinter(...)` registration at line 113-122)
- [x] **M5 `ValidateMetricql` RPC accepts an optional `experiment_id` field. When absent or empty, the validator builds its `known_metric_ids` set from `ListMetricDefinitions(filter=any)` instead of an experiment-scoped query.**
  → `crates/experimentation-management/src/grpc.rs::validate_metricql` builds `known_metric_ids` from `self.state.store.list_metrics(MetricFilter::default())` when `experiment_id.is_empty()`. Proto field documented at `proto/.../management_service.proto:218-227`.
- [x] **M6 metric-creation form passes `experimentId = null` (or omits) — live linter activates as the operator types.**
  → `ui/src/app/metrics/new/page.tsx:306` passes `experimentId={null}` (constant + stale comment block removed).
- [x] **M5 validator test: METRICQL expression with `@watch_time` where `watch_time` exists in the global metric set → `valid`, even with no `experiment_id`.**
  → `crates/experimentation-management/tests/validate_metricql_global_scope_test.rs::empty_experiment_id_with_known_metric_returns_valid` (DATABASE_URL-gated; passed locally).
- [x] **M5 validator test: same expression with `@unknown_metric` → `invalid`, `diagnostics` reports unresolved ref with line:col.**
  → `crates/experimentation-management/tests/validate_metricql_global_scope_test.rs::empty_experiment_id_with_unknown_metric_returns_diagnostic` (asserts exactly one diagnostic, message mentions the unknown id, `span.line >= 1`, `span.column >= 1`).
- [x] **M6 Vitest: render the new-metric form, mock the validator RPC to return one diagnostic, assert squiggle appears in CodeMirror's lint state.**
  → `ui/src/components/metrics/metricql-section.test.tsx::linter activates and surfaces diagnostics when experimentId is null` — asserts `.cm-lintRange-error` is present in the DOM (CM6's squiggle CSS class), plus `experimentId: ''` on the wire.
- [x] **M6 Playwright (or extend the existing B6 E2E): open `/metrics/new`, select METRICQL, type `@unknown` → squiggle appears within ~600ms.**
  → **Folded into the Vitest above.** No Playwright infrastructure exists in this repo (no `playwright.config*`, no `@playwright/test`, `ui/package.json` test script is just `vitest`). The "existing B6 E2E" referenced in the issue is `ui/src/components/metrics/metricql-section.test.tsx` (B6 = `MetricqlSection`), which is the closest analogue to an end-to-end test. The new test exercises the full path: renders `MetricqlSection` with `experimentId={null}` (mirroring the creation form's call shape), mocks `validateMetricql`, advances time past the 500ms debounce via `waitFor`, and asserts both the RPC wire shape (`experimentId: ''`) and the rendered squiggle. This is the same surface a Playwright test would exercise; only the runner is different.

## File-by-file changes

### Rust + proto (Task 1)

| File | Change |
| --- | --- |
| `proto/experimentation/management/v1/management_service.proto` | Comment-only — document empty `experiment_id` as global scope. Non-breaking (proto3 strings are already nullable on the wire). |
| `crates/experimentation-management/src/grpc.rs` | Remove empty-`experiment_id` rejection. Branch: when empty, fetch `list_metrics(MetricFilter::default())` and build `HashSet<String>` of `metric_id`s for `ValidateContext::known_metric_ids`. Adds `debug!` trace for the global-scope path. 2 new safety-net unit tests in `mod tests` (cover the contract without DATABASE_URL). |
| `crates/experimentation-management/src/contract_test_support.rs` | Remove empty-`experiment_id` rejection in the in-memory stub for wire-format parity. |
| `crates/experimentation-management/tests/validate_metricql_global_scope_test.rs` | **New** — 2 DATABASE_URL-gated integration tests covering positive (known global metric) and negative (unknown metric) AC paths. |

### UI / TypeScript (Task 2 + Task 3 folded in)

| File | Change |
| --- | --- |
| `ui/src/components/metrics/metricql/editor.tsx` | `experimentId?: string | null`. Linter registration now unconditional. |
| `ui/src/components/metrics/metricql/diagnostics.ts` | `MetricqlLinterOptions.experimentId: string | null | undefined`. Normalizes `?? ''` at the RPC boundary (one place, captured at mount). |
| `ui/src/components/metrics/metricql-section.tsx` | `experimentId?: string | null`. Passes `experimentId ?? ''` to `MetricqlPreview` (which still requires non-nullable string — same wire signal). |
| `ui/src/app/metrics/new/page.tsx` | Delete `METRICQL_FORM_EXPERIMENT_ID = ''` constant + stale JSDoc block. Pass `experimentId={null}` explicitly. |
| `ui/src/components/metrics/metricql/editor.test.tsx` | 2 new tests — linter fires for `experimentId={undefined}` AND `experimentId={null}`, asserts RPC called with `experimentId: ''`. |
| `ui/src/components/metrics/metricql/diagnostics.test.ts` | 3 new normalization tests — `null` / `undefined` / `''` all forward as `''` to `validateFn`. |
| `ui/src/components/metrics/metricql-section.test.tsx` | 2 new tests — the critical squiggle assertion (Task 3 AC) with `experimentId={null}`, plus the prop-omission codepath. Also asserts `MetricqlPreview` receives `data-experiment-id=""`. |

## Why translation-at-boundaries

Three layers, each with the idiomatic representation for that layer:

| Layer | Representation | Reason |
| --- | --- | --- |
| React components (`MetricqlSection`, `MetricqlEditor`) | `string \| null \| undefined` | Lets the form pass `null` (explicit intent) or omit the prop entirely |
| Linter boundary (`diagnostics.ts::metricqlLintSource`) | normalize to `''` via `?? ''` | Translation happens once, at the wire-format boundary |
| Wire (`ValidateMetricqlRequest.experiment_id`) | `string` | Proto3 has no nullable strings; `''` is the canonical "absent" signal |

`validateMetricql` in `ui/src/lib/api.ts` is intentionally unchanged.

## Test plan

- [x] `buf lint proto/` — clean
- [x] `buf breaking proto --against ".git#branch=main,subdir=proto"` — clean (comment-only)
- [x] `cargo test -p experimentation-management` — 335 lib + 7 integration suites green; 2 new e2e tests pass with DATABASE_URL (skip-clean without)
- [x] `cargo clippy -p experimentation-management --all-features -- -D warnings` — clean
- [x] `cd ui && npm run type-check` — clean
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm test` — 844+ passes (was 842 → +7 new tests)
- [x] `just check-branch-name` — `agent-5/feat/issue-571-metricql-live-lint-creation-form` matches canonical pattern
- [x] Stub-marker CI: zero new `Status::unimplemented(...)` / `todo!()` introduced

## Review provenance

This PR was developed via the `superpowers:subagent-driven-development` workflow. Each task went through two-stage independent review (spec compliance first, then code quality). All four reviews APPROVED:

1. Task 1 spec review: ✅ APPROVED — all 7 AC bullets satisfied, all 4 implementer adaptations justified
2. Task 1 quality review: ✅ APPROVED — 0 CRITICAL/HIGH, 2 MEDIUM + 3 LOW polish items (all applied in `03fd9cd`)
3. Task 2 spec review: ✅ APPROVED — all 11 AC bullets satisfied; Task 3 fully collapsed into the `metricql-section.test.tsx` addition
4. Task 2 quality review: ✅ APPROVED — 0 CRITICAL/HIGH, 1 MEDIUM + 2 LOW polish items (MEDIUM + 2 LOW applied in this PR's final polish commit; 1 pre-existing LOW deferred as a future cleanup)

## Backlog / follow-up (out of scope for #571)

- **Lean `ManagementStore::list_metric_ids()` query**: the current implementation calls `list_metrics(MetricFilter::default())` which fetches all 19 columns of `metric_definitions` on every debounced keystroke. A lean `SELECT metric_id FROM metric_definitions ORDER BY metric_id` would cut payload by ~90%. Flagged by code-quality reviewer; not a #571 AC.
- **Editor `experimentIdRef` sync effect** (`editor.tsx:91-94`): pre-existing pattern; the ref sync is dead code because the linter captures the initial value at mount and the parent remounts on change. Harmless but worth a future cleanup pass alongside the overall mount-once lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->