### PR TITLE
chore(metrics): consolidate composite-operator-to-string helper

### DIFF
--- a/services/metrics/internal/config/loader.go
+++ b/services/metrics/internal/config/loader.go
@@ -82,8 +82,13 @@ func TypeShortName(t commonv1.MetricType) string {
 	return strings.TrimPrefix(t.String(), "METRIC_TYPE_")
 }
 
-// CompositeOperatorShortName strips the "COMPOSITE_OPERATOR_" prefix.
+// CompositeOperatorShortName strips the "COMPOSITE_OPERATOR_" prefix. Returns
+// "" for the UNSPECIFIED zero value so callers don't leak a stale token into
+// Spark params or logs when the operator field is absent.
 func CompositeOperatorShortName(op commonv1.CompositeOperator) string {
+	if op == commonv1.CompositeOperator_COMPOSITE_OPERATOR_UNSPECIFIED {
+		return ""
+	}
 	return strings.TrimPrefix(op.String(), "COMPOSITE_OPERATOR_")
 }
 

--- a/services/metrics/internal/config/loader_test.go
+++ b/services/metrics/internal/config/loader_test.go
@@ -221,3 +221,23 @@ func TestMetricConfig_ADR026Phase1_RoundTrip(t *testing.T) {
 		assert.Nil(t, m.GetWindowedCount())
 	})
 }
+
+func TestCompositeOperatorShortName(t *testing.T) {
+	cases := []struct {
+		name string
+		op   commonv1.CompositeOperator
+		want string
+	}{
+		{"unspecified is empty", commonv1.CompositeOperator_COMPOSITE_OPERATOR_UNSPECIFIED, ""},
+		{"add", commonv1.CompositeOperator_COMPOSITE_OPERATOR_ADD, "ADD"},
+		{"subtract", commonv1.CompositeOperator_COMPOSITE_OPERATOR_SUBTRACT, "SUBTRACT"},
+		{"multiply", commonv1.CompositeOperator_COMPOSITE_OPERATOR_MULTIPLY, "MULTIPLY"},
+		{"divide", commonv1.CompositeOperator_COMPOSITE_OPERATOR_DIVIDE, "DIVIDE"},
+		{"weighted_sum", commonv1.CompositeOperator_COMPOSITE_OPERATOR_WEIGHTED_SUM, "WEIGHTED_SUM"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, CompositeOperatorShortName(tc.op))
+		})
+	}
+}

--- a/services/metrics/internal/jobs/shadow_runner.go
+++ b/services/metrics/internal/jobs/shadow_runner.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -262,7 +261,7 @@ func (j *StandardJob) renderShadowCandidate(
 				}
 			}
 			params.Operands = sparOps
-			params.Operator = compositeOperatorString(comp.GetOperator())
+			params.Operator = config.CompositeOperatorShortName(comp.GetOperator())
 		}
 
 	case commonv1.MetricType_METRIC_TYPE_WINDOWED_COUNT:
@@ -336,25 +335,5 @@ func protoMetricTypeToString(mt commonv1.MetricType) (string, error) {
 	// This default covers UNSPECIFIED and any future proto enum additions.
 	default:
 		return "", fmt.Errorf("protoMetricTypeToString: unexpected type %s", mt.String())
-	}
-}
-
-// compositeOperatorString maps a CompositeOperator proto enum to the uppercase
-// string that spark.SQLRenderer.RenderForType / RenderComposite expect.
-func compositeOperatorString(op commonv1.CompositeOperator) string {
-	switch op {
-	case commonv1.CompositeOperator_COMPOSITE_OPERATOR_ADD:
-		return "ADD"
-	case commonv1.CompositeOperator_COMPOSITE_OPERATOR_SUBTRACT:
-		return "SUBTRACT"
-	case commonv1.CompositeOperator_COMPOSITE_OPERATOR_MULTIPLY:
-		return "MULTIPLY"
-	case commonv1.CompositeOperator_COMPOSITE_OPERATOR_DIVIDE:
-		return "DIVIDE"
-	case commonv1.CompositeOperator_COMPOSITE_OPERATOR_WEIGHTED_SUM:
-		return "WEIGHTED_SUM"
-	default:
-		// UNSPECIFIED — leave blank; RenderForType will reject it.
-		return strings.ToUpper(op.String())
 	}
 }


### PR DESCRIPTION
## Summary

- Switch `shadow_runner.go` callsite to `config.CompositeOperatorShortName` and delete the local `compositeOperatorString` switch.
- Guard the UNSPECIFIED zero value in `CompositeOperatorShortName` to return `""` instead of `"UNSPECIFIED"`, which also fixes the sibling finding at `standard.go:245` where non-COMPOSITE metrics were leaking `"UNSPECIFIED"` into `params.Operator` via the nil-getter chain.
- Add a table-driven test for `CompositeOperatorShortName` covering UNSPECIFIED and all five known operators.

No behavioural change at any current callsite — both Spark renderers reject UNSPECIFIED-derived values the same way regardless of whether the string is `"UNSPECIFIED"`, `"COMPOSITE_OPERATOR_UNSPECIFIED"`, or `""`. Cleanup only.

Closes #615

## Test plan

- [x] `go test ./services/metrics/internal/config/... -run TestCompositeOperatorShortName -v` — 6/6 pass
- [x] `go test ./services/metrics/internal/jobs/... ./services/metrics/internal/config/...` — both packages green
- [x] `go vet ./services/metrics/...` — clean
- [x] `gofmt -l` on touched files — clean
- [x] `just check-branch-name` — matches `agent-N/<verb>/adr-XXX-<slug>`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->