### PR TITLE
🎨 Palette: Standardize search experience with shortcuts and clear actions

### DIFF
--- a/ui/src/__tests__/hooks/use-search-shortcut.test.ts
+++ b/ui/src/__tests__/hooks/use-search-shortcut.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSearchShortcut } from '@/hooks/use-search-shortcut';
+
+describe('useSearchShortcut', () => {
+  let inputRef: { current: HTMLInputElement };
+
+  beforeEach(() => {
+    inputRef = {
+      current: {
+        focus: vi.fn(),
+        blur: vi.fn(),
+      } as unknown as HTMLInputElement,
+    };
+    // Mock activeElement
+    Object.defineProperty(document, 'activeElement', {
+      value: document.body,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('focuses the input when "/" is pressed', () => {
+    renderHook(() => useSearchShortcut(inputRef as any));
+    const event = new KeyboardEvent('keydown', { key: '/' });
+    window.dispatchEvent(event);
+    expect(inputRef.current.focus).toHaveBeenCalled();
+  });
+
+  it('focuses the input when "Cmd+K" is pressed', () => {
+    renderHook(() => useSearchShortcut(inputRef as any));
+    const event = new KeyboardEvent('keydown', { key: 'k', metaKey: true });
+    window.dispatchEvent(event);
+    expect(inputRef.current.focus).toHaveBeenCalled();
+  });
+
+  it('focuses the input when "Ctrl+K" is pressed', () => {
+    renderHook(() => useSearchShortcut(inputRef as any));
+    const event = new KeyboardEvent('keydown', { key: 'k', ctrlKey: true });
+    window.dispatchEvent(event);
+    expect(inputRef.current.focus).toHaveBeenCalled();
+  });
+
+  it('blurs the input when "Escape" is pressed and input is focused', () => {
+    Object.defineProperty(document, 'activeElement', {
+      value: inputRef.current,
+      writable: true,
+      configurable: true,
+    });
+    renderHook(() => useSearchShortcut(inputRef as any));
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    window.dispatchEvent(event);
+    expect(inputRef.current.blur).toHaveBeenCalled();
+  });
+
+  it('does not focus when "/" is pressed and user is in an input', () => {
+    const activeInput = document.createElement('input');
+    Object.defineProperty(document, 'activeElement', {
+      value: activeInput,
+      writable: true,
+      configurable: true,
+    });
+    renderHook(() => useSearchShortcut(inputRef as any));
+    const event = new KeyboardEvent('keydown', { key: '/' });
+    window.dispatchEvent(event);
+    expect(inputRef.current.focus).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -131,7 +131,7 @@ function FlagListContent() {
         <>
 
       <div className="mb-4 flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 min-w-[300px] max-w-md">
+        <div className="group relative flex-1 min-w-[300px] max-w-md">
           <svg
             className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
             fill="none"
@@ -151,7 +151,19 @@ function FlagListContent() {
             data-testid="flag-search"
             aria-label="Search flags"
           />
-          <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center">
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
+              aria-label="Clear search"
+              data-testid="clear-search-button"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+          <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center group-focus-within:hidden group-[:not(:placeholder-shown)]:hidden">
             <span className="flex h-5 w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 text-[10px] font-medium text-gray-500">
               /
             </span>

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -408,7 +408,7 @@ function MetricBrowserContent() {
         <>
 
       <div className="mb-4 flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 min-w-[300px] max-w-md">
+        <div className="group relative flex-1 min-w-[300px] max-w-md">
           <svg
             className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
             fill="none"
@@ -428,7 +428,19 @@ function MetricBrowserContent() {
             data-testid="metric-search"
             aria-label="Search metrics"
           />
-          <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center">
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
+              aria-label="Clear search"
+              data-testid="clear-search-button"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+          <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center group-focus-within:hidden group-[:not(:placeholder-shown)]:hidden">
             <span className="flex h-5 w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 text-[10px] font-medium text-gray-500">
               /
             </span>

--- a/ui/src/components/audit-filters.tsx
+++ b/ui/src/components/audit-filters.tsx
@@ -52,7 +52,7 @@ export function AuditFilters({
   return (
     <div className="mb-4 flex flex-wrap items-center gap-3">
       {/* Experiment name search */}
-      <div className="relative flex-1 min-w-[200px] max-w-sm">
+      <div className="group relative flex-1 min-w-[200px] max-w-sm">
         <svg
           className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
           fill="none"
@@ -71,7 +71,19 @@ export function AuditFilters({
           className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-10 text-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
           aria-label="Search by experiment name"
         />
-        <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center">
+        {experimentQuery && (
+          <button
+            onClick={() => onExperimentQueryChange('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
+            aria-label="Clear search"
+            data-testid="clear-search-button"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+        <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center group-focus-within:hidden group-[:not(:placeholder-shown)]:hidden">
           <span className="flex h-5 w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 text-[10px] font-medium text-gray-500">
             /
           </span>

--- a/ui/src/components/experiment-filters.tsx
+++ b/ui/src/components/experiment-filters.tsx
@@ -28,7 +28,7 @@ export function ExperimentFiltersToolbar({ filters, totalCount, filteredCount }:
   return (
     <div className="mb-4 flex flex-wrap items-center gap-3">
       {/* Search input */}
-      <div className="relative flex-1 min-w-[200px] max-w-sm">
+      <div className="group relative flex-1 min-w-[200px] max-w-sm">
         <svg
           className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
           fill="none"
@@ -47,7 +47,19 @@ export function ExperimentFiltersToolbar({ filters, totalCount, filteredCount }:
           className="w-full rounded-md border border-gray-300 py-1.5 pl-9 pr-10 text-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
           aria-label="Search experiments"
         />
-        <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center">
+        {filters.query && (
+          <button
+            onClick={() => filters.setQuery('')}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
+            aria-label="Clear search"
+            data-testid="clear-search-button"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+        <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center group-focus-within:hidden group-[:not(:placeholder-shown)]:hidden">
           <span className="flex h-5 w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 text-[10px] font-medium text-gray-500">
             /
           </span>

--- a/ui/src/hooks/use-search-shortcut.ts
+++ b/ui/src/hooks/use-search-shortcut.ts
@@ -9,13 +9,19 @@ import { useEffect, type RefObject } from 'react';
 export function useSearchShortcut(inputRef: RefObject<HTMLInputElement>) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (
-        e.key === '/' &&
-        !['INPUT', 'TEXTAREA', 'SELECT'].includes(document.activeElement?.tagName || '') &&
-        !(document.activeElement as HTMLElement)?.isContentEditable
-      ) {
+      const isSearchShortcut =
+        (e.key === '/' &&
+          !['INPUT', 'TEXTAREA', 'SELECT'].includes(document.activeElement?.tagName || '') &&
+          !(document.activeElement as HTMLElement)?.isContentEditable) ||
+        ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k');
+
+      if (isSearchShortcut) {
         e.preventDefault();
         inputRef.current?.focus();
+      }
+
+      if (e.key === 'Escape' && document.activeElement === inputRef.current) {
+        inputRef.current?.blur();
       }
     };
 


### PR DESCRIPTION
This PR implements a micro-UX improvement to standardize the search experience across the experimentation platform.

### 💡 What:
- **Enhanced Shortcuts**: The \`useSearchShortcut\` hook now supports \`Cmd+K\` and \`Ctrl+K\` for focusing search inputs, and \`Escape\` for blurring.
- **Clear Action**: Added an inline 'X' button to quickly clear search queries on all main list pages (Experiments, Flags, Metrics, Audit Log).
- **Visual Polish**: Used the Tailwind \`group\` pattern to hide the '/' shortcut hint automatically when the input is focused or contains text, reducing visual noise.
- **Accessibility**: Added descriptive ARIA labels to clear buttons and ensured proper keyboard focus management.

### 🎯 Why:
Users previously had to manually backspace to clear searches, and power users only had the '/' shortcut available. This change provides a more efficient and standard interface for navigating and filtering resource lists.

### ♿ Accessibility:
- Added \`aria-label="Clear search"\` to all clear buttons.
- Ensured clear buttons are keyboard-accessible with \`focus-visible\` rings.
- Improved hook logic to respect existing user focus on inputs/textareas.

---
*PR created automatically by Jules for task [891405088254197231](https://jules.google.com/task/891405088254197231) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->