### PR TITLE
refactor(metrics): consume proto MetricDefinition directly in M3 loader

### DIFF
--- a/services/metrics/internal/config/loader.go
+++ b/services/metrics/internal/config/loader.go
@@ -182,6 +182,20 @@ func (c *ConfigStore) GetMetric(id string) (*MetricConfig, error) {
 	return m, nil
 }
 
+// GetMetricsForExperiment returns the MetricConfigs for an experiment.
+//
+// IMPORTANT — shallow-copy semantics: `MetricConfig` embeds
+// `*commonv1.MetricDefinition` (a pointer), so the value-copy at the
+// `append` below shares the underlying proto message with the
+// ConfigStore's map. The same applies to `standard.go` callers
+// (`m := *mPtr`).
+//
+// Current callers are read-only — they invoke proto getters, never
+// setters or `proto.Reset` — which keeps this safe in practice. A
+// future caller that needs to MUTATE a returned MetricConfig must
+// `proto.Clone(m.MetricDefinition)` first, otherwise the mutation
+// will corrupt the store. (Devin PR #610 📝 shallow-pointer-copy
+// caveat.)
 func (c *ConfigStore) GetMetricsForExperiment(id string) ([]MetricConfig, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/services/metrics/internal/config/loader.go
+++ b/services/metrics/internal/config/loader.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type VariantConfig struct {
@@ -57,58 +61,30 @@ type SurrogateModelConfig struct {
 	Intercept    float64            `json:"intercept,omitempty"`
 }
 
+// MetricConfig embeds the proto MetricDefinition so any field added to the proto
+// is automatically readable by M3 without code changes (issue #506). The four
+// trailing fields are M3-only and have no proto counterpart — they are loaded
+// from seed JSON in parallel with the protojson-parsed proto half.
 type MetricConfig struct {
-	MetricID               string  `json:"metric_id"`
-	Name                   string  `json:"name"`
-	Type                   string  `json:"type"`
-	SourceEventType        string  `json:"source_event_type"`
-	NumeratorEventType     string  `json:"numerator_event_type,omitempty"`
-	DenominatorEventType   string  `json:"denominator_event_type,omitempty"`
-	CupedCovariateMetricID string  `json:"cuped_covariate_metric_id,omitempty"`
-	Percentile             float64 `json:"percentile,omitempty"`
-	LowerIsBetter          bool    `json:"lower_is_better,omitempty"`
-	IsQoEMetric            bool    `json:"is_qoe_metric,omitempty"`
-	QoEField               string  `json:"qoe_field,omitempty"`
-	CustomSQL              string  `json:"custom_sql,omitempty"`
-	// MLRATE cross-fitting fields (ADR-015 Phase 2)
-	MLRATEFeatureEventTypes []string `json:"mlrate_feature_event_types,omitempty"` // pre-experiment event types as LightGBM features
-	MLRATEModelURI          string   `json:"mlrate_model_uri,omitempty"`           // MLflow model URI prefix (fold models at {uri}/fold_{k})
-	MLRATELookbackDays      int      `json:"mlrate_lookback_days,omitempty"`       // days of pre-experiment data for features (default 14)
+	*commonv1.MetricDefinition
 
-	// ADR-026 Phase 1 — FILTERED_MEAN
-	FilterSQL   string `json:"filter_sql,omitempty"`
-	ValueColumn string `json:"value_column,omitempty"`
-
-	// ADR-026 Phase 1 — COMPOSITE
-	Operands []OperandConfig `json:"operands,omitempty"`
-	Operator string          `json:"operator,omitempty"` // ADD, SUBTRACT, MULTIPLY, DIVIDE, WEIGHTED_SUM
-
-	// ADR-026 Phase 1 — WINDOWED_COUNT
-	EventType   string `json:"event_type,omitempty"` // distinct from SourceEventType
-	WindowHours int32  `json:"window_hours,omitempty"`
-
-	// ADR-026 Phase 2 — METRICQL. Raw source text of the MetricQL expression.
-	// Mutually exclusive with custom_sql and the Phase 1 oneof fields (M5 + M3
-	// enforce). Parsed + compiled to Spark SQL at scheduling time by M3.
-	MetricqlExpression string `json:"metricql_expression,omitempty"`
+	// M3-only fields (not in proto MetricDefinition):
+	QoEField                string   `json:"qoe_field,omitempty"`
+	MLRATEFeatureEventTypes []string `json:"mlrate_feature_event_types,omitempty"`
+	MLRATEModelURI          string   `json:"mlrate_model_uri,omitempty"`
+	MLRATELookbackDays      int      `json:"mlrate_lookback_days,omitempty"`
 }
 
-// OperandConfig is the config-layer representation of one operand of a
-// COMPOSITE metric. Mirrors the proto CompositeOperand fields (ADR-026 Phase 1).
-//
-// Weight is meaningful only for WEIGHTED_SUM operator; ignored otherwise.
-// Note: encoding/json deserialises a missing or null number to 0.0, so
-// WEIGHTED_SUM operands MUST set weight explicitly. The renderer's
-// RenderForType arm rejects weight <= 0 for WEIGHTED_SUM.
-type OperandConfig struct {
-	MetricID string  `json:"metric_id"`
-	Weight   float64 `json:"weight"`
+// TypeShortName returns the short form of a MetricType enum, stripping the
+// "METRIC_TYPE_" prefix. Use for string comparison in renderer/job switches
+// where the long form is awkward.
+func TypeShortName(t commonv1.MetricType) string {
+	return strings.TrimPrefix(t.String(), "METRIC_TYPE_")
 }
 
-type seedFile struct {
-	Experiments     []ExperimentConfig     `json:"experiments"`
-	Metrics         []MetricConfig         `json:"metrics"`
-	SurrogateModels []SurrogateModelConfig `json:"surrogate_models,omitempty"`
+// CompositeOperatorShortName strips the "COMPOSITE_OPERATOR_" prefix.
+func CompositeOperatorShortName(op commonv1.CompositeOperator) string {
+	return strings.TrimPrefix(op.String(), "COMPOSITE_OPERATOR_")
 }
 
 type ConfigStore struct {
@@ -124,26 +100,59 @@ func LoadFromFile(path string) (*ConfigStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("config: read file %s: %w", path, err)
 	}
-	var sf seedFile
-	if err := json.Unmarshal(data, &sf); err != nil {
+
+	// Top-level seed file shape (experiments + surrogate_models still use
+	// encoding/json into existing Go structs; only the metrics array gets the
+	// proto-direct treatment).
+	var top struct {
+		Experiments     []ExperimentConfig     `json:"experiments"`
+		Metrics         []json.RawMessage      `json:"metrics"`
+		SurrogateModels []SurrogateModelConfig `json:"surrogate_models,omitempty"`
+	}
+	if err := json.Unmarshal(data, &top); err != nil {
 		return nil, fmt.Errorf("config: parse JSON: %w", err)
 	}
+
 	cs := &ConfigStore{
-		experiments:     make(map[string]*ExperimentConfig, len(sf.Experiments)),
-		metrics:         make(map[string]*MetricConfig, len(sf.Metrics)),
-		expMetrics:      make(map[string][]string, len(sf.Experiments)),
-		surrogateModels: make(map[string]*SurrogateModelConfig, len(sf.SurrogateModels)),
+		experiments:     make(map[string]*ExperimentConfig, len(top.Experiments)),
+		metrics:         make(map[string]*MetricConfig, len(top.Metrics)),
+		expMetrics:      make(map[string][]string, len(top.Experiments)),
+		surrogateModels: make(map[string]*SurrogateModelConfig, len(top.SurrogateModels)),
 	}
-	for i := range sf.Metrics {
-		m := sf.Metrics[i]
-		cs.metrics[m.MetricID] = &m
+
+	// Use DiscardUnknown because seed entries carry the four M3-only fields
+	// (qoe_field, mlrate_*) that proto MetricDefinition does not know about.
+	protoOpts := protojson.UnmarshalOptions{DiscardUnknown: true}
+
+	for i, raw := range top.Metrics {
+		md := &commonv1.MetricDefinition{}
+		if err := protoOpts.Unmarshal(raw, md); err != nil {
+			return nil, fmt.Errorf("config: parse metric[%d] via protojson: %w", i, err)
+		}
+		var m3 struct {
+			QoEField                string   `json:"qoe_field"`
+			MLRATEFeatureEventTypes []string `json:"mlrate_feature_event_types"`
+			MLRATEModelURI          string   `json:"mlrate_model_uri"`
+			MLRATELookbackDays      int      `json:"mlrate_lookback_days"`
+		}
+		if err := json.Unmarshal(raw, &m3); err != nil {
+			return nil, fmt.Errorf("config: parse metric[%d] m3-only fields: %w", i, err)
+		}
+		cs.metrics[md.GetMetricId()] = &MetricConfig{
+			MetricDefinition:        md,
+			QoEField:                m3.QoEField,
+			MLRATEFeatureEventTypes: m3.MLRATEFeatureEventTypes,
+			MLRATEModelURI:          m3.MLRATEModelURI,
+			MLRATELookbackDays:      m3.MLRATELookbackDays,
+		}
 	}
-	for i := range sf.SurrogateModels {
-		sm := sf.SurrogateModels[i]
+
+	for i := range top.SurrogateModels {
+		sm := top.SurrogateModels[i]
 		cs.surrogateModels[sm.ModelID] = &sm
 	}
-	for i := range sf.Experiments {
-		e := sf.Experiments[i]
+	for i := range top.Experiments {
+		e := top.Experiments[i]
 		cs.experiments[e.ExperimentID] = &e
 		metricIDs := make([]string, 0, 1+len(e.SecondaryMetricIDs))
 		metricIDs = append(metricIDs, e.PrimaryMetricID)

--- a/services/metrics/internal/config/loader_test.go
+++ b/services/metrics/internal/config/loader_test.go
@@ -1,10 +1,12 @@
 package config
 
 import (
-	"encoding/json"
 	"testing"
+
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestLoadFromFile(t *testing.T) {
@@ -22,7 +24,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Run("metrics loaded", func(t *testing.T) {
 		m, err := cs.GetMetric("watch_time_minutes")
 		require.NoError(t, err)
-		assert.Equal(t, "MEAN", m.Type)
+		assert.Equal(t, commonv1.MetricType_METRIC_TYPE_MEAN, m.Type)
 	})
 
 	t.Run("metrics for experiment", func(t *testing.T) {
@@ -34,7 +36,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Run("ratio metric", func(t *testing.T) {
 		m, err := cs.GetMetric("rebuffer_rate")
 		require.NoError(t, err)
-		assert.Equal(t, "RATIO", m.Type)
+		assert.Equal(t, commonv1.MetricType_METRIC_TYPE_RATIO, m.Type)
 		assert.Equal(t, "rebuffer_event", m.NumeratorEventType)
 		assert.Equal(t, "playback_minute", m.DenominatorEventType)
 	})
@@ -42,7 +44,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Run("cuped covariate", func(t *testing.T) {
 		m, err := cs.GetMetric("watch_time_minutes")
 		require.NoError(t, err)
-		assert.Equal(t, "watch_time_minutes", m.CupedCovariateMetricID)
+		assert.Equal(t, "watch_time_minutes", m.CupedCovariateMetricId)
 	})
 
 	t.Run("guardrail configs", func(t *testing.T) {
@@ -81,7 +83,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Run("percentile metric", func(t *testing.T) {
 		m, err := cs.GetMetric("latency_p50_ms")
 		require.NoError(t, err)
-		assert.Equal(t, "PERCENTILE", m.Type)
+		assert.Equal(t, commonv1.MetricType_METRIC_TYPE_PERCENTILE, m.Type)
 		assert.Equal(t, 0.50, m.Percentile)
 		assert.True(t, m.LowerIsBetter)
 	})
@@ -89,7 +91,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Run("qoe metric", func(t *testing.T) {
 		m, err := cs.GetMetric("ttff_mean")
 		require.NoError(t, err)
-		assert.True(t, m.IsQoEMetric)
+		assert.True(t, m.IsQoeMetric)
 		assert.Equal(t, "time_to_first_frame_ms", m.QoEField)
 		assert.True(t, m.LowerIsBetter)
 	})
@@ -133,75 +135,89 @@ func TestLoadFromFile_InvalidJSON(t *testing.T) {
 }
 
 func TestMetricConfig_ADR026Phase1_RoundTrip(t *testing.T) {
+	// Now that MetricConfig embeds *commonv1.MetricDefinition, raw protojson
+	// drives the proto half; the four M3-only sibling fields are no longer
+	// exercised here.  Tier-1 (FILTERED_MEAN / COMPOSITE / WINDOWED_COUNT)
+	// round-trip via protojson's oneof handling.
+	protoOpts := protojson.UnmarshalOptions{DiscardUnknown: true}
+
 	t.Run("filtered_mean", func(t *testing.T) {
-		raw := `{
+		raw := []byte(`{
             "metric_id": "mobile_avg_watch_time",
             "name": "Mobile avg watch time",
-            "type": "FILTERED_MEAN",
+            "type": "METRIC_TYPE_FILTERED_MEAN",
             "source_event_type": "heartbeat",
-            "filter_sql": "platform = 'mobile'",
-            "value_column": "duration_ms"
-        }`
-		var m MetricConfig
-		require.NoError(t, json.Unmarshal([]byte(raw), &m))
-		assert.Equal(t, "FILTERED_MEAN", m.Type)
-		assert.Equal(t, "platform = 'mobile'", m.FilterSQL)
-		assert.Equal(t, "duration_ms", m.ValueColumn)
+            "filteredMean": {
+                "filter_sql": "platform = 'mobile'",
+                "value_column": "duration_ms"
+            }
+        }`)
+		md := &commonv1.MetricDefinition{}
+		require.NoError(t, protoOpts.Unmarshal(raw, md))
+		m := MetricConfig{MetricDefinition: md}
+		assert.Equal(t, commonv1.MetricType_METRIC_TYPE_FILTERED_MEAN, m.Type)
+		assert.Equal(t, "platform = 'mobile'", m.GetFilteredMean().GetFilterSql())
+		assert.Equal(t, "duration_ms", m.GetFilteredMean().GetValueColumn())
 	})
 
 	t.Run("composite", func(t *testing.T) {
-		raw := `{
+		raw := []byte(`{
             "metric_id": "engagement_score",
             "name": "Composite engagement",
-            "type": "COMPOSITE",
-            "operator": "WEIGHTED_SUM",
-            "operands": [
-                {"metric_id": "watch_time_minutes", "weight": 0.7},
-                {"metric_id": "stream_start_rate", "weight": 0.3}
-            ]
-        }`
-		var m MetricConfig
-		require.NoError(t, json.Unmarshal([]byte(raw), &m))
-		assert.Equal(t, "COMPOSITE", m.Type)
-		assert.Equal(t, "WEIGHTED_SUM", m.Operator)
-		require.Len(t, m.Operands, 2)
-		assert.Equal(t, "watch_time_minutes", m.Operands[0].MetricID)
-		assert.InDelta(t, 0.7, m.Operands[0].Weight, 1e-9)
-		assert.Equal(t, "stream_start_rate", m.Operands[1].MetricID)
-		assert.InDelta(t, 0.3, m.Operands[1].Weight, 1e-9)
+            "type": "METRIC_TYPE_COMPOSITE",
+            "composite": {
+                "operator": "COMPOSITE_OPERATOR_WEIGHTED_SUM",
+                "operands": [
+                    {"metric_id": "watch_time_minutes", "weight": 0.7},
+                    {"metric_id": "stream_start_rate", "weight": 0.3}
+                ]
+            }
+        }`)
+		md := &commonv1.MetricDefinition{}
+		require.NoError(t, protoOpts.Unmarshal(raw, md))
+		m := MetricConfig{MetricDefinition: md}
+		assert.Equal(t, commonv1.MetricType_METRIC_TYPE_COMPOSITE, m.Type)
+		assert.Equal(t, commonv1.CompositeOperator_COMPOSITE_OPERATOR_WEIGHTED_SUM, m.GetComposite().GetOperator())
+		operands := m.GetComposite().GetOperands()
+		require.Len(t, operands, 2)
+		assert.Equal(t, "watch_time_minutes", operands[0].GetMetricId())
+		assert.InDelta(t, 0.7, operands[0].GetWeight(), 1e-9)
+		assert.Equal(t, "stream_start_rate", operands[1].GetMetricId())
+		assert.InDelta(t, 0.3, operands[1].GetWeight(), 1e-9)
 	})
 
 	t.Run("windowed_count", func(t *testing.T) {
-		raw := `{
+		raw := []byte(`{
             "metric_id": "stream_starts_24h",
             "name": "Stream starts within 24h",
-            "type": "WINDOWED_COUNT",
-            "event_type": "stream_start",
-            "window_hours": 24
-        }`
-		var m MetricConfig
-		require.NoError(t, json.Unmarshal([]byte(raw), &m))
-		assert.Equal(t, "WINDOWED_COUNT", m.Type)
-		assert.Equal(t, "stream_start", m.EventType)
-		assert.Equal(t, int32(24), m.WindowHours)
+            "type": "METRIC_TYPE_WINDOWED_COUNT",
+            "windowedCount": {
+                "event_type": "stream_start",
+                "window_hours": 24
+            }
+        }`)
+		md := &commonv1.MetricDefinition{}
+		require.NoError(t, protoOpts.Unmarshal(raw, md))
+		m := MetricConfig{MetricDefinition: md}
+		assert.Equal(t, commonv1.MetricType_METRIC_TYPE_WINDOWED_COUNT, m.Type)
+		assert.Equal(t, "stream_start", m.GetWindowedCount().GetEventType())
+		assert.Equal(t, int32(24), m.GetWindowedCount().GetWindowHours())
 	})
 
 	t.Run("omitempty preserves backward compatibility", func(t *testing.T) {
 		// A pre-ADR-026 metric (e.g. MEAN) must still unmarshal cleanly with
 		// no JSON keys for the new fields.
-		raw := `{
+		raw := []byte(`{
             "metric_id": "watch_time_minutes",
             "name": "Watch time",
-            "type": "MEAN",
+            "type": "METRIC_TYPE_MEAN",
             "source_event_type": "heartbeat"
-        }`
-		var m MetricConfig
-		require.NoError(t, json.Unmarshal([]byte(raw), &m))
-		assert.Empty(t, m.FilterSQL)
-		assert.Empty(t, m.ValueColumn)
-		assert.Empty(t, m.Operands)
-		assert.Empty(t, m.Operator)
-		assert.Empty(t, m.EventType)
-		assert.Equal(t, int32(0), m.WindowHours)
+        }`)
+		md := &commonv1.MetricDefinition{}
+		require.NoError(t, protoOpts.Unmarshal(raw, md))
+		m := MetricConfig{MetricDefinition: md}
+		assert.Nil(t, m.GetFilteredMean())
+		assert.Nil(t, m.GetComposite())
+		assert.Nil(t, m.GetWindowedCount())
 	})
 }

--- a/services/metrics/internal/config/testdata/seed_adr026_phase1.json
+++ b/services/metrics/internal/config/testdata/seed_adr026_phase1.json
@@ -20,35 +20,41 @@
     {
       "metric_id": "mobile_avg_watch_time",
       "name": "Mobile avg watch time",
-      "type": "FILTERED_MEAN",
+      "type": "METRIC_TYPE_FILTERED_MEAN",
       "source_event_type": "heartbeat",
-      "filter_sql": "platform = 'mobile'",
-      "value_column": "duration_ms",
+      "filteredMean": {
+        "filter_sql": "platform = 'mobile'",
+        "value_column": "duration_ms"
+      },
       "cuped_covariate_metric_id": "legacy_watch_time"
     },
     {
       "metric_id": "composite_engagement",
       "name": "Composite engagement",
-      "type": "COMPOSITE",
+      "type": "METRIC_TYPE_COMPOSITE",
       "source_event_type": "n/a",
-      "operator": "WEIGHTED_SUM",
-      "operands": [
-        {"metric_id": "watch_time_minutes", "weight": 0.7},
-        {"metric_id": "stream_start_rate", "weight": 0.3}
-      ]
+      "composite": {
+        "operator": "COMPOSITE_OPERATOR_WEIGHTED_SUM",
+        "operands": [
+          {"metric_id": "watch_time_minutes", "weight": 0.7},
+          {"metric_id": "stream_start_rate", "weight": 0.3}
+        ]
+      }
     },
     {
       "metric_id": "stream_starts_24h",
       "name": "Stream starts within 24h of exposure",
-      "type": "WINDOWED_COUNT",
+      "type": "METRIC_TYPE_WINDOWED_COUNT",
       "source_event_type": "n/a",
-      "event_type": "stream_start",
-      "window_hours": 24
+      "windowedCount": {
+        "event_type": "stream_start",
+        "window_hours": 24
+      }
     },
     {
       "metric_id": "legacy_watch_time",
       "name": "Legacy watch time (MEAN)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "heartbeat"
     }
   ]

--- a/services/metrics/internal/config/testdata/seed_config.json
+++ b/services/metrics/internal/config/testdata/seed_config.json
@@ -200,26 +200,26 @@
     {
       "metric_id": "stream_start_rate",
       "name": "Stream Start Rate",
-      "type": "PROPORTION",
+      "type": "METRIC_TYPE_PROPORTION",
       "source_event_type": "stream_start"
     },
     {
       "metric_id": "watch_time_minutes",
       "name": "Watch Time (minutes)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "heartbeat",
       "cuped_covariate_metric_id": "watch_time_minutes"
     },
     {
       "metric_id": "completion_rate",
       "name": "Content Completion Rate",
-      "type": "PROPORTION",
+      "type": "METRIC_TYPE_PROPORTION",
       "source_event_type": "stream_end"
     },
     {
       "metric_id": "rebuffer_rate",
       "name": "Rebuffer Rate",
-      "type": "RATIO",
+      "type": "METRIC_TYPE_RATIO",
       "source_event_type": "qoe_rebuffer",
       "numerator_event_type": "rebuffer_event",
       "denominator_event_type": "playback_minute",
@@ -228,32 +228,32 @@
     {
       "metric_id": "search_success_rate",
       "name": "Search Success Rate",
-      "type": "PROPORTION",
+      "type": "METRIC_TYPE_PROPORTION",
       "source_event_type": "search"
     },
     {
       "metric_id": "ctr_recommendation",
       "name": "Recommendation CTR",
-      "type": "PROPORTION",
+      "type": "METRIC_TYPE_PROPORTION",
       "source_event_type": "impression",
       "cuped_covariate_metric_id": "ctr_recommendation"
     },
     {
       "metric_id": "revenue_per_user",
       "name": "Revenue per User",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "revenue"
     },
     {
       "metric_id": "churn_7d",
       "name": "Churn (7-day)",
-      "type": "PROPORTION",
+      "type": "METRIC_TYPE_PROPORTION",
       "source_event_type": "session"
     },
     {
       "metric_id": "latency_p50_ms",
       "name": "Playback Start Latency p50",
-      "type": "PERCENTILE",
+      "type": "METRIC_TYPE_PERCENTILE",
       "source_event_type": "playback_start",
       "percentile": 0.50,
       "lower_is_better": true
@@ -261,20 +261,20 @@
     {
       "metric_id": "error_rate",
       "name": "Error Rate",
-      "type": "PROPORTION",
+      "type": "METRIC_TYPE_PROPORTION",
       "source_event_type": "playback_error",
       "lower_is_better": true
     },
     {
       "metric_id": "power_users_watch_time",
       "name": "Power Users Watch Time",
-      "type": "CUSTOM",
+      "type": "METRIC_TYPE_CUSTOM",
       "custom_sql": "SELECT user_id, AVG(value) AS metric_value FROM delta.metric_events WHERE event_type = 'heartbeat' GROUP BY user_id HAVING COUNT(*) >= 10"
     },
     {
       "metric_id": "watch_time_minutes_mlrate",
       "name": "Watch Time (MLRATE)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "heartbeat",
       "mlrate_feature_event_types": ["heartbeat", "stream_start"],
       "mlrate_model_uri": "models:/mlrate-watch-time",
@@ -283,7 +283,7 @@
     {
       "metric_id": "ttff_mean",
       "name": "Time to First Frame (mean)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "qoe_playback",
       "is_qoe_metric": true,
       "qoe_field": "time_to_first_frame_ms",
@@ -292,7 +292,7 @@
     {
       "metric_id": "rebuffer_ratio_mean",
       "name": "Rebuffer Ratio (mean)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "qoe_playback",
       "is_qoe_metric": true,
       "qoe_field": "rebuffer_ratio",

--- a/services/metrics/internal/integration_test.go
+++ b/services/metrics/internal/integration_test.go
@@ -296,7 +296,7 @@ func TestExportNotebook_FromPgQueryLog(t *testing.T) {
 
 	// Export notebook — backed by PgWriter reading from PostgreSQL.
 	nbResp, err := env.client.ExportNotebook(ctx, connect.NewRequest(&metricsv1.ExportNotebookRequest{
-		ExperimentId: seedExpID,
+		ExperimentId:   seedExpID,
 		NotebookFormat: "jupyter",
 	}))
 	require.NoError(t, err)
@@ -514,11 +514,13 @@ func TestSQLTemplateEventSchemaAlignment(t *testing.T) {
 		{
 			name: "interleaving score references exposures with provenance + metric_events",
 			params: spark.TemplateParams{
-				ExperimentID: "e0000000-0000-0000-0000-000000000003",
+				ExperimentID:     "e0000000-0000-0000-0000-000000000003",
 				CreditAssignment: "proportional", EngagementEventType: "click",
 				ComputationDate: compDate,
 			},
-			render:          func(r *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return r.RenderInterleavingScore(p) },
+			render: func(r *spark.SQLRenderer, p spark.TemplateParams) (string, error) {
+				return r.RenderInterleavingScore(p)
+			},
 			expectedTables:  []string{"delta.exposures", "delta.metric_events"},
 			expectedColumns: []string{"user_id", "experiment_id", "interleaving_provenance", "content_id"},
 		},
@@ -528,7 +530,9 @@ func TestSQLTemplateEventSchemaAlignment(t *testing.T) {
 				ExperimentID: expID, ContentIDField: "content_id",
 				ComputationDate: compDate,
 			},
-			render:          func(r *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return r.RenderContentConsumption(p) },
+			render: func(r *spark.SQLRenderer, p spark.TemplateParams) (string, error) {
+				return r.RenderContentConsumption(p)
+			},
 			expectedTables:  []string{"delta.exposures", "delta.metric_events"},
 			expectedColumns: []string{"user_id", "variant_id", "experiment_id", "content_id"},
 		},
@@ -537,9 +541,11 @@ func TestSQLTemplateEventSchemaAlignment(t *testing.T) {
 			params: spark.TemplateParams{
 				ExperimentID: expID, MetricID: "watch_time_minutes",
 				ControlVariantID: "f0000000-0000-0000-0000-000000000001",
-				ComputationDate: compDate,
+				ComputationDate:  compDate,
 			},
-			render:          func(r *spark.SQLRenderer, p spark.TemplateParams) (string, error) { return r.RenderDailyTreatmentEffect(p) },
+			render: func(r *spark.SQLRenderer, p spark.TemplateParams) (string, error) {
+				return r.RenderDailyTreatmentEffect(p)
+			},
 			expectedTables:  []string{"delta.exposures", "delta.metric_summaries"},
 			expectedColumns: []string{"user_id", "variant_id", "experiment_id", "metric_id", "metric_value"},
 		},
@@ -578,13 +584,13 @@ func TestSQLTemplateNoUnknownDeltaTables(t *testing.T) {
 	require.NoError(t, err)
 
 	knownTables := map[string]bool{
-		"delta.exposures":              true,
-		"delta.metric_events":          true,
-		"delta.qoe_events":             true,
-		"delta.reward_events":          true,
-		"delta.metric_summaries":       true,
-		"delta.interleaving_scores":    true,
-		"delta.content_consumption":    true,
+		"delta.exposures":               true,
+		"delta.metric_events":           true,
+		"delta.qoe_events":              true,
+		"delta.reward_events":           true,
+		"delta.metric_summaries":        true,
+		"delta.interleaving_scores":     true,
+		"delta.content_consumption":     true,
 		"delta.daily_treatment_effects": true,
 	}
 
@@ -976,26 +982,27 @@ func TestComputeMetrics_CompositeOrdering_MultiCycle(t *testing.T) {
 			{
 				"metric_id": "it_session_score",
 				"name": "IT session score (MEAN)",
-				"type": "MEAN",
-				"source_event_type": "session_end",
-				"value_column": "session_score"
+				"type": "METRIC_TYPE_MEAN",
+				"source_event_type": "session_end"
 			},
 			{
 				"metric_id": "it_click_rate",
 				"name": "IT click rate (PROPORTION)",
-				"type": "PROPORTION",
+				"type": "METRIC_TYPE_PROPORTION",
 				"source_event_type": "click"
 			},
 			{
 				"metric_id": "it_engagement_index",
 				"name": "IT engagement index (COMPOSITE)",
-				"type": "COMPOSITE",
+				"type": "METRIC_TYPE_COMPOSITE",
 				"source_event_type": "n/a",
-				"operator": "WEIGHTED_SUM",
-				"operands": [
-					{"metric_id": "it_session_score", "weight": 0.6},
-					{"metric_id": "it_click_rate", "weight": 0.4}
-				]
+				"composite": {
+					"operator": "COMPOSITE_OPERATOR_WEIGHTED_SUM",
+					"operands": [
+						{"metric_id": "it_session_score", "weight": 0.6},
+						{"metric_id": "it_click_rate", "weight": 0.4}
+					]
+				}
 			}
 		]
 	}`

--- a/services/metrics/internal/jobs/dag.go
+++ b/services/metrics/internal/jobs/dag.go
@@ -2,16 +2,16 @@ package jobs
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
 	"github.com/org/experimentation-platform/services/metrics/internal/metricql"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 // operandIDs returns the metric IDs that the given metric depends on, used by
 // both the DAG builder and the upstream-failure gate in standard.go::Run.
 //
-//   - COMPOSITE: m.Operands (config-time slice).
+//   - COMPOSITE: m.GetComposite().GetOperands() (proto-direct slice).
 //   - METRICQL:  parsed @metric_refs from m.MetricqlExpression. Parse error
 //     here is propagated to the caller (TopologicalOrder records it in
 //     failedParse so the scheduler can write status.Failed upfront -- avoids
@@ -24,20 +24,21 @@ import (
 // reason that's actually a parse error. Propagating yields a single, clearer
 // Failed row with reason "metricql: parse: <msg>".
 func operandIDs(m *config.MetricConfig) ([]string, error) {
-	switch strings.ToUpper(m.Type) {
-	case "COMPOSITE":
-		ids := make([]string, len(m.Operands))
-		for i, op := range m.Operands {
-			ids[i] = op.MetricID
+	switch m.Type {
+	case commonv1.MetricType_METRIC_TYPE_COMPOSITE:
+		operands := m.GetComposite().GetOperands()
+		ids := make([]string, len(operands))
+		for i, op := range operands {
+			ids[i] = op.GetMetricId()
 		}
 		return ids, nil
-	case "METRICQL":
+	case commonv1.MetricType_METRIC_TYPE_METRICQL:
 		if m.MetricqlExpression == "" {
-			return nil, fmt.Errorf("metricql parse for %s: empty metricql_expression", m.MetricID)
+			return nil, fmt.Errorf("metricql parse for %s: empty metricql_expression", m.MetricId)
 		}
 		root, err := metricql.Parse(m.MetricqlExpression)
 		if err != nil {
-			return nil, fmt.Errorf("metricql parse for %s: %w", m.MetricID, err)
+			return nil, fmt.Errorf("metricql parse for %s: %w", m.MetricId, err)
 		}
 		return metricql.ExtractMetricRefs(root), nil
 	}
@@ -75,7 +76,7 @@ func TopologicalOrder(metrics []*config.MetricConfig) (
 ) {
 	byID := make(map[string]*config.MetricConfig, len(metrics))
 	for _, m := range metrics {
-		byID[m.MetricID] = m
+		byID[m.MetricId] = m
 	}
 
 	failedParse := make(map[string]error)
@@ -85,8 +86,8 @@ func TopologicalOrder(metrics []*config.MetricConfig) (
 	inDeg := make(map[string]int, len(metrics))
 	children := make(map[string][]string, len(metrics))
 	for _, m := range metrics {
-		if _, ok := inDeg[m.MetricID]; !ok {
-			inDeg[m.MetricID] = 0
+		if _, ok := inDeg[m.MetricId]; !ok {
+			inDeg[m.MetricId] = 0
 		}
 		ids, err := operandIDs(m)
 		if err != nil {
@@ -94,7 +95,7 @@ func TopologicalOrder(metrics []*config.MetricConfig) (
 			// The metric itself has no edges (we can't extract refs), so it
 			// stays in-degree 0 and lands in the topo output. The scheduler's
 			// pre-loop pre-mark + the renderer arm both surface the failure.
-			failedParse[m.MetricID] = err
+			failedParse[m.MetricId] = err
 			continue
 		}
 		for _, opID := range ids {
@@ -103,8 +104,8 @@ func TopologicalOrder(metrics []*config.MetricConfig) (
 				// and let the runtime status check skip it.
 				continue
 			}
-			inDeg[m.MetricID]++
-			children[opID] = append(children[opID], m.MetricID)
+			inDeg[m.MetricId]++
+			children[opID] = append(children[opID], m.MetricId)
 		}
 	}
 
@@ -113,8 +114,8 @@ func TopologicalOrder(metrics []*config.MetricConfig) (
 	// is stable across runs (Go map iteration is randomized).
 	queue := make([]string, 0, len(metrics))
 	for _, m := range metrics {
-		if inDeg[m.MetricID] == 0 {
-			queue = append(queue, m.MetricID)
+		if inDeg[m.MetricId] == 0 {
+			queue = append(queue, m.MetricId)
 		}
 	}
 

--- a/services/metrics/internal/jobs/dag_test.go
+++ b/services/metrics/internal/jobs/dag_test.go
@@ -4,15 +4,27 @@ import (
 	"testing"
 
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
+
+// mc builds a MetricConfig with a typed MetricDefinition core for tests.
+func mc(md *commonv1.MetricDefinition) *config.MetricConfig {
+	return &config.MetricConfig{MetricDefinition: md}
+}
 
 func TestTopologicalOrder_LinearChain(t *testing.T) {
 	// operand=watch_time, composite=engagement_score depending on watch_time
 	metrics := []*config.MetricConfig{
-		{MetricID: "engagement_score", Type: "COMPOSITE", Operands: []config.OperandConfig{
-			{MetricID: "watch_time", Weight: 1.0},
-		}},
-		{MetricID: "watch_time", Type: "MEAN"},
+		mc(&commonv1.MetricDefinition{
+			MetricId: "engagement_score",
+			Type:     commonv1.MetricType_METRIC_TYPE_COMPOSITE,
+			TypeConfig: &commonv1.MetricDefinition_Composite{
+				Composite: &commonv1.CompositeConfig{
+					Operands: []*commonv1.CompositeOperand{{MetricId: "watch_time", Weight: 1.0}},
+				},
+			},
+		}),
+		mc(&commonv1.MetricDefinition{MetricId: "watch_time", Type: commonv1.MetricType_METRIC_TYPE_MEAN}),
 	}
 
 	sorted, skipped, failedParse, err := TopologicalOrder(metrics)
@@ -28,20 +40,32 @@ func TestTopologicalOrder_LinearChain(t *testing.T) {
 	if len(sorted) != 2 {
 		t.Fatalf("expected 2 sorted, got %d", len(sorted))
 	}
-	if sorted[0].MetricID != "watch_time" {
-		t.Fatalf("expected watch_time first, got %s", sorted[0].MetricID)
+	if sorted[0].MetricId != "watch_time" {
+		t.Fatalf("expected watch_time first, got %s", sorted[0].MetricId)
 	}
-	if sorted[1].MetricID != "engagement_score" {
-		t.Fatalf("expected engagement_score second, got %s", sorted[1].MetricID)
+	if sorted[1].MetricId != "engagement_score" {
+		t.Fatalf("expected engagement_score second, got %s", sorted[1].MetricId)
 	}
 }
 
 func TestTopologicalOrder_NestedComposite(t *testing.T) {
 	// a (MEAN) -> b (COMPOSITE of a) -> c (COMPOSITE of b)
 	metrics := []*config.MetricConfig{
-		{MetricID: "c", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "b", Weight: 1}}},
-		{MetricID: "b", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "a", Weight: 1}}},
-		{MetricID: "a", Type: "MEAN"},
+		mc(&commonv1.MetricDefinition{
+			MetricId: "c",
+			Type:     commonv1.MetricType_METRIC_TYPE_COMPOSITE,
+			TypeConfig: &commonv1.MetricDefinition_Composite{
+				Composite: &commonv1.CompositeConfig{Operands: []*commonv1.CompositeOperand{{MetricId: "b", Weight: 1}}},
+			},
+		}),
+		mc(&commonv1.MetricDefinition{
+			MetricId: "b",
+			Type:     commonv1.MetricType_METRIC_TYPE_COMPOSITE,
+			TypeConfig: &commonv1.MetricDefinition_Composite{
+				Composite: &commonv1.CompositeConfig{Operands: []*commonv1.CompositeOperand{{MetricId: "a", Weight: 1}}},
+			},
+		}),
+		mc(&commonv1.MetricDefinition{MetricId: "a", Type: commonv1.MetricType_METRIC_TYPE_MEAN}),
 	}
 	sorted, skipped, failedParse, _ := TopologicalOrder(metrics)
 	if len(failedParse) != 0 {
@@ -50,7 +74,7 @@ func TestTopologicalOrder_NestedComposite(t *testing.T) {
 	if len(skipped) != 0 {
 		t.Fatalf("expected no skipped, got %v", skipped)
 	}
-	got := []string{sorted[0].MetricID, sorted[1].MetricID, sorted[2].MetricID}
+	got := []string{sorted[0].MetricId, sorted[1].MetricId, sorted[2].MetricId}
 	want := []string{"a", "b", "c"}
 	for i := range want {
 		if got[i] != want[i] {
@@ -62,9 +86,21 @@ func TestTopologicalOrder_NestedComposite(t *testing.T) {
 func TestTopologicalOrder_CycleIsSkipped(t *testing.T) {
 	// a -> b -> a (cycle); c is independent and should still be sorted.
 	metrics := []*config.MetricConfig{
-		{MetricID: "a", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "b", Weight: 1}}},
-		{MetricID: "b", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "a", Weight: 1}}},
-		{MetricID: "c", Type: "MEAN"},
+		mc(&commonv1.MetricDefinition{
+			MetricId: "a",
+			Type:     commonv1.MetricType_METRIC_TYPE_COMPOSITE,
+			TypeConfig: &commonv1.MetricDefinition_Composite{
+				Composite: &commonv1.CompositeConfig{Operands: []*commonv1.CompositeOperand{{MetricId: "b", Weight: 1}}},
+			},
+		}),
+		mc(&commonv1.MetricDefinition{
+			MetricId: "b",
+			Type:     commonv1.MetricType_METRIC_TYPE_COMPOSITE,
+			TypeConfig: &commonv1.MetricDefinition_Composite{
+				Composite: &commonv1.CompositeConfig{Operands: []*commonv1.CompositeOperand{{MetricId: "a", Weight: 1}}},
+			},
+		}),
+		mc(&commonv1.MetricDefinition{MetricId: "c", Type: commonv1.MetricType_METRIC_TYPE_MEAN}),
 	}
 	sorted, skipped, failedParse, err := TopologicalOrder(metrics)
 	if len(failedParse) != 0 {
@@ -76,36 +112,8 @@ func TestTopologicalOrder_CycleIsSkipped(t *testing.T) {
 	if !skipped["a"] || !skipped["b"] {
 		t.Fatalf("expected a + b skipped (cycle), got %v", skipped)
 	}
-	if len(sorted) != 1 || sorted[0].MetricID != "c" {
+	if len(sorted) != 1 || sorted[0].MetricId != "c" {
 		t.Fatalf("expected only c sorted, got %v", sorted)
-	}
-}
-
-func TestTopologicalOrder_LowercaseCompositeType(t *testing.T) {
-	// Devin BUG-0001 regression on #556: the loader / renderer / scheduler all
-	// normalize Type via strings.ToUpper, so a config with "composite" must
-	// build the same DAG as "COMPOSITE". Before the fix, edges weren't built
-	// for lowercase entries — the COMPOSITE landed before its operands in
-	// topo order and was wrongly marked SkippedUpstreamFailure at runtime.
-	metrics := []*config.MetricConfig{
-		{MetricID: "engagement", Type: "composite", Operands: []config.OperandConfig{
-			{MetricID: "watch_time", Weight: 1.0},
-		}},
-		{MetricID: "watch_time", Type: "mean"},
-	}
-	sorted, skipped, failedParse, err := TopologicalOrder(metrics)
-	if len(failedParse) != 0 {
-		t.Fatalf("expected no parse failures, got %v", failedParse)
-	}
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(skipped) != 0 {
-		t.Fatalf("expected no skipped, got %v", skipped)
-	}
-	if len(sorted) != 2 || sorted[0].MetricID != "watch_time" || sorted[1].MetricID != "engagement" {
-		ids := []string{sorted[0].MetricID, sorted[1].MetricID}
-		t.Fatalf("expected [watch_time, engagement], got %v", ids)
 	}
 }
 
@@ -115,9 +123,21 @@ func TestTopologicalOrder_LowercaseCompositeType(t *testing.T) {
 // in topo order. ADR-026 Phase 2 (#435).
 func TestTopologicalOrder_MetricqlChain(t *testing.T) {
 	metrics := []*config.MetricConfig{
-		{MetricID: "weighted", Type: "METRICQL", MetricqlExpression: "0.7 * @watch_time + 0.3 * @ctr"},
-		{MetricID: "watch_time", Type: "MEAN", SourceEventType: "heartbeat", ValueColumn: "value"},
-		{MetricID: "ctr", Type: "PROPORTION", SourceEventType: "click"},
+		mc(&commonv1.MetricDefinition{
+			MetricId:           "weighted",
+			Type:               commonv1.MetricType_METRIC_TYPE_METRICQL,
+			MetricqlExpression: "0.7 * @watch_time + 0.3 * @ctr",
+		}),
+		mc(&commonv1.MetricDefinition{
+			MetricId:        "watch_time",
+			Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+			SourceEventType: "heartbeat",
+		}),
+		mc(&commonv1.MetricDefinition{
+			MetricId:        "ctr",
+			Type:            commonv1.MetricType_METRIC_TYPE_PROPORTION,
+			SourceEventType: "click",
+		}),
 	}
 	sorted, skipped, failedParse, err := TopologicalOrder(metrics)
 	if err != nil {
@@ -132,8 +152,8 @@ func TestTopologicalOrder_MetricqlChain(t *testing.T) {
 	if len(sorted) != 3 {
 		t.Fatalf("expected 3 sorted, got %d: %v", len(sorted), sorted)
 	}
-	if sorted[2].MetricID != "weighted" {
-		ids := []string{sorted[0].MetricID, sorted[1].MetricID, sorted[2].MetricID}
+	if sorted[2].MetricId != "weighted" {
+		ids := []string{sorted[0].MetricId, sorted[1].MetricId, sorted[2].MetricId}
 		t.Fatalf("weighted must be last in topo order; got %v", ids)
 	}
 }
@@ -143,8 +163,16 @@ func TestTopologicalOrder_MetricqlChain(t *testing.T) {
 // edge-building, while the rest of the pass proceeds normally.
 func TestTopologicalOrder_MetricqlParseFailure(t *testing.T) {
 	metrics := []*config.MetricConfig{
-		{MetricID: "bad", Type: "METRICQL", MetricqlExpression: "mean( oops"}, // intentional syntax error
-		{MetricID: "good", Type: "MEAN", SourceEventType: "heartbeat", ValueColumn: "value"},
+		mc(&commonv1.MetricDefinition{
+			MetricId:           "bad",
+			Type:               commonv1.MetricType_METRIC_TYPE_METRICQL,
+			MetricqlExpression: "mean( oops", // intentional syntax error
+		}),
+		mc(&commonv1.MetricDefinition{
+			MetricId:        "good",
+			Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+			SourceEventType: "heartbeat",
+		}),
 	}
 	sorted, skipped, failedParse, err := TopologicalOrder(metrics)
 	if err != nil {
@@ -166,7 +194,13 @@ func TestTopologicalOrder_OperandOutsidePass(t *testing.T) {
 	// in-degree 0 (Kahn's emits it). The caller's status_map gates skipping on
 	// operand status at runtime.
 	metrics := []*config.MetricConfig{
-		{MetricID: "c", Type: "COMPOSITE", Operands: []config.OperandConfig{{MetricID: "x", Weight: 1}}},
+		mc(&commonv1.MetricDefinition{
+			MetricId: "c",
+			Type:     commonv1.MetricType_METRIC_TYPE_COMPOSITE,
+			TypeConfig: &commonv1.MetricDefinition_Composite{
+				Composite: &commonv1.CompositeConfig{Operands: []*commonv1.CompositeOperand{{MetricId: "x", Weight: 1}}},
+			},
+		}),
 	}
 	sorted, skipped, failedParse, _ := TopologicalOrder(metrics)
 	if len(failedParse) != 0 {
@@ -175,7 +209,7 @@ func TestTopologicalOrder_OperandOutsidePass(t *testing.T) {
 	if len(skipped) != 0 {
 		t.Fatalf("expected no skipped, got %v", skipped)
 	}
-	if len(sorted) != 1 || sorted[0].MetricID != "c" {
+	if len(sorted) != 1 || sorted[0].MetricId != "c" {
 		t.Fatalf("expected c sorted, got %v", sorted)
 	}
 }

--- a/services/metrics/internal/jobs/latency_sla_test.go
+++ b/services/metrics/internal/jobs/latency_sla_test.go
@@ -153,14 +153,14 @@ func generateScaledConfig(t *testing.T, n int) *config.ConfigStore {
 		IsControl       bool    `json:"is_control"`
 	}
 	type experiment struct {
-		ExperimentID     string   `json:"experiment_id"`
-		Name             string   `json:"name"`
-		Type             string   `json:"type"`
-		State            string   `json:"state"`
-		StartedAt        string   `json:"started_at"`
-		PrimaryMetricID  string   `json:"primary_metric_id"`
-		SecondaryMetricIDs []string `json:"secondary_metric_ids"`
-		Variants         []variant `json:"variants"`
+		ExperimentID       string    `json:"experiment_id"`
+		Name               string    `json:"name"`
+		Type               string    `json:"type"`
+		State              string    `json:"state"`
+		StartedAt          string    `json:"started_at"`
+		PrimaryMetricID    string    `json:"primary_metric_id"`
+		SecondaryMetricIDs []string  `json:"secondary_metric_ids"`
+		Variants           []variant `json:"variants"`
 	}
 	type metric struct {
 		MetricID        string `json:"metric_id"`
@@ -182,17 +182,17 @@ func generateScaledConfig(t *testing.T, n int) *config.ConfigStore {
 		sf.Metrics = append(sf.Metrics, metric{
 			MetricID:        mid,
 			Name:            fmt.Sprintf("Metric %d", i),
-			Type:            "MEAN",
+			Type:            "METRIC_TYPE_MEAN",
 			SourceEventType: "heartbeat",
 		})
 
 		sf.Experiments = append(sf.Experiments, experiment{
-			ExperimentID:     eid,
-			Name:             fmt.Sprintf("experiment_%d", i),
-			Type:             "AB",
-			State:            "RUNNING",
-			StartedAt:        "2024-01-01",
-			PrimaryMetricID:  mid,
+			ExperimentID:       eid,
+			Name:               fmt.Sprintf("experiment_%d", i),
+			Type:               "AB",
+			State:              "RUNNING",
+			StartedAt:          "2024-01-01",
+			PrimaryMetricID:    mid,
 			SecondaryMetricIDs: nil,
 			Variants: []variant{
 				{VariantID: fmt.Sprintf("cv-%04d", i), Name: "control", TrafficFraction: 0.5, IsControl: true},
@@ -304,7 +304,7 @@ func TestSLA_DailyPipeline_PerExperimentBreakdown(t *testing.T) {
 			experimentID: "e0000000-0000-0000-0000-000000000004",
 			wantTotal:    4,
 			wantJobTypes: map[string]int{
-				"qoe_metric":            2, // ttff_mean + rebuffer_ratio_mean
+				"qoe_metric":             2, // ttff_mean + rebuffer_ratio_mean
 				"daily_treatment_effect": 2,
 			},
 		},
@@ -406,8 +406,8 @@ func TestSLA_GuardrailPipeline_WallClock(t *testing.T) {
 
 func TestSLA_QueryCountFormula_PerMetricType(t *testing.T) {
 	tests := []struct {
-		name       string
-		config     string // JSON config
+		name        string
+		config      string // JSON config
 		wantQueries int
 	}{
 		{
@@ -421,7 +421,7 @@ func TestSLA_QueryCountFormula_PerMetricType(t *testing.T) {
 						{"variant_id": "tv", "name": "treatment", "traffic_fraction": 0.5, "is_control": false}
 					]
 				}],
-				"metrics": [{"metric_id": "m1", "name": "m", "type": "MEAN", "source_event_type": "hb"}]
+				"metrics": [{"metric_id": "m1", "name": "m", "type": "METRIC_TYPE_MEAN", "source_event_type": "hb"}]
 			}`,
 			wantQueries: 2, // base + treatment_effect
 		},
@@ -436,7 +436,7 @@ func TestSLA_QueryCountFormula_PerMetricType(t *testing.T) {
 						{"variant_id": "tv", "name": "treatment", "traffic_fraction": 0.5, "is_control": false}
 					]
 				}],
-				"metrics": [{"metric_id": "m1", "name": "m", "type": "MEAN", "source_event_type": "hb"}]
+				"metrics": [{"metric_id": "m1", "name": "m", "type": "METRIC_TYPE_MEAN", "source_event_type": "hb"}]
 			}`,
 			wantQueries: 3, // base + session + treatment_effect
 		},
@@ -452,7 +452,7 @@ func TestSLA_QueryCountFormula_PerMetricType(t *testing.T) {
 						{"variant_id": "tv", "name": "treatment", "traffic_fraction": 0.5, "is_control": false}
 					]
 				}],
-				"metrics": [{"metric_id": "m1", "name": "m", "type": "MEAN", "source_event_type": "hb"}]
+				"metrics": [{"metric_id": "m1", "name": "m", "type": "METRIC_TYPE_MEAN", "source_event_type": "hb"}]
 			}`,
 			wantQueries: 3, // base + lifecycle + treatment_effect
 		},
@@ -470,7 +470,7 @@ func TestSLA_QueryCountFormula_PerMetricType(t *testing.T) {
 					]
 				}],
 				"metrics": [{
-					"metric_id": "m1", "name": "m", "type": "MEAN", "source_event_type": "hb",
+					"metric_id": "m1", "name": "m", "type": "METRIC_TYPE_MEAN", "source_event_type": "hb",
 					"cuped_covariate_metric_id": "m1"
 				}]
 			}`,
@@ -488,7 +488,7 @@ func TestSLA_QueryCountFormula_PerMetricType(t *testing.T) {
 					]
 				}],
 				"metrics": [{
-					"metric_id": "m1", "name": "m", "type": "RATIO", "source_event_type": "ev",
+					"metric_id": "m1", "name": "m", "type": "METRIC_TYPE_RATIO", "source_event_type": "ev",
 					"numerator_event_type": "num", "denominator_event_type": "den"
 				}]
 			}`,
@@ -508,7 +508,7 @@ func TestSLA_QueryCountFormula_PerMetricType(t *testing.T) {
 					]
 				}],
 				"metrics": [{
-					"metric_id": "m1", "name": "m", "type": "MEAN", "source_event_type": "qoe",
+					"metric_id": "m1", "name": "m", "type": "METRIC_TYPE_MEAN", "source_event_type": "qoe",
 					"is_qoe_metric": true, "qoe_field": "time_to_first_frame_ms"
 				}]
 			}`,

--- a/services/metrics/internal/jobs/mlrate.go
+++ b/services/metrics/internal/jobs/mlrate.go
@@ -61,10 +61,10 @@ func (j *MLRATEJob) Run(
 	lookbackDays := metric.MLRATELookbackDaysOrDefault()
 
 	if len(metric.MLRATEFeatureEventTypes) == 0 {
-		return nil, fmt.Errorf("mlrate: metric %q has no mlrate_feature_event_types configured", metric.MetricID)
+		return nil, fmt.Errorf("mlrate: metric %q has no mlrate_feature_event_types configured", metric.MetricId)
 	}
 	if metric.MLRATEModelURI == "" {
-		return nil, fmt.Errorf("mlrate: metric %q has no mlrate_model_uri configured", metric.MetricID)
+		return nil, fmt.Errorf("mlrate: metric %q has no mlrate_model_uri configured", metric.MetricId)
 	}
 	if exp.StartedAt == "" {
 		return nil, fmt.Errorf("mlrate: experiment %q has no started_at date", exp.ExperimentID)
@@ -82,30 +82,30 @@ func (j *MLRATEJob) Run(
 
 	featSQL, err := j.renderer.RenderMLRATEFeatures(featParams)
 	if err != nil {
-		return nil, fmt.Errorf("mlrate: render features for %s: %w", metric.MetricID, err)
+		return nil, fmt.Errorf("mlrate: render features for %s: %w", metric.MetricId, err)
 	}
 
 	featResult, err := j.executor.ExecuteAndWrite(ctx, featSQL, "delta.mlrate_features")
 	if err != nil {
-		return nil, fmt.Errorf("mlrate: execute features for %s: %w", metric.MetricID, err)
+		return nil, fmt.Errorf("mlrate: execute features for %s: %w", metric.MetricId, err)
 	}
 	m3metrics.SparkQueryDuration.WithLabelValues("mlrate_features").Observe(featResult.Duration.Seconds())
 	m3metrics.SparkQueryRows.WithLabelValues("mlrate_features").Observe(float64(featResult.RowCount))
 
 	if err := j.queryLog.Log(ctx, querylog.Entry{
 		ExperimentID: exp.ExperimentID,
-		MetricID:     metric.MetricID,
+		MetricID:     metric.MetricId,
 		SQLText:      featSQL,
 		RowCount:     featResult.RowCount,
 		DurationMs:   featResult.Duration.Milliseconds(),
 		JobType:      "mlrate_features",
 	}); err != nil {
-		return nil, fmt.Errorf("mlrate: log features query for %s: %w", metric.MetricID, err)
+		return nil, fmt.Errorf("mlrate: log features query for %s: %w", metric.MetricId, err)
 	}
 
 	slog.Info("computed MLRATE features",
 		"experiment_id", exp.ExperimentID,
-		"metric_id", metric.MetricID,
+		"metric_id", metric.MetricId,
 		"folds", folds,
 		"lookback_days", lookbackDays,
 		"rows", featResult.RowCount,
@@ -116,7 +116,7 @@ func (j *MLRATEJob) Run(
 	for foldID := 1; foldID <= folds; foldID++ {
 		predParams := spark.TemplateParams{
 			ExperimentID:            exp.ExperimentID,
-			MetricID:                metric.MetricID,
+			MetricID:                metric.MetricId,
 			ComputationDate:         computationDate,
 			MLRATEFolds:             folds,
 			MLRATEFeatureEventTypes: metric.MLRATEFeatureEventTypes,
@@ -126,32 +126,32 @@ func (j *MLRATEJob) Run(
 
 		predSQL, err := j.renderer.RenderMLRATECrossFitPredict(predParams)
 		if err != nil {
-			return nil, fmt.Errorf("mlrate: render prediction fold %d for %s: %w", foldID, metric.MetricID, err)
+			return nil, fmt.Errorf("mlrate: render prediction fold %d for %s: %w", foldID, metric.MetricId, err)
 		}
 
 		predResult, err := j.executor.ExecuteAndWrite(ctx, predSQL, "delta.metric_summaries")
 		if err != nil {
-			return nil, fmt.Errorf("mlrate: execute prediction fold %d for %s: %w", foldID, metric.MetricID, err)
+			return nil, fmt.Errorf("mlrate: execute prediction fold %d for %s: %w", foldID, metric.MetricId, err)
 		}
 		m3metrics.SparkQueryDuration.WithLabelValues("mlrate_crossfit").Observe(predResult.Duration.Seconds())
 		m3metrics.SparkQueryRows.WithLabelValues("mlrate_crossfit").Observe(float64(predResult.RowCount))
 
 		if err := j.queryLog.Log(ctx, querylog.Entry{
 			ExperimentID: exp.ExperimentID,
-			MetricID:     metric.MetricID,
+			MetricID:     metric.MetricId,
 			SQLText:      predSQL,
 			RowCount:     predResult.RowCount,
 			DurationMs:   predResult.Duration.Milliseconds(),
 			JobType:      "mlrate_crossfit",
 		}); err != nil {
-			return nil, fmt.Errorf("mlrate: log prediction fold %d query for %s: %w", foldID, metric.MetricID, err)
+			return nil, fmt.Errorf("mlrate: log prediction fold %d query for %s: %w", foldID, metric.MetricId, err)
 		}
 
 		totalPredictionRows += predResult.RowCount
 
 		slog.Info("computed MLRATE cross-fit prediction",
 			"experiment_id", exp.ExperimentID,
-			"metric_id", metric.MetricID,
+			"metric_id", metric.MetricId,
 			"fold", foldID,
 			"rows", predResult.RowCount,
 		)
@@ -159,7 +159,7 @@ func (j *MLRATEJob) Run(
 
 	return &MLRATEResult{
 		ExperimentID: exp.ExperimentID,
-		MetricID:     metric.MetricID,
+		MetricID:     metric.MetricId,
 		Folds:        folds,
 		UsersScored:  totalPredictionRows,
 		CompletedAt:  time.Now(),

--- a/services/metrics/internal/jobs/mlrate_test.go
+++ b/services/metrics/internal/jobs/mlrate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 func setupMLRATEJob(t *testing.T) (*MLRATEJob, *spark.MockExecutor, *querylog.MemWriter) {
@@ -25,11 +26,11 @@ func setupMLRATEJob(t *testing.T) (*MLRATEJob, *spark.MockExecutor, *querylog.Me
 
 func mlrateTestExperiment() *config.ExperimentConfig {
 	return &config.ExperimentConfig{
-		ExperimentID: "e0000000-0000-0000-0000-000000000008",
-		Name:         "mlrate_crossfit_test",
-		Type:         "AB",
-		State:        "RUNNING",
-		StartedAt:    "2024-02-01",
+		ExperimentID:  "e0000000-0000-0000-0000-000000000008",
+		Name:          "mlrate_crossfit_test",
+		Type:          "AB",
+		State:         "RUNNING",
+		StartedAt:     "2024-02-01",
 		MLRATEEnabled: true,
 		MLRATEFolds:   3,
 		Variants: []config.VariantConfig{
@@ -41,10 +42,12 @@ func mlrateTestExperiment() *config.ExperimentConfig {
 
 func mlrateTestMetric() *config.MetricConfig {
 	return &config.MetricConfig{
-		MetricID:                "watch_time_minutes_mlrate",
-		Name:                    "Watch Time (MLRATE)",
-		Type:                    "MEAN",
-		SourceEventType:         "heartbeat",
+		MetricDefinition: &commonv1.MetricDefinition{
+			MetricId:        "watch_time_minutes_mlrate",
+			Name:            "Watch Time (MLRATE)",
+			Type:            commonv1.MetricType_METRIC_TYPE_MEAN,
+			SourceEventType: "heartbeat",
+		},
 		MLRATEFeatureEventTypes: []string{"heartbeat", "stream_start"},
 		MLRATEModelURI:          "models:/mlrate-watch-time",
 		MLRATELookbackDays:      14,
@@ -61,7 +64,7 @@ func TestMLRATEJob_Run(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, exp.ExperimentID, result.ExperimentID)
-	assert.Equal(t, metric.MetricID, result.MetricID)
+	assert.Equal(t, metric.MetricId, result.MetricID)
 	assert.Equal(t, 3, result.Folds)
 	assert.False(t, result.CompletedAt.IsZero())
 
@@ -94,7 +97,7 @@ func TestMLRATEJob_Run(t *testing.T) {
 	crossfitCount := 0
 	for _, e := range entries {
 		assert.Equal(t, exp.ExperimentID, e.ExperimentID)
-		assert.Equal(t, metric.MetricID, e.MetricID)
+		assert.Equal(t, metric.MetricId, e.MetricID)
 		switch e.JobType {
 		case "mlrate_features":
 			featCount++

--- a/services/metrics/internal/jobs/shadow_runner.go
+++ b/services/metrics/internal/jobs/shadow_runner.go
@@ -24,10 +24,11 @@ import (
 
 	"google.golang.org/protobuf/encoding/protojson"
 
-	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
+	"github.com/org/experimentation-platform/services/metrics/internal/config"
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/shadow"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 // runShadows executes all PENDING shadow runs that have not yet been computed
@@ -183,7 +184,7 @@ func (j *StandardJob) computeOneShadow(
 				"err", cfgErr,
 			)
 		} else {
-			if differErr := j.differ.Run(ctx, &run, experimentID, computationDate, origMetric.Type); differErr != nil {
+			if differErr := j.differ.Run(ctx, &run, experimentID, computationDate, config.TypeShortName(origMetric.Type)); differErr != nil {
 				slog.Error("shadow: differ failed (non-fatal)",
 					"shadow_id", shadowIDStr,
 					"original_metric_id", run.OriginalMetricID,

--- a/services/metrics/internal/jobs/shadow_runner_test.go
+++ b/services/metrics/internal/jobs/shadow_runner_test.go
@@ -66,7 +66,7 @@ func minimalExperimentFixture(t *testing.T) string {
 			{
 				"metric_id":        "watch_time",
 				"name":             "Watch time (MEAN)",
-				"type":             "MEAN",
+				"type":             "METRIC_TYPE_MEAN",
 				"source_event_type": "heartbeat"
 			}
 		]
@@ -467,7 +467,7 @@ func TestStandardJob_ShadowRun_RegularPassUnaffected(t *testing.T) {
 // TestStandardJob_ShadowRun_PropagatesExperimentID: regression test for Fix 2 —
 // the SQL sent to the executor must contain the real experiment_id, not an empty
 // string.  An empty ExperimentID in TemplateParams would render
-// `WHERE experiment_id = ''` in delta.exposures joins, producing zero-row output.
+// `WHERE experiment_id = ”` in delta.exposures joins, producing zero-row output.
 func TestStandardJob_ShadowRun_PropagatesExperimentID(t *testing.T) {
 	p := minimalExperimentFixture(t)
 	ms := shadow.NewMockStore()

--- a/services/metrics/internal/jobs/standard.go
+++ b/services/metrics/internal/jobs/standard.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
@@ -14,6 +13,7 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/shadow"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
 	"github.com/org/experimentation-platform/services/metrics/internal/status"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 // JobResult summarizes the outcome of a computation run.
@@ -178,12 +178,12 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 	for _, mPtr := range sortedMetrics {
 		// COMPOSITE: gate on operand status BEFORE attempting execution.
-		if strings.ToUpper(mPtr.Type) == "COMPOSITE" {
-			if blocker, blocked := sm.blockerFor(mPtr.Operands); blocked {
-				sm.markSkippedUpstream(mPtr.MetricID, blocker)
+		if mPtr.Type == commonv1.MetricType_METRIC_TYPE_COMPOSITE {
+			if blocker, blocked := sm.blockerFor(mPtr.GetComposite().GetOperands()); blocked {
+				sm.markSkippedUpstream(mPtr.MetricId, blocker)
 				slog.Warn("composite skipped (operand failed or missing)",
 					"experiment_id", experimentID,
-					"metric_id", mPtr.MetricID,
+					"metric_id", mPtr.MetricId,
 					"blocker", blocker,
 					"computation_date", computationDate,
 				)
@@ -199,26 +199,26 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 		// silently wrong numbers, not an error. Round-4 BUG-0002 fix.
 		// blockerForRefs is shared with markUnvisitedDependentsAsSkipped
 		// so "blocked" means the same thing in both places.
-		if strings.ToUpper(mPtr.Type) == "METRICQL" {
+		if mPtr.Type == commonv1.MetricType_METRIC_TYPE_METRICQL {
 			refs, parseErr := operandIDs(mPtr)
 			if parseErr != nil {
 				// Parse failure -- already recorded as Failed via the
 				// failedParse pre-mark; defensive re-mark in case the
 				// expression text changed between DAG build and gate.
-				sm.markFailed(mPtr.MetricID, "metricql: parse: "+parseErr.Error())
+				sm.markFailed(mPtr.MetricId, "metricql: parse: "+parseErr.Error())
 				slog.Warn("metricql skipped (parse failure)",
 					"experiment_id", experimentID,
-					"metric_id", mPtr.MetricID,
+					"metric_id", mPtr.MetricId,
 					"err", parseErr,
 					"computation_date", computationDate,
 				)
 				continue
 			}
 			if blocker := sm.blockerForRefs(refs); blocker != "" {
-				sm.markSkippedUpstream(mPtr.MetricID, blocker)
+				sm.markSkippedUpstream(mPtr.MetricId, blocker)
 				slog.Warn("metricql skipped (ref failed or missing)",
 					"experiment_id", experimentID,
-					"metric_id", mPtr.MetricID,
+					"metric_id", mPtr.MetricId,
 					"blocker", blocker,
 					"computation_date", computationDate,
 				)
@@ -232,45 +232,51 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 		params := spark.TemplateParams{
 			ExperimentID:         exp.ExperimentID,
-			MetricID:             m.MetricID,
+			MetricID:             m.MetricId,
 			SourceEventType:      m.SourceEventType,
 			ComputationDate:      computationDate,
 			NumeratorEventType:   m.NumeratorEventType,
 			DenominatorEventType: m.DenominatorEventType,
-			CustomSQL:            m.CustomSQL,
+			CustomSQL:            m.CustomSql,
 			Percentile:           m.Percentile,
 			// ADR-026 Phase 1
-			FilterSQL:   m.FilterSQL,
-			ValueColumn: m.ValueColumn,
-			Operator:    m.Operator,
-			EventType:   m.EventType,
-			WindowHours: m.WindowHours,
-			Operands:    toSparkOperands(m.Operands),
+			FilterSQL:   m.GetFilteredMean().GetFilterSql(),
+			ValueColumn: m.GetFilteredMean().GetValueColumn(),
+			Operator:    config.CompositeOperatorShortName(m.GetComposite().GetOperator()),
+			EventType:   m.GetWindowedCount().GetEventType(),
+			WindowHours: m.GetWindowedCount().GetWindowHours(),
+			Operands:    toSparkOperands(m.GetComposite().GetOperands()),
 			// ADR-026 Phase 2 (#435)
 			MetricqlExpression: m.MetricqlExpression,
+		}
+		// WINDOWED_COUNT's optional filter_sql lives in WindowedCountConfig and
+		// shares M3's params.FilterSQL field; only override if the FILTERED_MEAN
+		// arm did not already populate it.
+		if params.FilterSQL == "" {
+			params.FilterSQL = m.GetWindowedCount().GetFilterSql()
 		}
 
 		// QoE metrics use a separate template reading from delta.qoe_events.
 		var sql string
 		var jobType string
-		if m.IsQoEMetric {
+		if m.IsQoeMetric {
 			params.QoEField = m.QoEField
 			rendered, err := j.renderer.RenderQoEMetric(params)
 			if err != nil {
-				return nil, fmt.Errorf("jobs: render QoE metric %s: %w", m.MetricID, err)
+				return nil, fmt.Errorf("jobs: render QoE metric %s: %w", m.MetricId, err)
 			}
 			sql = rendered
 			jobType = "qoe_metric"
 		} else {
-			rendered, err := j.renderer.RenderForType(m.Type, params)
+			rendered, err := j.renderer.RenderForType(config.TypeShortName(m.Type), params)
 			if err != nil {
 				// Record the render failure in the status table so M4a can
 				// distinguish it from "metric was never scheduled". Mirrors the
 				// markFailed call on the execute-error path below. Devin
 				// observability finding on #556.
-				sm.markFailed(m.MetricID, fmt.Sprintf("render: %v", err))
+				sm.markFailed(m.MetricId, fmt.Sprintf("render: %v", err))
 				slog.Warn("skipping metric: render error",
-					"metric_id", m.MetricID, "type", m.Type, "error", err)
+					"metric_id", m.MetricId, "type", config.TypeShortName(m.Type), "error", err)
 				continue
 			}
 			sql = rendered
@@ -279,72 +285,72 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 		result, err := j.executor.ExecuteAndWrite(ctx, sql, "delta.metric_summaries")
 		if err != nil {
-			sm.markFailed(m.MetricID, fmt.Sprintf("execute: %v", err))
-			return nil, fmt.Errorf("jobs: execute metric %s: %w", m.MetricID, err)
+			sm.markFailed(m.MetricId, fmt.Sprintf("execute: %v", err))
+			return nil, fmt.Errorf("jobs: execute metric %s: %w", m.MetricId, err)
 		}
 		m3metrics.SparkQueryDuration.WithLabelValues(jobType).Observe(result.Duration.Seconds())
 		m3metrics.SparkQueryRows.WithLabelValues(jobType).Observe(float64(result.RowCount))
 
 		if err := j.queryLog.Log(ctx, querylog.Entry{
 			ExperimentID: experimentID,
-			MetricID:     m.MetricID,
+			MetricID:     m.MetricId,
 			SQLText:      sql,
 			RowCount:     result.RowCount,
 			DurationMs:   result.Duration.Milliseconds(),
 			JobType:      jobType,
 		}); err != nil {
-			sm.markFailed(m.MetricID, fmt.Sprintf("query_log: %v", err))
-			return nil, fmt.Errorf("jobs: log query for metric %s: %w", m.MetricID, err)
+			sm.markFailed(m.MetricId, fmt.Sprintf("query_log: %v", err))
+			return nil, fmt.Errorf("jobs: log query for metric %s: %w", m.MetricId, err)
 		}
 
 		totalRows += result.RowCount
 		metricsComputed++
 
 		// For RATIO metrics, also compute delta method variance components.
-		if strings.ToUpper(m.Type) == "RATIO" {
+		if m.Type == commonv1.MetricType_METRIC_TYPE_RATIO {
 			deltaSQL, err := j.renderer.RenderRatioDeltaMethod(params)
 			if err != nil {
-				return nil, fmt.Errorf("jobs: render delta method for %s: %w", m.MetricID, err)
+				return nil, fmt.Errorf("jobs: render delta method for %s: %w", m.MetricId, err)
 			}
 
 			deltaResult, err := j.executor.ExecuteAndWrite(ctx, deltaSQL, "delta.daily_treatment_effects")
 			if err != nil {
-				return nil, fmt.Errorf("jobs: execute delta method for %s: %w", m.MetricID, err)
+				return nil, fmt.Errorf("jobs: execute delta method for %s: %w", m.MetricId, err)
 			}
 			m3metrics.SparkQueryDuration.WithLabelValues("delta_method").Observe(deltaResult.Duration.Seconds())
 			m3metrics.SparkQueryRows.WithLabelValues("delta_method").Observe(float64(deltaResult.RowCount))
 
 			if err := j.queryLog.Log(ctx, querylog.Entry{
 				ExperimentID: experimentID,
-				MetricID:     m.MetricID,
+				MetricID:     m.MetricId,
 				SQLText:      deltaSQL,
 				RowCount:     deltaResult.RowCount,
 				DurationMs:   deltaResult.Duration.Milliseconds(),
 				JobType:      "delta_method",
 			}); err != nil {
-				return nil, fmt.Errorf("jobs: log delta method query for %s: %w", m.MetricID, err)
+				return nil, fmt.Errorf("jobs: log delta method query for %s: %w", m.MetricId, err)
 			}
 
 			slog.Info("computed delta method inputs",
 				"experiment_id", experimentID,
-				"metric_id", m.MetricID,
+				"metric_id", m.MetricId,
 				"rows", deltaResult.RowCount,
 			)
 		}
 
 		// If metric has a CUPED covariate configured and experiment has a start date,
 		// compute the pre-experiment covariate value for variance reduction.
-		if m.CupedCovariateMetricID != "" && exp.StartedAt != "" {
+		if m.CupedCovariateMetricId != "" && exp.StartedAt != "" {
 			if !isLegacyStyle(m.Type) {
 				slog.Info("skipping CUPED covariate: legacy column convention not supported for this metric type",
-					"metric_id", m.MetricID,
-					"type", m.Type,
+					"metric_id", m.MetricId,
+					"type", config.TypeShortName(m.Type),
 				)
 			} else {
-				covMetric, err := j.config.GetMetric(m.CupedCovariateMetricID)
+				covMetric, err := j.config.GetMetric(m.CupedCovariateMetricId)
 				if err != nil {
 					return nil, fmt.Errorf("jobs: resolve CUPED covariate metric %s for %s: %w",
-						m.CupedCovariateMetricID, m.MetricID, err)
+						m.CupedCovariateMetricId, m.MetricId, err)
 				}
 
 				cupedParams := params
@@ -355,31 +361,31 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 				cupedSQL, err := j.renderer.RenderCupedCovariate(cupedParams)
 				if err != nil {
-					return nil, fmt.Errorf("jobs: render CUPED covariate for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: render CUPED covariate for %s: %w", m.MetricId, err)
 				}
 
 				cupedResult, err := j.executor.ExecuteAndWrite(ctx, cupedSQL, "delta.metric_summaries")
 				if err != nil {
-					return nil, fmt.Errorf("jobs: execute CUPED covariate for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: execute CUPED covariate for %s: %w", m.MetricId, err)
 				}
 				m3metrics.SparkQueryDuration.WithLabelValues("cuped_covariate").Observe(cupedResult.Duration.Seconds())
 				m3metrics.SparkQueryRows.WithLabelValues("cuped_covariate").Observe(float64(cupedResult.RowCount))
 
 				if err := j.queryLog.Log(ctx, querylog.Entry{
 					ExperimentID: experimentID,
-					MetricID:     m.MetricID,
+					MetricID:     m.MetricId,
 					SQLText:      cupedSQL,
 					RowCount:     cupedResult.RowCount,
 					DurationMs:   cupedResult.Duration.Milliseconds(),
 					JobType:      "cuped_covariate",
 				}); err != nil {
-					return nil, fmt.Errorf("jobs: log CUPED covariate query for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: log CUPED covariate query for %s: %w", m.MetricId, err)
 				}
 
 				slog.Info("computed CUPED covariate",
 					"experiment_id", experimentID,
-					"metric_id", m.MetricID,
-					"covariate_metric_id", m.CupedCovariateMetricID,
+					"metric_id", m.MetricId,
+					"covariate_metric_id", m.CupedCovariateMetricId,
 					"rows", cupedResult.RowCount,
 				)
 			}
@@ -390,19 +396,19 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 		if exp.MLRATEEnabled && len(m.MLRATEFeatureEventTypes) > 0 && m.MLRATEModelURI != "" && exp.StartedAt != "" {
 			if !isLegacyStyle(m.Type) {
 				slog.Info("skipping MLRATE cross-fit: legacy column convention not supported for this metric type",
-					"metric_id", m.MetricID,
-					"type", m.Type,
+					"metric_id", m.MetricId,
+					"type", config.TypeShortName(m.Type),
 				)
 			} else {
 				mlrateJob := NewMLRATEJob(j.renderer, j.executor, j.queryLog)
 				mlrateResult, err := mlrateJob.Run(ctx, exp, &m, computationDate)
 				if err != nil {
-					return nil, fmt.Errorf("jobs: MLRATE cross-fit for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: MLRATE cross-fit for %s: %w", m.MetricId, err)
 				}
 
 				slog.Info("computed MLRATE cross-fitted predictions",
 					"experiment_id", experimentID,
-					"metric_id", m.MetricID,
+					"metric_id", m.MetricId,
 					"folds", mlrateResult.Folds,
 					"users_scored", mlrateResult.UsersScored,
 				)
@@ -410,11 +416,11 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 		}
 
 		// Session-level aggregation: if enabled, also compute per-session metrics.
-		if exp.SessionLevel && !m.IsQoEMetric {
+		if exp.SessionLevel && !m.IsQoeMetric {
 			if !isLegacyStyle(m.Type) {
 				slog.Info("skipping session-level metric: legacy column convention not supported for this metric type",
-					"metric_id", m.MetricID,
-					"type", m.Type,
+					"metric_id", m.MetricId,
+					"type", config.TypeShortName(m.Type),
 				)
 			} else {
 				slParams := params
@@ -422,41 +428,41 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 				slSQL, err := j.renderer.RenderSessionLevelMean(slParams)
 				if err != nil {
-					return nil, fmt.Errorf("jobs: render session-level metric for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: render session-level metric for %s: %w", m.MetricId, err)
 				}
 
 				slResult, err := j.executor.ExecuteAndWrite(ctx, slSQL, "delta.metric_summaries")
 				if err != nil {
-					return nil, fmt.Errorf("jobs: execute session-level metric for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: execute session-level metric for %s: %w", m.MetricId, err)
 				}
 				m3metrics.SparkQueryDuration.WithLabelValues("session_level_metric").Observe(slResult.Duration.Seconds())
 				m3metrics.SparkQueryRows.WithLabelValues("session_level_metric").Observe(float64(slResult.RowCount))
 
 				if err := j.queryLog.Log(ctx, querylog.Entry{
 					ExperimentID: experimentID,
-					MetricID:     m.MetricID,
+					MetricID:     m.MetricId,
 					SQLText:      slSQL,
 					RowCount:     slResult.RowCount,
 					DurationMs:   slResult.Duration.Milliseconds(),
 					JobType:      "session_level_metric",
 				}); err != nil {
-					return nil, fmt.Errorf("jobs: log session-level metric query for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: log session-level metric query for %s: %w", m.MetricId, err)
 				}
 
 				slog.Info("computed session-level metric",
 					"experiment_id", experimentID,
-					"metric_id", m.MetricID,
+					"metric_id", m.MetricId,
 					"rows", slResult.RowCount,
 				)
 			}
 		}
 
 		// Lifecycle segmentation: if enabled, also compute per-lifecycle-segment metrics.
-		if exp.LifecycleStratificationEnabled && !m.IsQoEMetric {
+		if exp.LifecycleStratificationEnabled && !m.IsQoeMetric {
 			if !isLegacyStyle(m.Type) {
 				slog.Info("skipping lifecycle metric: legacy column convention not supported for this metric type",
-					"metric_id", m.MetricID,
-					"type", m.Type,
+					"metric_id", m.MetricId,
+					"type", config.TypeShortName(m.Type),
 				)
 			} else {
 				lcParams := params
@@ -464,40 +470,40 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 				lcSQL, err := j.renderer.RenderLifecycleMean(lcParams)
 				if err != nil {
-					return nil, fmt.Errorf("jobs: render lifecycle metric for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: render lifecycle metric for %s: %w", m.MetricId, err)
 				}
 
 				lcResult, err := j.executor.ExecuteAndWrite(ctx, lcSQL, "delta.metric_summaries")
 				if err != nil {
-					return nil, fmt.Errorf("jobs: execute lifecycle metric for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: execute lifecycle metric for %s: %w", m.MetricId, err)
 				}
 				m3metrics.SparkQueryDuration.WithLabelValues("lifecycle_metric").Observe(lcResult.Duration.Seconds())
 				m3metrics.SparkQueryRows.WithLabelValues("lifecycle_metric").Observe(float64(lcResult.RowCount))
 
 				if err := j.queryLog.Log(ctx, querylog.Entry{
 					ExperimentID: experimentID,
-					MetricID:     m.MetricID,
+					MetricID:     m.MetricId,
 					SQLText:      lcSQL,
 					RowCount:     lcResult.RowCount,
 					DurationMs:   lcResult.Duration.Milliseconds(),
 					JobType:      "lifecycle_metric",
 				}); err != nil {
-					return nil, fmt.Errorf("jobs: log lifecycle metric query for %s: %w", m.MetricID, err)
+					return nil, fmt.Errorf("jobs: log lifecycle metric query for %s: %w", m.MetricId, err)
 				}
 
 				slog.Info("computed lifecycle metric",
 					"experiment_id", experimentID,
-					"metric_id", m.MetricID,
+					"metric_id", m.MetricId,
 					"rows", lcResult.RowCount,
 				)
 			}
 		}
 
-		sm.markCompleted(m.MetricID)
+		sm.markCompleted(m.MetricId)
 		slog.Info("computed metric",
 			"experiment_id", experimentID,
-			"metric_id", m.MetricID,
-			"type", m.Type,
+			"metric_id", m.MetricId,
+			"type", config.TypeShortName(m.Type),
 			"rows", result.RowCount,
 			"duration_ms", result.Duration.Milliseconds(),
 		)
@@ -512,7 +518,7 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 	// Devin BUG-0002 on #556.
 	completedMetrics := make([]config.MetricConfig, 0, len(metrics))
 	for _, m := range metrics {
-		if sm.entries[m.MetricID] == status.Completed {
+		if sm.entries[m.MetricId] == status.Completed {
 			completedMetrics = append(completedMetrics, m)
 		}
 	}
@@ -522,37 +528,37 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 		for _, m := range completedMetrics {
 			teParams := spark.TemplateParams{
 				ExperimentID:     exp.ExperimentID,
-				MetricID:         m.MetricID,
+				MetricID:         m.MetricId,
 				ComputationDate:  computationDate,
 				ControlVariantID: controlVariantID,
 			}
 
 			teSQL, err := j.renderer.RenderDailyTreatmentEffect(teParams)
 			if err != nil {
-				return nil, fmt.Errorf("jobs: render daily treatment effect for %s: %w", m.MetricID, err)
+				return nil, fmt.Errorf("jobs: render daily treatment effect for %s: %w", m.MetricId, err)
 			}
 
 			teResult, err := j.executor.ExecuteAndWrite(ctx, teSQL, "delta.daily_treatment_effects")
 			if err != nil {
-				return nil, fmt.Errorf("jobs: execute daily treatment effect for %s: %w", m.MetricID, err)
+				return nil, fmt.Errorf("jobs: execute daily treatment effect for %s: %w", m.MetricId, err)
 			}
 			m3metrics.SparkQueryDuration.WithLabelValues("daily_treatment_effect").Observe(teResult.Duration.Seconds())
 			m3metrics.SparkQueryRows.WithLabelValues("daily_treatment_effect").Observe(float64(teResult.RowCount))
 
 			if err := j.queryLog.Log(ctx, querylog.Entry{
 				ExperimentID: experimentID,
-				MetricID:     m.MetricID,
+				MetricID:     m.MetricId,
 				SQLText:      teSQL,
 				RowCount:     teResult.RowCount,
 				DurationMs:   teResult.Duration.Milliseconds(),
 				JobType:      "daily_treatment_effect",
 			}); err != nil {
-				return nil, fmt.Errorf("jobs: log daily treatment effect query for %s: %w", m.MetricID, err)
+				return nil, fmt.Errorf("jobs: log daily treatment effect query for %s: %w", m.MetricId, err)
 			}
 
 			slog.Info("computed daily treatment effect",
 				"experiment_id", experimentID,
-				"metric_id", m.MetricID,
+				"metric_id", m.MetricId,
 				"rows", teResult.RowCount,
 			)
 		}
@@ -564,9 +570,9 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 	var qoeMetrics []config.MetricConfig
 	var engagementMetrics []config.MetricConfig
 	for _, m := range completedMetrics {
-		if m.IsQoEMetric {
+		if m.IsQoeMetric {
 			qoeMetrics = append(qoeMetrics, m)
-		} else if !m.IsQoEMetric && m.Type != "RATIO" {
+		} else if !m.IsQoeMetric && m.Type != commonv1.MetricType_METRIC_TYPE_RATIO {
 			engagementMetrics = append(engagementMetrics, m)
 		}
 	}
@@ -582,19 +588,19 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 				corrSQL, err := j.renderer.RenderQoEEngagementCorrelation(corrParams)
 				if err != nil {
-					return nil, fmt.Errorf("jobs: render QoE-engagement correlation (%s × %s): %w", qm.MetricID, em.MetricID, err)
+					return nil, fmt.Errorf("jobs: render QoE-engagement correlation (%s × %s): %w", qm.MetricId, em.MetricId, err)
 				}
 
 				corrResult, err := j.executor.ExecuteAndWrite(ctx, corrSQL, "delta.daily_treatment_effects")
 				if err != nil {
-					return nil, fmt.Errorf("jobs: execute QoE-engagement correlation (%s × %s): %w", qm.MetricID, em.MetricID, err)
+					return nil, fmt.Errorf("jobs: execute QoE-engagement correlation (%s × %s): %w", qm.MetricId, em.MetricId, err)
 				}
 				m3metrics.SparkQueryDuration.WithLabelValues("qoe_engagement_correlation").Observe(corrResult.Duration.Seconds())
 				m3metrics.SparkQueryRows.WithLabelValues("qoe_engagement_correlation").Observe(float64(corrResult.RowCount))
 
 				if err := j.queryLog.Log(ctx, querylog.Entry{
 					ExperimentID: experimentID,
-					MetricID:     qm.MetricID + "×" + em.MetricID,
+					MetricID:     qm.MetricId + "×" + em.MetricId,
 					SQLText:      corrSQL,
 					RowCount:     corrResult.RowCount,
 					DurationMs:   corrResult.Duration.Milliseconds(),
@@ -605,8 +611,8 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 
 				slog.Info("computed QoE-engagement correlation",
 					"experiment_id", experimentID,
-					"qoe_metric", qm.MetricID,
-					"engagement_metric", em.MetricID,
+					"qoe_metric", qm.MetricId,
+					"engagement_metric", em.MetricId,
 					"rows", corrResult.RowCount,
 				)
 			}
@@ -635,9 +641,14 @@ func (j *StandardJob) Run(ctx context.Context, experimentID string) (*JobResult,
 // ADR-026 Phase 1 types (FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT) use
 // different column conventions and must skip post-processing until those
 // templates grow per-type variants (issue #511 option b).
-func isLegacyStyle(metricType string) bool {
-	switch strings.ToUpper(metricType) {
-	case "MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM":
+func isLegacyStyle(t commonv1.MetricType) bool {
+	switch t {
+	case commonv1.MetricType_METRIC_TYPE_MEAN,
+		commonv1.MetricType_METRIC_TYPE_PROPORTION,
+		commonv1.MetricType_METRIC_TYPE_COUNT,
+		commonv1.MetricType_METRIC_TYPE_RATIO,
+		commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+		commonv1.MetricType_METRIC_TYPE_CUSTOM:
 		return true
 	}
 	return false
@@ -692,7 +703,7 @@ func (j *StandardJob) flushStatus(
 // not "skipped".
 func markUnvisitedDependentsAsSkipped(sortedMetrics []*config.MetricConfig, sm *statusMap) {
 	for _, mPtr := range sortedMetrics {
-		if _, recorded := sm.entries[mPtr.MetricID]; recorded {
+		if _, recorded := sm.entries[mPtr.MetricId]; recorded {
 			// Already Completed / Failed / SkippedUpstreamFailure / SkippedCycle.
 			continue
 		}
@@ -701,7 +712,7 @@ func markUnvisitedDependentsAsSkipped(sortedMetrics []*config.MetricConfig, sm *
 			// METRICQL parse failure encountered here would normally already
 			// be recorded via the pre-loop pre-mark from failedParse; if not,
 			// surface it as Failed (defense-in-depth).
-			sm.markFailed(mPtr.MetricID, "metricql: parse: "+err.Error())
+			sm.markFailed(mPtr.MetricId, "metricql: parse: "+err.Error())
 			continue
 		}
 		if len(refs) == 0 {
@@ -709,23 +720,23 @@ func markUnvisitedDependentsAsSkipped(sortedMetrics []*config.MetricConfig, sm *
 			continue
 		}
 		if blocker := sm.blockerForRefs(refs); blocker != "" {
-			sm.markSkippedUpstream(mPtr.MetricID, blocker)
+			sm.markSkippedUpstream(mPtr.MetricId, blocker)
 		}
 	}
 }
 
-// toSparkOperands converts config-layer OperandConfig values to the
+// toSparkOperands converts proto-direct CompositeOperand values to the
 // spark.OperandParam shape consumed by the renderer's composite template.
 // Returns nil for an empty/nil input (matches Go's zero-value convention).
-func toSparkOperands(in []config.OperandConfig) []spark.OperandParam {
+func toSparkOperands(in []*commonv1.CompositeOperand) []spark.OperandParam {
 	if len(in) == 0 {
 		return nil
 	}
 	out := make([]spark.OperandParam, len(in))
 	for i, op := range in {
 		out[i] = spark.OperandParam{
-			MetricID: op.MetricID,
-			Weight:   op.Weight,
+			MetricID: op.GetMetricId(),
+			Weight:   op.GetWeight(),
 		}
 	}
 	return out

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/org/experimentation-platform/services/metrics/internal/querylog"
 	"github.com/org/experimentation-platform/services/metrics/internal/spark"
 	"github.com/org/experimentation-platform/services/metrics/internal/status"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 func setupTestJob(t *testing.T) (*StandardJob, *spark.MockExecutor, *querylog.MemWriter, *status.MockWriter) {
@@ -438,31 +439,33 @@ func TestStandardJob_Run_AllExperimentsWithExposureJoin(t *testing.T) {
 
 func TestIsLegacyStyle(t *testing.T) {
 	t.Run("legacy types return true", func(t *testing.T) {
-		legacy := []string{
-			"MEAN", "PROPORTION", "COUNT", "RATIO", "PERCENTILE", "CUSTOM",
-			"mean", "proportion", "count", "ratio", "percentile", "custom",
-			"Custom", "Ratio",
+		legacy := []commonv1.MetricType{
+			commonv1.MetricType_METRIC_TYPE_MEAN,
+			commonv1.MetricType_METRIC_TYPE_PROPORTION,
+			commonv1.MetricType_METRIC_TYPE_COUNT,
+			commonv1.MetricType_METRIC_TYPE_RATIO,
+			commonv1.MetricType_METRIC_TYPE_PERCENTILE,
+			commonv1.MetricType_METRIC_TYPE_CUSTOM,
 		}
 		for _, mt := range legacy {
-			assert.True(t, isLegacyStyle(mt), "%q should be legacy", mt)
+			assert.True(t, isLegacyStyle(mt), "%v should be legacy", mt)
 		}
 	})
 
-	t.Run("ADR-026 Phase 1 types return false", func(t *testing.T) {
-		nonLegacy := []string{
-			"FILTERED_MEAN", "COMPOSITE", "WINDOWED_COUNT",
-			"filtered_mean", "composite", "windowed_count",
+	t.Run("ADR-026 Phase 1 + Phase 2 types return false", func(t *testing.T) {
+		nonLegacy := []commonv1.MetricType{
+			commonv1.MetricType_METRIC_TYPE_FILTERED_MEAN,
+			commonv1.MetricType_METRIC_TYPE_COMPOSITE,
+			commonv1.MetricType_METRIC_TYPE_WINDOWED_COUNT,
+			commonv1.MetricType_METRIC_TYPE_METRICQL,
 		}
 		for _, mt := range nonLegacy {
-			assert.False(t, isLegacyStyle(mt), "%q should not be legacy", mt)
+			assert.False(t, isLegacyStyle(mt), "%v should not be legacy", mt)
 		}
 	})
 
-	t.Run("unknown types return false", func(t *testing.T) {
-		unknown := []string{"", " ", "UNKNOWN_TYPE", "FOO_BAR"}
-		for _, mt := range unknown {
-			assert.False(t, isLegacyStyle(mt), "%q should not be legacy", mt)
-		}
+	t.Run("unspecified returns false", func(t *testing.T) {
+		assert.False(t, isLegacyStyle(commonv1.MetricType_METRIC_TYPE_UNSPECIFIED))
 	})
 }
 
@@ -608,18 +611,20 @@ func TestStandardJob_Run_FailFastStillMarksDownstreamComposite(t *testing.T) {
 			{
 				"metric_id": "op_a",
 				"name": "Operand A (MEAN)",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "heartbeat"
 			},
 			{
 				"metric_id": "comp_b",
 				"name": "Downstream composite",
-				"type": "COMPOSITE",
+				"type": "METRIC_TYPE_COMPOSITE",
 				"source_event_type": "n/a",
-				"operator": "WEIGHTED_SUM",
-				"operands": [
-					{"metric_id": "op_a", "weight": 1.0}
-				]
+				"composite": {
+					"operator": "COMPOSITE_OPERATOR_WEIGHTED_SUM",
+					"operands": [
+						{"metric_id": "op_a", "weight": 1.0}
+					]
+				}
 			}
 		]
 	}`
@@ -701,20 +706,20 @@ func TestStandardJob_Run_MetricqlRunsAfterRefs(t *testing.T) {
 			{
 				"metric_id": "watch_time",
 				"name": "Watch time (MEAN)",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "heartbeat",
 				"value_column": "value"
 			},
 			{
 				"metric_id": "ctr",
 				"name": "Click-through rate (PROPORTION)",
-				"type": "PROPORTION",
+				"type": "METRIC_TYPE_PROPORTION",
 				"source_event_type": "click"
 			},
 			{
 				"metric_id": "engagement",
 				"name": "Engagement index (METRICQL)",
-				"type": "METRICQL",
+				"type": "METRIC_TYPE_METRICQL",
 				"source_event_type": "n/a",
 				"metricql_expression": "0.7 * @watch_time + 0.3 * @ctr"
 			}
@@ -800,7 +805,7 @@ func TestStandardJob_Run_MetricqlParseFailureMarksFailed(t *testing.T) {
 			{
 				"metric_id": "bad_metric",
 				"name": "Malformed expression",
-				"type": "METRICQL",
+				"type": "METRIC_TYPE_METRICQL",
 				"source_event_type": "n/a",
 				"metricql_expression": "mean(x"
 			}
@@ -898,21 +903,21 @@ func TestStandardJob_Run_MetricqlSkippedOnFailingRef(t *testing.T) {
 			{
 				"metric_id": "ok_metric",
 				"name": "OK operand",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "heartbeat",
 				"value_column": "value"
 			},
 			{
 				"metric_id": "failing_metric",
 				"name": "Operand that fails at exec",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "click",
 				"value_column": "value"
 			},
 			{
 				"metric_id": "weighted",
 				"name": "Weighted blend (METRICQL)",
-				"type": "METRICQL",
+				"type": "METRIC_TYPE_METRICQL",
 				"source_event_type": "n/a",
 				"metricql_expression": "0.7 * @failing_metric + 0.3 * @ok_metric"
 			}
@@ -1000,28 +1005,28 @@ func TestStandardJob_Run_MetricqlChainSkipPropagation(t *testing.T) {
 			{
 				"metric_id": "ok_metric",
 				"name": "OK operand",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "heartbeat",
 				"value_column": "value"
 			},
 			{
 				"metric_id": "failing_metric",
 				"name": "Operand that fails at exec",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "click",
 				"value_column": "value"
 			},
 			{
 				"metric_id": "weighted",
 				"name": "Weighted blend (METRICQL)",
-				"type": "METRICQL",
+				"type": "METRIC_TYPE_METRICQL",
 				"source_event_type": "n/a",
 				"metricql_expression": "0.7 * @failing_metric + 0.3 * @ok_metric"
 			},
 			{
 				"metric_id": "meta",
 				"name": "Meta METRICQL referencing weighted",
-				"type": "METRICQL",
+				"type": "METRIC_TYPE_METRICQL",
 				"source_event_type": "n/a",
 				"metricql_expression": "@weighted * 2"
 			}
@@ -1104,26 +1109,28 @@ func TestStandardJob_Run_CompositeRunsAfterOperands(t *testing.T) {
 			{
 				"metric_id": "session_score",
 				"name": "Session score (MEAN)",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "session_end",
 				"value_column": "session_score"
 			},
 			{
 				"metric_id": "click_rate",
 				"name": "Click rate (PROPORTION)",
-				"type": "PROPORTION",
+				"type": "METRIC_TYPE_PROPORTION",
 				"source_event_type": "click"
 			},
 			{
 				"metric_id": "engagement_index",
 				"name": "Engagement index (COMPOSITE)",
-				"type": "COMPOSITE",
+				"type": "METRIC_TYPE_COMPOSITE",
 				"source_event_type": "n/a",
-				"operator": "WEIGHTED_SUM",
-				"operands": [
-					{"metric_id": "session_score", "weight": 0.6},
-					{"metric_id": "click_rate", "weight": 0.4}
-				]
+				"composite": {
+					"operator": "COMPOSITE_OPERATOR_WEIGHTED_SUM",
+					"operands": [
+						{"metric_id": "session_score", "weight": 0.6},
+						{"metric_id": "click_rate", "weight": 0.4}
+					]
+				}
 			}
 		]
 	}`
@@ -1225,20 +1232,22 @@ func TestStandardJob_Run_SkippedCompositeDoesNotPostProcess(t *testing.T) {
 			{
 				"metric_id": "session_score",
 				"name": "Session score (MEAN)",
-				"type": "MEAN",
+				"type": "METRIC_TYPE_MEAN",
 				"source_event_type": "session_end",
 				"value_column": "session_score"
 			},
 			{
 				"metric_id": "engagement_index",
 				"name": "Engagement (COMPOSITE, operands OUT of pass)",
-				"type": "COMPOSITE",
+				"type": "METRIC_TYPE_COMPOSITE",
 				"source_event_type": "n/a",
-				"operator": "WEIGHTED_SUM",
-				"operands": [
-					{"metric_id": "watch_time_minutes", "weight": 0.6},
-					{"metric_id": "stream_start_rate", "weight": 0.4}
-				]
+				"composite": {
+					"operator": "COMPOSITE_OPERATOR_WEIGHTED_SUM",
+					"operands": [
+						{"metric_id": "watch_time_minutes", "weight": 0.6},
+						{"metric_id": "stream_start_rate", "weight": 0.4}
+					]
+				}
 			}
 		]
 	}`

--- a/services/metrics/internal/jobs/standard_test.go
+++ b/services/metrics/internal/jobs/standard_test.go
@@ -707,8 +707,7 @@ func TestStandardJob_Run_MetricqlRunsAfterRefs(t *testing.T) {
 				"metric_id": "watch_time",
 				"name": "Watch time (MEAN)",
 				"type": "METRIC_TYPE_MEAN",
-				"source_event_type": "heartbeat",
-				"value_column": "value"
+				"source_event_type": "heartbeat"
 			},
 			{
 				"metric_id": "ctr",
@@ -904,15 +903,13 @@ func TestStandardJob_Run_MetricqlSkippedOnFailingRef(t *testing.T) {
 				"metric_id": "ok_metric",
 				"name": "OK operand",
 				"type": "METRIC_TYPE_MEAN",
-				"source_event_type": "heartbeat",
-				"value_column": "value"
+				"source_event_type": "heartbeat"
 			},
 			{
 				"metric_id": "failing_metric",
 				"name": "Operand that fails at exec",
 				"type": "METRIC_TYPE_MEAN",
-				"source_event_type": "click",
-				"value_column": "value"
+				"source_event_type": "click"
 			},
 			{
 				"metric_id": "weighted",
@@ -1006,15 +1003,13 @@ func TestStandardJob_Run_MetricqlChainSkipPropagation(t *testing.T) {
 				"metric_id": "ok_metric",
 				"name": "OK operand",
 				"type": "METRIC_TYPE_MEAN",
-				"source_event_type": "heartbeat",
-				"value_column": "value"
+				"source_event_type": "heartbeat"
 			},
 			{
 				"metric_id": "failing_metric",
 				"name": "Operand that fails at exec",
 				"type": "METRIC_TYPE_MEAN",
-				"source_event_type": "click",
-				"value_column": "value"
+				"source_event_type": "click"
 			},
 			{
 				"metric_id": "weighted",

--- a/services/metrics/internal/jobs/status_map.go
+++ b/services/metrics/internal/jobs/status_map.go
@@ -1,8 +1,8 @@
 package jobs
 
 import (
-	"github.com/org/experimentation-platform/services/metrics/internal/config"
 	"github.com/org/experimentation-platform/services/metrics/internal/status"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 // statusMap tracks the per-metric outcome for one scheduling pass (one experiment
@@ -53,11 +53,11 @@ func (s *statusMap) markSkippedCycle(id string) {
 // COMPOSITE) are treated as blockers — the caller has iterated in topo order so
 // every operand within the pass will already have a recorded status by the time
 // the dependent COMPOSITE is evaluated.
-func (s *statusMap) blockerFor(operands []config.OperandConfig) (string, bool) {
+func (s *statusMap) blockerFor(operands []*commonv1.CompositeOperand) (string, bool) {
 	for _, op := range operands {
-		st, ok := s.entries[op.MetricID]
+		st, ok := s.entries[op.GetMetricId()]
 		if !ok || st != status.Completed {
-			return op.MetricID, true
+			return op.GetMetricId(), true
 		}
 	}
 	return "", false

--- a/services/metrics/internal/jobs/status_map_test.go
+++ b/services/metrics/internal/jobs/status_map_test.go
@@ -3,8 +3,8 @@ package jobs
 import (
 	"testing"
 
-	"github.com/org/experimentation-platform/services/metrics/internal/config"
 	"github.com/org/experimentation-platform/services/metrics/internal/status"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 func TestStatusMap_BlockerForOperands(t *testing.T) {
@@ -13,9 +13,9 @@ func TestStatusMap_BlockerForOperands(t *testing.T) {
 	sm.markFailed("ctr", "spark timeout")
 
 	// engagement_score depends on watch_time (completed) + ctr (failed).
-	operands := []config.OperandConfig{
-		{MetricID: "watch_time", Weight: 1.0},
-		{MetricID: "ctr", Weight: 1.0},
+	operands := []*commonv1.CompositeOperand{
+		{MetricId: "watch_time", Weight: 1.0},
+		{MetricId: "ctr", Weight: 1.0},
 	}
 	blocker, ok := sm.blockerFor(operands)
 	if !ok {
@@ -30,7 +30,7 @@ func TestStatusMap_NoBlockerWhenAllCompleted(t *testing.T) {
 	sm := newStatusMap()
 	sm.markCompleted("a")
 	sm.markCompleted("b")
-	_, ok := sm.blockerFor([]config.OperandConfig{{MetricID: "a"}, {MetricID: "b"}})
+	_, ok := sm.blockerFor([]*commonv1.CompositeOperand{{MetricId: "a"}, {MetricId: "b"}})
 	if ok {
 		t.Fatalf("expected no blocker")
 	}
@@ -41,7 +41,7 @@ func TestStatusMap_OperandNotYetRunIsBlocker(t *testing.T) {
 	// dependent. The caller must have iterated in topo order so this case = upstream not in pass.
 	sm := newStatusMap()
 	sm.markCompleted("a")
-	blocker, ok := sm.blockerFor([]config.OperandConfig{{MetricID: "a"}, {MetricID: "missing"}})
+	blocker, ok := sm.blockerFor([]*commonv1.CompositeOperand{{MetricId: "a"}, {MetricId: "missing"}})
 	if !ok || blocker != "missing" {
 		t.Fatalf("expected blocker=missing, got blocker=%q ok=%v", blocker, ok)
 	}

--- a/services/metrics/internal/jobs/testdata/e2e_pipeline_config.json
+++ b/services/metrics/internal/jobs/testdata/e2e_pipeline_config.json
@@ -76,19 +76,19 @@
     {
       "metric_id": "watch_time_minutes",
       "name": "Watch Time (minutes)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "heartbeat"
     },
     {
       "metric_id": "stream_start_rate",
       "name": "Stream Start Rate",
-      "type": "PROPORTION",
+      "type": "METRIC_TYPE_PROPORTION",
       "source_event_type": "stream_start"
     },
     {
       "metric_id": "ttff_mean",
       "name": "Time to First Frame (mean)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "qoe_playback",
       "is_qoe_metric": true,
       "qoe_field": "time_to_first_frame_ms",
@@ -97,7 +97,7 @@
     {
       "metric_id": "rebuffer_ratio_mean",
       "name": "Rebuffer Ratio (mean)",
-      "type": "MEAN",
+      "type": "METRIC_TYPE_MEAN",
       "source_event_type": "qoe_playback",
       "is_qoe_metric": true,
       "qoe_field": "rebuffer_ratio",

--- a/services/metrics/internal/m3m5_wire_format_contract_test.go
+++ b/services/metrics/internal/m3m5_wire_format_contract_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/org/experimentation-platform/services/metrics/internal/config"
+	commonv1 "github.com/org/experimentation/gen/go/experimentation/common/v1"
 )
 
 // ---------------------------------------------------------------------------
@@ -225,32 +226,41 @@ func TestM3M5_ExperimentConfig_FieldCompleteness(t *testing.T) {
 
 // TestM3M5_MetricConfig_FieldCompleteness verifies that every field M3's
 // MetricConfig uses has a corresponding field in M5's MetricDefinition wire format.
+//
+// Since #506 M3 embeds *commonv1.MetricDefinition, so the proto-generated JSON
+// tags (snake_case, including the oneof TypeConfig arms) appear in extractJSONTags
+// alongside the four M3-only sibling fields (qoe_field, mlrate_*).
 func TestM3M5_MetricConfig_FieldCompleteness(t *testing.T) {
 	m3ToM5 := map[string]string{
+		// Proto fields (auto-mirrored via embed):
 		"metric_id":                  "metricId",
 		"name":                       "name",
+		"description":                "description",
 		"type":                       "type",
 		"source_event_type":          "sourceEventType",
 		"numerator_event_type":       "numeratorEventType",
 		"denominator_event_type":     "denominatorEventType",
-		"cuped_covariate_metric_id":  "cupedCovariateMetricId",
 		"percentile":                 "percentile",
-		"lower_is_better":            "lowerIsBetter",
-		"is_qoe_metric":              "isQoeMetric",
-		"qoe_field":                  "", // M3-only; not in M5 proto (derived from source_event_type)
 		"custom_sql":                 "customSql",
+		"lower_is_better":            "lowerIsBetter",
+		"surrogate_target_metric_id": "surrogateTargetMetricId",
+		"is_qoe_metric":              "isQoeMetric",
+		"cuped_covariate_metric_id":  "cupedCovariateMetricId",
+		"minimum_detectable_effect":  "minimumDetectableEffect",
+		"stakeholder":                "stakeholder",
+		"aggregation_level":          "aggregationLevel",
+		// ADR-026 Phase 1 — oneof type_config arms (protojson snake_case tags).
+		"filtered_mean":  "filteredMean",
+		"composite":      "composite",
+		"windowed_count": "windowedCount",
+		// ADR-026 Phase 2 — METRICQL expression source text.
+		"metricql_expression": "metricqlExpression",
+
+		// M3-only sibling fields (not in proto):
+		"qoe_field":                  "", // M3-only; not in M5 proto (derived from source_event_type)
 		"mlrate_feature_event_types": "mlrateConfig.featureEventTypes",
 		"mlrate_model_uri":           "mlrateConfig.modelUri",
 		"mlrate_lookback_days":       "mlrateConfig.lookbackDays",
-		// ADR-026 Phase 1 — new-type fields map to protojson oneof type_config branches.
-		"filter_sql":   "filteredMean.filterSql",    // FilteredMeanConfig.filter_sql
-		"value_column": "filteredMean.valueColumn",  // FilteredMeanConfig.value_column
-		"operands":     "composite.operands",        // CompositeConfig.operands
-		"operator":     "composite.operator",        // CompositeConfig.operator
-		"event_type":   "windowedCount.eventType",   // WindowedCountConfig.event_type
-		"window_hours": "windowedCount.windowHours", // WindowedCountConfig.window_hours
-		// ADR-026 Phase 2 (#435) — METRICQL expression source text.
-		"metricql_expression": "metricqlExpression", // MetricDefinition.metricql_expression (field 20)
 	}
 
 	m3Tags := extractJSONTags(reflect.TypeOf(config.MetricConfig{}))
@@ -523,7 +533,7 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 	cases := []struct {
 		name     string
 		wire     m5WireMetricDefinition
-		wantType string
+		wantType commonv1.MetricType
 	}{
 		{
 			name: "MEAN",
@@ -531,7 +541,7 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 				MetricID: "watch_time", Name: "Watch Time", Type: "METRIC_TYPE_MEAN",
 				SourceEventType: "heartbeat", CupedCovariateMetricID: "watch_time",
 			},
-			wantType: "MEAN",
+			wantType: commonv1.MetricType_METRIC_TYPE_MEAN,
 		},
 		{
 			name: "PROPORTION",
@@ -539,7 +549,7 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 				MetricID: "ctr", Name: "CTR", Type: "METRIC_TYPE_PROPORTION",
 				SourceEventType: "impression",
 			},
-			wantType: "PROPORTION",
+			wantType: commonv1.MetricType_METRIC_TYPE_PROPORTION,
 		},
 		{
 			name: "RATIO",
@@ -548,7 +558,7 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 				NumeratorEventType: "rebuffer_event", DenominatorEventType: "playback_minute",
 				LowerIsBetter: true,
 			},
-			wantType: "RATIO",
+			wantType: commonv1.MetricType_METRIC_TYPE_RATIO,
 		},
 		{
 			name: "COUNT",
@@ -556,7 +566,7 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 				MetricID: "sessions", Name: "Sessions", Type: "METRIC_TYPE_COUNT",
 				SourceEventType: "session_start",
 			},
-			wantType: "COUNT",
+			wantType: commonv1.MetricType_METRIC_TYPE_COUNT,
 		},
 		{
 			name: "PERCENTILE",
@@ -564,7 +574,7 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 				MetricID: "latency_p50", Name: "Latency p50", Type: "METRIC_TYPE_PERCENTILE",
 				SourceEventType: "playback_start", Percentile: 0.50, LowerIsBetter: true,
 			},
-			wantType: "PERCENTILE",
+			wantType: commonv1.MetricType_METRIC_TYPE_PERCENTILE,
 		},
 		{
 			name: "CUSTOM",
@@ -572,7 +582,7 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 				MetricID: "power_users", Name: "Power Users", Type: "METRIC_TYPE_CUSTOM",
 				CustomSQL: "SELECT user_id, AVG(value) FROM events GROUP BY user_id HAVING COUNT(*) >= 10",
 			},
-			wantType: "CUSTOM",
+			wantType: commonv1.MetricType_METRIC_TYPE_CUSTOM,
 		},
 	}
 
@@ -580,8 +590,8 @@ func TestM3M5_MetricWireToConfig_AllTypes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m3 := m5MetricToConfig(tc.wire)
 			assert.Equal(t, tc.wantType, m3.Type,
-				"metric type must be stripped of METRIC_TYPE_ prefix")
-			assert.Equal(t, tc.wire.MetricID, m3.MetricID)
+				"metric type must round-trip into the proto enum")
+			assert.Equal(t, tc.wire.MetricID, m3.MetricId)
 			assert.Equal(t, tc.wire.Name, m3.Name)
 			assert.Equal(t, tc.wire.LowerIsBetter, m3.LowerIsBetter)
 		})
@@ -630,15 +640,14 @@ func TestM3M5_WireFormat_FilteredMean(t *testing.T) {
 	assert.Nil(t, decoded.Composite, "non-active oneof arms must remain nil")
 	assert.Nil(t, decoded.WindowedCount, "non-active oneof arms must remain nil")
 
-	// Flatten into M3's config view and assert the conversion picked up
-	// both new fields under their snake_case M3 names.
+	// Build M3's proto-direct view and assert the oneof FilteredMean payload survives.
 	m3 := m5MetricToConfig(decoded)
-	assert.Equal(t, "FILTERED_MEAN", m3.Type,
-		"M3 strips METRIC_TYPE_ prefix from FILTERED_MEAN as for legacy types")
-	assert.Equal(t, "platform = 'mobile' AND duration_ms > 5000", m3.FilterSQL,
-		"M3 MetricConfig.filter_sql must be populated from the oneof arm")
-	assert.Equal(t, "duration_ms", m3.ValueColumn,
-		"M3 MetricConfig.value_column must be populated from the oneof arm")
+	assert.Equal(t, commonv1.MetricType_METRIC_TYPE_FILTERED_MEAN, m3.Type,
+		"M3 MetricConfig.Type retains the proto enum (no string stripping)")
+	assert.Equal(t, "platform = 'mobile' AND duration_ms > 5000", m3.GetFilteredMean().GetFilterSql(),
+		"FilteredMean.filter_sql must be populated from the oneof arm")
+	assert.Equal(t, "duration_ms", m3.GetFilteredMean().GetValueColumn(),
+		"FilteredMean.value_column must be populated from the oneof arm")
 	assert.Equal(t, "playback_heartbeat", m3.SourceEventType,
 		"FILTERED_MEAN still needs source_event_type to identify the scan table")
 }
@@ -681,17 +690,18 @@ func TestM3M5_WireFormat_Composite(t *testing.T) {
 	assert.Nil(t, decoded.FilteredMean, "non-active oneof arms must remain nil")
 	assert.Nil(t, decoded.WindowedCount, "non-active oneof arms must remain nil")
 
-	// Flatten into M3's config view.
+	// Build M3's proto-direct view.
 	m3 := m5MetricToConfig(decoded)
-	assert.Equal(t, "COMPOSITE", m3.Type)
-	assert.Equal(t, "WEIGHTED_SUM", m3.Operator,
-		"M3 strips COMPOSITE_OPERATOR_ prefix to match the renderer's switch arms")
-	require.Len(t, m3.Operands, 2,
-		"M3 MetricConfig.operands must mirror the wire-format array length")
-	assert.Equal(t, "watch_time_minutes", m3.Operands[0].MetricID)
-	assert.InDelta(t, 0.7, m3.Operands[0].Weight, 1e-9)
-	assert.Equal(t, "completion_rate", m3.Operands[1].MetricID)
-	assert.InDelta(t, 0.3, m3.Operands[1].Weight, 1e-9)
+	assert.Equal(t, commonv1.MetricType_METRIC_TYPE_COMPOSITE, m3.Type)
+	assert.Equal(t, commonv1.CompositeOperator_COMPOSITE_OPERATOR_WEIGHTED_SUM, m3.GetComposite().GetOperator(),
+		"Composite.operator round-trips as proto enum")
+	operands := m3.GetComposite().GetOperands()
+	require.Len(t, operands, 2,
+		"M3 MetricConfig.composite.operands must mirror the wire-format array length")
+	assert.Equal(t, "watch_time_minutes", operands[0].GetMetricId())
+	assert.InDelta(t, 0.7, operands[0].GetWeight(), 1e-9)
+	assert.Equal(t, "completion_rate", operands[1].GetMetricId())
+	assert.InDelta(t, 0.3, operands[1].GetWeight(), 1e-9)
 }
 
 // TestM3M5_WireFormat_WindowedCount verifies a WINDOWED_COUNT metric
@@ -727,15 +737,15 @@ func TestM3M5_WireFormat_WindowedCount(t *testing.T) {
 	assert.Nil(t, decoded.FilteredMean, "non-active oneof arms must remain nil")
 	assert.Nil(t, decoded.Composite, "non-active oneof arms must remain nil")
 
-	// Flatten into M3's config view.
+	// Build M3's proto-direct view.
 	m3 := m5MetricToConfig(decoded)
-	assert.Equal(t, "WINDOWED_COUNT", m3.Type)
-	assert.Equal(t, "trial_signup", m3.EventType,
-		"M3 MetricConfig.event_type (distinct from source_event_type)")
-	assert.Equal(t, "country = 'US'", m3.FilterSQL,
-		"M3 MetricConfig.filter_sql is shared between FILTERED_MEAN and WINDOWED_COUNT")
-	assert.Equal(t, int32(168), m3.WindowHours,
-		"M3 MetricConfig.window_hours must preserve the int32 from the wire")
+	assert.Equal(t, commonv1.MetricType_METRIC_TYPE_WINDOWED_COUNT, m3.Type)
+	assert.Equal(t, "trial_signup", m3.GetWindowedCount().GetEventType(),
+		"WindowedCount.event_type (distinct from source_event_type)")
+	assert.Equal(t, "country = 'US'", m3.GetWindowedCount().GetFilterSql(),
+		"WindowedCount.filter_sql lives on its own oneof arm")
+	assert.Equal(t, int32(168), m3.GetWindowedCount().GetWindowHours(),
+		"WindowedCount.window_hours must preserve the int32 from the wire")
 }
 
 // TestM3M5_MetricWireToConfig_RatioFields verifies RATIO-specific fields map correctly.
@@ -767,7 +777,7 @@ func TestM3M5_MetricWireToConfig_QoEFields(t *testing.T) {
 	}
 
 	m3 := m5MetricToConfig(wire)
-	assert.Equal(t, true, m3.IsQoEMetric)
+	assert.Equal(t, true, m3.IsQoeMetric)
 	assert.Equal(t, true, m3.LowerIsBetter)
 	assert.Equal(t, "qoe_playback", m3.SourceEventType)
 }
@@ -783,7 +793,7 @@ func TestM3M5_MetricWireToConfig_CupedCovariate(t *testing.T) {
 	}
 
 	m3 := m5MetricToConfig(wire)
-	assert.Equal(t, "watch_time", m3.CupedCovariateMetricID,
+	assert.Equal(t, "watch_time", m3.CupedCovariateMetricId,
 		"CUPED covariate metric ID must be preserved")
 }
 
@@ -966,7 +976,10 @@ func TestM3M5_TimestampFormat_RFC3339(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestM3M5_SeedConfig_EnumsAreShort verifies that M3's current seed config
-// uses short enum strings (not prefixed), documenting the conversion requirement.
+// uses short enum strings for experiment-side fields (Experiment.Type, State,
+// GuardrailAction) and the proto-direct METRIC_TYPE_* enum for MetricConfig
+// (since #506 — MetricConfig embeds *commonv1.MetricDefinition, so seed JSON
+// carries the prefixed protojson form).
 func TestM3M5_SeedConfig_EnumsAreShort(t *testing.T) {
 	cs, err := config.LoadFromFile("config/testdata/seed_config.json")
 	require.NoError(t, err)
@@ -983,8 +996,8 @@ func TestM3M5_SeedConfig_EnumsAreShort(t *testing.T) {
 
 	metric, err := cs.GetMetric("rebuffer_rate")
 	require.NoError(t, err)
-	assert.Equal(t, "RATIO", metric.Type,
-		"M3 config uses short 'RATIO', not M5's 'METRIC_TYPE_RATIO'")
+	assert.Equal(t, commonv1.MetricType_METRIC_TYPE_RATIO, metric.Type,
+		"M3 MetricConfig.Type is the proto-direct typed enum")
 }
 
 // TestM3M5_SeedConfig_RunningFilter verifies M3's RunningExperimentIDs filter
@@ -1119,44 +1132,53 @@ func m5ExperimentToConfig(m5 m5WireExperiment) config.ExperimentConfig {
 }
 
 func m5MetricToConfig(m5 m5WireMetricDefinition) config.MetricConfig {
-	cfg := config.MetricConfig{
-		MetricID:               m5.MetricID,
+	// Since #506 the proto fields live on the embedded MetricDefinition.
+	// Map enum strings back to typed enums; sibling fields keep their slots.
+	md := &commonv1.MetricDefinition{
+		MetricId:               m5.MetricID,
 		Name:                   m5.Name,
-		Type:                   stripEnumPrefix(m5.Type, m5MetricTypePrefix),
+		Type:                   commonv1.MetricType(commonv1.MetricType_value[m5.Type]),
 		SourceEventType:        m5.SourceEventType,
 		NumeratorEventType:     m5.NumeratorEventType,
 		DenominatorEventType:   m5.DenominatorEventType,
-		CupedCovariateMetricID: m5.CupedCovariateMetricID,
+		CupedCovariateMetricId: m5.CupedCovariateMetricID,
 		Percentile:             m5.Percentile,
 		LowerIsBetter:          m5.LowerIsBetter,
-		IsQoEMetric:            m5.IsQoEMetric,
-		CustomSQL:              m5.CustomSQL,
+		IsQoeMetric:            m5.IsQoEMetric,
+		CustomSql:              m5.CustomSQL,
 	}
 
-	// ADR-026 Phase 1 — flatten the oneof type_config into M3's flat fields.
+	// ADR-026 Phase 1 — preserve oneof type_config arms directly on the proto.
 	if m5.FilteredMean != nil {
-		cfg.FilterSQL = m5.FilteredMean.FilterSQL
-		cfg.ValueColumn = m5.FilteredMean.ValueColumn
+		md.TypeConfig = &commonv1.MetricDefinition_FilteredMean{
+			FilteredMean: &commonv1.FilteredMeanConfig{
+				FilterSql:   m5.FilteredMean.FilterSQL,
+				ValueColumn: m5.FilteredMean.ValueColumn,
+			},
+		}
 	}
 	if m5.Composite != nil {
-		cfg.Operator = stripEnumPrefix(m5.Composite.Operator, m5CompositeOperatorPrefix)
-		for _, op := range m5.Composite.Operands {
-			cfg.Operands = append(cfg.Operands, config.OperandConfig{
-				MetricID: op.MetricID,
-				Weight:   op.Weight,
-			})
+		operands := make([]*commonv1.CompositeOperand, len(m5.Composite.Operands))
+		for i, op := range m5.Composite.Operands {
+			operands[i] = &commonv1.CompositeOperand{MetricId: op.MetricID, Weight: op.Weight}
+		}
+		md.TypeConfig = &commonv1.MetricDefinition_Composite{
+			Composite: &commonv1.CompositeConfig{
+				Operands: operands,
+				Operator: commonv1.CompositeOperator(commonv1.CompositeOperator_value[m5.Composite.Operator]),
+			},
 		}
 	}
 	if m5.WindowedCount != nil {
-		cfg.EventType = m5.WindowedCount.EventType
-		cfg.WindowHours = m5.WindowedCount.WindowHours
-		// WindowedCountConfig.filter_sql shares M3's flat filter_sql column.
-		if m5.WindowedCount.FilterSQL != "" {
-			cfg.FilterSQL = m5.WindowedCount.FilterSQL
+		md.TypeConfig = &commonv1.MetricDefinition_WindowedCount{
+			WindowedCount: &commonv1.WindowedCountConfig{
+				EventType:   m5.WindowedCount.EventType,
+				FilterSql:   m5.WindowedCount.FilterSQL,
+				WindowHours: m5.WindowedCount.WindowHours,
+			},
 		}
 	}
-
-	return cfg
+	return config.MetricConfig{MetricDefinition: md}
 }
 
 func m5SurrogateToConfig(m5 m5WireSurrogateModel) config.SurrogateModelConfig {
@@ -1172,11 +1194,25 @@ func m5SurrogateToConfig(m5 m5WireSurrogateModel) config.SurrogateModelConfig {
 	}
 }
 
-// extractJSONTags returns all JSON field names (without options like omitempty) from a struct type.
+// extractJSONTags returns all JSON field names (without options like omitempty)
+// from a struct type. Walks anonymous-embedded structs (and pointers to them)
+// so that MetricConfig — which now embeds *commonv1.MetricDefinition — exposes
+// the proto-generated JSON tags alongside its own M3-only tags (issue #506).
 func extractJSONTags(t reflect.Type) []string {
 	var tags []string
 	for i := 0; i < t.NumField(); i++ {
-		tag := t.Field(i).Tag.Get("json")
+		f := t.Field(i)
+		if f.Anonymous {
+			ft := f.Type
+			if ft.Kind() == reflect.Ptr {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Struct {
+				tags = append(tags, extractJSONTags(ft)...)
+				continue
+			}
+		}
+		tag := f.Tag.Get("json")
 		if tag == "" || tag == "-" {
 			continue
 		}


### PR DESCRIPTION
## Summary

Refactors M3's runtime `MetricConfig` (`services/metrics/internal/config/loader.go`) to embed `*commonv1.MetricDefinition` directly, eliminating the hand-mirrored JSON-shadow drift that ADR-026 Phases 1, 2, and 3 each had to pay.

**Schema parity**: any new field added to proto `MetricDefinition` is now automatically readable from M3 via the embedded type — no Go-side mirror needed.

Closes #506.

## What changed

- `config.MetricConfig` embeds `*commonv1.MetricDefinition` + 4 M3-only sidecar fields (`QoEField`, `MLRATEFeatureEventTypes`, `MLRATEModelURI`, `MLRATELookbackDays`) that have no proto counterpart.
- `config.OperandConfig` deleted — callers now use `*commonv1.CompositeOperand` via `m.GetComposite().GetOperands()`.
- New helpers in `package config`: `TypeShortName(commonv1.MetricType) string` and `CompositeOperatorShortName(commonv1.CompositeOperator) string` — strip the `METRIC_TYPE_` / `COMPOSITE_OPERATOR_` prefixes for log labels.
- `LoadFromFile` does a two-step parse per metric: `protojson.UnmarshalOptions{DiscardUnknown: true}` for the proto half, `encoding/json` into a local anonymous struct for the M3-only sidecar fields. The sidecar struct is immediately discarded after copying into `MetricConfig`.
- Seed JSON files migrated to protojson canonical shape: `"type": "MEAN"` → `"type": "METRIC_TYPE_MEAN"`; Phase 1 flat fields (`filter_sql`, `operands`, `operator`, `event_type`, `window_hours`) moved into `filteredMean` / `composite` / `windowedCount` oneof blocks; `"operator": "WEIGHTED_SUM"` → `"operator": "COMPOSITE_OPERATOR_WEIGHTED_SUM"`.
- ~233 call-site renames across `services/metrics/internal/`:
  - `m.MetricID` → `m.MetricId` (and `CustomSQL`/`IsQoEMetric`/`CupedCovariateMetricID` similar)
  - `strings.ToUpper(m.Type) == "X"` → `m.Type == commonv1.MetricType_METRIC_TYPE_X` (now a compile-time-checked enum, not a stringly-typed comparison)
  - Flat `m.FilterSQL` / `m.Operands` / `m.EventType` etc. → oneof getters (`m.GetFilteredMean().GetFilterSql()` style)
- Wire-format contract test (`m3m5_wire_format_contract_test.go`): `extractJSONTags` now walks anonymous-embedded structs so proto-generated tags surface alongside the four sidecar tags; `m5MetricToConfig` rebuilt to construct a real `*commonv1.MetricDefinition` with the oneof `TypeConfig` populated, exercising the same code path as the production loader.

Touches 18 files exclusively under `services/metrics/`.

## Why this matters

Each ADR-026 phase had to hand-mirror proto fields to the Go shadow struct:
- Phase 1 (#475/#552/#555): 6 new sibling fields on `MetricConfig`
- Phase 2 (#435): `metricql_expression` added on both sides
- Phase 3 (#603): no new fields, but the deprecation work would have re-touched the drift

Subsequent ADR-026 work (#599 pattern expansion, future metric-type additions) no longer pays this tax.

## Test plan

- [x] `go test ./services/metrics/...` — all 14 packages pass
- [x] `go test -race ./services/metrics/...` — no races
- [x] `go vet ./services/metrics/...` — clean
- [x] `gofmt -l services/metrics/` — clean
- [x] Spec-compliance review (independent) — APPROVED, all 9 DoD items met
- [x] Code-quality review (independent) — APPROVED with advisory-only findings (see follow-ups)
- [x] Wire-format contract test strengthened (now exercises real production code path via constructed proto)
- [x] Branch passes `just check-branch-name`

## Notes on test changes

- `TestTopologicalOrder_LowercaseCompositeType` deleted: it asserted that `"composite"` (lowercase) still built edges via `strings.ToUpper` normalization. With the typed enum, lowercase variants are no longer representable, so the regression class no longer exists.
- A few stray `"value_column": "value"` survive on `METRIC_TYPE_MEAN` entries in `standard_test.go`; with `DiscardUnknown: true` protojson silently drops them, so they're behaviorally inert. Left untouched to keep the diff surgical — see follow-up below.

## Follow-ups (not in scope here)

From the code-quality review, advisory items captured for separate issues:

- **Defensive `metric_id` guard** in `LoadFromFile`: a typo'd `"metricid"` key would silently produce a metric stored under `""`. Pre-existing gap, but `DiscardUnknown` makes it slightly more visible. A 4-line guard after `protoOpts.Unmarshal` is the fix.
- **`Operator="UNSPECIFIED"` leak** in `jobs/standard.go:245`: every non-COMPOSITE metric ends up with `params.Operator = "UNSPECIFIED"` via `CompositeOperatorShortName(nil)` chain. Behaviorally harmless (only read inside the COMPOSITE arm) but noisy in logs.
- **Clean up stray `"value_column": "value"`** on MEAN test fixtures in `standard_test.go` — three entries.
- **Explicit unknown-enum-string fatal** in `m5MetricToConfig` instead of silently zeroing — test-only.

These are all defensive/cosmetic, not regressions, and would be in-scope for a small follow-up PR rather than expanding this one.

## Out of scope

Per task spec: no proto edits, no M5 Rust changes, no M6 UI, no M4a, no infra. ExperimentConfig / SurrogateModelConfig / VariantConfig / GuardrailConfig still use encoding/json into Go structs — out of scope per issue #506's focused scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->