### PR TITLE
🎨 Palette: Standardize CopyButton interactions and improve Audit Log accessibility

### DIFF
--- a/ui/next_dev.log
+++ b/ui/next_dev.log
@@ -1,0 +1,17 @@
+
+> experimentation-ui@0.1.0 dev /app/ui
+> next dev
+
+  ▲ Next.js 14.2.35
+  - Local:        http://localhost:3000
+
+ ✓ Starting...
+ ✓ Ready in 1938ms
+ ○ Compiling /metrics ...
+ ✓ Compiled /metrics in 9.9s (1002 modules)
+ GET /metrics 200 in 10442ms
+ ○ Compiling /audit ...
+ ✓ Compiled /audit in 2.4s (1014 modules)
+ GET /audit 200 in 2581ms
+ GET /metrics 200 in 65ms
+ GET /audit 200 in 35ms

--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -93,7 +93,7 @@ export default function AuditLogPage() {
       ) : error ? (
         <RetryableError message={error} onRetry={fetchData} context="audit log" />
       ) : entries.length === 0 ? (
-        <div className="py-12 text-center">
+        <div className="py-12 text-center" data-testid="empty-state">
           <p className="text-sm text-gray-500">No audit log entries found.</p>
         </div>
       ) : (

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -147,7 +147,7 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
   return (
     <>
       <tr
-        className="cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+        className="group cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
         onClick={() => setExpanded(!expanded)}
         onKeyDown={handleKeyDown}
         tabIndex={0}
@@ -177,7 +177,7 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
               value={metric.metricId}
               label="Copy metric ID"
               successMessage="Metric ID copied"
-              className="h-4 w-4"
+              className="h-4 w-4 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
             />
           </div>
         </td>

--- a/ui/src/components/audit-log-table.tsx
+++ b/ui/src/components/audit-log-table.tsx
@@ -58,7 +58,7 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
             return (
               <tr
                 key={entry.entryId}
-                className="cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+                className="group cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
                 onClick={() => toggleExpand(entry.entryId)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {
@@ -69,6 +69,7 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
+                aria-label={`Toggle details for ${entry.action} action on ${entry.experimentName}`}
                 data-testid={`audit-row-${entry.entryId}`}
               >
                 <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap align-top">
@@ -87,7 +88,17 @@ export function AuditLogTable({ entries }: AuditLogTableProps) {
                   <AuditActionBadge action={entry.action} />
                 </td>
                 <td className="px-4 py-3 text-sm text-gray-600 align-top">
-                  {entry.actorEmail}
+                  <div className="flex items-center gap-2">
+                    <span className="truncate max-w-[150px]" title={entry.actorEmail}>
+                      {entry.actorEmail}
+                    </span>
+                    <CopyButton
+                      value={entry.actorEmail}
+                      label="Copy actor email"
+                      successMessage="Actor email copied"
+                      className="h-4 w-4 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                    />
+                  </div>
                 </td>
                 <td className="px-4 py-3 text-sm text-gray-700 align-top">
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
This PR implements several micro-UX and accessibility improvements across the platform:

1.  **Standardized 'Reveal on Hover/Focus' for Copy Buttons**: In the Metric Browser and Audit Log tables, `CopyButton` icons are now hidden by default to reduce visual clutter and only appear when the user hovers over the row or focuses on the button. This maintains utility while providing a cleaner interface.
2.  **Audit Log Accessibility**: Expandable rows in the Audit Log now use descriptive `aria-label` attributes (e.g., "Toggle details for Started action on playback_buffer_strategy") instead of generic labels, helping screen reader users understand the context of each toggle.
3.  **Audit Log Actor Copying**: Added a `CopyButton` for actor emails in the Audit Log table, using the same hover/focus reveal pattern. Long emails are now truncated with an ellipsis and include a `title` tooltip for the full value.
4.  **Testing Consistency**: Added `data-testid="empty-state"` to the Audit Log's empty state container.

All changes were verified with unit tests and visual inspection via Playwright screenshots.

---
*PR created automatically by Jules for task [15737954784556337244](https://jules.google.com/task/15737954784556337244) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->