### PR TITLE
🎨 Palette: Add skip-to-content link for accessibility

### DIFF
--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -15,11 +15,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="min-h-screen bg-gray-50 text-gray-900 antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-indigo-600 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        >
+          Skip to main content
+        </a>
         <MswProvider>
           <AuthProvider>
             <ToastProvider>
               <NavHeader />
-              <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+              <main
+                id="main-content"
+                tabIndex={-1}
+                className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 focus:outline-none"
+              >
                 <ErrorBoundary>
                   {children}
                 </ErrorBoundary>


### PR DESCRIPTION
💡 **What**: Added a "Skip to main content" link at the root of the application layout.
🎯 **Why**: To improve accessibility for keyboard and screen reader users by allowing them to bypass the global navigation and jump straight to the primary content.
♿ **Accessibility**:
- Implementation follows the `sr-only focus:not-sr-only` pattern, ensuring the link is only visible when focused.
- Targeted the `<main>` element with `id="main-content"` and `tabIndex={-1}` for correct focus management across all browsers.
- Verified with Playwright that the link appears on focus and correctly shifts focus to the main content area.
- Recorded implementation details and learnings in the Palette journal.

---
*PR created automatically by Jules for task [5538130289745469062](https://jules.google.com/task/5538130289745469062) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->