### PR TITLE
feat(ui,management): ADR-026 Phase 3 L6 phase 3.B — sunset flag + counter (Refs #437)

### DIFF
--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -1109,11 +1109,36 @@ impl ExperimentManagementService for ManagementServiceHandler {
                 "x-kaizen-deprecation",
                 tonic::metadata::MetadataValue::from_static(DEPRECATION_HEADER_CUSTOM),
             );
+            // ADR-026 Phase 3 — L6 phase 3.B observable trigger telemetry.
+            //
+            // Canonical counter key: `metric_definition_custom_created_total`.
+            //
+            // This is the counter the L6 sunset-gate operators watch to confirm
+            // the "4 weeks of zero new CUSTOMs" criterion before flipping the
+            // M6 flag `m6.metric_type.custom.hidden`. Once flipped, a separate
+            // 2-cycle clock starts toward #602 (proto enum removal).
+            //
+            // M5 (`experimentation-management`) currently does NOT depend on
+            // the `prometheus` or `metrics` facade crates. Rather than pull
+            // either in for a single counter (which would be a separate
+            // ADR-level decision), we annotate the existing `tracing::info!`
+            // with a `monotonic_counter.*` field. When this crate later wires
+            // a Prometheus exporter via `tracing-subscriber` +
+            // `metrics-tracing-context`, the field automatically projects to
+            // a Prometheus counter of the same name with no call-site change.
+            // Until then, the counter is observable via structured log
+            // aggregation (Loki / CloudWatch Logs Insights / Datadog) by
+            // filtering `target=m5.deprecation` and counting
+            // `event=metric_definition_created`.
+            //
+            // Refs: #602 (proto enum removal trigger),
+            //       docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md (L6).
             tracing::info!(
                 target: "m5.deprecation",
                 metric_type = "CUSTOM",
                 metric_id = %metric_id_for_log,
                 event = "metric_definition_created",
+                monotonic_counter.metric_definition_custom_created_total = 1u64,
                 "custom metric created — emitting x-kaizen-deprecation header"
             );
         }

--- a/ui/src/components/metrics/metric-type-select.test.tsx
+++ b/ui/src/components/metrics/metric-type-select.test.tsx
@@ -92,6 +92,19 @@ describe('MetricTypeSelect', () => {
         screen.getByRole('option', { name: 'MetricQL expression' }),
       ).toBeInTheDocument();
     });
