### PR TITLE
feat(ui): salvage Audit Log aria-label + empty-state testid from superseded Palette PRs

### DIFF
--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -93,7 +93,7 @@ export default function AuditLogPage() {
       ) : error ? (
         <RetryableError message={error} onRetry={fetchData} context="audit log" />
       ) : entries.length === 0 ? (
-        <div className="py-12 text-center">
+        <div className="py-12 text-center" data-testid="empty-state">
           <p className="text-sm text-gray-500">No audit log entries found.</p>
         </div>
       ) : (

--- a/ui/src/components/audit-log-table.tsx
+++ b/ui/src/components/audit-log-table.tsx
@@ -69,6 +69,7 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
+                aria-label={`Toggle details for ${entry.action} on ${entry.experimentName}`}
                 data-testid={`audit-row-${entry.entryId}`}
               >
                 <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap align-top">


### PR DESCRIPTION
## Summary

Salvages the only net-new improvements from four superseded Palette PRs — **#638, #639, #640, #646** — which are being closed as obsolete.

Those four were competing attempts at the **Audit Log expandable-row** UX, but that feature already landed in `main` via **#636** (chevron affordance, `role="button"`, `aria-expanded`, keyboard handling). Re-applying the PRs would have re-added redundant code and *removed* the toggling expand/collapse hint #636 introduced — a regression.

After diffing all four against current `main`, only two small things were genuinely missing:

1. **`aria-label`** on the expandable row — #636 made it a `role="button"` with `aria-expanded` but gave it no accessible name; this adds a description (`"Toggle details for <action> on <experiment>"`).
2. **`data-testid="empty-state"`** on the no-entries empty state — the *filtered*-empty case already had `no-filter-matches`; this gives the genuinely-empty case a parallel hook.

## Changes

```diff
# ui/src/components/audit-log-table.tsx (the expandable <tr>)
+ aria-label={`Toggle details for ${entry.action} on ${entry.experimentName}`}

# ui/src/app/audit/page.tsx (no-entries empty state)
- <div className="py-12 text-center">
+ <div className="py-12 text-center" data-testid="empty-state">
```

## Test plan

- [ ] Reviewer: confirm `aria-label` reads sensibly with a screen reader on the audit rows
- [ ] Reviewer: confirm `empty-state` testid targets the no-entries case (filtered case keeps `no-filter-matches`)

> Note: full `tsc`/lint not run locally — change is two standard JSX attributes on existing DOM elements with already-rendered fields, so it can't change types. CI will typecheck.

Closes the loop on #638, #639, #640, #646.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->