### PR TITLE
chore: repo settings-as-code — auto-delete merged branches

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,17 @@
+# Repository settings as code.
+#
+# Recognized by the Probot "Settings" GitHub App (https://github.com/apps/settings)
+# and by github/safe-settings. Install one of those on this repo/org to have GitHub
+# apply this file automatically on every push to the default branch.
+#
+# Status: `delete_branch_on_merge` is ALSO enabled live via the REST API
+# (PATCH /repos/{owner}/{repo}). This file is the version-controlled source of truth,
+# so the setting is auditable and survives manual UI edits once an app is syncing it.
+#
+# Keep this file minimal: the Settings app fully manages any *section* it finds
+# (e.g. adding a `branches:` block would take over branch-protection rules). List
+# only what you intend to control from code.
+repository:
+  # Automatically delete head branches after their PRs are merged, so merged
+  # branches stop accumulating on the remote (this repo had 132 such leftovers).
+  delete_branch_on_merge: true


### PR DESCRIPTION
## What
Adds .github/settings.yml declaring delete_branch_on_merge=true as version-controlled repo config.

## Why
The setting is already enabled live via the REST API (PATCH /repos/{owner}/{repo}). This file is the auditable source of truth and auto-applies if the Probot Settings app or github/safe-settings is later adopted. Part of the branch-hygiene cleanup that pruned 132 merged remote branches.

## Note
Without a settings-sync app installed, the file is declarative only; the live API setting is what currently enforces auto-delete.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->