### PR TITLE
refactor(m5/migration): extract shared SQL-AST helpers into sql_ast module (Closes #587)

### DIFF
--- a/crates/experimentation-management/src/migration/mod.rs
+++ b/crates/experimentation-management/src/migration/mod.rs
@@ -18,6 +18,7 @@
 pub mod classifier;
 pub mod cli;
 pub mod report;
+pub mod sql_ast;
 pub mod tier1;
 pub mod tier2;
 

--- a/crates/experimentation-management/src/migration/sql_ast.rs
+++ b/crates/experimentation-management/src/migration/sql_ast.rs
@@ -1,0 +1,154 @@
+//! Shared `sqlparser::ast` helpers for the CUSTOM-metric migration tiers.
+//!
+//! Extracted from `tier1.rs` in #587: these helpers manipulate AST primitives
+//! (`Expr`, `Select`, `Statement`, `TableWithJoins`) and are called from both
+//! `tier1.rs` and `tier2.rs` at roughly even rates (37 / 33 references). Hosting
+//! them in a sibling module makes `tier1` and `tier2` true siblings instead of
+//! one implicitly depending on the other.
+//!
+//! Pure code-motion — no behavior change.
+
+use sqlparser::ast::{
+    BinaryOperator, Expr, JoinConstraint, JoinOperator, SetExpr, Statement,
+};
+
+// ---------------------------------------------------------------------------
+// FROM-clause shape gates
+// ---------------------------------------------------------------------------
+
+/// Validate that the FILTERED_MEAN FROM clause matches one of:
+///   - single table `metric_events` (no joins)
+///   - `metric_events JOIN exposures` (exactly one join, joined table is `exposures`)
+///
+/// Rejects any other shape (multiple joins, joined table is not `exposures`, etc.).
+/// This guards against the multi-table-join Tier 3 case where predicates on
+/// non-events tables (e.g. `user_profiles.country`) can't be captured in `filter_sql`.
+pub(crate) fn from_is_events_with_optional_exposures_join(
+    from: &[sqlparser::ast::TableWithJoins],
+) -> bool {
+    if from.len() != 1 {
+        return false;
+    }
+    let twj = &from[0];
+    // Main table must be metric_events.
+    let main_table = table_name_from_factor_str(&twj.relation);
+    if !main_table.map(|n| n.contains("metric_events")).unwrap_or(false) {
+        return false;
+    }
+    // Zero or one join allowed; if one, it must be to exposures.
+    match twj.joins.len() {
+        0 => true,
+        1 => {
+            let joined = table_name_from_factor_str(&twj.joins[0].relation);
+            joined.map(|n| n.contains("exposures")).unwrap_or(false)
+        }
+        _ => false, // multiple joins → Tier 3
+    }
+}
+
+/// Validate that the WINDOWED_COUNT FROM clause is `exposures JOIN metric_events`.
+///
+/// The WINDOWED_COUNT pattern (per `windowed_count.sql.tmpl`) requires:
+///   - main table: `exposures` or `delta.exposures`
+///   - exactly one join: `metric_events` or `delta.metric_events`
+///
+/// Any other table pair (e.g. `orders JOIN shipments`) violates L4 conservatism
+/// and must fall through to Tier 3.
+pub(crate) fn from_is_exposures_with_metric_events_join(
+    from: &[sqlparser::ast::TableWithJoins],
+) -> bool {
+    if from.len() != 1 {
+        return false;
+    }
+    let twj = &from[0];
+    // Main table must be exposures.
+    let main_table = table_name_from_factor_str(&twj.relation);
+    if !main_table.map(|n| n.contains("exposures")).unwrap_or(false) {
+        return false;
+    }
+    // Exactly one join required, joined table must be metric_events.
+    if twj.joins.len() != 1 {
+        return false;
+    }
+    let joined = table_name_from_factor_str(&twj.joins[0].relation);
+    joined.map(|n| n.contains("metric_events")).unwrap_or(false)
+}
+
+fn table_name_from_factor_str(factor: &sqlparser::ast::TableFactor) -> Option<String> {
+    match factor {
+        sqlparser::ast::TableFactor::Table { name, .. } => {
+            Some(name.to_string().to_ascii_lowercase())
+        }
+        _ => None,
+    }
+}
+
+/// Find the single JOIN ON expression in the FROM clause.
+pub(crate) fn find_join_on_expr(from: &[sqlparser::ast::TableWithJoins]) -> Option<&Expr> {
+    for twj in from {
+        for join in &twj.joins {
+            let constraint = match &join.join_operator {
+                JoinOperator::Inner(c)
+                | JoinOperator::LeftOuter(c)
+                | JoinOperator::RightOuter(c)
+                | JoinOperator::FullOuter(c)
+                | JoinOperator::LeftSemi(c)
+                | JoinOperator::RightSemi(c)
+                | JoinOperator::LeftAnti(c)
+                | JoinOperator::RightAnti(c) => c,
+                _ => continue,
+            };
+            if let JoinConstraint::On(ref on_expr) = constraint {
+                return Some(on_expr);
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Statement / Expr utilities
+// ---------------------------------------------------------------------------
+
+/// Extract the `Select` body from a `Statement::Query`.
+pub(crate) fn extract_select(stmt: &Statement) -> Option<&sqlparser::ast::Select> {
+    if let Statement::Query(q) = stmt {
+        if let SetExpr::Select(s) = q.body.as_ref() {
+            return Some(s.as_ref());
+        }
+    }
+    None
+}
+
+/// Recursively collect all leaf predicates of an AND tree.
+pub(crate) fn collect_and_predicates(expr: &Expr) -> Vec<&Expr> {
+    match expr {
+        Expr::BinaryOp { left, op: BinaryOperator::And, right } => {
+            let mut v = collect_and_predicates(left);
+            v.extend(collect_and_predicates(right));
+            v
+        }
+        Expr::Nested(inner) => collect_and_predicates(inner),
+        other => vec![other],
+    }
+}
+
+/// Strip table alias from `alias.col` → `col`. Returns `None` for complex expressions.
+pub(crate) fn strip_table_alias(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Identifier(id) => Some(id.value.clone()),
+        Expr::CompoundIdentifier(parts) => {
+            // `alias.col` → take the last ident.
+            parts.last().map(|id| id.value.clone())
+        }
+        _ => None,
+    }
+}
+
+/// Unwrap `Expr::Nested(...)` recursively.
+pub(crate) fn unwrap_nested(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Nested(inner) => unwrap_nested(inner),
+        other => other,
+    }
+}

--- a/crates/experimentation-management/src/migration/tier1.rs
+++ b/crates/experimentation-management/src/migration/tier1.rs
@@ -22,8 +22,7 @@
 //! must be in a tokio runtime. Do NOT use `block_on` inside this module.
 
 use sqlparser::ast::{
-    BinaryOperator, Expr, FunctionArguments, Interval, JoinConstraint, JoinOperator, SelectItem,
-    SetExpr, Statement,
+    BinaryOperator, Expr, FunctionArguments, Interval, SelectItem, Statement,
 };
 use sqlparser::ast::DateTimeField;
 
@@ -34,6 +33,11 @@ use experimentation_proto::experimentation::common::v1::{
 
 use crate::validators::{validate_metric_definition, MetricLookup};
 use super::classifier::ShapeHint;
+use super::sql_ast::{
+    collect_and_predicates, extract_select, find_join_on_expr,
+    from_is_events_with_optional_exposures_join, from_is_exposures_with_metric_events_join,
+    strip_table_alias, unwrap_nested,
+};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -484,98 +488,6 @@ fn extract_event_type_literal(expr: &Expr) -> Option<String> {
 // AST walking helpers — WINDOWED_COUNT
 // ---------------------------------------------------------------------------
 
-/// Validate that the FILTERED_MEAN FROM clause is `metric_events [JOIN exposures]`.
-///
-/// Accepts:
-///   - single table `metric_events` (no joins)
-///   - `metric_events JOIN exposures` (exactly one join, joined table is `exposures`)
-///
-/// Rejects any other shape (multiple joins, joined table is not `exposures`, etc.).
-/// This guards against the multi-table-join Tier 3 case where predicates on
-/// non-events tables (e.g. `user_profiles.country`) can't be captured in `filter_sql`.
-pub(crate) fn from_is_events_with_optional_exposures_join(
-    from: &[sqlparser::ast::TableWithJoins],
-) -> bool {
-    if from.len() != 1 {
-        return false;
-    }
-    let twj = &from[0];
-    // Main table must be metric_events.
-    let main_table = table_name_from_factor_str(&twj.relation);
-    if !main_table.map(|n| n.contains("metric_events")).unwrap_or(false) {
-        return false;
-    }
-    // Zero or one join allowed; if one, it must be to exposures.
-    match twj.joins.len() {
-        0 => true,
-        1 => {
-            let joined = table_name_from_factor_str(&twj.joins[0].relation);
-            joined.map(|n| n.contains("exposures")).unwrap_or(false)
-        }
-        _ => false, // multiple joins → Tier 3
-    }
-}
-
-/// Validate that the WINDOWED_COUNT FROM clause is `exposures JOIN metric_events`.
-///
-/// The WINDOWED_COUNT pattern (per `windowed_count.sql.tmpl`) requires:
-///   - main table: `exposures` or `delta.exposures`
-///   - exactly one join: `metric_events` or `delta.metric_events`
-///
-/// Any other table pair (e.g. `orders JOIN shipments`) violates L4 conservatism
-/// and must fall through to Tier 3.
-pub(crate) fn from_is_exposures_with_metric_events_join(
-    from: &[sqlparser::ast::TableWithJoins],
-) -> bool {
-    if from.len() != 1 {
-        return false;
-    }
-    let twj = &from[0];
-    // Main table must be exposures.
-    let main_table = table_name_from_factor_str(&twj.relation);
-    if !main_table.map(|n| n.contains("exposures")).unwrap_or(false) {
-        return false;
-    }
-    // Exactly one join required, joined table must be metric_events.
-    if twj.joins.len() != 1 {
-        return false;
-    }
-    let joined = table_name_from_factor_str(&twj.joins[0].relation);
-    joined.map(|n| n.contains("metric_events")).unwrap_or(false)
-}
-
-fn table_name_from_factor_str(factor: &sqlparser::ast::TableFactor) -> Option<String> {
-    match factor {
-        sqlparser::ast::TableFactor::Table { name, .. } => {
-            Some(name.to_string().to_ascii_lowercase())
-        }
-        _ => None,
-    }
-}
-
-/// Find the single JOIN ON expression in the FROM clause.
-pub(crate) fn find_join_on_expr(from: &[sqlparser::ast::TableWithJoins]) -> Option<&Expr> {
-    for twj in from {
-        for join in &twj.joins {
-            let constraint = match &join.join_operator {
-                JoinOperator::Inner(c)
-                | JoinOperator::LeftOuter(c)
-                | JoinOperator::RightOuter(c)
-                | JoinOperator::FullOuter(c)
-                | JoinOperator::LeftSemi(c)
-                | JoinOperator::RightSemi(c)
-                | JoinOperator::LeftAnti(c)
-                | JoinOperator::RightAnti(c) => c,
-                _ => continue,
-            };
-            if let JoinConstraint::On(ref on_expr) = constraint {
-                return Some(on_expr);
-            }
-        }
-    }
-    None
-}
-
 /// True if `pred` is `eu.user_id = me.user_id` (or similar user_id equality join).
 fn is_user_id_join_predicate(pred: &Expr) -> bool {
     if let Expr::BinaryOp { left, op: BinaryOperator::Eq, right } = pred {
@@ -986,53 +898,6 @@ fn binary_op_str(op: &BinaryOperator) -> Option<&'static str> {
         BinaryOperator::And => Some("AND"),
         BinaryOperator::Or => Some("OR"),
         _ => None,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Shared AST utilities
-// ---------------------------------------------------------------------------
-
-/// Extract the `Select` body from a `Statement::Query`.
-pub(crate) fn extract_select(stmt: &Statement) -> Option<&sqlparser::ast::Select> {
-    if let Statement::Query(q) = stmt {
-        if let SetExpr::Select(s) = q.body.as_ref() {
-            return Some(s.as_ref());
-        }
-    }
-    None
-}
-
-/// Recursively collect all leaf predicates of an AND tree.
-pub(crate) fn collect_and_predicates(expr: &Expr) -> Vec<&Expr> {
-    match expr {
-        Expr::BinaryOp { left, op: BinaryOperator::And, right } => {
-            let mut v = collect_and_predicates(left);
-            v.extend(collect_and_predicates(right));
-            v
-        }
-        Expr::Nested(inner) => collect_and_predicates(inner),
-        other => vec![other],
-    }
-}
-
-/// Strip table alias from `alias.col` → `col`. Returns `None` for complex expressions.
-pub(crate) fn strip_table_alias(expr: &Expr) -> Option<String> {
-    match expr {
-        Expr::Identifier(id) => Some(id.value.clone()),
-        Expr::CompoundIdentifier(parts) => {
-            // `alias.col` → take the last ident.
-            parts.last().map(|id| id.value.clone())
-        }
-        _ => None,
-    }
-}
-
-/// Unwrap `Expr::Nested(...)` recursively.
-pub(crate) fn unwrap_nested(expr: &Expr) -> &Expr {
-    match expr {
-        Expr::Nested(inner) => unwrap_nested(inner),
-        other => other,
     }
 }
 

--- a/crates/experimentation-management/src/migration/tier2.rs
+++ b/crates/experimentation-management/src/migration/tier2.rs
@@ -37,7 +37,7 @@ use crate::validators::{
 };
 
 use super::classifier::ShapeHint;
-use super::tier1::{
+use super::sql_ast::{
     collect_and_predicates, extract_select, find_join_on_expr,
     from_is_events_with_optional_exposures_join, from_is_exposures_with_metric_events_join,
     strip_table_alias, unwrap_nested,


### PR DESCRIPTION
## Summary

Move seven `pub(crate)` AST helpers from `crates/experimentation-management/src/migration/tier1.rs` into a new sibling module `migration/sql_ast.rs`. The helpers manipulate `sqlparser::ast::{Expr, Select, Statement, TableWithJoins}` and are called from both `tier1.rs` and `tier2.rs` at near-even rates (37 / 33 references per #587's grep). Before this change, `tier2.rs` was implicitly importing them from `tier1.rs` — the wrong direction for sibling modules.

Pure code-motion refactor — **no behavior change**.

### Module-dependency consequence

**Before**
```
tier1 ←── tier2   (tier2 implicitly depends on tier1 for SQL-AST helpers)
```

**After**
```
sql_ast ←── tier1
sql_ast ←── tier2
(tier1 and tier2 become true siblings)
```

This matches the conceptual model in ADR-026 Phase 3 — tier1 and tier2 are migration tiers for different metric shapes, not one building on the other.

## What moved

Verbatim copies from `tier1.rs` to `sql_ast.rs`:

| Helper | Original line | tier1 callers | tier2 callers |
|---|---:|---:|---:|
| `from_is_events_with_optional_exposures_join` | 496 | 1 | 1 |
| `from_is_exposures_with_metric_events_join` | 527 | 1 | 1 |
| `find_join_on_expr` | 557 | 1 | 1 |
| `extract_select` | 997 | 3 | 4 |
| `collect_and_predicates` | 1007 | 5 | 3 |
| `strip_table_alias` | 1020 | 6 | 5 |
| `unwrap_nested` | 1032 | 20 | 18 |

Plus the private `table_name_from_factor_str` (line 547) — only called by the two `from_is_*` helpers, so it follows.

Three sqlparser imports that became unused in `tier1.rs` after the move (`JoinConstraint`, `JoinOperator`, `SetExpr`) are dropped.

## File diff stats

```
crates/experimentation-management/src/migration/mod.rs       |   1 +
crates/experimentation-management/src/migration/sql_ast.rs   | 154 +++++++ (new)
crates/experimentation-management/src/migration/tier1.rs     | 147 +-
crates/experimentation-management/src/migration/tier2.rs     |   2 +-
4 files changed, 162 insertions(+), 142 deletions(-)
```

tier1.rs: 1600 → 1465 lines.

## Acceptance criteria (per #587)

- [x] `cargo test -p experimentation-management` passes with all existing assertions unchanged — 335 lib tests + 22+ integration tests, 0 failed.
- [x] `cargo clippy -p experimentation-management --no-deps` is clean.
- [x] `grep -rn "use.*migration::tier1::" crates/` returns empty (tier2 imports from `sql_ast` instead).
- [x] `sql_ast` exposes exactly the seven `pub(crate) fn` listed in the issue.

## Out of scope (per issue)

- `translate_filtered_aggregation()` in `tier2.rs` — the mirror "pull-toward-tier1" finding from the graphify clustering pass. Left alone; flagged for a follow-up to verify whether it's genuinely tier2-specific.
- No new helpers or abstractions beyond moving what's listed.

## Test plan

- [x] `cargo test -p experimentation-management` (335 + 22 = 357+ tests pass)
- [x] `cargo clippy -p experimentation-management --no-deps` (clean)
- [ ] Workspace-wide CI green (will trigger on push)

## How this was discovered

`/graphify` knowledge-graph build on `crates/` + `docs/adrs/`. Same diagnostic pattern as PR #583 (`welch_standard_error` → `ttest.rs`) and PR #584 (`fail_fast.rs`): nodes whose community has a strict (>50%) owner-file different from their own source file.

Closes #587
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->