### PR TITLE
chore: GitHub Projects + Goals work-tracking model & Milestone→Iteration migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📋 Work-tracking conventions (Projects, Goals, Iterations)
+    url: https://github.com/wunderkennd/kaizen-experimentation/blob/main/docs/guides/projects-and-goals.md
+    about: How Goals, Iterations, and Project fields work. Read before filing a Goal.
+  - name: 📝 Issue body format & labels
+    url: https://github.com/wunderkennd/kaizen-experimentation/blob/main/docs/guides/github-issues-workflow.md
+    about: Standard Issue structure, labels, and the Closes #N convention.

--- a/.github/ISSUE_TEMPLATE/goal.md
+++ b/.github/ISSUE_TEMPLATE/goal.md
@@ -1,0 +1,61 @@
+---
+name: "🎯 Goal"
+about: "An outcome with a measurable success metric, spanning ≥1 iteration and ≥2 child issues. One Goal per ADR or named initiative."
+title: "Goal: <ADR-NNN or initiative name> — <outcome>"
+labels: ["goal"]
+---
+
+<!--
+A Goal is an OUTCOME, not a task. Before filing, confirm all four hold:
+  1. Exactly one measurable success metric (a threshold, not "done").
+  2. Spans ≥ 1 iteration.
+  3. Owns ≥ 2 child issues.
+  4. Maps to an ADR number OR a named initiative.
+If it is a single unit of work, file a regular Issue instead.
+See docs/guides/projects-and-goals.md.
+-->
+
+## Outcome
+
+<!-- One or two sentences: what becomes true in the world when this Goal is met. -->
+
+## Success metric
+
+<!--
+A single, measurable threshold. NOT a checklist of work.
+Good:  "Operators define custom metrics with <5% validation-error rate over 30 days."
+Good:  "TOST golden files match R `TOSTER` (tsum_TOST) to 6 decimal places."
+Bad:   "All three metric types implemented."  ← that's work, not an outcome.
+-->
+
+**Metric:**
+**Target / threshold:**
+**Measured by:**
+
+## Source
+
+- **ADR:** <!-- ADR-NNN, or "none (initiative)" -->
+- **Cluster:** <!-- cluster-a .. cluster-g, or n/a -->
+- **Primary modules:** <!-- e.g. M5, M3, M4a -->
+
+## Child issues
+
+<!--
+Add these as NATIVE sub-issues via the Issue sidebar (Create sub-issue / Add existing)
+so the parent progress bar tracks closure. List them here for readability too.
+-->
+
+- [ ] #
+- [ ] #
+
+## Project fields to set
+
+When adding to the Project, set:
+
+- **Goal** field → this issue's title
+- **Iteration** → the iteration where the metric is expected to be met
+- **Owner**, **Priority**, **ADR** → as applicable
+
+## Out of scope
+
+<!-- What this Goal explicitly does NOT cover, to keep the metric honest. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ gh issue view <number>
 | --- | --- |
 | `agent-1` through `agent-7` | Agent ownership |
 | `P0` through `P4` | Priority tier |
-| `cluster-a` through `cluster-f` | Capability cluster |
+| `cluster-a` through `cluster-g` | Capability cluster (cluster-g = ADR-029 Personalization Orchestration) |
 | `blocked` | Waiting on another issue or agent |
 | `contract-test` | Cross-module contract test |
 

--- a/docs/guides/github-issues-workflow.md
+++ b/docs/guides/github-issues-workflow.md
@@ -1,5 +1,11 @@
 # GitHub Issues Workflow
 
+> **⚠️ Sprint tracking is migrating off Milestones.** Going forward, **Sprints are the
+> Project's Iteration field** and a new **Goal** concept tracks outcomes — see
+> [projects-and-goals.md](./projects-and-goals.md). The Issue body format, labels, and
+> `Closes #N` convention below are **unchanged**. The "Milestones = Sprints" section
+> here is retained for the transition period only.
+
 Work tracking for Phase 5 uses GitHub Milestones, Issues, and Labels. This replaces the per-agent status markdown files used in Phases 0–4.
 
 ## Why Issues Instead of Status Files

