### PR TITLE
feat: extend PreviewMetricDefinition to global scope (Closes #597)

### DIFF
--- a/crates/experimentation-management/src/contract_test_support.rs
+++ b/crates/experimentation-management/src/contract_test_support.rs
@@ -765,9 +765,9 @@ impl ExperimentManagementService for ManagementServiceHandler {
         let req = request.into_inner();
         // Mirror the production handler's input validation so wire-format
         // contract tests can exercise the INVALID_ARGUMENT paths without M3.
-        if req.experiment_id.trim().is_empty() {
-            return Err(Status::invalid_argument("experiment_id is required"));
-        }
+        // Empty `experiment_id` is accepted as the global scope — symmetric
+        // to grpc.rs::preview_metric_definition (#597) and the validate-side
+        // relaxation in #571.
         if req.metricql_expression.trim().is_empty() {
             return Err(Status::invalid_argument("metricql_expression is required"));
         }

--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -1698,9 +1698,12 @@ impl ExperimentManagementService for ManagementServiceHandler {
 
         let req = request.into_inner();
 
-        if req.experiment_id.trim().is_empty() {
-            return Err(Status::invalid_argument("experiment_id is required"));
-        }
+        // ADR-026 Phase 2 follow-up (#597): empty `experiment_id` is the global
+        // scope used by the metric-creation form (which has no experiment
+        // context). Symmetric to the validate_metricql relaxation in #571 /
+        // PR #595 — empty no longer short-circuits with INVALID_ARGUMENT;
+        // M5 proxies the empty string through to M3, which builds its own
+        // known-metric-id set from the full metric_definitions catalog.
         if req.metricql_expression.trim().is_empty() {
             return Err(Status::invalid_argument("metricql_expression is required"));
         }
@@ -2126,5 +2129,93 @@ mod tests {
                 assert_eq!(line, 2);
             }
         }
+    }
+
+    // ── preview_metric_definition global-scope contract (#597) ───────────────
+    // Symmetric to PR #595's validate_metricql relaxation. The M5 handler must
+    // accept empty experiment_id and proxy the empty string through to M3
+    // (where Task 2 of this PR builds the global metric catalog). The pure-Rust
+    // safety net here proves the early-return guard is gone in CI environments
+    // without a mock M3 — the live wire-format test lives in
+    // `tests/contract_preview_test.rs`.
+
+    #[tokio::test]
+    async fn preview_metric_definition_empty_experiment_id_does_not_short_circuit() {
+        use sqlx::postgres::PgPoolOptions;
+        use tonic::Code;
+
+        // Build a no-IO production handler: connect_lazy on both store and
+        // metrics_client. preview_metric_definition never touches the store,
+        // and the metrics_client points at port 1 (nothing listens) so the
+        // proxy call surfaces as Code::Unavailable once the early-return guard
+        // is gone. If the guard were still present, we'd see InvalidArgument
+        // instead — that's the contract this test pins.
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/nonexistent")
+            .expect("connect_lazy should not dial");
+        let store = ManagementStore::from_pool(pool);
+        let endpoint = tonic::transport::Endpoint::from_static("http://127.0.0.1:1");
+        let channel = endpoint.connect_lazy();
+        let client = MetricComputationServiceClient::new(channel);
+        let state = SharedState::new_with_channel(store, client);
+        let handler = ManagementServiceHandler::new(state);
+
+        let err = handler
+            .preview_metric_definition(Request::new(PreviewMetricDefinitionRequest {
+                experiment_id: String::new(),
+                metricql_expression: "@watch_time + 0".to_string(),
+            }))
+            .await
+            .expect_err("M3 is unreachable so the proxy call must fail");
+
+        assert_ne!(
+            err.code(),
+            Code::InvalidArgument,
+            "empty experiment_id must NOT short-circuit with InvalidArgument; \
+             got code={:?} message={:?}",
+            err.code(),
+            err.message(),
+        );
+        assert!(
+            !err.message().contains("experiment_id is required"),
+            "error must not reference the removed experiment_id guard; got: {}",
+            err.message(),
+        );
+    }
+
+    #[tokio::test]
+    async fn preview_metric_definition_empty_expression_still_rejected() {
+        // Sanity check: the relaxation only removed the experiment_id guard.
+        // Empty `metricql_expression` must still return INVALID_ARGUMENT
+        // before any M3 round-trip.
+        use sqlx::postgres::PgPoolOptions;
+        use tonic::Code;
+
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgresql://postgres:postgres@127.0.0.1:1/nonexistent")
+            .expect("connect_lazy should not dial");
+        let store = ManagementStore::from_pool(pool);
+        let endpoint = tonic::transport::Endpoint::from_static("http://127.0.0.1:1");
+        let channel = endpoint.connect_lazy();
+        let client = MetricComputationServiceClient::new(channel);
+        let state = SharedState::new_with_channel(store, client);
+        let handler = ManagementServiceHandler::new(state);
+
+        let err = handler
+            .preview_metric_definition(Request::new(PreviewMetricDefinitionRequest {
+                experiment_id: String::new(),
+                metricql_expression: String::new(),
+            }))
+            .await
+            .expect_err("empty expression must be rejected");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(
+            err.message().contains("metricql_expression"),
+            "error message should mention metricql_expression; got: {}",
+            err.message(),
+        );
     }
 }

