### PR TITLE
ci: auto-mark PRs ready for review on an explicit "done" signal

### DIFF
--- a/.github/issue-banner-template.md
+++ b/.github/issue-banner-template.md
@@ -5,6 +5,8 @@
 >
 > **Branch convention:** `agent-N/feat/adr-XXX-<slug>` per CLAUDE.md. PR body must include `Closes #${ISSUE_NUM}`. Never use auto-generated worker names as branches.
 >
+> **Ready for review:** mark the PR ready (not draft) once the work is complete — or, if you opened a draft, add the `ready` label as your final step (the auto-ready workflow flips it).
+>
 > **Read the plan's Locks section first** — they are normative. If a Lock seems wrong, BLOCK and surface it via an issue comment rather than drifting. Recent precedent (PR #567): off-plan PRs that override merged Locks get rejected and waste the review investment.
 >
 > **Workflow:** invoke `superpowers:subagent-driven-development` — implementer → spec-reviewer → code-quality-reviewer per task; no parallel implementers within a single plan.

--- a/.github/workflows/auto-ready.yml
+++ b/.github/workflows/auto-ready.yml
@@ -1,0 +1,81 @@
+name: Auto ready-for-review
+
+# Flips a draft PR to "ready for review" once the author signals the work is
+# done. Two EXPLICIT signals (deliberately not CI-green — a green draft is not
+# necessarily finished, and draft means "author says not ready"):
+#   • the `ready` label is added to the PR, or
+#   • a maintainer comments `/ready` on the PR.
+#
+# Draft→ready is a GraphQL-only mutation (markPullRequestReadyForReview) — there
+# is no REST endpoint or branch-ruleset toggle for it — so this small Action is
+# the mechanism.
+#
+# One-time setup for the label path (the `/ready` comment works without it):
+#   gh label create ready -c 0e8a16 -d "Work complete — flip draft PR to ready"
+#
+# Note: `issue_comment` workflows always run from the DEFAULT branch, so the
+# `/ready` path only works once this file is on `main`. The `labeled` path runs
+# from the PR head branch and works immediately.
+
+on:
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  ready:
+    runs-on: ubuntu-latest
+    # Cheap pre-filter: only spin up for the `ready` label or a comment on a PR.
+    if: >-
+      (github.event_name == 'pull_request' && github.event.label.name == 'ready') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+    steps:
+      - name: Mark ready for review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            let prNumber, isDraft, nodeId;
+
+            if (context.eventName === 'pull_request') {
+              // `labeled` event — already filtered to label == "ready".
+              const pr = context.payload.pull_request;
+              prNumber = pr.number;
+              isDraft = pr.draft;
+              nodeId = pr.node_id;
+            } else {
+              // `issue_comment` on a PR.
+              const body = (context.payload.comment.body || '').trim();
+              if (!/^\/ready\b/.test(body)) {
+                core.info('Comment is not the "/ready" command — skipping.');
+                return;
+              }
+              const assoc = context.payload.comment.author_association;
+              if (!['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc)) {
+                core.info(`Commenter association "${assoc}" lacks write access — skipping.`);
+                return;
+              }
+              prNumber = context.payload.issue.number;
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              isDraft = pr.draft;
+              nodeId = pr.node_id;
+            }
+
+            if (!isDraft) {
+              core.info(`PR #${prNumber} is already ready for review — nothing to do.`);
+              return;
+            }
+
+            await github.graphql(
+              `mutation($id: ID!) {
+                 markPullRequestReadyForReview(input: { pullRequestId: $id }) {
+                   pullRequest { number isDraft }
+                 }
+               }`,
+              { id: nodeId },
+            );
+            core.info(`Marked PR #${prNumber} ready for review.`);

--- a/justfile
+++ b/justfile
@@ -931,7 +931,7 @@ work-on issue:
     echo "=== Launching worker for Issue #{{issue}} ==="
     echo "$TASK" | head -3
     echo "..."
-    multiclaude worker create "$TASK. Branch: use the agent-N/feat/adr-XXX naming convention. PR must include 'Closes #{{issue}}'."
+    multiclaude worker create "$TASK. Branch: use the agent-N/feat/adr-XXX naming convention. PR must include 'Closes #{{issue}}'. Mark the PR ready for review (not draft) when the work is complete — or, if you opened a draft, add the 'ready' label as your final step."
 
 # --- Beads (GitHub Issues ↔ Gas Town projection) ---
 # GitHub Issues remain the source of truth. Beads are a read-side projection
@@ -1194,7 +1194,7 @@ autonomous-sprint sprint_num:
       else
         BRANCH_HINT="Branch: use agent-N/feat/adr-XXX naming."
       fi
-      multiclaude worker create "$title. $body. $BRANCH_HINT PR must include 'Closes #$num'."
+      multiclaude worker create "$title. $body. $BRANCH_HINT PR must include 'Closes #$num'. Mark the PR ready for review (not draft) when done — or add the 'ready' label as your final step."
       COUNT=$((COUNT + 1))
     done <<< "$ISSUES"
     echo "✓ Workers launched for $MS ($COUNT ready issues)"


### PR DESCRIPTION
## Summary
Makes "PR is ready for review once work is complete" an actual rule instead of a manual chore. Two parts, mirroring the branch-naming approach (fix the source + a light Action for the explicit signal):

1. **`.github/workflows/auto-ready.yml`** (new) — flips a **draft → ready-for-review** when the author signals completion:
   - the **`ready` label** is added to the PR, or
   - a maintainer comments **`/ready`** (gated on write-access `author_association`).
   Uses the GraphQL `markPullRequestReadyForReview` mutation (the only API for draft→ready). **Deliberately not CI-green-based** — a green draft isn't necessarily finished, and "draft" means the author said *not ready*, so promotion needs an explicit signal.
2. **Worker-dispatch hints** — `justfile` (`work-on`, `autonomous-sprint`) and `.github/issue-banner-template.md` now tell workers to **open the PR ready-for-review** (not draft), or **add the `ready` label as their final step**. This fixes the root cause (creation defaults to draft) for the autonomous fleet.

## Agent
N/A — repo-wide CI/tooling (chore); no single agent owner.

## Type
ci

## Related Issues
Implements the "auto ready-for-review" rule discussed in the session. Closes no issue (deliberately no `Closes #N`).

## Contract Changes
N/A — CI workflow + dispatch-hint text only.

## Testing
- [x] `auto-ready.yml` YAML parses; embedded github-script passes `node --check`.
- [x] Edited `justfile` recipe lines keep balanced quoting (single-quotes only inside the double-quoted worker-create string).
- [ ] End-to-end: `ready` label / `/ready` on a draft flips it (validated live post-merge — see note).

## Checklist
- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] Proto changes are backward-compatible — N/A
- [x] Documentation updated — inline workflow/hint comments
- [x] No new warnings from linters

### One-time setup (for the label path)
```
gh label create ready -c 0e8a16 -d "Work complete — flip draft PR to ready for review"
```
The **`/ready` comment path works without any label**, but only once this workflow is on `main` (`issue_comment` workflows always run from the default branch). The `ready`-label path runs from the PR head branch and works immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmiyaMHMzb2j3rtKtY9VEZ)_