### PR TITLE
refactor(stats): consolidate Welch mean/variance helpers across cate/ttest/tost

### DIFF
--- a/crates/experimentation-stats/src/cate.rs
+++ b/crates/experimentation-stats/src/cate.rs
@@ -11,7 +11,7 @@ use experimentation_core::error::{assert_finite, Error, Result};
 use statrs::distribution::{ChiSquared, ContinuousCDF};
 
 use crate::multiple_comparison::benjamini_hochberg;
-use crate::ttest::{welch_standard_error, welch_ttest, WelchSe};
+use crate::ttest::{mean, sample_variance, welch_standard_error, welch_ttest, WelchSe};
 
 /// Input data for a single subgroup (lifecycle segment).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -304,11 +304,11 @@ pub(crate) fn compute_welch_se(control: &[f64], treatment: &[f64]) -> f64 {
     let n_c = control.len() as f64;
     let n_t = treatment.len() as f64;
 
-    let mean_c = control.iter().sum::<f64>() / n_c;
-    let mean_t = treatment.iter().sum::<f64>() / n_t;
+    let mean_c = mean(control);
+    let mean_t = mean(treatment);
 
-    let var_c = control.iter().map(|x| (x - mean_c).powi(2)).sum::<f64>() / (n_c - 1.0);
-    let var_t = treatment.iter().map(|x| (x - mean_t).powi(2)).sum::<f64>() / (n_t - 1.0);
+    let var_c = sample_variance(control, mean_c);
+    let var_t = sample_variance(treatment, mean_t);
 
     let WelchSe { se, df: _ } = welch_standard_error(n_c, n_t, var_c, var_t)
         .expect("welch SE computation failed: zero variance in pooled samples");

--- a/crates/experimentation-stats/src/tost.rs
+++ b/crates/experimentation-stats/src/tost.rs
@@ -37,7 +37,7 @@
 use experimentation_core::error::{assert_finite, Error, Result};
 use statrs::distribution::{ContinuousCDF, Normal, StudentsT};
 
-use crate::ttest::welch_standard_error;
+use crate::ttest::{mean, sample_variance, welch_standard_error};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -491,16 +491,6 @@ fn cuped_adjusted_samples(
     };
 
     Ok((adjust(control_y, control_x), adjust(treatment_y, treatment_x)))
