### PR TITLE
fix(ci): build Go service images on golang:1.26-bookworm

### DIFF
--- a/services/management/Dockerfile
+++ b/services/management/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /build
 COPY services/ services/
 COPY gen/go/ gen/go/

--- a/services/metrics/Dockerfile
+++ b/services/metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /build
 COPY services/ services/
 COPY gen/go/ gen/go/

--- a/services/orchestration/Dockerfile
+++ b/services/orchestration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 WORKDIR /build
 COPY services/ services/
 COPY gen/go/ gen/go/


### PR DESCRIPTION
## Summary
Fixes the **red docker image-publish jobs on `main`** introduced by the ADR-031 tracer-bullet merge (#661, closing #641). Affects the Go service images (M3 metrics, M5 management, M2 orchestration) — no application code changes.

The merge regenerated `gen/go` (Connect Go stubs), and the freshly generated module now declares **`go 1.26`**. The Go service Dockerfiles built on `golang:1.25-bookworm` with `GOTOOLCHAIN=local`, so buildkit couldn't satisfy the toolchain requirement:

```
go: module ../gen/go requires go >= 1.26 (running go 1.25.11; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c CGO_ENABLED=0 go build -o /app ./metrics/cmd/" did not complete successfully: exit code: 1
```

`go.work` (`go 1.26.1`) and the CI `go` job (`setup-go 1.26`) had already moved to 1.26 — only the service Dockerfiles lagged, so unit/integration CI stayed green while the image builds broke.

**Change:** bump the Go service builder images to `golang:1.26-bookworm`:
| Dockerfile | before | after | note |
| --- | --- | --- | --- |
| `services/metrics/Dockerfile` | `1.25` | `1.26` | was failing on `main` |
| `services/management/Dockerfile` | `1.25` | `1.26` | was failing on `main` |
| `services/orchestration/Dockerfile` | `1.22` | `1.26` | stale (`services/go.mod` already requires 1.25); aligned for consistency |

## Agent
Agent-1 (ADR-031 fallout) / infra — CI toolchain.

## Type
fix

## Related Issues
Fixes the docker-publish regression from the #661 / #641 (ADR-031 pilot) merge. Root cause + fix also recorded in `docs/coordination/status-2026-07-02.md` (rev.4, on PR #667).

## Contract Changes
N/A — builder base image only; runtime image (`gcr.io/distroless/static-debian12`) and produced binaries unchanged.

## Testing
- [x] `GOWORK=off go build ./metrics/cmd/` and `./orchestration/cmd/` compile clean under `go 1.26.1` locally.
- [ ] `management/cmd/` not locally verifiable — the working-tree `gen/go` is a pre-ADR-031 copy missing the connect stubs, and `buf` isn't available to regenerate; CI regenerates `gen/go` fresh before the docker build.
- [ ] Full multi-arch image build + `golang:1.26-bookworm` pull — validated by the CI `docker` matrix on this PR (local registry egress is blocked in the authoring environment).

## Checklist
- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] Proto changes are backward-compatible (or ADR documents the break) — N/A
- [x] Documentation updated (if user-facing) — status snapshot updated on PR #667
- [x] No new warnings from linters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmiyaMHMzb2j3rtKtY9VEZ)_