--- a/crates/experimentation-management/tests/contract_preview_test.rs
+++ b/crates/experimentation-management/tests/contract_preview_test.rs
@@ -413,8 +413,9 @@ async fn empty_metricql_expression_returns_invalid_argument_without_m3_call() {
 #[tokio::test]
 async fn whitespace_only_experiment_id_is_forwarded_to_m3_as_global_scope() {
     // #597: whitespace-only experiment_id is treated identically to empty
-    // — trim().is_empty() is the global-scope signal. M5 forwards the
-    // string verbatim; M3 trims on its side when building the catalog.
+    // — trim().is_empty() is the global-scope signal on M5's side. M5
+    // forwards the string verbatim; M3 decides how to interpret
+    // whitespace-only when building the catalog (Task 2).
     let (addr, captured, _resp) = spawn_mock_m3(PresetResponse::Ok(
         CompileMetricqlPreviewResponse {
             compiled_sql: "SELECT avg(v) FROM t".into(),

--- a/crates/experimentation-management/tests/contract_preview_test.rs
+++ b/crates/experimentation-management/tests/contract_preview_test.rs
@@ -1,14 +1,16 @@
 //! Contract test for M5 PreviewMetricDefinition → M3 CompileMetricqlPreview proxy.
 //!
-//! Verifies (ADR-026 Phase 2 / #436):
+//! Verifies (ADR-026 Phase 2 / #436, updated for #597 global-scope relaxation):
 //!  1. Request forwarding — M5 forwards experiment_id + metricql_expression to M3 unmodified.
 //!  2. Response passthrough — compiled_sql returned verbatim.
 //!  3. Diagnostics propagated unmodified (field values, span coords).
 //!  4. M3 returns a non-OK status → the status code propagates.
 //!  5. M3 unavailable → UNAVAILABLE (connect_lazy fails at first send).
-//!  6. Empty experiment_id → INVALID_ARGUMENT before any M3 round-trip.
+//!  6. Empty experiment_id → forwarded to M3 as global-scope (#597, symmetric
+//!     to PR #595's validate_metricql relaxation); no longer short-circuited.
 //!  7. Empty metricql_expression → INVALID_ARGUMENT before any M3 round-trip.
-//!  8. Whitespace-only experiment_id → INVALID_ARGUMENT.
+//!  8. Whitespace-only experiment_id → forwarded to M3 verbatim (#597 — the
+//!     trim().is_empty() check is treated as the global-scope signal).
 //!
 //! ## Design
 //!
@@ -354,25 +356,38 @@ async fn m3_unavailable_returns_unavailable() {
 }
 
 #[tokio::test]
-async fn empty_experiment_id_returns_invalid_argument_without_m3_call() {
-    // Port 1 — no server. If M5 were to call M3, it would time out.
-    // The validator must short-circuit before the proxy.
-    let handler = make_handler("http://127.0.0.1:1".into()).await;
+async fn empty_experiment_id_is_forwarded_to_m3_as_global_scope() {
+    // #597 (symmetric to PR #595): empty experiment_id is the global-scope
+    // signal used by the metric-creation form. M5 must NOT short-circuit
+    // with INVALID_ARGUMENT; instead it forwards the empty string verbatim
+    // and M3 resolves the catalog itself.
+    let (addr, captured, _resp) = spawn_mock_m3(PresetResponse::Ok(
+        CompileMetricqlPreviewResponse {
+            compiled_sql: "SELECT avg(v) FROM t".into(),
+            diagnostics: vec![],
+        },
+    ))
+    .await;
+    let handler = make_handler(format!("http://{}", addr)).await;
 
-    let err = handler
+    handler
         .preview_metric_definition(Request::new(PreviewMetricDefinitionRequest {
-            experiment_id: "".into(),
+            experiment_id: String::new(),
             metricql_expression: "mean(x.y)".into(),
         }))
         .await
-        .unwrap_err();
+        .expect("empty experiment_id must proxy through to M3, not short-circuit");
 
-    assert_eq!(err.code(), Code::InvalidArgument);
-    assert!(
-        err.message().contains("experiment_id"),
-        "error message should mention experiment_id, got: {}",
-        err.message()
+    let call = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("M3 must have received the proxied call");
+    assert_eq!(
+        call.experiment_id, "",
+        "empty experiment_id must be forwarded verbatim, not rewritten"
     );
+    assert_eq!(call.metricql_expression, "mean(x.y)");
 }
 
 #[tokio::test]
@@ -396,16 +411,34 @@ async fn empty_metricql_expression_returns_invalid_argument_without_m3_call() {
 }
 
 #[tokio::test]
-async fn whitespace_only_experiment_id_returns_invalid_argument() {
-    let handler = make_handler("http://127.0.0.1:1".into()).await;
+async fn whitespace_only_experiment_id_is_forwarded_to_m3_as_global_scope() {
+    // #597: whitespace-only experiment_id is treated identically to empty
+    // — trim().is_empty() is the global-scope signal. M5 forwards the
+    // string verbatim; M3 trims on its side when building the catalog.
+    let (addr, captured, _resp) = spawn_mock_m3(PresetResponse::Ok(
+        CompileMetricqlPreviewResponse {
+            compiled_sql: "SELECT avg(v) FROM t".into(),
+            diagnostics: vec![],
+        },
+    ))
+    .await;
+    let handler = make_handler(format!("http://{}", addr)).await;
 
-    let err = handler
+    handler
         .preview_metric_definition(Request::new(PreviewMetricDefinitionRequest {
             experiment_id: "   \t".into(),
             metricql_expression: "mean(x.y)".into(),
         }))
         .await
-        .unwrap_err();
+        .expect("whitespace-only experiment_id must proxy through to M3, not short-circuit");
 
-    assert_eq!(err.code(), Code::InvalidArgument);
+    let call = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("M3 must have received the proxied call");
+    assert_eq!(
+        call.experiment_id, "   \t",
+        "whitespace-only experiment_id must be forwarded verbatim"
+    );
 }

--- a/proto/experimentation/management/v1/management_service.proto
+++ b/proto/experimentation/management/v1/management_service.proto
@@ -197,7 +197,11 @@ message MigrateMetricDefinitionResponse {
 // scoping the KnownMetricIDs lookup to the experiment on M3's side.
 // No side effects; safe to call at the editor's preview cadence.
 message PreviewMetricDefinitionRequest {
-  // Scopes the KnownMetricIDs lookup on M3. Required.
+  // Scopes the KnownMetricIDs lookup on M3. Empty string = global scope:
+  // M3 builds its known set from the full metric_definitions catalog so the
+  // editor's preview surface can compile expressions before an experiment
+  // exists (mirrors ValidateMetricql). Set to a specific experiment id to
+  // scope to that experiment.
   string experiment_id = 1;
   // The MetricQL source text to compile. Required.
   string metricql_expression = 2;

--- a/services/metrics/cmd/main.go
+++ b/services/metrics/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/org/experimentation-platform/services/metrics/internal/metrics"
 
 	"github.com/org/experimentation-platform/services/metrics/internal/alerts"
+	"github.com/org/experimentation-platform/services/metrics/internal/catalog"
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
 	"github.com/org/experimentation-platform/services/metrics/internal/handler"
 	"github.com/org/experimentation-platform/services/metrics/internal/jobs"
@@ -45,6 +46,7 @@ func main() {
 	executor := spark.NewRetryExecutor(baseExecutor, spark.DefaultRetryConfig())
 	var qlWriter querylog.Writer
 	var statusWriter status.Writer
+	var catalogReader catalog.CatalogReader
 	pgURL := os.Getenv("POSTGRES_URL")
 	if pgURL != "" {
 		pool, err := pgxpool.New(context.Background(), pgURL)
@@ -53,10 +55,18 @@ func main() {
 		qlWriter = querylog.NewPgWriter(pool)
 		// ADR-026 #475: same pool feeds the metric_computation_status writer.
 		statusWriter = status.NewPgWriter(pool)
+		// Issue #597: global-scope MetricQL preview reads from M5's
+		// metric_definitions table (shared Postgres DB) to flag unknown
+		// @metric_refs as SEVERITY_ERROR diagnostics. Lean SELECT metric_id
+		// query — see catalog.PgPoolCatalog for rationale.
+		catalogReader = catalog.NewPgPoolCatalog(pool)
 	} else {
 		qlWriter = querylog.NewMemWriter()
 		statusWriter = status.NewMockWriter()
 		slog.Warn("POSTGRES_URL not set, using in-memory query log + status writer")
+		// catalogReader stays nil — CompileMetricqlPreview falls back to the
+		// legacy KnownMetricIDs=nil behavior in global scope, preserving
+		// dev/test ergonomics without a Postgres dependency.
 	}
 	stdJob := jobs.NewStandardJob(cfgStore, renderer, executor, qlWriter, jobs.WithStatusWriter(statusWriter))
 	kafkaBrokers := os.Getenv("KAFKA_BROKERS")
@@ -77,7 +87,11 @@ func main() {
 	ilJob := jobs.NewInterleavingJob(cfgStore, renderer, executor, qlWriter)
 	calibUpdater := surrogate.NewMemCalibrationUpdater()
 	recalJob := jobs.NewRecalibrationJob(cfgStore, renderer, mockInputProvider, qlWriter, projWriter, calibUpdater)
-	metricsHandler := handler.NewMetricsHandler(stdJob, gJob, ccJob, surrJob, ilJob, recalJob, qlWriter)
+	var handlerOpts []handler.MetricsHandlerOption
+	if catalogReader != nil {
+		handlerOpts = append(handlerOpts, handler.WithCatalogReader(catalogReader))
+	}
+	metricsHandler := handler.NewMetricsHandler(stdJob, gJob, ccJob, surrJob, ilJob, recalJob, qlWriter, handlerOpts...)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200); fmt.Fprint(w, "ok") })
 	path, h := metricsv1connect.NewMetricComputationServiceHandler(metricsHandler)

--- a/services/metrics/cmd/main.go
+++ b/services/metrics/cmd/main.go
@@ -63,7 +63,17 @@ func main() {
 	} else {
 		qlWriter = querylog.NewMemWriter()
 		statusWriter = status.NewMockWriter()
-		slog.Warn("POSTGRES_URL not set, using in-memory query log + status writer")
+		// Surface the dev-mode degradation at boot so operators see ONE
+		// warning rather than only a per-request slog.Debug from preview.go.
+		// (Devin PR #609 📝 silent-degradation finding — the original message
+		// only named the query log + status writer; the catalog/preview
+		// implication was buried in the source comment.)
+		slog.Warn(
+			"POSTGRES_URL not set — running in dev-mode degradation: in-memory query log + status writer, " +
+				"AND CompileMetricqlPreview global-scope existence checks are DISABLED (KnownMetricIDs=nil, " +
+				"@metric_refs in preview will not flag unknown-id diagnostics). " +
+				"Set POSTGRES_URL to enable the full path.",
+		)
 		// catalogReader stays nil — CompileMetricqlPreview falls back to the
 		// legacy KnownMetricIDs=nil behavior in global scope, preserving
 		// dev/test ergonomics without a Postgres dependency.

--- a/services/metrics/internal/catalog/catalog.go
+++ b/services/metrics/internal/catalog/catalog.go
@@ -1,0 +1,92 @@
+// Package catalog provides a lightweight read-only view of M5's
+// `metric_definitions` table for M3's MetricQL preview path.
+//
+// Background (Issue #597 / ADR-026 Phase 2):
+//
+//   - The legacy CompileMetricqlPreview RPC required a non-empty
+//     experiment_id and skipped the @metric_ref existence check by passing
+//     `KnownMetricIDs: nil` to the analyzer.
+//   - PR #595 made the M5 `ValidateMetricql` lint path global-scoped (no
+//     experiment required); Issue #597 extends the same change to the
+//     `PreviewMetricDefinition` path. Task 2 is the M3 half of that change.
+//
+// To reject unknown @metric_refs in the global preview path, the handler
+// needs the global catalog of metric IDs. M3 and M5 share the same Postgres
+// DB (see services/metrics/internal/integration_test.go:52 and
+// sql/migrations/001_schema.sql:33), so M3 reads `metric_definitions`
+// directly with a lean `SELECT metric_id` query.
+//
+// Why a separate package?
+//
+//   - Mirrors the established `internal/shadow/` pattern (interface + Pg
+//     implementation + functional handler option).
+//   - Keeps the handler package focused on RPC dispatch.
+//   - Gives future tasks (experiment-scoped lookup, caching) a place to
+//     live.
+//
+// Why `SELECT metric_id` rather than `SELECT *`? Devin's review of PR #595
+// flagged that the original `list_metrics()` hot-loop fetched 18 columns
+// including large JSON/SQL text blobs on every ~500ms lint cycle. Preview
+// is colder (only on toggle-open + post-debounce expression change), but
+// applying the perf lesson preemptively avoids the same regression here.
+package catalog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CatalogReader is the read-only view of M5's `metric_definitions` table
+// used by M3's MetricQL preview path to populate
+// `metricql.AnalyzeContext.KnownMetricIDs` so unknown @metric_refs become
+// SEVERITY_ERROR diagnostics in the global-scope preview.
+//
+// Implementations: PgPoolCatalog (production), in-test stubs (handler tests).
+type CatalogReader interface {
+	// ListMetricIDs returns every metric_id currently registered in M5's
+	// catalog. Order is sorted by metric_id ascending so callers that care
+	// about determinism (logs, golden files) don't need to re-sort.
+	ListMetricIDs(ctx context.Context) ([]string, error)
+}
+
+// PgPoolCatalog is the PostgreSQL-backed implementation of CatalogReader.
+// Modelled on shadow.PgStore — small, side-effect-free, no caching at this
+// layer. (If preview latency becomes a problem we'll add an in-memory TTL
+// cache in front; the bare query is sub-millisecond on the expected catalog
+// size of <10k rows.)
+type PgPoolCatalog struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgPoolCatalog returns a PgPoolCatalog backed by the given connection
+// pool. The pool is owned by the caller (cmd/main.go); PgPoolCatalog never
+// closes it.
+func NewPgPoolCatalog(pool *pgxpool.Pool) *PgPoolCatalog {
+	return &PgPoolCatalog{pool: pool}
+}
+
+// ListMetricIDs runs `SELECT metric_id FROM metric_definitions ORDER BY
+// metric_id`. Deliberately lean: no JOINs, no JSONB columns, no SQL/MetricQL
+// text blobs. (Devin perf lesson from PR #595.)
+func (c *PgPoolCatalog) ListMetricIDs(ctx context.Context) ([]string, error) {
+	rows, err := c.pool.Query(ctx, `SELECT metric_id FROM metric_definitions ORDER BY metric_id`)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: list metric_ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("catalog: list metric_ids scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: list metric_ids iterate: %w", err)
+	}
+	return ids, nil
+}

--- a/services/metrics/internal/handler/handler.go
+++ b/services/metrics/internal/handler/handler.go
@@ -11,6 +11,7 @@ import (
 	metricsv1 "github.com/org/experimentation/gen/go/experimentation/metrics/v1"
 	"github.com/org/experimentation/gen/go/experimentation/metrics/v1/metricsv1connect"
 
+	"github.com/org/experimentation-platform/services/metrics/internal/catalog"
 	"github.com/org/experimentation-platform/services/metrics/internal/export"
 	"github.com/org/experimentation-platform/services/metrics/internal/jobs"
 	m3metrics "github.com/org/experimentation-platform/services/metrics/internal/metrics"
@@ -31,6 +32,13 @@ type MetricsHandler struct {
 	// shadowStore is optional (ADR-026 Phase 3 #437). When nil the three
 	// shadow-run RPCs return CodeUnavailable so existing callers are unaffected.
 	shadowStore shadow.Store
+	// catalogReader is optional (Issue #597). When wired, the
+	// CompileMetricqlPreview RPC populates KnownMetricIDs from M5's global
+	// metric_definitions catalog when the request omits experiment_id, so
+	// unknown @metric_refs surface as SEVERITY_ERROR diagnostics. When nil
+	// (legacy callers / older tests) the empty-experiment_id path falls back
+	// to KnownMetricIDs=nil (existence check skipped) for backward compat.
+	catalogReader catalog.CatalogReader
 }
 
 // MetricsHandlerOption configures optional MetricsHandler behavior.
@@ -43,6 +51,16 @@ type MetricsHandlerOption func(*MetricsHandler)
 // CodeUnavailable — no production behavior changes.
 func WithShadowStore(s shadow.Store) MetricsHandlerOption {
 	return func(h *MetricsHandler) { h.shadowStore = s }
+}
+
+// WithCatalogReader wires a catalog.CatalogReader so that
+// CompileMetricqlPreview can populate KnownMetricIDs from M5's global
+// `metric_definitions` table when the request omits experiment_id (Issue
+// #597). When unset, the empty-experiment_id path falls back to skipping
+// the existence check (KnownMetricIDs=nil) — preserves backward compat for
+// legacy callers / tests with no Postgres dependency.
+func WithCatalogReader(r catalog.CatalogReader) MetricsHandlerOption {
+	return func(h *MetricsHandler) { h.catalogReader = r }
 }
 
 func NewMetricsHandler(job *jobs.StandardJob, gj *jobs.GuardrailJob, ccj *jobs.ContentConsumptionJob, sj *jobs.SurrogateJob, ilj *jobs.InterleavingJob, rj *jobs.RecalibrationJob, ql querylog.Writer, opts ...MetricsHandlerOption) *MetricsHandler {

--- a/services/metrics/internal/handler/preview.go
+++ b/services/metrics/internal/handler/preview.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -18,11 +19,19 @@ import (
 // persisting or executing. Used by the M6 editor's preview pane (ADR-026
 // Phase 2 / #436).
 //
-// KnownMetricIDs is intentionally not derived from the experiment in v1:
-// the preview is informational and the M5 Create/Update path is the source
-// of truth for existence checks. Passing nil to AnalyzeContext skips the
-// @metric_ref existence check (per the analyzer's documented nil-means-skip
-// contract).
+// Scope (Issue #597): the preview RPC operates in either experiment scope
+// or global scope, mirroring PR #595's `ValidateMetricql` change on the M5
+// side:
+//
+//   - Empty / whitespace-only experiment_id → GLOBAL scope. If a
+//     catalog.CatalogReader is wired via WithCatalogReader, KnownMetricIDs
+//     is populated from M5's `metric_definitions` table so unknown
+//     @metric_refs surface as SEVERITY_ERROR diagnostics. If no reader is
+//     wired (legacy callers / tests with no Postgres), KnownMetricIDs falls
+//     back to nil (existence check skipped) for backward compat.
+//   - Non-empty experiment_id → EXPERIMENT scope. KnownMetricIDs stays nil
+//     (current behavior). Experiment-scoped catalog lookup is a future task
+//     — Issue #597 only widens the global path.
 //
 // Honors the incoming gRPC/Connect deadline: ctx.Err() is checked before
 // parsing so an already-expired context fails fast with DeadlineExceeded.
@@ -30,9 +39,8 @@ func (h *MetricsHandler) CompileMetricqlPreview(
 	ctx context.Context,
 	req *connect.Request[metricsv1.CompileMetricqlPreviewRequest],
 ) (*connect.Response[metricsv1.CompileMetricqlPreviewResponse], error) {
-	if req.Msg.GetExperimentId() == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errorf("experiment_id is required"))
-	}
+	experimentID := req.Msg.GetExperimentId()
+	isGlobalScope := strings.TrimSpace(experimentID) == ""
 
 	expr := strings.TrimSpace(req.Msg.GetMetricqlExpression())
 	if expr == "" {
@@ -48,16 +56,41 @@ func (h *MetricsHandler) CompileMetricqlPreview(
 		return nil, connect.NewError(connect.CodeDeadlineExceeded, err)
 	}
 
-	// Phase 2 v1: skip KnownMetricIDs existence check in the preview path.
-	// The analyzer's nil-KnownMetricIDs contract explicitly allows this.
+	// Build the @metric_ref existence-check context.
+	//
+	//   - Global scope + catalog reader wired → query the catalog.
+	//   - Global scope, no catalog reader → nil (skip check; backward compat).
+	//   - Experiment scope → nil (current behavior; experiment-scoped
+	//     catalog lookup is intentionally out of scope for Issue #597).
+	var knownIDs map[string]bool
+	if isGlobalScope {
+		if h.catalogReader != nil {
+			ids, err := h.catalogReader.ListMetricIDs(ctx)
+			if err != nil {
+				// Treat catalog failure as Internal — the operator should
+				// see this rather than a silent fall-through to "no
+				// existence check" (which would hide unknown refs).
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
+			knownIDs = make(map[string]bool, len(ids))
+			for _, id := range ids {
+				knownIDs[id] = true
+			}
+		} else {
+			slog.DebugContext(ctx, "CompileMetricqlPreview: empty experiment_id with no catalogReader wired; skipping existence check (legacy backward-compat path)")
+		}
+	}
+
 	sql, _, err := metricql.Compile(expr, metricql.CompileContext{
 		// ExperimentID and MetricID are injected for template rendering.
 		// The preview uses a sentinel value — operators see realistic but
 		// non-binding SQL. The actual scheduling path injects real IDs.
-		ExperimentID:    req.Msg.GetExperimentId(),
+		// For global scope we pass an empty ExperimentID; the templates
+		// tolerate it because the rendered SQL is informational.
+		ExperimentID:    experimentID,
 		ComputationDate: "PREVIEW",
 		MetricID:        "preview",
-		KnownMetricIDs:  nil,
+		KnownMetricIDs:  knownIDs,
 	})
 	if err != nil {
 		return connect.NewResponse(diagnosticResponseFromError(expr, err)), nil
@@ -126,13 +159,3 @@ func lineColFromOffset(source string, offset int) (line, col int) {
 	}
 	return line, col
 }
-
-// errorf returns a plain error for use with connect.NewError. Using a
-// package-local helper avoids importing fmt in the hot path of the handler.
-func errorf(msg string) error {
-	return &plainError{msg}
-}
-
-type plainError struct{ msg string }
-
-func (e *plainError) Error() string { return e.msg }

--- a/services/metrics/internal/handler/preview_test.go
+++ b/services/metrics/internal/handler/preview_test.go
@@ -19,6 +19,23 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 )
 
+// stubCatalogReader is a test-local catalog.CatalogReader that returns a
+// canned slice of metric IDs. Test-local on purpose — we don't want a mock
+// living in the production `catalog` package, and the real PgPoolCatalog is
+// covered by integration tests rather than unit tests against a real
+// Postgres.
+type stubCatalogReader struct {
+	ids []string
+	err error
+}
+
+func (s *stubCatalogReader) ListMetricIDs(context.Context) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.ids, nil
+}
+
 // setupPreviewClient constructs a minimal MetricsHandler — only
 // CompileMetricqlPreview is exercised here, so all job dependencies are nil.
 func setupPreviewClient(t *testing.T) metricsv1connect.MetricComputationServiceClient {
@@ -33,14 +50,105 @@ func setupPreviewClient(t *testing.T) metricsv1connect.MetricComputationServiceC
 	return metricsv1connect.NewMetricComputationServiceClient(http.DefaultClient, srv.URL)
 }
 
+// setupPreviewClientWithCatalog constructs a handler with a stub
+// catalog.CatalogReader wired via WithCatalogReader, returning the canned
+// list of known metric IDs. Used by the Issue #597 global-scope tests.
+func setupPreviewClientWithCatalog(t *testing.T, knownIDs []string) metricsv1connect.MetricComputationServiceClient {
+	t.Helper()
+	ql := querylog.NewMemWriter()
+	h := NewMetricsHandler(nil, nil, nil, nil, nil, nil, ql, WithCatalogReader(&stubCatalogReader{ids: knownIDs}))
+	mux := http.NewServeMux()
+	path, hnd := metricsv1connect.NewMetricComputationServiceHandler(h)
+	mux.Handle(path, hnd)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return metricsv1connect.NewMetricComputationServiceClient(http.DefaultClient, srv.URL)
+}
+
+// TestCompileMetricqlPreview_EmptyExperimentId verifies the Issue #597
+// relaxation: an empty experiment_id is now treated as GLOBAL scope. With a
+// catalogReader wired and "watch_time" in the catalog, a plain aggregation
+// expression with no @metric_refs should succeed with empty diagnostics.
 func TestCompileMetricqlPreview_EmptyExperimentId(t *testing.T) {
-	client := setupPreviewClient(t)
-	_, err := client.CompileMetricqlPreview(context.Background(), connect.NewRequest(&metricsv1.CompileMetricqlPreviewRequest{
+	client := setupPreviewClientWithCatalog(t, []string{"watch_time"})
+	resp, err := client.CompileMetricqlPreview(context.Background(), connect.NewRequest(&metricsv1.CompileMetricqlPreviewRequest{
 		ExperimentId:       "",
 		MetricqlExpression: "mean(heartbeat.value)",
 	}))
-	require.Error(t, err)
-	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.GetDiagnostics())
+	assert.NotEmpty(t, resp.Msg.GetCompiledSql())
+}
+
+// TestCompileMetricqlPreview_EmptyExperimentId_UnknownRefReturnsDiagnostic
+// verifies that with the catalog populated to {known_metric}, an expression
+// referencing @unknown_metric returns 200 OK with one SEVERITY_ERROR
+// diagnostic whose message mentions "unknown_metric".
+func TestCompileMetricqlPreview_EmptyExperimentId_UnknownRefReturnsDiagnostic(t *testing.T) {
+	client := setupPreviewClientWithCatalog(t, []string{"known_metric"})
+	resp, err := client.CompileMetricqlPreview(context.Background(), connect.NewRequest(&metricsv1.CompileMetricqlPreviewRequest{
+		ExperimentId:       "",
+		MetricqlExpression: "@unknown_metric + 0",
+	}))
+	require.NoError(t, err) // handler returns 200 with diagnostics, not a gRPC error
+	assert.Empty(t, resp.Msg.GetCompiledSql())
+	require.Len(t, resp.Msg.GetDiagnostics(), 1)
+	d := resp.Msg.GetDiagnostics()[0]
+	assert.Equal(t, commonv1.MetricqlDiagnostic_SEVERITY_ERROR, d.GetSeverity())
+	assert.Contains(t, d.GetMessage(), "unknown_metric")
+}
+
+// TestCompileMetricqlPreview_EmptyExperimentId_KnownRefReturnsSql verifies
+// that with the catalog containing the referenced metric, the expression
+// compiles to SQL with no diagnostics.
+func TestCompileMetricqlPreview_EmptyExperimentId_KnownRefReturnsSql(t *testing.T) {
+	client := setupPreviewClientWithCatalog(t, []string{"watch_time"})
+	resp, err := client.CompileMetricqlPreview(context.Background(), connect.NewRequest(&metricsv1.CompileMetricqlPreviewRequest{
+		ExperimentId:       "",
+		MetricqlExpression: "@watch_time + 0",
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.GetDiagnostics())
+	assert.NotEmpty(t, resp.Msg.GetCompiledSql())
+}
+
+// TestCompileMetricqlPreview_EmptyExperimentId_NoCatalogReader verifies
+// the legacy backward-compat path: when no WithCatalogReader option is
+// passed, an empty experiment_id still succeeds — but with KnownMetricIDs
+// effectively nil, so even unknown @metric_refs are accepted (existence
+// check skipped per the analyzer's nil-means-skip contract).
+func TestCompileMetricqlPreview_EmptyExperimentId_NoCatalogReader(t *testing.T) {
+	client := setupPreviewClient(t) // no WithCatalogReader option
+	resp, err := client.CompileMetricqlPreview(context.Background(), connect.NewRequest(&metricsv1.CompileMetricqlPreviewRequest{
+		ExperimentId:       "",
+		MetricqlExpression: "@unknown_metric + 0",
+	}))
+	require.NoError(t, err)
+	// Skip-existence-check path: no unknown-reference diagnostic, and the
+	// expression compiles (the analyzer accepts the @metric_ref because
+	// KnownMetricIDs is nil).
+	assert.Empty(t, resp.Msg.GetDiagnostics())
+	assert.NotEmpty(t, resp.Msg.GetCompiledSql())
+}
+
+// TestCompileMetricqlPreview_WhitespaceOnlyExperimentId_TreatedAsGlobal
+// verifies symmetry with PR #595 / Task 1's M5 normalization: an
+// experiment_id consisting only of whitespace is treated identically to
+// the empty string (i.e. as GLOBAL scope).
+func TestCompileMetricqlPreview_WhitespaceOnlyExperimentId_TreatedAsGlobal(t *testing.T) {
+	client := setupPreviewClientWithCatalog(t, []string{"known_metric"})
+	resp, err := client.CompileMetricqlPreview(context.Background(), connect.NewRequest(&metricsv1.CompileMetricqlPreviewRequest{
+		ExperimentId:       "   \t  ",
+		MetricqlExpression: "@unknown_metric + 0",
+	}))
+	require.NoError(t, err)
+	// Whitespace-only experiment_id is normalized to global scope, so the
+	// stub catalog applies and @unknown_metric is flagged.
+	assert.Empty(t, resp.Msg.GetCompiledSql())
+	require.Len(t, resp.Msg.GetDiagnostics(), 1)
+	d := resp.Msg.GetDiagnostics()[0]
+	assert.Equal(t, commonv1.MetricqlDiagnostic_SEVERITY_ERROR, d.GetSeverity())
+	assert.Contains(t, d.GetMessage(), "unknown_metric")
 }
 
 func TestCompileMetricqlPreview_EmptyExpression(t *testing.T) {

--- a/services/metrics/internal/handler/preview_test.go
+++ b/services/metrics/internal/handler/preview_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -129,6 +130,31 @@ func TestCompileMetricqlPreview_EmptyExperimentId_NoCatalogReader(t *testing.T) 
 	// KnownMetricIDs is nil).
 	assert.Empty(t, resp.Msg.GetDiagnostics())
 	assert.NotEmpty(t, resp.Msg.GetCompiledSql())
+}
+
+// TestCompileMetricqlPreview_EmptyExperimentId_CatalogError_ReturnsInternal
+// verifies that when the catalog reader fails (e.g. DB unavailable), the
+// handler surfaces CodeInternal rather than silently falling through to
+// the skip-existence-check path. The fallthrough would mask unknown
+// @metric_refs from the operator, so a hard error is the correct signal.
+func TestCompileMetricqlPreview_EmptyExperimentId_CatalogError_ReturnsInternal(t *testing.T) {
+	t.Helper()
+	ql := querylog.NewMemWriter()
+	h := NewMetricsHandler(nil, nil, nil, nil, nil, nil, ql,
+		WithCatalogReader(&stubCatalogReader{err: errors.New("db down")}))
+	mux := http.NewServeMux()
+	path, hnd := metricsv1connect.NewMetricComputationServiceHandler(h)
+	mux.Handle(path, hnd)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client := metricsv1connect.NewMetricComputationServiceClient(http.DefaultClient, srv.URL)
+
+	_, err := client.CompileMetricqlPreview(context.Background(), connect.NewRequest(&metricsv1.CompileMetricqlPreviewRequest{
+		ExperimentId:       "",
+		MetricqlExpression: "mean(heartbeat.value)",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 }
 
 // TestCompileMetricqlPreview_WhitespaceOnlyExperimentId_TreatedAsGlobal

--- a/ui/src/components/metrics/metricql-section.test.tsx
+++ b/ui/src/components/metrics/metricql-section.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MetricqlSection } from './metricql-section';
 
 // ---------------------------------------------------------------------------
@@ -28,22 +28,46 @@ vi.mock('./metricql', async () => {
 // Stub the preview pane — its behaviour is fully tested in preview.test.tsx.
 // We expose data-testid="metricql-preview-toggle" so B6 section tests can
 // assert on its presence without coupling to preview internals.
-vi.mock('./metricql/preview', () => ({
-  MetricqlPreview: ({ experimentId, metricqlExpression, hasErrors, className }: {
-    experimentId: string;
+//
+// One test (the Issue #597 global-scope render) needs the REAL preview
+// component so it actually invokes previewFn and renders the compiled SQL.
+// We use a `useRealPreview` flag inside vi.hoisted so the mock factory can
+// branch — when the flag is true, we delegate to the actual preview module.
+const { useRealPreviewFlag } = vi.hoisted(() => ({
+  useRealPreviewFlag: { current: false },
+}));
+
+vi.mock('./metricql/preview', async () => {
+  const actual = await vi.importActual<typeof import('./metricql/preview')>(
+    './metricql/preview',
+  );
+  const StubPreview = ({ experimentId, metricqlExpression, hasErrors, className }: {
+    experimentId: string | null | undefined;
     metricqlExpression: string;
     hasErrors?: boolean;
     className?: string;
   }) => (
     <div
       data-testid="metricql-preview-toggle"
-      data-experiment-id={experimentId}
+      // data-experiment-id normalises null/undefined → '' for back-compat with
+      // existing assertions; data-experiment-id-raw exposes the raw value so
+      // the Issue #597 test can verify the section passes null through
+      // unchanged.
+      data-experiment-id={experimentId ?? ''}
+      data-experiment-id-raw={String(experimentId)}
       data-expression={metricqlExpression}
       data-has-errors={String(hasErrors ?? false)}
       className={className}
     />
-  ),
-}));
+  );
+
+  return {
+    MetricqlPreview: (props: Parameters<typeof actual.MetricqlPreview>[0]) =>
+      useRealPreviewFlag.current
+        ? actual.MetricqlPreview(props)
+        : StubPreview(props),
+  };
+});
 
 // Stub API calls so the linter (B4) and preview pane don't hit the network.
 vi.mock('@/lib/api', () => ({
@@ -273,11 +297,12 @@ describe('MetricqlSection', () => {
       { timeout: 3000 },
     );
 
-    // MetricqlSection normalises `experimentId ?? ''` for MetricqlPreview
-    // (which requires a non-nullable string). Verify the preview stub
-    // receives the empty wire signal, mirroring the linter's RPC wire shape.
+    // MetricqlSection now passes `experimentId` through to MetricqlPreview
+    // unchanged — the preview component itself normalises null/undefined → ''
+    // at the RPC call site (Issue #597, mirrors PR #595's diagnostics.ts
+    // pattern). Verify the stub records the raw null value the section passed.
     const previewToggle = screen.getByTestId('metricql-preview-toggle');
-    expect(previewToggle.getAttribute('data-experiment-id')).toBe('');
+    expect(previewToggle.getAttribute('data-experiment-id-raw')).toBe('null');
   });
 
   test('linter activates when experimentId prop is omitted entirely', async () => {
@@ -311,5 +336,60 @@ describe('MetricqlSection', () => {
       { experimentId: '', metricqlExpression: '@another' },
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
+  });
+
+  // ─── Global-scope live-preview (Issue #597 Task 3) ─────────────────────────
+  //
+  // After Tasks 1+2, M5 + M3 both accept empty experiment_id on the preview
+  // RPC. The UI used to paper over the server-side rejection by normalising
+  // `experimentId ?? ''` at the section boundary. Task 3 removes that
+  // normalisation — the section passes null through to MetricqlPreview, which
+  // normalises once at the previewFn call site. This test renders the section
+  // with the REAL preview component (via the `useRealPreviewFlag` escape hatch
+  // on the top-level mock) and the module-level previewMetricDefinition mock
+  // that returns compiled SQL. Asserts the SQL renders and no error copy
+  // appears.
+  test('preview pane renders compiled SQL when experimentId is null', async () => {
+    useRealPreviewFlag.current = true;
+    try {
+      render(
+        <MetricqlSection
+          value="mean(heartbeat.value)"
+          onChange={() => {}}
+          experimentId={null}
+          knownMetricIds={[]}
+        />,
+      );
+
+      // Editor must mount first so the section's children resolve.
+      await screen.findByTestId('metricql-editor');
+
+      // Toggle the preview pane open. The real component's previewFn will fire.
+      fireEvent.click(screen.getByTestId('metricql-preview-toggle'));
+
+      // Wait for the compiled SQL to render (status='success', CodeMirror
+      // mounts into the data-testid="metricql-preview-sql" container).
+      await waitFor(
+        () => {
+          expect(screen.queryByTestId('metricql-preview-sql')).toBeInTheDocument();
+        },
+        { timeout: 3000 },
+      );
+
+      // Negative assertions — the bug Tasks 1+2 fixed produced these copy
+      // strings. They must NOT appear when experimentId is null.
+      expect(screen.queryByText(/preview failed/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/experiment_id is required/i)).not.toBeInTheDocument();
+
+      // Confirm the real preview component normalised null → '' at the RPC
+      // call site (proto3 wire format).
+      const { previewMetricDefinition } = await import('@/lib/api');
+      expect(vi.mocked(previewMetricDefinition)).toHaveBeenCalledWith(
+        { experimentId: '', metricqlExpression: 'mean(heartbeat.value)' },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      useRealPreviewFlag.current = false;
+    }
   });
 });

--- a/ui/src/components/metrics/metricql-section.tsx
+++ b/ui/src/components/metrics/metricql-section.tsx
@@ -76,9 +76,10 @@ export function MetricqlSection({
       </div>
 
       <MetricqlPreview
-        // Normalise null/undefined → '' so the preview RPC matches the wire
-        // format (M5 treats empty experiment_id as global scope, Issue #571).
-        experimentId={experimentId ?? ''}
+        // Pass null/undefined through directly — MetricqlPreview normalises
+        // to '' once at the RPC call site (Issue #597). Mirrors the
+        // translation-at-boundaries pattern PR #595 established for the linter.
+        experimentId={experimentId}
         metricqlExpression={value}
         hasErrors={hasObviousErrors}
         className="mt-2"

--- a/ui/src/components/metrics/metricql/preview.test.tsx
+++ b/ui/src/components/metrics/metricql/preview.test.tsx
@@ -378,6 +378,56 @@ describe('MetricqlPreview', () => {
     );
   });
 
+  // ── Global-scope normalisation (Issue #597) ────────────────────────────────
+  //
+  // The metric-creation form renders MetricqlPreview with experimentId={null}
+  // because a metric is not yet bound to an experiment at creation time. The
+  // component accepts `string | null | undefined`, normalises to `''` once at
+  // the previewFn call site (mirrors PR #595's diagnostics.ts pattern), and
+  // forwards the empty wire signal that M5/M3 treat as global scope.
+
+  test('experimentId={null} normalizes to \'\' on the wire', async () => {
+    const previewFn = makePreviewFn({ compiledSql: 'SELECT 1', diagnostics: [] });
+
+    render(
+      <MetricqlPreview
+        experimentId={null}
+        metricqlExpression="count(play.start)"
+        previewFn={previewFn}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('metricql-preview-toggle'));
+
+    await waitFor(() => expect(previewFn).toHaveBeenCalledTimes(1));
+
+    expect(previewFn).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: 'count(play.start)' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  test('experimentId={undefined} normalizes to \'\' on the wire', async () => {
+    const previewFn = makePreviewFn({ compiledSql: 'SELECT 1', diagnostics: [] });
+
+    render(
+      <MetricqlPreview
+        experimentId={undefined}
+        metricqlExpression="count(play.start)"
+        previewFn={previewFn}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('metricql-preview-toggle'));
+
+    await waitFor(() => expect(previewFn).toHaveBeenCalledTimes(1));
+
+    expect(previewFn).toHaveBeenCalledWith(
+      { experimentId: '', metricqlExpression: 'count(play.start)' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   // ── className passthrough ───────────────────────────────────────────────────
 
   test('applies className to the outer wrapper', () => {

--- a/ui/src/components/metrics/metricql/preview.tsx
+++ b/ui/src/components/metrics/metricql/preview.tsx
@@ -30,7 +30,19 @@ import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { previewMetricDefinition } from '@/lib/api';
 
 export interface MetricqlPreviewProps {
-  experimentId: string;
+  /**
+   * Experiment ID forwarded to M5's PreviewMetricDefinition RPC (via the C2 proxy).
+   *
+   * Empty / null / undefined all mean "global scope" — Issue #597 taught the M5
+   * and M3 preview handlers to accept an empty experiment_id and build the
+   * known-metric set from the global metric catalog. This lets the metric
+   * creation form (which has no experiment binding yet) preview compiled SQL.
+   *
+   * Normalised to `''` at the RPC call site so the wire format stays a plain
+   * string (matches `PreviewMetricDefinitionRequest.experiment_id: string` in
+   * proto3). Mirrors the diagnostics.ts pattern (PR #595).
+   */
+  experimentId: string | null | undefined;
   metricqlExpression: string;
   /**
    * Whether the expression currently has parse/semantic errors (from B4 linter).
@@ -103,8 +115,11 @@ export function MetricqlPreview({
 
     setState({ status: 'loading' });
 
+    // Normalise null / undefined → '' at the RPC boundary so the wire format
+    // stays a plain string (matches proto3). M5/M3 treat '' as global scope
+    // (Issue #597). Mirrors diagnostics.ts pattern (PR #595).
     previewFn(
-      { experimentId, metricqlExpression },
+      { experimentId: experimentId ?? '', metricqlExpression },
       { signal: ctl.signal },
     )
       .then((resp) => {


### PR DESCRIPTION
## Summary

ADR-026 Phase 2 follow-up — extends the global-scope wire contract PR #595 established for `ValidateMetricql` to the symmetric `PreviewMetricDefinition` RPC. **Closes #597.**

Before this PR, the preview pane on `/metrics/new` always showed `Preview failed: experiment_id is required` because the M5 and M3 preview handlers rejected the empty `experiment_id` that the creation form passes (no experiment binding exists at metric-create time). PR #595 fixed this for the live linter; this PR mirrors it across the preview path:

- **M5** (`PreviewMetricDefinition`): empty `experiment_id` is now valid; M5 proxies to M3 verbatim.
- **M3** (`CompileMetricqlPreview`): empty `experiment_id` triggers global-scope mode — builds `KnownMetricIDs` from the full `metric_definitions` catalog via a lightweight `SELECT metric_id` query (applies Devin's #595 🟡 perf lesson preemptively).
- **UI**: `MetricqlPreview` accepts `string | null | undefined` and normalises to `''` once at the RPC call site (mirrors PR #595's `diagnostics.ts` pattern).

## Acceptance criteria (verbatim from #597)

- [x] **M5 `PreviewMetricDefinition` handler: when `request.experiment_id.trim().is_empty()`, do NOT return `INVALID_ARGUMENT`; proxy to M3 with empty `experiment_id`.**
  → `crates/experimentation-management/src/grpc.rs::preview_metric_definition` (commit `2c99939`). Empty-experiment_id guard removed; expression-empty guard preserved.
- [x] **M3 `CompileMetricqlPreview` handler: when `experiment_id` is empty, build the operand-resolution context from the global metric catalog (mirror what M5's `ValidateMetricql` does after PR #595). The known-ids set should come from a lightweight `SELECT metric_id` query, not a full table scan.**
  → `services/metrics/internal/handler/preview.go::CompileMetricqlPreview` + new `services/metrics/internal/catalog/` package (commits `57e023c`, `dec6430`). `PgPoolCatalog.ListMetricIDs` runs `SELECT metric_id FROM metric_definitions ORDER BY metric_id`. Falls back to `KnownMetricIDs: nil` when no `CatalogReader` wired (backward compat).
- [x] **UI: remove the `experimentId ?? ''` normalization in `metricql-section.tsx:81` once the RPC accepts null; pass through directly.**
  → `ui/src/components/metrics/metricql-section.tsx:82` (commit `6bbc137`). `MetricqlPreviewProps.experimentId` widened to `string | null | undefined`; normalisation moved to the `previewFn(...)` wire boundary inside `preview.tsx`.
- [x] **Rust + Go integ test: empty `experiment_id` + valid expression → `compiled_sql` returned with no diagnostics.**
  → Rust: `crates/experimentation-management/tests/contract_preview_test.rs::empty_experiment_id_is_forwarded_to_m3_as_global_scope` (forwarding assertion with mock M3).
  → Go: `services/metrics/internal/handler/preview_test.go::TestCompileMetricqlPreview_EmptyExperimentId_KnownRefReturnsSql`.
- [x] **Rust + Go integ test: empty `experiment_id` + `@unknown_metric` → response with `INVALID_ARGUMENT` diagnostic naming the unresolved ref.**
  → Go: `TestCompileMetricqlPreview_EmptyExperimentId_UnknownRefReturnsDiagnostic` (asserts `SEVERITY_ERROR` diagnostic containing `"unknown_metric"`). Rust side covered via the M3 forwarding contract — M5 just proxies, so the diagnostic generation lives on M3.
- [x] **Playwright (extend B6 or new): open `/metrics/new`, select METRICQL, type a valid expression, click the preview toggle, assert compiled SQL renders (no "Preview failed" error).**
  → Folded into the Vitest at `ui/src/components/metrics/metricql-section.test.tsx::preview pane renders compiled SQL when experimentId is null` (same approach as PR #595 — no Playwright infrastructure in repo). Uses a `useRealPreviewFlag` escape hatch to render the **real** `MetricqlPreview` (not the stub) with `experimentId={null}`, clicks the toggle, asserts `metricql-preview-sql` renders AND `/experiment_id is required/i` text is absent.

## File-by-file changes

### Rust + proto (Task 1, M5)

| File | Change |
| --- | --- |
| `proto/experimentation/management/v1/management_service.proto` | Comment-only — document empty `experiment_id` on `PreviewMetricDefinitionRequest` as global scope, mirroring the validate-side wording. Non-breaking. |
| `crates/experimentation-management/src/grpc.rs` | Remove `experiment_id is required` early-return in `preview_metric_definition`. Keep `metricql_expression is required` guard. Add 2 unit tests in `mod tests` covering relaxation contract via `connect_lazy` (no DB needed). |
| `crates/experimentation-management/src/contract_test_support.rs` | Mirror relaxation in the in-memory stub. |
| `crates/experimentation-management/tests/contract_preview_test.rs` | Invert 2 existing tests that previously asserted `InvalidArgument` for empty/whitespace experiment_id — they now assert M3 receives the empty/whitespace string verbatim via mock M3. |

### Go (Task 2, M3)

| File | Change |
| --- | --- |
| `services/metrics/internal/catalog/catalog.go` (NEW) | `CatalogReader` interface + `PgPoolCatalog` impl backed by `*pgxpool.Pool`. Lean `SELECT metric_id FROM metric_definitions ORDER BY metric_id` query — does NOT fetch full metric rows. |
| `services/metrics/internal/handler/handler.go` | Add `catalogReader catalog.CatalogReader` field + `WithCatalogReader` functional option mirroring `WithShadowStore` pattern. |
| `services/metrics/internal/handler/preview.go` | Remove `experiment_id is required` rejection. When `strings.TrimSpace(experimentID) == ""` (matches Rust `trim().is_empty()` semantics) AND `catalogReader` set → populate `KnownMetricIDs` from catalog. When unset → fall back to `KnownMetricIDs: nil` (backward compat for tests + dev environments without `POSTGRES_URL`). Catalog query failure → `CodeInternal`. Drop now-unused `errorf`/`plainError` helpers. |
| `services/metrics/internal/handler/preview_test.go` | Invert existing `_EmptyExperimentId` test; add `_UnknownRefReturnsDiagnostic`, `_KnownRefReturnsSql`, `_NoCatalogReader`, `_WhitespaceOnlyExperimentId_TreatedAsGlobal`, `_CatalogError_ReturnsInternal`. Test-local `stubCatalogReader` (not exported). |
| `services/metrics/cmd/main.go` | Wire `catalog.NewPgPoolCatalog(pool)` when `POSTGRES_URL` is set; leave nil otherwise (preserves dev/test path). Conditional `handler.WithCatalogReader(...)` only appended when non-nil. |

### UI / TypeScript (Task 3)

| File | Change |
| --- | --- |
| `ui/src/components/metrics/metricql/preview.tsx` | Widen `MetricqlPreviewProps.experimentId` from `string` to `string | null | undefined`. Normalise `experimentId ?? ''` at the `previewFn(...)` call site (single wire-boundary translation point, mirroring `diagnostics.ts`). useEffect deps preserved. |
| `ui/src/components/metrics/metricql-section.tsx` | Remove `experimentId ?? ''` at line 81. Pass `experimentId={experimentId}` through directly. Comment updated to point at preview component's wire-boundary normalisation. |
| `ui/src/components/metrics/metricql/preview.test.tsx` | Add 2 tests — `experimentId={null}` and `experimentId={undefined}` both normalise to `''` on the wire. |
| `ui/src/components/metrics/metricql-section.test.tsx` | Update existing `experimentId={null}` linter test to assert raw null pass-through via `data-experiment-id-raw="null"`. Add new `preview pane renders compiled SQL when experimentId is null` — uses `useRealPreviewFlag.current = true` to render the **real** preview component, asserts `metricql-preview-sql` renders AND error copy is absent. |

## Architectural notes

- **`metric_definitions` ownership.** This table is owned by M5 (`sql/migrations/001_schema.sql:33`) but M3 now reads its `metric_id` column directly. This is consistent with M3's existing read access to other shared tables (`metric_computation_status` already read by `cmd/main.go:56`). A future refactor could turn this DB-coupling into wire-coupling via an `M5.ListMetricIDs` RPC — flagged in the Task 2 implementer's report as a low-effort follow-up; deferred as out-of-scope here.
- **Translation-at-boundaries pattern (mirrors PR #595).** React layer accepts `string | null | undefined`; the RPC client boundary normalises to `''` once; the wire (`PreviewMetricDefinitionRequest.experiment_id: string` per proto3) stays a plain string.

## Test plan

- [x] `buf lint proto/` — clean
- [x] `buf breaking proto --against ".git#branch=main,subdir=proto"` — clean (comment-only proto change)
- [x] `cargo test -p experimentation-management` — all passing (337 lib + 8 contract_preview_test + 24 contract_tests)
- [x] `cargo clippy -p experimentation-management --all-features -- -D warnings` — clean
- [x] `go test ./services/metrics/...` — all packages OK
- [x] `go vet ./services/metrics/...` — clean
- [x] `cd ui && npm run type-check` — clean
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm test src/components/metrics/metricql-section.test.tsx src/components/metrics/metricql/preview.test.tsx` — 32/32 pass
- [x] `just check-branch-name` — matches canonical pattern
- [x] `python3 scripts/check_stub_markers.py --base origin/main --head HEAD` — no new stub markers

## Review provenance

Developed via `superpowers:subagent-driven-development` workflow. Each task went through two-stage review (spec compliance first, then code quality):

1. **Task 1 (M5 Rust) spec review:** ✅ Spec compliant — all 4 files in scope, list_metric_ids correctly NOT called in preview path (M5 just proxies), inverted contract tests cover the new forwarding path with mock M3.
2. **Task 1 quality review:** ✅ APPROVED — 0 CRITICAL/HIGH/IMPORTANT; minor docstring softening applied (`9d88566`).
3. **Task 2 (M3 Go) spec review:** ✅ Spec compliant — all 5 required tests present with exact spec names, SQL query verbatim `SELECT metric_id FROM metric_definitions ORDER BY metric_id`, backward compat preserved.
4. **Task 2 quality review:** ✅ APPROVED with 1 IMPORTANT (catalog-error path untested) — fixed in `90a7415`.
5. **Task 3 (UI) spec + quality review:** ✅ APPROVED (verified inline after subagent socket drops on UI work — diff was small and well-scoped enough to audit directly).

## Out of scope / follow-ups

- **Optional `M5.ListMetricIDs` RPC.** Would replace M3's direct read of `metric_definitions` with a wire call (turns DB-coupling into wire-coupling). Low-effort but a different shape of decision; flag for ADR-026 Phase 2 backlog.
- **Experiment-scoped preview catalog.** When `experiment_id` is non-empty, M3 still passes `KnownMetricIDs: nil` (skips existence check). Aligning that path with the global path would catch unknown @refs at preview time for experiment-scoped previews too; intentionally out-of-scope for #597 (issue is global-scope only).
- **`metric_definitions` ADR amendment.** A one-line note documenting M3's read access to this table could go on ADR-026 Phase 2. Not blocking; M3 already reads several shared tables.

Closes #597
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->