### PR TITLE
docs: accept ADR-031 (ConnectRPC Rust pilot on M1)

### DIFF
--- a/docs/adrs/031-connectrpc-rust-assignment-pilot.md
+++ b/docs/adrs/031-connectrpc-rust-assignment-pilot.md
@@ -1,7 +1,7 @@
 # ADR-031: ConnectRPC (Rust) Pilot on M1 Assignment Service
 
-**Status**: Proposed
-**Date**: 2026-06-22
+**Status**: Accepted
+**Date**: 2026-06-22 (proposed); 2026-06-23 (accepted via #634 — pilot approved; fleet-wide adoption remains gated on the success criteria below)
 **Deciders**: Agent-1 (M1 Assignment), Agent-0 (cross-cutting RPC / coordination), SDK maintainers
 **Cluster**: — (cross-cutting RPC infrastructure; scoped revisit of ADR-010)
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -55,7 +55,7 @@ First instance: [#634](https://github.com/wunderkennd/kaizen-experimentation/iss
 | [028](028-m4b-shadow-inference.md) | M4b shadow inference path for bandit policy promotion (dedicated shadow core, column-family isolation) | **Proposed** | M4b, M4a, M5, M6 |
 | [029](029-cross-modal-score-calibration.md) | Cross-modal score calibration for heterogeneous slates (unified NEV scale across video, manga, commerce) | **Proposed** | M4a, M4b, M5, Personalization service |
 | [030](030-shadow-experiment-mode.md) | Shadow mode flag on experiments — run candidate variants on production traffic without user exposure | **Proposed** | M1, M4a, M4b, M5, M6 |
-| [031](031-connectrpc-rust-assignment-pilot.md) | ConnectRPC (Rust) pilot on M1 Assignment — scoped revisit of ADR-010's "tonic for Rust" | **Proposed** | M1, SDKs, proto codegen |
+| [031](031-connectrpc-rust-assignment-pilot.md) | ConnectRPC (Rust) pilot on M1 Assignment — scoped revisit of ADR-010's "tonic for Rust" | **Accepted** | M1, SDKs, proto codegen |
 
 ## Proposed ADR Clusters
 


### PR DESCRIPTION
## Decision

**Accepts ADR-031** — run the single-service ConnectRPC (Rust) pilot on M1 `AssignmentService`. Flips status **Proposed → Accepted** and updates the index row.

Scope of this acceptance is the **pilot only**, behind a Cargo feature with tonic kept shippable. Fleet-wide adoption is **not** accepted here — it stays gated on the pilot meeting its success criteria (net-negative LOC, p99 within ±10%, clean buffa/prost coexistence, all 5 RPCs passing contract tests over Connect / gRPC / gRPC-Web).

### Why accept
- The "do nothing" baseline is already incomplete: 2 of M1's 5 RPCs (`GetInterleavedList`, `StreamConfigUpdates`) have no JSON path today.
- Contained and reversible: one service, feature-flagged, tonic untouched, explicit kill criteria.

## Process

First exercise of the `rfc` acceptance-issue practice codified in #635 — this is the "small follow-up PR" that records the decision.

Closes #634.

## Verification

- [x] ADR-031 Status → Accepted; README index row → Accepted
- [x] Docs-only — no code touched
- [x] `just check-branch-name` passes for `agent-1/docs/adr-031-accept`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->