### PR TITLE
refactor(stats): consolidate mean/sample_variance across orl/cuped/bootstrap

### DIFF
--- a/crates/experimentation-stats/src/bootstrap.rs
+++ b/crates/experimentation-stats/src/bootstrap.rs
@@ -9,6 +9,7 @@
 //! Both methods use seeded RNG for exact reproducibility.
 //! Validated against scipy.stats.bootstrap() with golden-file tests.
 
+use crate::ttest::mean;
 use experimentation_core::error::{assert_finite, Error, Result};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -232,10 +233,6 @@ fn generate_replicates(
 fn quantile_index(q: f64, len: usize) -> usize {
     let idx = (q * len as f64).floor() as usize;
     idx.min(len - 1)
-}
-
-fn mean(data: &[f64]) -> f64 {
-    data.iter().sum::<f64>() / data.len() as f64
 }
 
 fn validate_inputs(

--- a/crates/experimentation-stats/src/cuped.rs
+++ b/crates/experimentation-stats/src/cuped.rs
@@ -8,6 +8,7 @@
 //!
 //! Validated against numpy/scipy with ddof=1 (equivalent to R's var()/cov()).
 
+use crate::ttest::{mean, sample_variance};
 use experimentation_core::error::{assert_finite, Error, Result};
 use statrs::distribution::{ContinuousCDF, Normal};
 
@@ -89,7 +90,7 @@ pub fn cuped_adjust(
     let mean_x = mean(&all_x);
     assert_finite(mean_x, "mean_pooled_x");
 
-    let var_x = variance(&all_x, mean_x);
+    let var_x = sample_variance(&all_x, mean_x);
     assert_finite(var_x, "var_x");
     if var_x == 0.0 {
         return Err(Error::Numerical(
@@ -131,16 +132,16 @@ pub fn cuped_adjust(
     let raw_effect = mean_ty - mean_cy;
     assert_finite(raw_effect, "raw_effect");
 
-    let raw_var_c = variance(control_y, mean_cy);
-    let raw_var_t = variance(treatment_y, mean_ty);
+    let raw_var_c = sample_variance(control_y, mean_cy);
+    let raw_var_t = sample_variance(treatment_y, mean_ty);
     let raw_se = (raw_var_c / n_c + raw_var_t / n_t).sqrt();
     assert_finite(raw_se, "raw_se");
 
     let adjusted_effect = treatment_adj_mean - control_adj_mean;
     assert_finite(adjusted_effect, "adjusted_effect");
 
-    let adj_var_c = variance(&control_adj, control_adj_mean);
-    let adj_var_t = variance(&treatment_adj, treatment_adj_mean);
+    let adj_var_c = sample_variance(&control_adj, control_adj_mean);
+    let adj_var_t = sample_variance(&treatment_adj, treatment_adj_mean);
     let adjusted_se = (adj_var_c / n_c + adj_var_t / n_t).sqrt();
     assert_finite(adjusted_se, "adjusted_se");
 
@@ -177,16 +178,6 @@ pub fn cuped_adjust(
     })
 }
 
-fn mean(data: &[f64]) -> f64 {
-    data.iter().sum::<f64>() / data.len() as f64
-}
-
-fn variance(data: &[f64], mean: f64) -> f64 {
-    let n = data.len() as f64;
-    let ss: f64 = data.iter().map(|&x| (x - mean).powi(2)).sum();
-    ss / (n - 1.0)
-}
-
 fn covariance(y: &[f64], x: &[f64], mean_y: f64, mean_x: f64) -> f64 {
     let n = y.len() as f64;
     let ss: f64 = y
@@ -210,7 +201,7 @@ mod tests {
     fn test_variance_basic() {
         let data = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let m = mean(&data);
-        let v = variance(&data, m);
+        let v = sample_variance(&data, m);
         assert!((v - 4.571429).abs() < 1e-4);
     }
 

--- a/crates/experimentation-stats/src/orl.rs
+++ b/crates/experimentation-stats/src/orl.rs
@@ -34,6 +34,7 @@
 //! Netflix KDD 2024 Table 2 — bias/variance/RMSE across three confounding
 //! scenarios (ρ_UY ∈ {0.0, 0.3, 0.6}).  Golden files in `tests/golden/`.
 
+use crate::ttest::{mean, sample_variance};
 use experimentation_core::error::{assert_finite, Error, Result};
 
 // ---------------------------------------------------------------------------
@@ -242,7 +243,7 @@ pub fn kfold_iv_calibrate(
     };
     assert_finite(ols_resid_var, "ols_resid_var");
 
-    let var_s = sample_var(&s);
+    let var_s = sample_variance(&s, mean_s);
     assert_finite(var_s, "var_s");
 
     let ols_se = if var_s > 0.0 {
@@ -259,7 +260,7 @@ pub fn kfold_iv_calibrate(
     let (_, fs_slope) = ols_with_intercept(&z, &s)?;
     assert_finite(fs_slope, "fs_slope");
 
-    let var_z = sample_var(&z);
+    let var_z = sample_variance(&z, mean(&z));
     assert_finite(var_z, "var_z");
 
     let (first_stage_f_stat, first_stage_r_squared) = if var_z < 1e-14 {
@@ -388,16 +389,6 @@ fn ols_with_intercept(x: &[f64], y: &[f64]) -> Result<(f64, f64)> {
     assert_finite(intercept, "ols_intercept");
 
     Ok((intercept, slope))
-}
-
-fn mean(x: &[f64]) -> f64 {
-    x.iter().sum::<f64>() / x.len() as f64
-}
-
-fn sample_var(x: &[f64]) -> f64 {
-    let n = x.len();
-    let m = mean(x);
-    x.iter().map(|&xi| (xi - m).powi(2)).sum::<f64>() / (n - 1) as f64
 }
 
 fn sample_cov_with_means(x: &[f64], y: &[f64], mx: f64, my: f64) -> f64 {

--- a/crates/experimentation-stats/src/switchback.rs
+++ b/crates/experimentation-stats/src/switchback.rs
@@ -514,7 +514,8 @@ fn lag1_autocorr(x: &[f64]) -> f64 {
         return 0.0;
     }
     let nf = n as f64;
-    let mean = x.iter().sum::<f64>() / nf;
+    let mean = crate::ttest::mean(x);
+    // ponytail: population variance (divides by n) — switchback's lag-1 autocorr math; only callsite.
     let variance = x.iter().map(|&xi| (xi - mean).powi(2)).sum::<f64>() / nf;
     if variance < 1e-15 {
         return 0.0;


### PR DESCRIPTION
## Summary

Closes #614. Follow-up to #607.

The Welch helpers promoted to `pub(crate) ttest::{mean, sample_variance}` in #607 were duplicated by private functions in four more sites. Three (`orl.rs`, `cuped.rs`, `bootstrap.rs`) match exactly and now delegate.

### The population-variance edge case landed in the *other* file

The task spec's caveat flagged `cuped.rs:184` as a population-variance site. Inspection showed it actually divides by `(n - 1.0)` — Bessel-corrected, identical to `ttest::sample_variance`. The real population-variance site is `switchback.rs::lag1_autocorr` (divides by `nf`).

With **one callsite** tied to the specific autocorrelation math, that one keeps the local inline arithmetic with a `ponytail:` comment marking the deliberate ceiling — task path (2). Only its `mean` is rerouted. Promoting a `population_variance` helper for a single user would be premature.

## Changes

- **`cuped.rs`** — deleted local `fn mean` + `fn variance`; rewired 7 `mean` sites + 4 `sample_variance` sites (signature already matched); test renamed accordingly.
- **`orl.rs`** — deleted local `fn mean` + `fn sample_var`; rewired 7 `mean` sites. The two `sample_var(&x)` callsites now pass an explicit `mean` (reusing the pre-computed `mean_s` at one site; recomputing for `z` — matches `sample_var`'s prior internal behaviour, zero perf delta).
- **`bootstrap.rs`** — deleted local `fn mean`; 7 callsites unchanged (same signature).
- **`switchback.rs`** — `lag1_autocorr`'s mean → `crate::ttest::mean(x)`; variance/covariance kept local with a `ponytail:` comment (population /n, single callsite).

`sample_cov_with_means` (orl), `covariance` (cuped), and the lag-1 covariance (switchback) are intentionally untouched — same discipline #607 applied to `tost::sample_covariance`. None has a second consumer yet.

**Net: -20 lines. No behaviour change.**

## Test plan

- [x] `cargo test -p experimentation-stats --lib` — **365 passed**, 0 failed (matches #607 baseline)
- [x] `cargo test -p experimentation-stats` — all integration suites + golden files pass
- [x] `cargo clippy -p experimentation-stats -- -D warnings` — clean
- [x] `just check-branch-name` — matches `^agent-[0-9]+/(feat|fix|port|design|chore|refactor|docs|test|perf)/[a-z0-9-]+\$`

## Known orthogonal issue

`cargo clippy -p experimentation-stats --all-features` hits the same pre-existing pyo3 0.22.6 / Python 3.14 incompatibility noted in #607. Not a regression from this PR — touched code has no Python bindings.

## Follow-up opportunities (noted, not implemented per scope discipline)

- `cuped::covariance`, `orl::sample_cov_with_means`, `switchback::lag1_autocorr`'s covariance — three near-identical Bessel-corrected covariance helpers. Promote when a fourth consumer appears.
- If a second population-variance consumer ever lands, promote `pub(crate) fn population_variance` from `switchback.rs` to `ttest.rs`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->