### PR TITLE
🎨 Palette: announce copied state on CopyButton + cover search-shortcut hook

### DIFF
--- a/ui/src/__tests__/hooks/use-search-shortcut.test.tsx
+++ b/ui/src/__tests__/hooks/use-search-shortcut.test.tsx
@@ -1,0 +1,67 @@
+import { render, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { useSearchShortcut } from '../../hooks/use-search-shortcut';
+
+function TestComponent() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  useSearchShortcut(inputRef);
+  return <input data-testid="search-input" ref={inputRef} />;
+}
+
+describe('useSearchShortcut', () => {
+  it('focuses the input when "/" is pressed', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const input = getByTestId('search-input');
+
+    expect(document.activeElement).not.toBe(input);
+
+    fireEvent.keyDown(window, { key: '/' });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('focuses the input when "Cmd+K" is pressed', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const input = getByTestId('search-input');
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('focuses the input when "Ctrl+K" is pressed', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const input = getByTestId('search-input');
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('blurs the input when "Escape" is pressed', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const input = getByTestId('search-input');
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it('does not focus the input when already in an input', () => {
+    const { getByTestId } = render(
+      <div>
+        <TestComponent />
+        <input data-testid="other-input" />
+      </div>
+    );
+    const searchInput = getByTestId('search-input');
+    const otherInput = getByTestId('other-input');
+
+    otherInput.focus();
+    expect(document.activeElement).toBe(otherInput);
+
+    fireEvent.keyDown(window, { key: '/' });
+    expect(document.activeElement).toBe(otherInput);
+    expect(document.activeElement).not.toBe(searchInput);
+  });
+});

--- a/ui/src/components/copy-button.tsx
+++ b/ui/src/components/copy-button.tsx
@@ -49,8 +49,8 @@ export function CopyButton({
       type="button"
       onClick={handleCopy}
       className={`group relative flex h-6 w-6 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 ${className}`}
-      aria-label={label}
-      title={label}
+      aria-label={copied ? 'Copied to clipboard' : label}
+      title={copied ? 'Copied!' : label}
     >
       {copied ? (
         <svg


### PR DESCRIPTION
Consolidates the distinct value from #618 onto current `main` after the search-input standardization landed in #624 (which superseded #618's overlapping search work).

## What's here
- **CopyButton a11y**: `aria-label`/`title` now switch to "Copied!" while in the copied state, giving screen-reader users the same confirmation the checkmark icon conveys visually.
- **Hook coverage**: new unit tests for `useSearchShortcut` — `/`, Cmd+K, Ctrl+K focus; Escape blur; and the "don't steal focus while already typing" guard — validating the hook as merged in #624.

## Why a new PR instead of #618
After #624 merged, #618's hook + `experiment-filters` edits became redundant (same Cmd/Ctrl+K + Escape enhancement). This PR carries forward only the non-redundant bits cleanly on top of `main`; #618 is closed as superseded.

## Test plan
- [x] `npx vitest run src/__tests__/hooks/use-search-shortcut.test.tsx` — 5/5 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->