### PR TITLE
refactor(management): consolidate identifier helper in validators

### DIFF
--- a/crates/experimentation-management/src/validators/metric_definition.rs
+++ b/crates/experimentation-management/src/validators/metric_definition.rs
@@ -7,9 +7,6 @@
 //! (`validators::cycle`) and by this module to perform operand-existence and
 //! cycle checks without leaking storage details into the validator.
 
-use std::sync::OnceLock;
-
-use regex::Regex;
 use tonic::Status;
 
 use experimentation_proto::experimentation::common::v1::{
@@ -20,17 +17,6 @@ use experimentation_proto::experimentation::common::v1::{
 use crate::store::{ManagementStore, StoreError};
 
 use super::{cycle, filter_sql, metricql};
-
-// ---------------------------------------------------------------------------
-// Shared identifier regex (used by B2 WINDOWED_COUNT.event_type and, when B3
-// lands, FILTERED_MEAN.value_column). Compiled once via OnceLock.
-// ---------------------------------------------------------------------------
-fn identifier_re() -> &'static Regex {
-    static IDENT_RE: OnceLock<Regex> = OnceLock::new();
-    IDENT_RE.get_or_init(|| {
-        Regex::new(r"^[a-z_][a-z0-9_]*$").expect("identifier regex is a compile-time constant")
-    })
-}
 
 // ---------------------------------------------------------------------------
 // MetricLookup — the minimal surface the cycle-detection validator needs.
@@ -249,7 +235,7 @@ fn validate_windowed_count(cfg: Option<&WindowedCountConfig>) -> Result<(), Box<
             "windowed_count.event_type must not be empty",
         )));
     }
-    if !identifier_re().is_match(&cfg.event_type) {
+    if !filter_sql::is_identifier(&cfg.event_type) {
         return Err(Box::new(Status::invalid_argument(format!(
             "windowed_count.event_type must match identifier regex ^[a-z_][a-z0-9_]*$, got {}",
             cfg.event_type


### PR DESCRIPTION
## Summary

`validators::metric_definition::identifier_re()` and `validators::filter_sql::is_identifier()` were enforcing the same `^[a-z_][a-z0-9_]*$` shape via two separate implementations (one OnceLock-backed regex, one hand-rolled char-by-char check). `validate_filtered_mean` already reached for `filter_sql::is_identifier`; this PR switches `validate_windowed_count` to do the same and removes the duplicate regex + its `regex::Regex` / `std::sync::OnceLock` imports.

Net: −15 / +1, no behavior change. Error messages and accepted/rejected inputs are byte-identical (proven by the existing `windowed_count_*_event_type_*` test cases, which continue to pass unchanged).

Closes #613

## Scope notes

- Touches only `crates/experimentation-management/src/validators/metric_definition.rs`.
- I left `is_identifier` at its existing `pub` visibility (effectively crate-scoped — the validators module isn't re-exported from `lib.rs`). Acceptance permitted either `pub(crate)` or a new `identifier_regex()` accessor; neither is strictly necessary since the existing API already covers the consolidation, so the lazier choice is to add nothing.
- **Opportunity (not in this PR):** `crates/experimentation-management/src/validators/metricql/analyze.rs:29` keeps its own `identifier_re()` with a comment explicitly noting it exists only because the shared one is private. Now that `is_identifier()` is the canonical helper, all 5 call sites in `analyze.rs` can switch to it too — and the `regex` dep can be dropped from this crate entirely. Filing as a follow-up to keep this PR strictly scoped to #613.

## Test plan

- [x] `cargo test -p experimentation-management --lib validators` — 208 passed, 0 failed
- [x] `cargo build -p experimentation-management` clean
- [x] Existing `windowed_count_invalid_event_type_rejected` (5 sub-cases) and `windowed_count_valid_event_type_accepted` (5 sub-cases) exercise the consolidated path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->