### PR TITLE
🎨 Palette: Standardize Audit Log expandable rows with chevron

### DIFF
--- a/ui/src/components/audit-log-table.tsx
+++ b/ui/src/components/audit-log-table.tsx
@@ -1,20 +1,20 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import Link from 'next/link';
-import type { AuditLogEntry } from '@/lib/types';
-import { AuditActionBadge } from '@/components/audit-action-badge';
-import { CopyButton } from '@/components/copy-button';
+import { useState } from "react";
+import Link from "next/link";
+import type { AuditLogEntry } from "@/lib/types";
+import { AuditActionBadge } from "@/components/audit-action-badge";
+import { CopyButton } from "@/components/copy-button";
 
 function formatTimestamp(iso: string): string {
   const d = new Date(iso);
-  return d.toLocaleString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
+  return d.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
     hour12: false,
   });
 }
@@ -61,7 +61,7 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                 className="cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
                 onClick={() => toggleExpand(entry.entryId)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
+                  if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
                     toggleExpand(entry.entryId);
                   }
@@ -69,10 +69,27 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
+                aria-label={`Toggle details for ${entry.action} action on ${entry.experimentName}`}
                 data-testid={`audit-row-${entry.entryId}`}
               >
                 <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap align-top">
-                  {formatTimestamp(entry.timestamp)}
+                  <div className="flex items-center gap-2">
+                    <svg
+                      className={`h-4 w-4 text-gray-400 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                    {formatTimestamp(entry.timestamp)}
+                  </div>
                 </td>
                 <td className="px-4 py-3 text-sm align-top">
                   <Link
@@ -91,14 +108,16 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                 </td>
                 <td className="px-4 py-3 text-sm text-gray-700 align-top">
                   <div>{entry.details}</div>
-                  <span className="text-xs text-gray-400">
-                    {isExpanded ? '(click to collapse)' : '(click to expand details)'}
-                  </span>
                   {isExpanded && (
-                    <div className="mt-2 rounded-md bg-gray-50 p-3 text-xs" data-testid={`audit-detail-${entry.entryId}`}>
+                    <div
+                      className="mt-2 rounded-md bg-gray-50 p-3 text-xs"
+                      data-testid={`audit-detail-${entry.entryId}`}
+                    >
                       <div className="mb-2">
                         <div className="flex items-center justify-between gap-2">
-                          <span className="font-semibold text-gray-500">Experiment ID: </span>
+                          <span className="font-semibold text-gray-500">
+                            Experiment ID:{" "}
+                          </span>
                           <CopyButton
                             value={entry.experimentId}
                             label="Copy experiment ID"
@@ -113,7 +132,9 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                       {entry.previousValue && (
                         <div className="mb-2">
                           <div className="flex items-center justify-between gap-2">
-                            <span className="font-semibold text-red-600">Previous: </span>
+                            <span className="font-semibold text-red-600">
+                              Previous:{" "}
+                            </span>
                             <CopyButton
                               value={entry.previousValue}
                               label="Copy previous value"
@@ -121,13 +142,17 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                               className="h-4 w-4"
                             />
                           </div>
-                          <code className="mt-1 block break-all rounded bg-red-50/50 p-1">{entry.previousValue}</code>
+                          <code className="mt-1 block break-all rounded bg-red-50/50 p-1">
+                            {entry.previousValue}
+                          </code>
                         </div>
                       )}
                       {entry.newValue && (
                         <div>
                           <div className="flex items-center justify-between gap-2">
-                            <span className="font-semibold text-green-600">New: </span>
+                            <span className="font-semibold text-green-600">
+                              New:{" "}
+                            </span>
                             <CopyButton
                               value={entry.newValue}
                               label="Copy new value"
@@ -135,7 +160,9 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                               className="h-4 w-4"
                             />
                           </div>
-                          <code className="mt-1 block break-all rounded bg-green-50/50 p-1">{entry.newValue}</code>
+                          <code className="mt-1 block break-all rounded bg-green-50/50 p-1">
+                            {entry.newValue}
+                          </code>
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
🎨 Palette: Standardize Audit Log expandable rows with chevron

This PR standardizes the expandable row interaction in the Audit Log table to match the platform's established pattern (rotating chevron icon).

Key Changes:
- **Visual Affordance**: Added a rotating chevron SVG to the "Timestamp" column.
- **Accessibility**: Replaced static instructions with a dynamic `aria-label` providing context about the specific audit entry being toggled.
- **Visual Polish**: Removed redundant helper text and ensured proper focus states for keyboard users.

♿ Accessibility:
- Descriptive ARIA labels for expandable rows.
- Clear visual focus indicators via `focus-within`.
- Semantic roles maintained.

Tests:
- Passed existing `audit-log.test.tsx` suite.
- Verified visual behavior in Next.js dev server with mocked API.

---
*PR created automatically by Jules for task [10182571649575140375](https://jules.google.com/task/10182571649575140375) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->