### PR TITLE
🎨 Palette: Enhance Audit Log expandability and accessibility

### DIFF
--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -93,7 +93,7 @@ export default function AuditLogPage() {
       ) : error ? (
         <RetryableError message={error} onRetry={fetchData} context="audit log" />
       ) : entries.length === 0 ? (
-        <div className="py-12 text-center">
+        <div className="py-12 text-center" data-testid="empty-state">
           <p className="text-sm text-gray-500">No audit log entries found.</p>
         </div>
       ) : (

--- a/ui/src/components/audit-log-table.tsx
+++ b/ui/src/components/audit-log-table.tsx
@@ -69,10 +69,22 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
+                aria-label={`Toggle details for ${entry.action} action on ${entry.experimentName}`}
                 data-testid={`audit-row-${entry.entryId}`}
               >
                 <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap align-top">
-                  {formatTimestamp(entry.timestamp)}
+                  <div className="flex items-center gap-2">
+                    <svg
+                      className={`h-4 w-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                    {formatTimestamp(entry.timestamp)}
+                  </div>
                 </td>
                 <td className="px-4 py-3 text-sm align-top">
                   <Link
@@ -91,9 +103,6 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                 </td>
                 <td className="px-4 py-3 text-sm text-gray-700 align-top">
                   <div>{entry.details}</div>
-                  <span className="text-xs text-gray-400">
-                    {isExpanded ? '(click to collapse)' : '(click to expand details)'}
-                  </span>
                   {isExpanded && (
                     <div className="mt-2 rounded-md bg-gray-50 p-3 text-xs" data-testid={`audit-detail-${entry.entryId}`}>
                       <div className="mb-2">


### PR DESCRIPTION
This PR introduces micro-UX and accessibility improvements to the Audit Log.

💡 **What:**
- Added a rotating chevron SVG icon to the Timestamp column in the Audit Log table to clearly signal that rows are expandable.
- Implemented `aria-label` on table rows to provide screen reader users with context about the toggle action (e.g., "Toggle details for CREATED action on experiment_name").
- Removed the manual "(click to expand details)" text which cluttered the interface.
- Standardized the empty state with a `data-testid="empty-state"`.

🎯 **Why:**
Expandable table rows often lack clear affordances for keyboard and screen reader users. By adding the chevron and proper ARIA labeling, the interaction becomes more discoverable and accessible.

♿ **Accessibility:**
- Improved screen reader support for row expansion.
- Better visual signaling for interactive elements.
- Maintained existing keyboard navigation (Enter/Space to toggle).

---
*PR created automatically by Jules for task [12510119817898813638](https://jules.google.com/task/12510119817898813638) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->