+
+    // Devin PR #603 📝 future-caller defensive-gate regression. The current
+    // `/metrics/new` caller can't reach `value='CUSTOM'` when the flag is on
+    // (CUSTOM is filtered out, so the <select> can't be set to it), but a
+    // future edit-context caller mounting on an existing CUSTOM metric
+    // would. Without the `&& !isCustomHidden()` gate, the deprecation icon
+    // would render next to a <select> value with no matching <option>.
+    test('does NOT render the deprecation icon when value=CUSTOM and flag is on (future-caller guard)', () => {
+      render(<MetricTypeSelect value="CUSTOM" onChange={() => {}} />);
+      expect(
+        screen.queryByTestId('metric-type-deprecated-icon'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   /**

--- a/ui/src/components/metrics/metric-type-select.test.tsx
+++ b/ui/src/components/metrics/metric-type-select.test.tsx
@@ -1,15 +1,19 @@
 /**
- * Tests for MetricTypeSelect (ADR-026 Phase 3, Task D1).
+ * Tests for MetricTypeSelect (ADR-026 Phase 3, Task D1 + L6 phase 3.B).
  *
  * Verifies the CUSTOM deprecation surface in the metric-create form:
- *   - Label rewrite ("Custom SQL (deprecated)")
- *   - Description rewrite (migration-guide pointer)
- *   - Inline AlertTriangle warning icon shown only when CUSTOM is selected
- *   - Icon absent for non-CUSTOM types (MEAN, FILTERED_MEAN)
- *   - onChange still propagates the selected MetricType
+ *   - Phase 3.A (default state, flag unset/false):
+ *     - Label rewrite ("Custom SQL (deprecated)")
+ *     - Description rewrite (migration-guide pointer)
+ *     - Inline AlertTriangle warning icon shown only when CUSTOM is selected
+ *     - Icon absent for non-CUSTOM types (MEAN, FILTERED_MEAN)
+ *     - onChange still propagates the selected MetricType
+ *   - L6 phase 3.B (sunset flag `m6.metric_type.custom.hidden` = true):
+ *     - CUSTOM option is removed from the <select> entirely
+ *     - All other options remain visible
  */
 
-import { describe, test, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, test, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MetricTypeSelect } from './metric-type-select';
 
@@ -42,5 +46,81 @@ describe('MetricTypeSelect', () => {
     render(<MetricTypeSelect value="MEAN" onChange={onChange} />);
     fireEvent.change(screen.getByTestId('metric-type-select'), { target: { value: 'CUSTOM' } });
     expect(onChange).toHaveBeenCalledWith('CUSTOM');
+  });
+
+  /**
+   * L6 phase 3.B sunset gate.
+   *
+   * The flag key `m6.metric_type.custom.hidden` is exposed today as the
+   * Next.js public env var NEXT_PUBLIC_METRIC_TYPE_CUSTOM_HIDDEN. When set
+   * to "true", the CUSTOM option must be filtered out of the create-form
+   * <select> entirely (per the locked plan, ADR-026 Phase 3 L6).
+   *
+   * Operators flip this flag after observing 4 weeks of zero CUSTOM creates
+   * via the `metric_definition_custom_created_total` counter emitted from M5.
+   * Flipping it begins the 2-cycle countdown for #602 (proto enum removal).
+   */
+  describe('when m6.metric_type.custom.hidden flag is true', () => {
+    const ENV_KEY = 'NEXT_PUBLIC_METRIC_TYPE_CUSTOM_HIDDEN';
+    let previous: string | undefined;
+
+    beforeEach(() => {
+      previous = process.env[ENV_KEY];
+      process.env[ENV_KEY] = 'true';
+    });
+
+    afterEach(() => {
+      if (previous === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = previous;
+      }
+    });
+
+    test('omits the CUSTOM option from the <select>', () => {
+      render(<MetricTypeSelect value="MEAN" onChange={() => {}} />);
+      expect(
+        screen.queryByRole('option', { name: /custom sql.*deprecated/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('still renders the other metric-type options', () => {
+      render(<MetricTypeSelect value="MEAN" onChange={() => {}} />);
+      expect(screen.getByRole('option', { name: 'Mean' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Filtered Mean' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: 'MetricQL expression' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * Regression guard: when the env var is explicitly "false" (or any value
+   * other than the literal string "true"), the gate is OFF and CUSTOM
+   * remains visible with its Phase 3.A deprecated label.
+   */
+  describe('when m6.metric_type.custom.hidden flag is false', () => {
+    const ENV_KEY = 'NEXT_PUBLIC_METRIC_TYPE_CUSTOM_HIDDEN';
+    let previous: string | undefined;
+
+    beforeEach(() => {
+      previous = process.env[ENV_KEY];
+      process.env[ENV_KEY] = 'false';
+    });
+
+    afterEach(() => {
+      if (previous === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = previous;
+      }
+    });
+
+    test('keeps the deprecated CUSTOM option visible', () => {
+      render(<MetricTypeSelect value="MEAN" onChange={() => {}} />);
+      expect(
+        screen.getByRole('option', { name: /custom sql.*deprecated/i }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/ui/src/components/metrics/metric-type-select.tsx
+++ b/ui/src/components/metrics/metric-type-select.tsx
@@ -10,7 +10,7 @@ interface MetricTypeSelectProps {
 
 // Order: legacy types first (most-used), then new ADR-026 Phase 1 types.
 // Labels match METRIC_TYPE_BADGE / ALL_METRIC_TYPES in src/app/metrics/page.tsx.
-const TYPE_OPTIONS: { value: MetricType; label: string; description: string }[] = [
+const ALL_TYPE_OPTIONS: { value: MetricType; label: string; description: string }[] = [
   { value: 'MEAN',           label: 'Mean',           description: 'Average of a numeric value per user (e.g. watch time).' },
   { value: 'PROPORTION',     label: 'Proportion',     description: 'Binary event rate per user (e.g. conversion).' },
   { value: 'RATIO',          label: 'Ratio',          description: 'Numerator sum / denominator sum, delta-method variance.' },
@@ -23,8 +23,34 @@ const TYPE_OPTIONS: { value: MetricType; label: string; description: string }[] 
   { value: 'METRICQL',      label: 'MetricQL expression', description: 'Custom expression with arithmetic, filters, and @metric_ref references (ADR-026 Phase 2).' },
 ];
 
+// ADR-026 Phase 3 — L6 phase 3.B sunset gate.
+//
+// Flag key (canonical): `m6.metric_type.custom.hidden` (default: false).
+// Today the gate is read from a Next.js public env var so operators can flip
+// it at deploy time without depending on an M7 UI flag client:
+//
+//   NEXT_PUBLIC_METRIC_TYPE_CUSTOM_HIDDEN=true
+//
+// When this repo grows a first-class M7 UI flag client, replace the env-var
+// read below with the equivalent `useFeatureFlag('m6.metric_type.custom.hidden')`
+// call — the option-filter logic stays the same. The flag key above is the
+// stable contract.
+//
+// Flipping the gate begins the 2-cycle countdown for #602 (proto enum removal).
+// The 4-week zero-CUSTOMs criterion is observed via the
+// `metric_definition_custom_created_total` counter emitted from M5 (see
+// crates/experimentation-management/src/grpc.rs::create_metric_definition).
+//
+// Locked plan: docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md (L6).
+function isCustomHidden(): boolean {
+  return process.env.NEXT_PUBLIC_METRIC_TYPE_CUSTOM_HIDDEN === 'true';
+}
+
 export function MetricTypeSelect({ value, onChange, disabled }: MetricTypeSelectProps) {
-  const description = TYPE_OPTIONS.find((o) => o.value === value)?.description ?? '';
+  const options = isCustomHidden()
+    ? ALL_TYPE_OPTIONS.filter((o) => o.value !== 'CUSTOM')
+    : ALL_TYPE_OPTIONS;
+  const description = options.find((o) => o.value === value)?.description ?? '';
   const isDeprecated = value === 'CUSTOM';
 
   return (
@@ -41,7 +67,7 @@ export function MetricTypeSelect({ value, onChange, disabled }: MetricTypeSelect
         data-testid="metric-type-select"
         className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-500"
       >
-        {TYPE_OPTIONS.map((opt) => (
+        {options.map((opt) => (
           <option key={opt.value} value={opt.value}>{opt.label}</option>
         ))}
       </select>

--- a/ui/src/components/metrics/metric-type-select.tsx
+++ b/ui/src/components/metrics/metric-type-select.tsx
@@ -51,7 +51,14 @@ export function MetricTypeSelect({ value, onChange, disabled }: MetricTypeSelect
     ? ALL_TYPE_OPTIONS.filter((o) => o.value !== 'CUSTOM')
     : ALL_TYPE_OPTIONS;
   const description = options.find((o) => o.value === value)?.description ?? '';
-  const isDeprecated = value === 'CUSTOM';
+  // `isDeprecated` only renders the deprecation icon for CUSTOM when CUSTOM is
+  // still in `options`. The current caller (`/metrics/new`) cannot reach the
+  // `value='CUSTOM' && isCustomHidden()` state — the option is filtered out so
+  // the select can't be set to it — but a future edit-context caller that
+  // re-mounts this component on an existing CUSTOM metric would: without the
+  // gate, the icon would render next to a `<select>` value that has no
+  // matching `<option>`. (Devin PR #603 📝 future-caller defensive gate.)
+  const isDeprecated = value === 'CUSTOM' && !isCustomHidden();
 
   return (
     <div>


### PR DESCRIPTION
## Summary

ADR-026 Phase 3 **L6 phase 3.B** per the locked plan ([`docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md`](../tree/main/docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md)) — this PR wires the gate; **operators flip the flag after the 4-week criterion**.

Two surfaces:

1. **UI sunset flag** (`ui/src/components/metrics/metric-type-select.tsx`)
   Adds a feature gate keyed by `m6.metric_type.custom.hidden` (default false). When the flag evaluates true, the CUSTOM option is filtered out of the create-form `<select>` entirely. When false/unset, the Phase 3.A deprecated label remains (no regression for current operators creating CUSTOMs during the observation window).

2. **Observable trigger telemetry** (`crates/experimentation-management/src/grpc.rs`)
   Strengthens the existing `tracing::info!` on CUSTOM create with a `monotonic_counter.metric_definition_custom_created_total = 1u64` field. The counter name matches the trigger criterion in #602 verbatim. Until M5 wires a Prometheus exporter via `tracing-subscriber` + `metrics-tracing-context`, the counter is observable via structured-log aggregation by filtering `target=m5.deprecation`.

## Flag transport (today vs. future)

The repo has no M7 UI flag client yet, so the gate reads `NEXT_PUBLIC_METRIC_TYPE_CUSTOM_HIDDEN=true` (Next.js public env var). The component carries an inline comment naming the canonical flag key `m6.metric_type.custom.hidden`; when the M7 UI client lands, the env-var read swaps to `useFeatureFlag('m6.metric_type.custom.hidden')` with no other call-site changes. Introducing a full M7 UI client is intentionally **out of scope** for this PR — it is a separate ADR-level decision.

Similarly, the M5 telemetry path uses the tracing-field idiom because `experimentation-management` does not depend on `prometheus` or `metrics` crates today. The locked plan explicitly permits this fallback; the field projects to a Prometheus counter of the same name once an exporter ships.

## Operator workflow (cross-PR contract)

1. This PR ships. Both surfaces become live (the flag defaults off — no user-facing change).
2. Operators watch the `metric_definition_custom_created_total` counter (via log aggregation today; via Prometheus once the M5 exporter ships).
3. After **4 weeks of zero new CUSTOMs**, operators flip `NEXT_PUBLIC_METRIC_TYPE_CUSTOM_HIDDEN=true` (or the equivalent M7 flag once wired). CUSTOM disappears from the create form.
4. Flipping the gate begins the 2-cycle countdown to #602 (proto enum removal — that PR is **blocked** until the data conditions in its trigger checklist hold).

## What this PR is NOT

- **Not** the proto enum removal. That's #602 and remains blocked.
- **Not** an M7 UI flag-client introduction. That's a separate ADR.
- **Not** a Prometheus integration for M5. That's a separate ADR-level decision (the monotonic_counter field plays nice with future wiring).
- **Not** a change to the deprecation-header trailer or migration tool — those Phase 3.A surfaces are unchanged.

## Test plan

- [x] `cd ui && npm test` — 847 pass / 6 skipped / 0 fail (61 test files), including 3 new vitest cases in `metric-type-select.test.tsx`:
  - flag=true → CUSTOM option absent from `<select>`; other types still rendered
  - flag=false → CUSTOM option present with the deprecated label
  - default unset → matches the flag=false path (via the pre-existing top-level tests)
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo build -p experimentation-management` — clean
- [x] `just check-branch-name` — `agent-6/feat/adr-026-l6-phase-3b-sunset-flag` matches `^agent-[0-9]+/(feat|fix|port|design|chore|refactor|docs|test|perf)/[a-z0-9-]+$`
- [ ] CI green (rust + go + typescript + schema + stub-markers + branch-naming)

## References

- Refs #437 (Phase 3 parent — already closed; this PR is a follow-up to the L6 lock)
- Refs #602 (downstream proto enum removal — names the canonical counter key verbatim in its trigger criteria)
- Locked plan: [`docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md`](../tree/main/docs/superpowers/plans/2026-05-30-adr-026-phase-3-custom-migration.md) (L6 section)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->