### PR TITLE
chore: reconcile CLAUDE.md cluster labels to cluster-a..g

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ gh issue view <number>
 ### Labels
 - `agent-1` through `agent-7` — ownership
 - `P0` through `P4` — priority
-- `cluster-a` through `cluster-f` — capability cluster
+- `cluster-a` through `cluster-g` — capability cluster (cluster-g = ADR-029 Personalization Orchestration)
 - `blocked` — waiting on another issue/agent
 - `contract-test` — cross-module contract test
 


### PR DESCRIPTION
## Summary

Reconciles the last remaining `cluster-a..f` straggler in the repo's docs. `CLAUDE.md`'s **Labels** list said `cluster-a` through `cluster-f`, but **cluster-g** (ADR-029, Personalization Orchestration) already exists and is referenced elsewhere in the same file.

This aligns `CLAUDE.md` with `CONTRIBUTING.md` and the Projects bootstrap field config, both of which were reconciled to `cluster-a..g` in #656.

## Change

```diff
- - `cluster-a` through `cluster-f` — capability cluster
+ - `cluster-a` through `cluster-g` — capability cluster (cluster-g = ADR-029 Personalization Orchestration)
```

## Context

Follow-up to a review note on #656 (the GitHub Projects + Goals PR), which I deliberately kept out of that PR's scope since `CLAUDE.md` is the core context file and the staleness predated it. Filing it as its own chore.

Docs-only — no code or behavior change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->