### PR TITLE
🎨 Palette: Context-aware Default Value inputs for Feature Flags

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "@codemirror/autocomplete": "^6.20.2",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-sql": "^6.10.0",
+    "@codemirror/language": "^6.12.3",
     "@codemirror/lint": "^6.9.6",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@codemirror/lang-sql':
         specifier: ^6.10.0
         version: 6.10.0
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
       '@codemirror/lint':
         specifier: ^6.9.6
         version: 6.9.6

--- a/ui/src/app/flags/[id]/edit/page.tsx
+++ b/ui/src/app/flags/[id]/edit/page.tsx
@@ -28,6 +28,25 @@ function EditFlagContent() {
   const [type, setType] = useState<FlagType>('BOOLEAN');
   const [defaultValue, setDefaultValue] = useState('');
   const [enabled, setEnabled] = useState(false);
+
+  const handleTypeChange = (newType: FlagType) => {
+    setType(newType);
+    // Set sensible default values when type changes
+    switch (newType) {
+      case 'BOOLEAN':
+        setDefaultValue('false');
+        break;
+      case 'NUMERIC':
+        setDefaultValue('0');
+        break;
+      case 'JSON':
+        setDefaultValue('{}');
+        break;
+      case 'STRING':
+        setDefaultValue('');
+        break;
+    }
+  };
   const [rolloutPct, setRolloutPct] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -152,8 +171,8 @@ function EditFlagContent() {
           <select
             id="flag-type"
             value={type}
-            onChange={(e) => setType(e.target.value as FlagType)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            onChange={(e) => handleTypeChange(e.target.value as FlagType)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
             data-testid="edit-flag-type"
           >
             {FLAG_TYPES.map((t) => (
@@ -164,14 +183,34 @@ function EditFlagContent() {
 
         <div className="mb-4">
           <label htmlFor="flag-default" className="mb-1 block text-sm font-medium text-gray-700">Default Value</label>
-          <input
-            id="flag-default"
-            type="text"
-            value={defaultValue}
-            onChange={(e) => setDefaultValue(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-            data-testid="edit-flag-default"
-          />
+          {type === 'BOOLEAN' ? (
+            <select
+              id="flag-default"
+              value={defaultValue}
+              onChange={(e) => setDefaultValue(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              data-testid="edit-flag-default"
+            >
+              <option value="true">true</option>
+              <option value="false">false</option>
+            </select>
+          ) : (
+            <input
+              id="flag-default"
+              type={type === 'NUMERIC' ? 'number' : 'text'}
+              value={defaultValue}
+              onChange={(e) => setDefaultValue(e.target.value)}
+              placeholder={type === 'JSON' ? '{ "key": "value" }' : ''}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              data-testid="edit-flag-default"
+            />
+          )}
+          {type === 'JSON' && (
+            <p className="mt-1 text-xs text-gray-500">Must be a valid JSON string.</p>
+          )}
+          {type === 'NUMERIC' && (
+            <p className="mt-1 text-xs text-gray-500">Enter a numeric value.</p>
+          )}
         </div>
 
         <div className="mb-4 flex items-center gap-2">

--- a/ui/src/app/flags/new/page.tsx
+++ b/ui/src/app/flags/new/page.tsx
@@ -21,6 +21,25 @@ function CreateFlagContent() {
   const [type, setType] = useState<FlagType>('BOOLEAN');
   const [defaultValue, setDefaultValue] = useState('false');
   const [enabled, setEnabled] = useState(false);
+
+  const handleTypeChange = (newType: FlagType) => {
+    setType(newType);
+    // Set sensible default values when type changes
+    switch (newType) {
+      case 'BOOLEAN':
+        setDefaultValue('false');
+        break;
+      case 'NUMERIC':
+        setDefaultValue('0');
+        break;
+      case 'JSON':
+        setDefaultValue('{}');
+        break;
+      case 'STRING':
+        setDefaultValue('');
+        break;
+    }
+  };
   const [rolloutPct, setRolloutPct] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -111,8 +130,8 @@ function CreateFlagContent() {
           <select
             id="flag-type"
             value={type}
-            onChange={(e) => setType(e.target.value as FlagType)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            onChange={(e) => handleTypeChange(e.target.value as FlagType)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
             data-testid="flag-type-select"
           >
             {FLAG_TYPES.map((t) => (
@@ -123,14 +142,34 @@ function CreateFlagContent() {
 
         <div className="mb-4">
           <label htmlFor="flag-default" className="mb-1 block text-sm font-medium text-gray-700">Default Value</label>
-          <input
-            id="flag-default"
-            type="text"
-            value={defaultValue}
-            onChange={(e) => setDefaultValue(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-            data-testid="flag-default-input"
-          />
+          {type === 'BOOLEAN' ? (
+            <select
+              id="flag-default"
+              value={defaultValue}
+              onChange={(e) => setDefaultValue(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              data-testid="flag-default-input"
+            >
+              <option value="true">true</option>
+              <option value="false">false</option>
+            </select>
+          ) : (
+            <input
+              id="flag-default"
+              type={type === 'NUMERIC' ? 'number' : 'text'}
+              value={defaultValue}
+              onChange={(e) => setDefaultValue(e.target.value)}
+              placeholder={type === 'JSON' ? '{ "key": "value" }' : ''}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              data-testid="flag-default-input"
+            />
+          )}
+          {type === 'JSON' && (
+            <p className="mt-1 text-xs text-gray-500">Must be a valid JSON string.</p>
+          )}
+          {type === 'NUMERIC' && (
+            <p className="mt-1 text-xs text-gray-500">Enter a numeric value.</p>
+          )}
         </div>
 
         <div className="mb-4 flex items-center gap-2">


### PR DESCRIPTION
This PR implements a micro-UX improvement for the feature flag management interface. The "Default Value" field in the creation and edit forms now adapts its input type based on the selected flag type, providing a dropdown for booleans and a numeric input for numbers. It also sets sensible defaults when the type is switched, reducing manual effort and potential for error.

---
*PR created automatically by Jules for task [12854007150238023053](https://jules.google.com/task/12854007150238023053) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->