-}
-
-fn mean(data: &[f64]) -> f64 {
-    data.iter().sum::<f64>() / data.len() as f64
-}
-
-fn sample_variance(data: &[f64], mean: f64) -> f64 {
-    let n = data.len() as f64;
-    let ss: f64 = data.iter().map(|&x| (x - mean).powi(2)).sum();
-    ss / (n - 1.0)
 }
 
 fn sample_covariance(y: &[f64], x: &[f64], mean_y: f64, mean_x: f64) -> f64 {

--- a/crates/experimentation-stats/src/ttest.rs
+++ b/crates/experimentation-stats/src/ttest.rs
@@ -56,6 +56,26 @@ pub(crate) fn welch_standard_error(
     Ok(WelchSe { se, df })
 }
 
+/// Shared Welch primitive — arithmetic mean of a sample slice.
+///
+/// This is the canonical mean helper for the `experimentation-stats` crate,
+/// consolidating identical inline arithmetic from `ttest`, `tost`, and `cate`.
+/// See issue #598.
+pub(crate) fn mean(xs: &[f64]) -> f64 {
+    xs.iter().sum::<f64>() / xs.len() as f64
+}
+
+/// Shared Welch primitive — Bessel-corrected sample variance given a pre-computed mean.
+///
+/// This is the canonical sample-variance helper for the `experimentation-stats` crate,
+/// consolidating identical inline arithmetic from `ttest`, `tost`, and `cate`.
+/// See issue #598.
+pub(crate) fn sample_variance(xs: &[f64], mean: f64) -> f64 {
+    let n = xs.len() as f64;
+    let ss: f64 = xs.iter().map(|&x| (x - mean).powi(2)).sum();
+    ss / (n - 1.0)
+}
+
 /// Result of a two-sample Welch's t-test.
 #[derive(Debug, Clone)]
 pub struct TTestResult {
@@ -101,13 +121,13 @@ pub fn welch_ttest(control: &[f64], treatment: &[f64], alpha: f64) -> Result<TTe
     let n_c = control.len() as f64;
     let n_t = treatment.len() as f64;
 
-    let mean_c = control.iter().sum::<f64>() / n_c;
-    let mean_t = treatment.iter().sum::<f64>() / n_t;
+    let mean_c = mean(control);
+    let mean_t = mean(treatment);
     assert_finite(mean_c, "control mean");
     assert_finite(mean_t, "treatment mean");
 
-    let var_c = control.iter().map(|x| (x - mean_c).powi(2)).sum::<f64>() / (n_c - 1.0);
-    let var_t = treatment.iter().map(|x| (x - mean_t).powi(2)).sum::<f64>() / (n_t - 1.0);
+    let var_c = sample_variance(control, mean_c);
+    let var_t = sample_variance(treatment, mean_t);
     assert_finite(var_c, "control variance");
     assert_finite(var_t, "treatment variance");
 

--- a/crates/experimentation-stats/src/ttest.rs
+++ b/crates/experimentation-stats/src/ttest.rs
@@ -233,4 +233,56 @@ mod tests {
             .expect("tost_equivalence_test should not fail on valid data");
         assert_eq!(se_canonical, tost_result.std_error, "tost path");
     }
+
+    /// Verify that `mean` and `sample_variance` produce bit-identical results to
+    /// the inline arithmetic that existed at each of the three former call sites
+    /// (`ttest`, `tost`, `cate`) before the helpers were introduced.
+    ///
+    /// Bit-identity (not float tolerance) is required here because the refactor is
+    /// only semantically valid if the helper is mathematically and floating-point
+    /// equivalent to the old inline arithmetic — even a single ULP of difference
+    /// would indicate that the consolidation changed numerical behaviour. See #598.
+    #[test]
+    fn mean_variance_parity_across_call_paths() {
+        let control = vec![1.0f64, 2.0, 3.0, 4.0, 5.0];
+        let treatment = vec![2.0f64, 3.0, 4.0, 5.0, 6.0];
+
+        // ---- Inline arithmetic (verbatim from the three former call sites) ----
+
+        // ttest.rs / cate.rs shared inline form
+        let n_c = control.len() as f64;
+        let n_t = treatment.len() as f64;
+        let mean_c_inline = control.iter().sum::<f64>() / n_c;
+        let mean_t_inline = treatment.iter().sum::<f64>() / n_t;
+        let var_c_inline =
+            control.iter().map(|x| (x - mean_c_inline).powi(2)).sum::<f64>() / (n_c - 1.0);
+        let var_t_inline =
+            treatment.iter().map(|x| (x - mean_t_inline).powi(2)).sum::<f64>() / (n_t - 1.0);
+
+        // ---- Helper calls (introduced by #598) ----
+
+        let mean_c_helper = mean(&control);
+        let mean_t_helper = mean(&treatment);
+        let var_c_helper = sample_variance(&control, mean(&control));
+        let var_t_helper = sample_variance(&treatment, mean(&treatment));
+
+        // ---- Bit-identical assertions ----
+
+        assert_eq!(
+            mean_c_inline, mean_c_helper,
+            "mean(control) must be bit-identical to inline arithmetic (issue #598)"
+        );
+        assert_eq!(
+            mean_t_inline, mean_t_helper,
+            "mean(treatment) must be bit-identical to inline arithmetic (issue #598)"
+        );
+        assert_eq!(
+            var_c_inline, var_c_helper,
+            "sample_variance(control) must be bit-identical to inline arithmetic (issue #598)"
+        );
+        assert_eq!(
+            var_t_inline, var_t_helper,
+            "sample_variance(treatment) must be bit-identical to inline arithmetic (issue #598)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #598. Promotes `mean` and `sample_variance` from `tost.rs` private helpers to `pub(crate)` in `ttest.rs` (the natural home for shared Welch primitives, alongside `welch_standard_error` from #583). The three former sites of identical inline arithmetic — `welch_ttest`, `cate::compute_welch_se`, and the two tost call paths — now delegate to the canonical helpers.

Pure refactor. No behaviour change; no statistical results change.

## Changes

- `crates/experimentation-stats/src/ttest.rs`
  - Added `pub(crate) fn mean(xs: &[f64]) -> f64` and `pub(crate) fn sample_variance(xs: &[f64], mean: f64) -> f64`, placed immediately after `welch_standard_error` so all three Welch primitives live together.
  - Rewired `welch_ttest`'s inline mean/variance computation to call the helpers; **every** `assert_finite!` invariant (`mean_c`, `mean_t`, `var_c`, `var_t`) preserved in its original position validating helper output.
  - Added `mean_variance_parity_across_call_paths` test (next commit).
- `crates/experimentation-stats/src/cate.rs`
  - `compute_welch_se` now calls the new helpers; the four lines of inline arithmetic are gone.
- `crates/experimentation-stats/src/tost.rs`
  - Local `fn mean` / `fn sample_variance` deleted; import rewritten to `use crate::ttest::{mean, sample_variance, welch_standard_error};`.
  - `fn sample_covariance` intentionally left alone (out of scope for #598 — separate consolidation opportunity).

## Why two commits

1. `refactor(stats): consolidate Welch mean/variance helpers` — the structural move. All 364 pre-existing tests pass on this commit alone, demonstrating zero behaviour change.
2. `test(stats): byte-identity parity for Welch mean/variance helpers` — the regression guard. `assert_eq!` on raw f64 (not `(a-b).abs() < eps`) pins the bit-equivalence so any future drift in the helper bodies — or in Rust's iterator-sum codegen — is caught immediately.

## Test plan

- [x] `cargo test -p experimentation-stats` — 364 → 365 passing, parity test green.
- [x] `cargo clippy -p experimentation-stats --all-features -- -D warnings` — zero diagnostics.
- [x] Integration / proptest / golden-file suites — all 458 tests across 22 suites green.
- [x] `just check-branch-name` — branch matches `^agent-[0-9]+/(feat|fix|port|design|chore|refactor|docs|test|perf)/[a-z0-9-]+$`.
- [x] Two-stage subagent review (spec compliance + code quality) — both ✅.
- [x] No credential strings in diff; temp backups cleaned.

## Known orthogonal issue

`cargo clippy --workspace --all-features` fails on this machine due to a pre-existing pyo3 0.22.6 / Python 3.14 incompatibility (`error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)`). Reproduced on clean main at SHA `f7a8b19` — **not** a regression from this PR. Tracked separately; not blocking this refactor since the touched code has no Python bindings.

## Follow-up opportunity (noted, not implemented per scope discipline)

`tost.rs::sample_covariance` is the only Welch-adjacent arithmetic still inline. If a future PR introduces a CUPED helper module (the only other call site is `cuped_adjust` in tost.rs), this could be promoted too. Filing as a separate issue if/when a second consumer emerges.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->