--- a/docs/guides/projects-and-goals.md
+++ b/docs/guides/projects-and-goals.md
@@ -59,13 +59,13 @@ Filed via `scripts/projects/seed-goals.sh` (active goals first, then the rest).
 | --- | --- | --- | --- |
 | Infrastructure GA (Pulumi/AWS) | [#647](https://github.com/wunderkennd/kaizen-experimentation/issues/647) | Sprints I.0–I.3 | All 9 Kaizen services deployed; mock suite green; observability wired |
 | ADR-031 ConnectRPC Pilot | [#648](https://github.com/wunderkennd/kaizen-experimentation/issues/648) | ADR-031 | M1 RPCs over Connect; JSON shim retired; pilot meets success/kill criteria |
-| ADR-026 Custom Metrics Layer → GA | _pending_ | ADR-026 | 3 Tier-1 metric types GA; operators self-serve; <5% definition-validation error rate |
-| ADR-027 TOST Equivalence Testing → GA | _pending_ | ADR-027 | TOST exposed in M4a/M5/M6; golden files match R `TOSTER` to 6 dp |
-| ADR-028 M4b Shadow Inference | _pending_ | ADR-028 | Shadow core promotes policies with zero prod-traffic exposure regressions |
-| ADR-029 Cross-Modal Score Calibration | _pending_ | ADR-029 | Unified NEV scale across ≥3 modalities; calibration error within target band |
-| ADR-030 Shadow Experiment Mode | _pending_ | ADR-030 | Candidate variants run on prod traffic with 0 user-facing exposure incidents |
-| QoE Observability GA | _pending_ | EBVS + HeartbeatSessionizer | Server-side QoE aggregation live; EBVS first-class on `PlaybackMetrics` |
-| Palette / M6 Design-System Standardization | _pending_ | Palette polish | Search, empty states, filter-clear, CopyButton standardized across M6; a11y pass |
+| ADR-026 Custom Metrics Layer → GA | [#649](https://github.com/wunderkennd/kaizen-experimentation/issues/649) | ADR-026 | 3 Tier-1 metric types GA; operators self-serve; <5% definition-validation error rate |
+| ADR-027 TOST Equivalence Testing → GA | [#650](https://github.com/wunderkennd/kaizen-experimentation/issues/650) | ADR-027 | TOST exposed in M4a/M5/M6; golden files match R `TOSTER` to 6 dp |
+| ADR-028 M4b Shadow Inference | [#651](https://github.com/wunderkennd/kaizen-experimentation/issues/651) | ADR-028 | Shadow core promotes policies with zero prod-traffic exposure regressions |
+| ADR-029 Cross-Modal Score Calibration | [#652](https://github.com/wunderkennd/kaizen-experimentation/issues/652) | ADR-029 | Unified NEV scale across ≥3 modalities; calibration error within target band |
+| ADR-030 Shadow Experiment Mode | [#653](https://github.com/wunderkennd/kaizen-experimentation/issues/653) | ADR-030 | Candidate variants run on prod traffic with 0 user-facing exposure incidents |
+| QoE Observability GA | [#654](https://github.com/wunderkennd/kaizen-experimentation/issues/654) | EBVS + HeartbeatSessionizer | Server-side QoE aggregation live; EBVS first-class on `PlaybackMetrics` |
+| Palette / M6 Design-System Standardization | [#655](https://github.com/wunderkennd/kaizen-experimentation/issues/655) | Palette polish | Search, empty states, filter-clear, CopyButton standardized across M6; a11y pass |
 
 > The two **active** goals (live open work) are filed first; the remaining seven are
 > filed in a second batch. ADR-031 is a ninth goal that spun up after the original

--- a/docs/guides/projects-and-goals.md
+++ b/docs/guides/projects-and-goals.md
@@ -1,0 +1,158 @@
+# GitHub Projects & Goals
+
+This guide defines how the kaizen-experimentation repo tracks work after adopting
+**GitHub Projects (v2)**. It supersedes the Milestone-as-Sprint model documented in
+[github-issues-workflow.md](./github-issues-workflow.md) — see
+[Migration from Milestones](#migration-from-milestones) below.
+
+> **TL;DR**
+> - **Sprint** moves from a Milestone to the Project's native **Iteration** field.
+> - **Goal** is a new top-level concept: a typed parent Issue with one success metric and a tree of native sub-issues.
+> - Reporting labels (`P0..P4`, `cluster-a..f`) become Project **fields**.
+> - `agent-N` and `sprint-N` **labels stay** — orchestration tooling reads them over the REST API.
+
+## The four axes
+
+Work is described along four orthogonal axes. None is a "size" of another — each
+answers a different question.
+
+| Concept | Question it answers | GitHub primitive | Time-bound? |
+| --- | --- | --- | --- |
+| **Goal** | *What outcome are we causing, and how do we know we hit it?* | Parent **Issue** (type `Goal`) + sub-issues | No (closes when metric met) |
+| **Sprint** | *When does this batch of work happen?* | Project **Iteration** field | Yes (2-week cadence) |
+| **Issue** | *What unit of work needs doing?* | **Issue** | No (open/closed) |
+| **ADR** | *What decision did we make, and why?* | `docs/adrs/NNN-*.md` | No (immutable record) |
+
+A Goal **cuts across** the other three: it spans multiple iterations, may reference
+several ADRs, and owns many issues. That cross-cutting property is the tell that it
+is a distinct top layer, not a synonym for a big issue or a small sprint.
+
+```
+GOAL  (outcome + metric)         "ADR-026 Custom Metrics GA — 3 metric types live,
+  │                               operators self-serve, <5% definition error rate"
+  ├─ sub-issue #552              (native GitHub sub-issue → drives the progress bar)
+  ├─ sub-issue #555
+  ├─ sub-issue #435
+  └─ sub-issue #436
+        each leaf: Iteration field = "Sprint 5.6", Owner = agent-3, Closes #N on merge
+```
+
+## Goal granularity
+
+**One Goal per ADR, or per named non-ADR initiative. Never per-issue; never one mega-goal.**
+
+A work item qualifies as a Goal **only if all four hold**:
+
+1. It has exactly **one measurable success metric** (a threshold, not "done").
+2. It spans **≥ 1 iteration**.
+3. It owns **≥ 2 child issues**.
+4. It maps to an **ADR number** *or* a **named initiative**.
+
+If a piece of work is a single issue, it is an Issue — not a Goal. If it is "all of
+Phase 6", it is too coarse to measure — split it per ADR.
+
+### Seed goals (current state, 2026-06)
+
+Filed via `scripts/projects/seed-goals.sh` (active goals first, then the rest).
+
+| Goal | Issue | Source | Success metric (example — refine on creation) |
+| --- | --- | --- | --- |
+| Infrastructure GA (Pulumi/AWS) | [#647](https://github.com/wunderkennd/kaizen-experimentation/issues/647) | Sprints I.0–I.3 | All 9 Kaizen services deployed; mock suite green; observability wired |
+| ADR-031 ConnectRPC Pilot | [#648](https://github.com/wunderkennd/kaizen-experimentation/issues/648) | ADR-031 | M1 RPCs over Connect; JSON shim retired; pilot meets success/kill criteria |
+| ADR-026 Custom Metrics Layer → GA | _pending_ | ADR-026 | 3 Tier-1 metric types GA; operators self-serve; <5% definition-validation error rate |
+| ADR-027 TOST Equivalence Testing → GA | _pending_ | ADR-027 | TOST exposed in M4a/M5/M6; golden files match R `TOSTER` to 6 dp |
+| ADR-028 M4b Shadow Inference | _pending_ | ADR-028 | Shadow core promotes policies with zero prod-traffic exposure regressions |
+| ADR-029 Cross-Modal Score Calibration | _pending_ | ADR-029 | Unified NEV scale across ≥3 modalities; calibration error within target band |
+| ADR-030 Shadow Experiment Mode | _pending_ | ADR-030 | Candidate variants run on prod traffic with 0 user-facing exposure incidents |
+| QoE Observability GA | _pending_ | EBVS + HeartbeatSessionizer | Server-side QoE aggregation live; EBVS first-class on `PlaybackMetrics` |
+| Palette / M6 Design-System Standardization | _pending_ | Palette polish | Search, empty states, filter-clear, CopyButton standardized across M6; a11y pass |
+
+> The two **active** goals (live open work) are filed first; the remaining seven are
+> filed in a second batch. ADR-031 is a ninth goal that spun up after the original
+> eight were drafted.
+
+## Project field schema
+
+Configure these on the Project. Fields beat labels for *reporting* dimensions — they
+are sortable, groupable, and do not pollute the global label namespace. We promote
+reporting labels to fields and keep only the labels orchestration tooling reads.
+
+| Field | Type | Replaces | Notes |
+| --- | --- | --- | --- |
+| **Status** | Single-select | (new) | `Backlog → Ready → In Progress → In Review → Blocked → Done` |
+| **Iteration** | Iteration | **Milestones** | 2-week cadence; "Sprint 5.6", "Sprint I.2" become iterations |
+| **Goal** | Single-select | (new) | Mirror of the parent-issue title, for table grouping when sub-issue view is not used |
+| **Owner** | Single-select | mirrors `agent-N` / `infra-N` label | Field is for humans/Roadmap; the **label stays** for automation (see caveat) |
+| **Priority** | Single-select | `P0..P4` labels | Drop the labels once migrated |
+| **Cluster** | Single-select | `cluster-a..f` labels | Drop the labels once migrated |
+| **ADR** | Text | (new) | e.g. `ADR-026`; filter "all work for an ADR" across iterations |
+| **Estimate** | Number | (new) | Optional; enables burn-up charts in Insights |
+
+## Views
+
+Three saved views are "same data, three lenses" — no duplication:
+
+| View | Layout | Grouped by | Used for |
+| --- | --- | --- | --- |
+| **Board** | Board | `Status` | Daily execution (Gas Town / Multiclaude operational view) |
+| **Roadmap** | Roadmap | `Goal`, laid on `Iteration` | The outcome view — goals across time |
+| **By Agent** | Table | `Owner` | Per-agent load balancing |
+
+## Creating a Goal
+
+1. Open a new Issue using the **Goal** template (`.github/ISSUE_TEMPLATE/goal.md`).
+2. Fill the **Success Metric** — a threshold, not a checklist.
+3. Add the child issues as **native sub-issues** (Issue sidebar → *Create sub-issue* /
+   *Add existing*). The parent's progress bar is driven by sub-issue closure.
+4. Add the Goal issue to the Project; set the `Goal` field on each child to match.
+5. Leaf issues keep using `Closes #N` in their PRs — unchanged.
+
+## Migration from Milestones
+
+The repo already runs a parallel `sprint-N` **label** system (`beads-sync`,
+`sprint-status`, `evening` all key off labels). So automation keeps working if we keep
+those labels and move only the human/reporting sprint axis to the Iteration field.
+
+**Blast radius** (everything that reads Milestones today):
+
+| Consumer | Today | After migration |
+| --- | --- | --- |
+| `just morning` | `gh api repos/:owner/:repo/milestones` → active milestone | Reads current Iteration from the Project (GraphQL), falls back to active `sprint-N` label |
+| `just agent-work` | prints `.milestone.title` | prints `sprint-N` label (REST-visible) |
+| `docs/guides/github-issues-workflow.md` | "Milestones = Sprints" | Banner points here |
+
+> **The caveat that bites automation:** Project v2 fields and Iterations are reachable
+> **only via the GraphQL API** — they are invisible to REST `gh issue list --milestone`
+> and to label-based hooks. That is why `agent-N` and `sprint-N` stay as labels: the
+> Owner/Iteration *fields* are for humans and the Roadmap; the *labels* are for machines,
+> until the orchestration layer speaks GraphQL.
+
+### Procedure
+
+> **UI steps the API can't do** (the bootstrap script prints these): GitHub seeds a
+> default **Status** field with `Todo|In Progress|Done` — reconcile it to
+> `Backlog, Ready, In Progress, In Review, Blocked, Done`. The **Iteration** field and
+> the three **Views** are also UI-only (single-select option editing, iteration fields,
+> and view creation are not exposed by the Projects-v2 API).
+
+```bash
+# 1. Create the Project + fields (idempotent; dry-run by default). Single-select fields
+#    whose options drift are reported as WARN, not silently skipped.
+./scripts/projects/bootstrap-project.sh --owner <org-or-user> --apply
+
+# 2. Migrate existing Milestones → Iterations and move their issues (dry-run by default)
+./scripts/projects/migrate-milestones-to-iterations.sh --owner <org-or-user> --project <number> --apply
+
+# 3. Verify, then close (do not delete) the old Milestones so history is preserved
+```
+
+Run a **transition sprint with both systems live** before removing Milestone reads
+from the justfile. Do not delete Milestones — close them; their `due_on` dates seed the
+iteration boundaries.
+
+## See also
+
+- [github-issues-workflow.md](./github-issues-workflow.md) — Issue body format, labels, `Closes #N`
+- [orchestration-workflow.md](./orchestration-workflow.md) — Gas Town / Multiclaude dispatch
+- `.github/ISSUE_TEMPLATE/goal.md` — the Goal issue template
+- `scripts/projects/` — bootstrap + migration scripts

--- a/docs/guides/projects-and-goals.md
+++ b/docs/guides/projects-and-goals.md
@@ -8,7 +8,7 @@ This guide defines how the kaizen-experimentation repo tracks work after adoptin
 > **TL;DR**
 > - **Sprint** moves from a Milestone to the Project's native **Iteration** field.
 > - **Goal** is a new top-level concept: a typed parent Issue with one success metric and a tree of native sub-issues.
-> - Reporting labels (`P0..P4`, `cluster-a..f`) become Project **fields**.
+> - Reporting labels (`P0..P4`, `cluster-a..g`) become Project **fields**.
 > - `agent-N` and `sprint-N` **labels stay** — orchestration tooling reads them over the REST API.
 
 ## The four axes
@@ -84,7 +84,7 @@ reporting labels to fields and keep only the labels orchestration tooling reads.
 | **Goal** | Single-select | (new) | Mirror of the parent-issue title, for table grouping when sub-issue view is not used |
 | **Owner** | Single-select | mirrors `agent-N` / `infra-N` label | Field is for humans/Roadmap; the **label stays** for automation (see caveat) |
 | **Priority** | Single-select | `P0..P4` labels | Drop the labels once migrated |
-| **Cluster** | Single-select | `cluster-a..f` labels | Drop the labels once migrated |
+| **Cluster** | Single-select | `cluster-a..g` labels | Drop the labels once migrated |
 | **ADR** | Text | (new) | e.g. `ADR-026`; filter "all work for an ADR" across iterations |
 | **Estimate** | Number | (new) | Optional; enables burn-up charts in Insights |
 

--- a/docs/guides/projects-and-goals.md
+++ b/docs/guides/projects-and-goals.md
@@ -129,11 +129,15 @@ those labels and move only the human/reporting sprint axis to the Iteration fiel
 
 ### Procedure
 
-> **UI steps the API can't do** (the bootstrap script prints these): GitHub seeds a
-> default **Status** field with `Todo|In Progress|Done` — reconcile it to
-> `Backlog, Ready, In Progress, In Review, Blocked, Done`. The **Iteration** field and
-> the three **Views** are also UI-only (single-select option editing, iteration fields,
-> and view creation are not exposed by the Projects-v2 API).
+> **The only genuinely UI-only step is Views** — the Projects-v2 API has no
+> view-creation mutation. Two things the bootstrap script leaves to you but that
+> *are* API-capable (it just doesn't automate them):
+> - **Status options**: GitHub seeds `Todo|In Progress|Done`; reconcile to
+>   `Backlog, Ready, In Progress, In Review, Blocked, Done` via `updateProjectV2Field`
+>   (or the UI). It replaces the whole option set, so only do it before items use the
+>   field. This is the same mutation used to add the `ADR-031 ConnectRPC` Goal option.
+> - **Iteration field**: creatable via `createProjectV2Field` (dataType `ITERATION`),
+>   but it needs a cadence/seed schedule — create it in the UI for now.
 
 ```bash
 # 1. Create the Project + fields (idempotent; dry-run by default). Single-select fields

--- a/justfile
+++ b/justfile
@@ -834,6 +834,29 @@ agent-work agent_label:
     gh issue list --label "{{agent_label}}" --state open --json number,title,milestone \
       --jq '.[] | "#\(.number)\t\(.milestone.title // "no milestone")\t\(.title)"'
 
+# --- GitHub Projects & Goals (see docs/guides/projects-and-goals.md) ---
+# These are ADDITIVE. The Milestone-based recipes above keep working until a
+# full transition sprint has run on both systems (per the migration plan).
+
+# Create the kaizen Project (v2) + fields. Dry-run unless `apply=1`.
+project-bootstrap apply="0":
+    #!/usr/bin/env bash
+    OWNER=$(gh repo view --json owner --jq '.owner.login')
+    FLAG=$([ "{{apply}}" = "1" ] && echo "--apply" || echo "")
+    ./scripts/projects/bootstrap-project.sh --owner "$OWNER" $FLAG
+
+# Migrate open Milestones → Iteration field + sprint-N labels. Dry-run unless `apply=1`.
+project-migrate project apply="0":
+    #!/usr/bin/env bash
+    OWNER=$(gh repo view --json owner --jq '.owner.login')
+    FLAG=$([ "{{apply}}" = "1" ] && echo "--apply" || echo "")
+    ./scripts/projects/migrate-milestones-to-iterations.sh --owner "$OWNER" --project "{{project}}" $FLAG
+
+# List open Goal issues (label:goal) with assignee.
+goals:
+    gh issue list --label "goal" --state open --json number,title,assignees \
+      --jq '.[] | "🎯 #\(.number)\t\(.assignees | map(.login) | join(",") // "unassigned")\t\(.title)"'
+
 # Idempotent: re-running rewrites the <!-- EXEC-BANNER:START/END --> block
 # in place without appending. Looks for a plan file under
 # docs/superpowers/plans/ that references this issue ("Refs #N", "Closes #N",

--- a/scripts/projects/bootstrap-project.sh
+++ b/scripts/projects/bootstrap-project.sh
@@ -11,10 +11,16 @@
 #   - Create text field: ADR.
 #   - Create number field: Estimate.
 #
-# What it CANNOT do (GitHub API does not expose these — do them in the UI):
-#   - Create the ITERATION field (Projects v2 API cannot create iteration fields).
-#   - Create saved VIEWS (Board / Roadmap / By Agent) with grouping.
-# The script prints exact UI instructions for both at the end.
+# What this script LEAVES TO YOU:
+#   - ITERATION field: IS creatable via the API (createProjectV2Field, dataType
+#     ITERATION) but needs cadence + seed-iteration decisions, so this script leaves
+#     it to the UI / a follow-up rather than guessing a schedule.
+#   - Saved VIEWS (Board / Roadmap / By Agent): genuinely UI-only — the Projects-v2
+#     API has NO view-creation mutation. This is the only true UI-only step.
+# NOTE: single-select options ARE editable via the API (updateProjectV2Field — the
+# mutation used to add the ConnectRPC Goal option). But it REPLACES the whole option
+# set and can orphan in-use values, so on drift this script WARNs and lets you
+# reconcile deliberately rather than auto-replacing. It prints the steps at the end.
 #
 # Requirements: gh CLI authenticated with the `project` scope:
 #   gh auth refresh -s project,read:project
@@ -101,7 +107,8 @@ create_single_select() {
     if [ "$have" = "$want" ]; then
       echo "  field '$name' exists with correct options — skip"
     else
-      echo "  WARN: field '$name' exists but options differ — reconcile in the UI:"
+      echo "  WARN: field '$name' exists but options differ. Reconcile deliberately —"
+      echo "        updateProjectV2Field REPLACES the whole set & can orphan in-use values."
       echo "        have: ${have:-<none>}"
       echo "        want: $want"
     fi
@@ -132,30 +139,34 @@ echo "-- Text / number fields --"
 create_field "ADR"      TEXT
 create_field "Estimate" NUMBER
 
-# --- Manual steps the API cannot do ------------------------------------------
+# --- Remaining steps ----------------------------------------------------------
 cat <<EOF
 
 == DONE (API portion) ==
 Project: https://github.com/users/$OWNER/projects/$PROJECT_NUMBER
 
-== MANUAL UI STEPS (GitHub API cannot create these) ==
+== REMAINING STEPS ==
 
-0. STATUS OPTIONS  (Project → ⚙ Settings → Status field)
-   - GitHub seeds Status with Todo|In Progress|Done. Reconcile to:
+0. STATUS OPTIONS  — reconcile the default Todo|In Progress|Done to:
      Backlog, Ready, In Progress, In Review, Blocked, Done
-   - (Single-select options cannot be reliably set via the API; see WARN above.)
+   API-capable (updateProjectV2Field replaces the option set — safe on a fresh
+   project where nothing uses Status yet). One-liner once you have the field id
+   from \`gh project field-list $PROJECT_NUMBER --owner $OWNER --format json\`:
+     gh api graphql -f query='mutation{updateProjectV2Field(input:{fieldId:"<id>",
+       singleSelectOptions:[{name:"Backlog",color:GRAY,description:""},
+       {name:"Ready",color:GRAY,description:""},{name:"In Progress",color:GRAY,description:""},
+       {name:"In Review",color:GRAY,description:""},{name:"Blocked",color:GRAY,description:""},
+       {name:"Done",color:GRAY,description:""}]}){clientMutationId}}'
+   …or just edit it in the UI (Settings → Status field).
 
-1. ITERATION FIELD  (Project → ⚙ Settings → + New field → Iteration)
-   - Name:      Iteration
-   - Duration:  2 weeks
-   - Then add iterations named to match sprints: "Sprint 5.6", "Sprint I.2", ...
-   - (The migrate-milestones-to-iterations.sh script will tell you which to add,
-      derived from existing Milestone due dates.)
+1. ITERATION FIELD  — API-capable (createProjectV2Field, dataType ITERATION) but
+   needs a cadence/seed schedule, so create in the UI for now:
+     Settings → + New field → Iteration, Duration 2 weeks.
 
-2. VIEWS  (Project → + New view)
-   a. "Board"     — Layout: Board    — Group by: Status
-   b. "Roadmap"   — Layout: Roadmap  — Group by: Goal    — Date field: Iteration
-   c. "By Agent"  — Layout: Table    — Group by: Owner
+2. VIEWS  (the ONLY genuinely UI-only step — no view-creation API):
+   a. "Board"    — Board   — Group by: Status
+   b. "Roadmap"  — Roadmap — Group by: Goal — Date field: Iteration
+   c. "By Agent" — Table   — Group by: Owner
 
 After the Iteration field exists, run:
    ./scripts/projects/migrate-milestones-to-iterations.sh --owner $OWNER --project $PROJECT_NUMBER

--- a/scripts/projects/bootstrap-project.sh
+++ b/scripts/projects/bootstrap-project.sh
@@ -172,14 +172,14 @@ create_single_select() {
   fi
   run gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
     --name "$name" --data-type SINGLE_SELECT --single-select-options "$opts"
-  [ "$APPLY" -eq 1 ] && echo "  created single-select '$name'"
+  if [ "$APPLY" -eq 1 ]; then echo "  created single-select '$name'"; fi
 }
 create_field() {
   local name="$1" dtype="$2"
   if has_field "$name"; then echo "  field '$name' exists — skip"; return; fi
   run gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
     --name "$name" --data-type "$dtype"
-  [ "$APPLY" -eq 1 ] && echo "  created $dtype '$name'"
+  if [ "$APPLY" -eq 1 ]; then echo "  created $dtype '$name'"; fi
 }
 create_iteration_field() {
   if has_field "Iteration"; then echo "  field 'Iteration' exists — skip"; return; fi

--- a/scripts/projects/bootstrap-project.sh
+++ b/scripts/projects/bootstrap-project.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# bootstrap-project.sh — Create the kaizen GitHub Project (v2) and its fields.
+#
+# Idempotent: re-running skips fields that already exist (matched by name).
+# Dry-run by default — pass --apply to actually mutate.
+#
+# What it DOES (GitHub Projects v2 API supports these):
+#   - Create the Project (if missing).
+#   - Create single-select fields: Status, Goal, Owner, Priority, Cluster.
+#   - Create text field: ADR.
+#   - Create number field: Estimate.
+#
+# What it CANNOT do (GitHub API does not expose these — do them in the UI):
+#   - Create the ITERATION field (Projects v2 API cannot create iteration fields).
+#   - Create saved VIEWS (Board / Roadmap / By Agent) with grouping.
+# The script prints exact UI instructions for both at the end.
+#
+# Requirements: gh CLI authenticated with the `project` scope:
+#   gh auth refresh -s project,read:project
+#
+# Usage:
+#   ./scripts/projects/bootstrap-project.sh --owner wunderkennd [--title "..."] [--apply]
+#
+set -euo pipefail
+
+OWNER=""
+TITLE="Kaizen Experimentation"
+APPLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner) OWNER="$2"; shift 2 ;;
+    --title) TITLE="$2"; shift 2 ;;
+    --apply) APPLY=1; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$OWNER" ]; then
+  echo "ERROR: --owner <org-or-user> is required (e.g. --owner wunderkennd)" >&2
+  exit 2
+fi
+
+run() {
+  if [ "$APPLY" -eq 1 ]; then
+    "$@"
+  else
+    echo "DRY-RUN: $*"
+  fi
+}
+
+# --- Preflight ----------------------------------------------------------------
+command -v gh >/dev/null || { echo "ERROR: gh CLI not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "ERROR: jq not found" >&2; exit 1; }
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh not authenticated. Run: gh auth login" >&2; exit 1
+fi
+if ! gh auth status 2>&1 | grep -qiE "project"; then
+  echo "WARN: token may lack the 'project' scope. If field creation fails, run:" >&2
+  echo "      gh auth refresh -s project,read:project" >&2
+fi
+
+echo "== Bootstrapping Project '$TITLE' for owner '$OWNER' (apply=$APPLY) =="
+
+# --- Find or create the Project ----------------------------------------------
+PROJECT_NUMBER=$(gh project list --owner "$OWNER" --format json \
+  --jq ".projects[] | select(.title == \"$TITLE\") | .number" 2>/dev/null | head -1 || true)
+
+if [ -n "$PROJECT_NUMBER" ]; then
+  echo "Project exists: #$PROJECT_NUMBER"
+else
+  if [ "$APPLY" -eq 1 ]; then
+    PROJECT_NUMBER=$(gh project create --owner "$OWNER" --title "$TITLE" \
+      --format json --jq '.number')
+    echo "Created Project #$PROJECT_NUMBER"
+  else
+    echo "DRY-RUN: gh project create --owner $OWNER --title \"$TITLE\""
+    PROJECT_NUMBER="<new>"
+  fi
+fi
+
+# --- Field helpers ------------------------------------------------------------
+# Cache the full field JSON so we can compare single-select options, not just names.
+# (GitHub auto-creates a default "Status" field with Todo|In Progress|Done — a
+# name-only check would silently skip it and leave the wrong options.)
+FIELDS_JSON='{"fields":[]}'
+if [ "$PROJECT_NUMBER" != "<new>" ]; then
+  FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json 2>/dev/null || echo '{"fields":[]}')"
+fi
+
+has_field()     { printf '%s' "$FIELDS_JSON" | jq -e --arg n "$1" '.fields[]? | select(.name==$n)' >/dev/null 2>&1; }
+field_options() { printf '%s' "$FIELDS_JSON" | jq -r --arg n "$1" '.fields[]? | select(.name==$n) | [.options[]?.name] | join("|")'; }
+
+create_single_select() {
+  local name="$1" opts="$2" want have
+  want="$(printf '%s' "$opts" | tr ',' '|')"
+  if has_field "$name"; then
+    have="$(field_options "$name")"
+    if [ "$have" = "$want" ]; then
+      echo "  field '$name' exists with correct options — skip"
+    else
+      echo "  WARN: field '$name' exists but options differ — reconcile in the UI:"
+      echo "        have: ${have:-<none>}"
+      echo "        want: $want"
+    fi
+    return
+  fi
+  run gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
+    --name "$name" --data-type SINGLE_SELECT --single-select-options "$opts"
+  [ "$APPLY" -eq 1 ] && echo "  created single-select '$name'"
+}
+create_field() {
+  local name="$1" dtype="$2"
+  if has_field "$name"; then echo "  field '$name' exists — skip"; return; fi
+  run gh project field-create "$PROJECT_NUMBER" --owner "$OWNER" \
+    --name "$name" --data-type "$dtype"
+  [ "$APPLY" -eq 1 ] && echo "  created $dtype '$name'"
+}
+
+# --- Create fields ------------------------------------------------------------
+echo "-- Single-select fields --"
+create_single_select "Status"   "Backlog,Ready,In Progress,In Review,Blocked,Done"
+create_single_select "Priority" "P0,P1,P2,P3,P4"
+create_single_select "Cluster"  "cluster-a,cluster-b,cluster-c,cluster-d,cluster-e,cluster-f,cluster-g"
+create_single_select "Owner"    "agent-1,agent-2,agent-3,agent-4,agent-5,agent-6,agent-7,infra-1,infra-2,infra-3,infra-4,infra-5"
+# Goal mirrors parent-issue titles; seed with the 8 current goals (extend as needed).
+create_single_select "Goal"     "ADR-026 Custom Metrics,ADR-027 TOST,ADR-028 Shadow Inference,ADR-029 Calibration,ADR-030 Shadow Mode,Infrastructure GA,QoE Observability GA,Palette Standardization"
+
+echo "-- Text / number fields --"
+create_field "ADR"      TEXT
+create_field "Estimate" NUMBER
+
+# --- Manual steps the API cannot do ------------------------------------------
+cat <<EOF
+
+== DONE (API portion) ==
+Project: https://github.com/users/$OWNER/projects/$PROJECT_NUMBER
+
+== MANUAL UI STEPS (GitHub API cannot create these) ==
+
+0. STATUS OPTIONS  (Project → ⚙ Settings → Status field)
+   - GitHub seeds Status with Todo|In Progress|Done. Reconcile to:
+     Backlog, Ready, In Progress, In Review, Blocked, Done
+   - (Single-select options cannot be reliably set via the API; see WARN above.)
+
+1. ITERATION FIELD  (Project → ⚙ Settings → + New field → Iteration)
+   - Name:      Iteration
+   - Duration:  2 weeks
+   - Then add iterations named to match sprints: "Sprint 5.6", "Sprint I.2", ...
+   - (The migrate-milestones-to-iterations.sh script will tell you which to add,
+      derived from existing Milestone due dates.)
+
+2. VIEWS  (Project → + New view)
+   a. "Board"     — Layout: Board    — Group by: Status
+   b. "Roadmap"   — Layout: Roadmap  — Group by: Goal    — Date field: Iteration
+   c. "By Agent"  — Layout: Table    — Group by: Owner
+
+After the Iteration field exists, run:
+   ./scripts/projects/migrate-milestones-to-iterations.sh --owner $OWNER --project $PROJECT_NUMBER
+EOF

--- a/scripts/projects/bootstrap-project.sh
+++ b/scripts/projects/bootstrap-project.sh
@@ -5,22 +5,18 @@
 # Idempotent: re-running skips fields that already exist (matched by name).
 # Dry-run by default — pass --apply to actually mutate.
 #
-# What it DOES (GitHub Projects v2 API supports these):
+# What it DOES (all via the Projects-v2 API):
 #   - Create the Project (if missing).
 #   - Create single-select fields: Status, Goal, Owner, Priority, Cluster.
-#   - Create text field: ADR.
-#   - Create number field: Estimate.
+#   - Create text field (ADR) and number field (Estimate).
+#   - Create the ITERATION field, seeded with 3 × 14-day iterations from next Monday.
+#   - Reconcile single-select option drift (e.g. GitHub's default Status options)
+#     WHEN SAFE — i.e. when no project items use the field yet. updateProjectV2Field
+#     replaces the whole option set and can orphan in-use values, so if items already
+#     use the field the script WARNs instead of auto-replacing.
 #
-# What this script LEAVES TO YOU:
-#   - ITERATION field: IS creatable via the API (createProjectV2Field, dataType
-#     ITERATION) but needs cadence + seed-iteration decisions, so this script leaves
-#     it to the UI / a follow-up rather than guessing a schedule.
-#   - Saved VIEWS (Board / Roadmap / By Agent): genuinely UI-only — the Projects-v2
-#     API has NO view-creation mutation. This is the only true UI-only step.
-# NOTE: single-select options ARE editable via the API (updateProjectV2Field — the
-# mutation used to add the ConnectRPC Goal option). But it REPLACES the whole option
-# set and can orphan in-use values, so on drift this script WARNs and lets you
-# reconcile deliberately rather than auto-replacing. It prints the steps at the end.
+# The ONLY genuinely UI-only step is VIEWS (Board / Roadmap / By Agent) — the
+# Projects-v2 API has no view-creation mutation. The script prints the view spec.
 #
 # Requirements: gh CLI authenticated with the `project` scope:
 #   gh auth refresh -s project,read:project
@@ -98,19 +94,79 @@ fi
 
 has_field()     { printf '%s' "$FIELDS_JSON" | jq -e --arg n "$1" '.fields[]? | select(.name==$n)' >/dev/null 2>&1; }
 field_options() { printf '%s' "$FIELDS_JSON" | jq -r --arg n "$1" '.fields[]? | select(.name==$n) | [.options[]?.name] | join("|")'; }
+field_id()      { printf '%s' "$FIELDS_JSON" | jq -r --arg n "$1" '.fields[]? | select(.name==$n) | .id'; }
+
+# Project node id (needed for GraphQL field create + usage checks).
+PROJECT_ID=""
+if [ "$PROJECT_NUMBER" != "<new>" ]; then
+  PROJECT_ID="$(gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.id' 2>/dev/null || true)"
+fi
+
+gql() { gh api graphql -f query="$1" "${@:2}"; }
+
+# "A,B,C" -> {name:"A",color:GRAY,description:""},{name:"B",...}
+opts_to_gql() {
+  local IFS=',' parts=() o out=""
+  read -ra parts <<<"$1"
+  for o in "${parts[@]}"; do out+="{name:\"$o\",color:GRAY,description:\"\"},"; done
+  printf '%s' "${out%,}"
+}
+
+# Is a single-select field in use? echoes no|yes|unknown.
+# "no" = safe to replace options; "yes"/"unknown" = do NOT auto-replace.
+field_in_use() {
+  local name="$1" total used
+  [ -z "$PROJECT_ID" ] && { echo "unknown"; return; }
+  total=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --jq '.items | length' 2>/dev/null || echo "?")
+  [ "$total" = "?" ] && { echo "unknown"; return; }
+  [ "$total" -eq 0 ] && { echo "no"; return; }
+  used=$(gql 'query($pid:ID!,$fn:String!){node(id:$pid){... on ProjectV2{items(first:100){nodes{fieldValueByName(name:$fn){__typename}}}}}}' \
+           -f pid="$PROJECT_ID" -f fn="$name" \
+           --jq '[.data.node.items.nodes[]? | select(.fieldValueByName!=null)] | length' 2>/dev/null || echo "?")
+  [ "$used" = "?" ] && { echo "unknown"; return; }
+  if   [ "$used" -gt 0 ];   then echo "yes"
+  elif [ "$total" -gt 100 ]; then echo "unknown"   # only sampled 100 — can't be sure
+  else echo "no"; fi
+}
+
+# Portable date helpers (GNU then BSD then today-fallback).
+next_monday() {
+  date -d "next monday" +%Y-%m-%d 2>/dev/null && return
+  date -v+Mon +%Y-%m-%d 2>/dev/null && return
+  date +%Y-%m-%d
+}
+add_days() {  # $1=YYYY-MM-DD $2=N
+  date -d "$1 +$2 days" +%Y-%m-%d 2>/dev/null && return
+  date -j -v+"$2"d -f "%Y-%m-%d" "$1" +%Y-%m-%d 2>/dev/null && return
+  printf '%s' "$1"
+}
 
 create_single_select() {
-  local name="$1" opts="$2" want have
-  want="$(printf '%s' "$opts" | tr ',' '|')"
+  local name="$1" opts="$2" want_set have_raw have_set usage fid gqlopts
+  # Compare as a SET (order-insensitive): a mere reorder isn't worth a reconcile.
+  want_set="$(printf '%s' "$opts" | tr ',' '\n' | sort | paste -sd',' -)"
   if has_field "$name"; then
-    have="$(field_options "$name")"
-    if [ "$have" = "$want" ]; then
-      echo "  field '$name' exists with correct options — skip"
+    have_raw="$(field_options "$name")"
+    have_set="$(printf '%s' "$have_raw" | tr '|' '\n' | sort | paste -sd',' -)"
+    if [ "$have_set" = "$want_set" ]; then
+      echo "  field '$name' exists with the right option set — skip"; return
+    fi
+    # Option SET drift. Auto-reconcile only if no items use the field (else orphan risk).
+    usage="$(field_in_use "$name")"
+    echo "  field '$name' option set differs (usage=$usage)"
+    echo "    have: ${have_raw:-<none>}"
+    echo "    want: $opts"
+    if [ "$usage" = "no" ]; then
+      if [ "$APPLY" -eq 1 ]; then
+        fid="$(field_id "$name")"; gqlopts="$(opts_to_gql "$opts")"
+        gql "mutation{updateProjectV2Field(input:{fieldId:\"$fid\",singleSelectOptions:[$gqlopts]}){clientMutationId}}" >/dev/null \
+          && echo "    reconciled '$name' options via API (no items used it)"
+      else
+        echo "    DRY-RUN: would reconcile '$name' options via updateProjectV2Field (safe — unused)"
+      fi
     else
-      echo "  WARN: field '$name' exists but options differ. Reconcile deliberately —"
-      echo "        updateProjectV2Field REPLACES the whole set & can orphan in-use values."
-      echo "        have: ${have:-<none>}"
-      echo "        want: $want"
+      echo "    WARN: usage=$usage — NOT auto-reconciling (replace can orphan in-use values)."
+      echo "          Reconcile deliberately in the UI or via updateProjectV2Field."
     fi
     return
   fi
@@ -125,6 +181,21 @@ create_field() {
     --name "$name" --data-type "$dtype"
   [ "$APPLY" -eq 1 ] && echo "  created $dtype '$name'"
 }
+create_iteration_field() {
+  if has_field "Iteration"; then echo "  field 'Iteration' exists — skip"; return; fi
+  local d1 d2 d3 iters
+  d1="$(next_monday)"; d2="$(add_days "$d1" 14)"; d3="$(add_days "$d1" 28)"
+  iters="{title:\"Iteration 1\",startDate:\"$d1\",duration:14},"
+  iters+="{title:\"Iteration 2\",startDate:\"$d2\",duration:14},"
+  iters+="{title:\"Iteration 3\",startDate:\"$d3\",duration:14}"
+  if [ "$APPLY" -eq 1 ]; then
+    [ -n "$PROJECT_ID" ] || { echo "  WARN: no PROJECT_ID — cannot create Iteration field"; return; }
+    gql "mutation{createProjectV2Field(input:{projectId:\"$PROJECT_ID\",dataType:ITERATION,name:\"Iteration\",iterationConfiguration:{startDate:\"$d1\",duration:14,iterations:[$iters]}}){projectV2Field{... on ProjectV2IterationField{id}}}}" >/dev/null \
+      && echo "  created Iteration field (3 × 14-day iterations from $d1)"
+  else
+    echo "  DRY-RUN: create Iteration field — 3 × 14-day iterations from $d1"
+  fi
+}
 
 # --- Create fields ------------------------------------------------------------
 echo "-- Single-select fields --"
@@ -133,11 +204,14 @@ create_single_select "Priority" "P0,P1,P2,P3,P4"
 create_single_select "Cluster"  "cluster-a,cluster-b,cluster-c,cluster-d,cluster-e,cluster-f,cluster-g"
 create_single_select "Owner"    "agent-1,agent-2,agent-3,agent-4,agent-5,agent-6,agent-7,infra-1,infra-2,infra-3,infra-4,infra-5"
 # Goal mirrors parent-issue titles; seed with the 8 current goals (extend as needed).
-create_single_select "Goal"     "ADR-026 Custom Metrics,ADR-027 TOST,ADR-028 Shadow Inference,ADR-029 Calibration,ADR-030 Shadow Mode,Infrastructure GA,QoE Observability GA,Palette Standardization"
+create_single_select "Goal"     "ADR-026 Custom Metrics,ADR-027 TOST,ADR-028 Shadow Inference,ADR-029 Calibration,ADR-030 Shadow Mode,Infrastructure GA,QoE Observability GA,Palette Standardization,ADR-031 ConnectRPC"
 
 echo "-- Text / number fields --"
 create_field "ADR"      TEXT
 create_field "Estimate" NUMBER
+
+echo "-- Iteration field --"
+create_iteration_field
 
 # --- Remaining steps ----------------------------------------------------------
 cat <<EOF
@@ -145,29 +219,21 @@ cat <<EOF
 == DONE (API portion) ==
 Project: https://github.com/users/$OWNER/projects/$PROJECT_NUMBER
 
-== REMAINING STEPS ==
+Automated above (when --apply): all fields incl. Iteration (3 × 14-day iterations),
+plus Status option reconciliation when no items use the field yet.
 
-0. STATUS OPTIONS  — reconcile the default Todo|In Progress|Done to:
-     Backlog, Ready, In Progress, In Review, Blocked, Done
-   API-capable (updateProjectV2Field replaces the option set — safe on a fresh
-   project where nothing uses Status yet). One-liner once you have the field id
-   from \`gh project field-list $PROJECT_NUMBER --owner $OWNER --format json\`:
-     gh api graphql -f query='mutation{updateProjectV2Field(input:{fieldId:"<id>",
-       singleSelectOptions:[{name:"Backlog",color:GRAY,description:""},
-       {name:"Ready",color:GRAY,description:""},{name:"In Progress",color:GRAY,description:""},
-       {name:"In Review",color:GRAY,description:""},{name:"Blocked",color:GRAY,description:""},
-       {name:"Done",color:GRAY,description:""}]}){clientMutationId}}'
-   …or just edit it in the UI (Settings → Status field).
+== REMAINING STEP (the only genuinely UI-only piece) ==
 
-1. ITERATION FIELD  — API-capable (createProjectV2Field, dataType ITERATION) but
-   needs a cadence/seed schedule, so create in the UI for now:
-     Settings → + New field → Iteration, Duration 2 weeks.
-
-2. VIEWS  (the ONLY genuinely UI-only step — no view-creation API):
+VIEWS  (Projects-v2 has no view-creation API — create in the UI):
    a. "Board"    — Board   — Group by: Status
    b. "Roadmap"  — Roadmap — Group by: Goal — Date field: Iteration
    c. "By Agent" — Table   — Group by: Owner
 
-After the Iteration field exists, run:
+Notes:
+ - If Status options drifted but items already use the field, the script WARNs
+   instead of replacing (replacing can orphan in-use values) — reconcile manually.
+ - Iteration iterations are named Iteration 1/2/3; rename in the UI to match sprints.
+
+Then run:
    ./scripts/projects/migrate-milestones-to-iterations.sh --owner $OWNER --project $PROJECT_NUMBER
 EOF

--- a/scripts/projects/migrate-milestones-to-iterations.sh
+++ b/scripts/projects/migrate-milestones-to-iterations.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# migrate-milestones-to-iterations.sh
+#   Onboard Milestone-tracked work onto a Projects-v2 board + Iteration field.
+#
+# Dry-run by default — pass --apply to mutate. Idempotent and re-runnable.
+#
+# Model (see docs/guides/projects-and-goals.md):
+#   - Iterations are FORWARD-LOOKING cadence buckets and can't be created via API.
+#     So we do NOT back-date one iteration per historical sprint. Instead:
+#       * Active (open) work is added to the Project and assigned the current
+#         Iteration, plus a machine-readable `sprint-N` mirror label.
+#       * Closed historical sprints stay as their (closed) Milestones — the
+#         archive — and are migrated only if you ask (--state all/closed).
+#   - `sprint-N` labels remain the REST-visible sprint record that existing
+#     orchestration tooling reads.
+#
+# Iteration data is read via GraphQL (gh project field-list does NOT return
+# iteration titles/ids — only id|name|type).
+#
+# Requirements: gh CLI with `project` scope; jq.
+#
+# Usage (active-only, the default and recommended path):
+#   ./scripts/projects/migrate-milestones-to-iterations.sh \
+#       --owner wunderkennd --project 5 [--state open] [--iteration "Iteration 1"] [--apply]
+#
+# Flags:
+#   --owner <login>        (required)
+#   --project <number>     (required)
+#   --state open|closed|all   issues to migrate per milestone   (default: open)
+#   --milestone "TITLE"       only this milestone                (default: all)
+#   --iteration "TITLE"       iteration assigned to migrated OPEN issues
+#                             (default: the earliest current/upcoming iteration)
+#   --apply                   actually mutate (default: dry-run)
+#
+set -euo pipefail
+
+OWNER=""; PROJECT=""; STATE="open"; ONLY_MS=""; ITER_TITLE=""; APPLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner)     OWNER="$2"; shift 2 ;;
+    --project)   PROJECT="$2"; shift 2 ;;
+    --state)     STATE="$2"; shift 2 ;;
+    --milestone) ONLY_MS="$2"; shift 2 ;;
+    --iteration) ITER_TITLE="$2"; shift 2 ;;
+    --apply)     APPLY=1; shift ;;
+    -h|--help)   sed -n '2,40p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$OWNER" ]   || { echo "ERROR: --owner required" >&2; exit 2; }
+[ -n "$PROJECT" ] || { echo "ERROR: --project <number> required" >&2; exit 2; }
+case "$STATE" in open|closed|all) ;; *) echo "ERROR: --state must be open|closed|all" >&2; exit 2 ;; esac
+
+REPO="$OWNER/kaizen-experimentation"
+run() { if [ "$APPLY" -eq 1 ]; then "$@"; else echo "DRY-RUN: $*"; fi; }
+
+sprint_label() {  # "Sprint I.3: Multi-Cloud" -> "sprint-i.3"
+  local title="$1" tok
+  tok=$(printf '%s' "$title" | grep -oiE '[0-9I]+\.[0-9]+' | head -1 || true)
+  if [ -n "$tok" ]; then
+    printf 'sprint-%s' "$(printf '%s' "$tok" | tr '[:upper:]' '[:lower:]')"
+  else
+    printf 'sprint-%s' "$(printf '%s' "$title" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9.-' | cut -c1-30)"
+  fi
+}
+
+# --- Preflight ----------------------------------------------------------------
+command -v gh >/dev/null || { echo "ERROR: gh CLI not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "ERROR: jq not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "ERROR: gh not authenticated" >&2; exit 1; }
+
+# --- Resolve Project + Iteration field via GraphQL ----------------------------
+PROJECT_ID=$(gh project view "$PROJECT" --owner "$OWNER" --format json --jq '.id')
+[ -n "$PROJECT_ID" ] || { echo "ERROR: could not resolve project id" >&2; exit 1; }
+
+ITER_GQL=$(gh api graphql -f query='
+  query($pid:ID!){ node(id:$pid){ ... on ProjectV2 {
+    field(name:"Iteration"){ ... on ProjectV2IterationField {
+      id configuration { iterations { id title startDate } } } } } } }' \
+  -f pid="$PROJECT_ID" 2>/dev/null || echo '{}')
+
+ITER_FIELD_ID=$(printf '%s' "$ITER_GQL" | jq -r '.data.node.field.id // empty')
+# Choose target iteration id: explicit --iteration title, else earliest available.
+if [ -n "$ITER_TITLE" ]; then
+  ITER_ID=$(printf '%s' "$ITER_GQL" | jq -r --arg t "$ITER_TITLE" \
+    '.data.node.field.configuration.iterations[]? | select(.title==$t) | .id' | head -1)
+  ITER_PICK="$ITER_TITLE"
+else
+  ITER_ID=$(printf '%s'  "$ITER_GQL" | jq -r '.data.node.field.configuration.iterations[0]?.id // empty')
+  ITER_PICK=$(printf '%s' "$ITER_GQL" | jq -r '.data.node.field.configuration.iterations[0]?.title // empty')
+fi
+
+echo "== Migration plan =="
+echo "  Project:        #$PROJECT ($PROJECT_ID)"
+echo "  Issue state:    $STATE"
+echo "  Iteration field:${ITER_FIELD_ID:-<none>}"
+if [ -n "$ITER_FIELD_ID" ] && [ -n "$ITER_ID" ]; then
+  echo "  Assign open →   '$ITER_PICK' ($ITER_ID)"
+else
+  echo "  Assign open →   (no iteration available — open issues get label+board only)"
+fi
+echo
+
+# --- Milestones ---------------------------------------------------------------
+MS_JSON=$(gh api "repos/$REPO/milestones?state=all&per_page=100")
+TITLES=$(printf '%s' "$MS_JSON" | jq -r --arg only "$ONLY_MS" \
+  '.[] | select(($only=="") or (.title==$only)) | .title')
+
+[ -n "$TITLES" ] || { echo "No matching milestones."; exit 0; }
+
+printf '%s\n' "$TITLES" | while IFS= read -r title; do
+  label=$(sprint_label "$title")
+  echo "-- $title  (label=$label) --"
+  run gh label create "$label" --repo "$REPO" --color "ededed" \
+      --description "Sprint mirror of '$title'" 2>/dev/null || true
+
+  gh issue list --repo "$REPO" --milestone "$title" --state "$STATE" \
+      --limit 500 --json number,url,state \
+      --jq '.[] | [.number, .url, .state] | @tsv' \
+  | while IFS=$'\t' read -r num url istate; do
+      echo "   #$num ($istate)"
+      run gh issue edit "$num" --repo "$REPO" --add-label "$label"
+      if [ "$APPLY" -eq 1 ]; then
+        ITEM_ID=$(gh project item-add "$PROJECT" --owner "$OWNER" --url "$url" \
+                  --format json --jq '.id' 2>/dev/null || true)
+      else
+        echo "   DRY-RUN: gh project item-add $PROJECT --owner $OWNER --url $url"
+        ITEM_ID=""
+      fi
+      # Assign the current iteration to OPEN issues only.
+      if [ "$istate" = "OPEN" ] && [ -n "$ITER_FIELD_ID" ] && [ -n "$ITER_ID" ]; then
+        if [ -n "${ITEM_ID:-}" ]; then
+          run gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" \
+              --field-id "$ITER_FIELD_ID" --iteration-id "$ITER_ID"
+        else
+          echo "   DRY-RUN: gh project item-edit --id <item> --field-id $ITER_FIELD_ID --iteration-id $ITER_ID"
+        fi
+      fi
+    done
+done
+
+cat <<EOF
+
+== NEXT ==
+  - Verify open items landed on Project #$PROJECT with iteration '$ITER_PICK'.
+  - Closed historical sprints remain as (closeable) Milestones — the archive.
+  - After a transition sprint on both systems, drop Milestone reads from the
+    justfile (see docs/guides/projects-and-goals.md → Migration from Milestones).
+EOF

--- a/scripts/projects/seed-goals.sh
+++ b/scripts/projects/seed-goals.sh
@@ -6,7 +6,7 @@
 # One per ADR or named initiative (see docs/guides/projects-and-goals.md).
 #
 # Dry-run by default — pass --apply to mutate. Idempotent: skips a goal whose
-# exact title already exists as an open issue.
+# exact title already exists as an issue (open or closed — query uses --state all).
 #
 # For each goal it: creates the issue (label:goal), adds it to the Project, and
 # links its child issues as NATIVE sub-issues (REST sub_issues API) so the

--- a/scripts/projects/seed-goals.sh
+++ b/scripts/projects/seed-goals.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# seed-goals.sh — File Goal issues (label:goal) and add them to the Project.
+#
+# A Goal = an outcome with ONE success metric, parent of native sub-issues.
+# One per ADR or named initiative (see docs/guides/projects-and-goals.md).
+#
+# Dry-run by default — pass --apply to mutate. Idempotent: skips a goal whose
+# exact title already exists as an open issue.
+#
+# For each goal it: creates the issue (label:goal), adds it to the Project, and
+# links its child issues as NATIVE sub-issues (REST sub_issues API) so the
+# parent progress bar tracks closure.
+#
+# Requirements: gh CLI with `project` scope; jq.
+#
+# Usage:
+#   ./scripts/projects/seed-goals.sh --owner wunderkennd --project 5 [--filter k1,k2] [--apply]
+#
+# Filter keys: infra connectrpc adr-026 adr-027 adr-028 adr-029 adr-030 qoe palette
+#
+set -euo pipefail
+
+OWNER=""; PROJECT=""; FILTER=""; APPLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner)   OWNER="$2"; shift 2 ;;
+    --project) PROJECT="$2"; shift 2 ;;
+    --filter)  FILTER="$2"; shift 2 ;;
+    --apply)   APPLY=1; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$OWNER" ]   || { echo "ERROR: --owner required" >&2; exit 2; }
+[ -n "$PROJECT" ] || { echo "ERROR: --project <number> required" >&2; exit 2; }
+
+REPO="$OWNER/kaizen-experimentation"
+command -v gh >/dev/null || { echo "ERROR: gh CLI not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "ERROR: jq not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "ERROR: gh not authenticated" >&2; exit 1; }
+run() { if [ "$APPLY" -eq 1 ]; then "$@"; else echo "DRY-RUN: $*"; fi; }
+
+in_filter() { [ -z "$FILTER" ] && return 0; printf ',%s,' "$FILTER" | grep -q ",$1,"; }
+
+# Ensure the `goal` label exists.
+run gh label create goal --repo "$REPO" --color "5319e7" \
+    --description "Outcome with a success metric; parent of sub-issues" 2>/dev/null || true
+
+# Cache existing goal issue titles for idempotency.
+EXISTING=$(gh issue list --repo "$REPO" --label goal --state all --limit 200 \
+           --json title --jq '.[].title' 2>/dev/null || true)
+
+seed_goal() {
+  local key="$1" title="$2" adr="$3" outcome="$4" metric="$5" children="$6"
+  in_filter "$key" || return 0
+  echo "== [$key] $title =="
+  if printf '%s\n' "$EXISTING" | grep -qxF "$title"; then
+    echo "  exists — skip"; return 0
+  fi
+
+  local kids_md="_none yet — add child issues as work is filed_"
+  if [ -n "$children" ]; then
+    kids_md=""
+    IFS=',' read -ra arr <<<"$children"
+    for n in "${arr[@]}"; do kids_md+="- [ ] #$n"$'\n'; done
+  fi
+
+  local body
+  body=$(cat <<EOF
+## Outcome
+$outcome
+
+## Success metric
+$metric
+
+## Source
+- **ADR:** $adr
+
+## Child issues
+$kids_md
+
+> Filed by scripts/projects/seed-goals.sh. Child issues are linked as native
+> sub-issues; the progress bar above tracks their closure.
+> See docs/guides/projects-and-goals.md.
+EOF
+)
+
+  if [ "$APPLY" -eq 1 ]; then
+    local url num
+    url=$(gh issue create --repo "$REPO" --title "$title" --label goal --body "$body")
+    echo "  created: $url"
+    num="${url##*/}"
+    gh project item-add "$PROJECT" --owner "$OWNER" --url "$url" >/dev/null && echo "  added to project #$PROJECT"
+    if [ -n "$children" ]; then
+      IFS=',' read -ra arr <<<"$children"
+      for n in "${arr[@]}"; do
+        local cid
+        cid=$(gh api "repos/$REPO/issues/$n" --jq '.id' 2>/dev/null || true)
+        if [ -n "$cid" ]; then
+          gh api -X POST "repos/$REPO/issues/$num/sub_issues" -F sub_issue_id="$cid" >/dev/null 2>&1 \
+            && echo "  linked sub-issue #$n" || echo "  WARN: could not link #$n (may already be linked)"
+        fi
+      done
+    fi
+  else
+    echo "  DRY-RUN: gh issue create --title \"$title\" --label goal"
+    [ -n "$children" ] && echo "  DRY-RUN: link sub-issues: $children"
+    echo "  DRY-RUN: add to project #$PROJECT"
+  fi
+}
+
+#         key          title                                                                          ADR                outcome                                                                                          metric                                                                                            children
+seed_goal infra        "Goal: Infrastructure GA (Pulumi/AWS) — all 9 Kaizen services deployed"         "none (initiative)" "All 9 Kaizen services deployed on AWS via Pulumi with observability and green mock suites."        "9/9 services deployed; fullstack mock suite green; observability (logging/metrics/tracing) wired." "496,498,500,501,502"
+seed_goal connectrpc   "Goal: ADR-031 ConnectRPC Pilot — unified Connect transport for M1 assignment"  "ADR-031"           "M1 assignment RPCs served over ConnectRPC, retiring hand-rolled JSON shims."                      "GetAssignment + remaining unary + StreamConfigUpdates over Connect; JSON shim retired; pilot meets success/kill criteria." "641,642,643,644,645"
+seed_goal adr-026      "Goal: ADR-026 Custom Metrics Layer — operators self-serve custom metrics"      "ADR-026"           "Operators define composite/derived/joined metrics beyond the six built-in types without engineering." "3 Tier-1 types (FILTERED_MEAN, COMPOSITE, WINDOWED_COUNT) GA; <5% definition-validation error over 30 days." ""
+seed_goal adr-027      "Goal: ADR-027 TOST Equivalence Testing — prove equivalence for migrations"     "ADR-027"           "Teams prove statistical equivalence (not just non-difference) for infra migrations and refactors."  "TOST exposed in M4a/M5/M6; golden files match R TOSTER (tsum_TOST) to 6 decimal places."           ""
+seed_goal adr-028      "Goal: ADR-028 M4b Shadow Inference — safe bandit policy promotion"             "ADR-028"           "Bandit policies promote via a dedicated shadow core with column-family isolation, no prod impact."  "Shadow core promotes policies with zero prod-traffic exposure regressions."                        ""
+seed_goal adr-029      "Goal: ADR-029 Cross-Modal Score Calibration — unified NEV scale"               "ADR-029"           "Heterogeneous slates (video, manga, commerce) score on one calibrated NEV scale."                  "Unified NEV scale across >=3 modalities; calibration error within target band."                   ""
+seed_goal adr-030      "Goal: ADR-030 Shadow Experiment Mode — candidate variants on prod traffic"     "ADR-030"           "Experiments run candidate variants on production traffic without exposing users."                   "Candidate variants run on prod traffic with 0 user-facing exposure incidents."                    ""
+seed_goal qoe          "Goal: QoE Observability GA — server-side QoE aggregation"                      "none (initiative)" "EBVS is first-class on PlaybackMetrics and HeartbeatSessionizer delivers server-side QoE aggregation." "Server-side QoE aggregation live; EBVS first-class on PlaybackMetrics; heartbeat sessionization in prod." ""
+seed_goal palette      "Goal: Palette / M6 Design-System Standardization"                             "none (initiative)" "Search, empty states, filter-clearing, and CopyButton are standardized across M6 with a11y passing." "Standardized patterns across M6 surfaces; accessibility audit passes."                             ""
+
+echo
+echo "== DONE (filter='${FILTER:-all}', apply=$APPLY) =="
+echo "Goals board: https://github.com/users/$OWNER/projects/$PROJECT"


### PR DESCRIPTION
## Summary

Introduces a **GitHub Projects (v2)** work-tracking model that adds a **Goal** layer
(an outcome with one measurable success metric, one per ADR or named initiative) above
the existing Sprint / Issue / ADR axes, and migrates sprints from **Milestones** to the
Project **Iteration** field.

Goals are the previously-missing *outcome* axis: ADRs record decisions, Issues track
work, Sprints are calendar buckets — but nothing carried "what outcome, and how do we
know we hit it." A Goal is a typed parent Issue (`label:goal`) with native sub-issues,
so it gets a roll-up progress bar for free.

## What's included

| Area | Change |
| --- | --- |
| Convention | `docs/guides/projects-and-goals.md` — four axes, goal granularity rule, field schema, views, Milestone→Iteration migration + blast radius |
| Template | `.github/ISSUE_TEMPLATE/goal.md` + `config.yml` — Goal issue template (forces a success metric, not a checklist) |
| Bootstrap | `scripts/projects/bootstrap-project.sh` — create Project + API-creatable fields; warns on option drift; flags UI-only steps |
| Migration | `scripts/projects/migrate-milestones-to-iterations.sh` — active-only model, reads iterations via GraphQL, `--state`/`--iteration` flags |
| Seeding | `scripts/projects/seed-goals.sh` — file Goal issues with native sub-issue links, idempotent |
| Tooling | `justfile` — additive `project-bootstrap` / `project-migrate` / `goals` recipes |
| Transition | `github-issues-workflow.md` — banner pointing to the new model |

All scripts are **dry-run by default** and idempotent.

## Decisions

- **Goal granularity:** one per ADR or named initiative (not per-issue, not one mega-goal). Qualifies only if it has one measurable metric, spans ≥1 iteration, owns ≥2 child issues.
- **Migrate from Milestones** to the Iteration field; keep `agent-N` / `sprint-N` **labels** as the REST-visible mirror that orchestration tooling reads (Projects-v2 fields are GraphQL-only).
- **Active-only migration:** only open work onboarded; 7 closed historical sprints stay as archived Milestones.

## Already applied against Project #5

- Project #5 created with fields Status / Priority / Cluster / Owner / Goal / ADR / Estimate (Iteration field + 3 views created in UI — API can't).
- 10 open issues onboarded (Sprint I.3 + ConnectRPC ADR-031) on Iteration 1 with `sprint-*` labels.
- 9 Goal issues filed with sub-issues linked: #647 Infra GA, #648 ConnectRPC, #649–655 (ADR-026/027/028/029/030, QoE, Palette).

## Honest limitations (documented in the guide)

GitHub's Projects-v2 API **cannot** create Iteration fields, edit single-select options, or create views — those are UI-only. The bootstrap script does the automatable parts and prints exact UI instructions for the rest.

## Test plan

- [x] `bash -n` syntax + dry-run on all three scripts
- [x] Bootstrap applied; fields verified via `field-list`; option-drift warning verified
- [x] Migration applied; 10 items verified on Project #5 with Iteration 1 + labels
- [x] Goals seeded; native sub-issue links verified via `sub_issues` API (9 goals)
- [x] `just` parses new recipes
- [ ] Reviewer: confirm field/view config matches the guide before retiring Milestone reads in the justfile
- [ ] Follow-up (not in this PR): after a transition sprint, drop Milestone reads from `just morning` / `agent-work`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->