### PR TITLE
ci: split rust job into core / features / wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,19 @@ jobs:
           path: proto/gen/
 
   # ───────── Stage 2: Rust Build & Test ─────────
+  #
+  # Split into three parallel jobs along feature-set boundaries. Cargo does
+  # not share artifacts across feature resolutions, so one job used to
+  # accumulate five distinct builds (--all-features clippy, default tests,
+  # simd, connectrpc, wasm) in a single target/ and intermittently exhausted
+  # runner disk (os error 28). Separate runners give each build its own disk
+  # and cut wall-clock to the slowest job instead of the sum.
+  #
+  # Caching: only `rust` (core) persists target/ in the actions cache — three
+  # target/ caches would thrash the 10GB repo cache budget and evict each
+  # other into permanent cold starts. The feature/wasm jobs cache just the
+  # cargo registry and rely on sccache (GHA backend, shared across all three
+  # jobs) for compiled dependencies.
   rust:
     runs-on: ubuntu-latest
     needs: [changes, schema]
@@ -88,7 +101,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          targets: wasm32-unknown-unknown
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.4
 
@@ -132,24 +144,103 @@ jobs:
       - name: Hash determinism vectors
         run: cargo test --package experimentation-hash -- hash_vectors
 
+  # Opt-in feature trees (simd proptests, ADR-031 connectrpc pilot). These
+  # build feature resolutions the core job never produces, so they gain
+  # nothing from its target/ cache — sccache covers the shared dependencies.
+  rust-features:
+    runs-on: ubuntu-latest
+    needs: [changes, schema]
+    if: needs.changes.outputs.rust == 'true'
+    timeout-minutes: 30
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: mozilla-actions/sccache-action@v0.0.4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-${{ runner.os }}-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq protobuf-compiler libcurl4-openssl-dev libssl-dev pkg-config
+
+      - name: Ensure sccache is working
+        run: |
+          if ! sccache --start-server 2>/dev/null; then
+            echo "::warning::sccache server failed to start; disabling RUSTC_WRAPPER"
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+          elif ! echo 'fn main(){}' | RUSTC_WRAPPER=sccache rustc --edition 2021 - -o /dev/null 2>/dev/null; then
+            echo "::warning::sccache cannot wrap rustc; disabling RUSTC_WRAPPER"
+            sccache --stop-server 2>/dev/null || true
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+          fi
+
       - name: Property tests (stats)
         run: cargo test --package experimentation-stats --features simd
         timeout-minutes: 15
 
-      - name: Free disk space before the connectrpc build (ADR-031)
-        run: |
-          # The connectrpc feature pulls the buffa + connectrpc dep tree on top of
-          # the workspace target/ from earlier steps, which can exhaust the runner
-          # disk (os error 28, intermittently). Reclaim preinstalled SDKs this job
-          # never uses — non-destructive to the Rust build cache. Do NOT remove
-          # $AGENT_TOOLSDIRECTORY: the WASM steps below rely on it.
-          df -h /
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/share/boost || true
-          df -h /
-
       - name: ADR-031 pilot — assignment connectrpc feature
         run: cargo test --package experimentation-assignment --features connectrpc
         timeout-minutes: 15
+
+  # wasm32 is a different compilation target entirely — nothing in target/
+  # from the host jobs applies. ~/.cargo/bin/wasm-pack is cached so the
+  # install below is a fast no-op instead of a multi-minute compile per run.
+  rust-wasm:
+    runs-on: ubuntu-latest
+    needs: [changes, schema]
+    if: needs.changes.outputs.rust == 'true'
+    timeout-minutes: 30
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: mozilla-actions/sccache-action@v0.0.4
+
+      - name: Cache cargo registry and wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cargo/bin/wasm-pack
+          key: cargo-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-wasm-${{ runner.os }}-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq protobuf-compiler libcurl4-openssl-dev libssl-dev pkg-config
+
+      - name: Ensure sccache is working
+        run: |
+          if ! sccache --start-server 2>/dev/null; then
+            echo "::warning::sccache server failed to start; disabling RUSTC_WRAPPER"
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+          elif ! echo 'fn main(){}' | RUSTC_WRAPPER=sccache rustc --edition 2021 - -o /dev/null 2>/dev/null; then
+            echo "::warning::sccache cannot wrap rustc; disabling RUSTC_WRAPPER"
+            sccache --stop-server 2>/dev/null || true
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+          fi
 
       - name: WASM build
         run: cargo build --package experimentation-hash --target wasm32-unknown-unknown --features wasm
@@ -158,7 +249,7 @@ jobs:
         timeout-minutes: 20
         working-directory: crates/experimentation-hash
         run: |
-          cargo install wasm-pack --locked
+          command -v wasm-pack >/dev/null || cargo install wasm-pack --locked
           wasm-pack test --node --features wasm
 
   # ───────── Stage 3: Go Build & Test ─────────
@@ -344,7 +435,7 @@ jobs:
   docker:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [rust, go, typescript, hash-parity, infra]
+    needs: [rust, rust-features, rust-wasm, go, typescript, hash-parity, infra]
     permissions:
       id-token: write    # required for OIDC to AWS + GCP
       contents: read


### PR DESCRIPTION
## Summary

Splits the monolithic `rust` CI job into three parallel jobs along feature-set boundaries. Cargo does not share artifacts across feature resolutions, so the one job accumulated five distinct builds (`--all-features` clippy, default tests, `simd`, `connectrpc`, wasm) in a single `target/` — ~28 min serial wall-clock and intermittent runner disk exhaustion (os error 28, last seen on #661's first run).

| Job | Steps | Cache |
| --- | --- | --- |
| `rust` (core) | clippy, `cargo test --workspace`, hash vectors | `target/` + registry (unchanged key) |
| `rust-features` | `simd` proptests, ADR-031 `connectrpc` pilot | registry only |
| `rust-wasm` | wasm32 build, wasm-pack vectors | registry + `~/.cargo/bin/wasm-pack` |

Design notes:

- **Core keeps the `rust` name** so `go` / `hash-parity` `needs` and their skip-guard logic are untouched. `docker` (main-only image push) now gates on all three rust jobs.
- **Only core persists `target/`** — three `target/` caches would thrash the 10GB repo cache budget and evict each other into permanent cold starts. The feature/wasm jobs rely on sccache (GHA backend, shared across all three jobs) for compiled deps.
- **Drops the preinstalled-SDK `rm -rf` workaround** from e4b98ae — each job now has its own runner disk, removing the root cause rather than reclaiming around it. Re-add per-job if os-28 ever recurs.
- **wasm-pack is cached** and the install is guarded by `command -v`, so the previous multi-minute `cargo install wasm-pack` per run becomes a no-op on cache hit.

Expected effect: rust critical path drops from ~28 min serial to the slowest of three parallel jobs (~10–15 min), and a flake in one feature set no longer forces a full rerun of everything.

## Test plan

- [x] YAML parses cleanly
- [ ] CI on this PR: all three rust jobs run (this PR touches ci.yml, which triggers the `rust` changes filter) and pass
- [ ] `go`, `hash-parity`, `typescript`, `infra` unaffected and green
- [ ] Observe first few main runs: rust-features/rust-wasm cold-start times acceptable with sccache only

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->