### PR TITLE
🎨 Palette: Standardize table row interactions and CopyButton visibility

### DIFF
--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -272,7 +272,10 @@ export default function ExperimentDetailPage() {
               </thead>
               <tbody className="divide-y divide-gray-200 bg-white">
                 {experiment.guardrailConfigs.map((g) => (
-                  <tr key={g.metricId}>
+                  <tr
+                    key={g.metricId}
+                    className="group hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+                  >
                     <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
                       <div className="flex items-center gap-2">
                         <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
@@ -282,6 +285,7 @@ export default function ExperimentDetailPage() {
                           value={g.metricId}
                           label="Copy metric ID"
                           successMessage="Metric ID copied"
+                          className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
                         />
                       </div>
                     </td>

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -147,7 +147,7 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
   return (
     <>
       <tr
-        className="cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+        className="group cursor-pointer hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
         onClick={() => setExpanded(!expanded)}
         onKeyDown={handleKeyDown}
         tabIndex={0}
@@ -177,7 +177,7 @@ function MetricRow({ metric }: { metric: MetricDefinition }) {
               value={metric.metricId}
               label="Copy metric ID"
               successMessage="Metric ID copied"
-              className="h-4 w-4"
+              className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
             />
           </div>
         </td>

--- a/ui/src/components/variant-table.tsx
+++ b/ui/src/components/variant-table.tsx
@@ -33,7 +33,10 @@ export function VariantTable({ variants }: VariantTableProps) {
         </thead>
         <tbody className="divide-y divide-gray-200 bg-white">
           {variants.map((v) => (
-            <tr key={v.variantId}>
+            <tr
+              key={v.variantId}
+              className="group hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+            >
               <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
                 {v.name}
               </td>
@@ -46,6 +49,7 @@ export function VariantTable({ variants }: VariantTableProps) {
                     value={v.variantId}
                     label="Copy variant ID"
                     successMessage="Variant ID copied"
+                    className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
                   />
                 </div>
               </td>


### PR DESCRIPTION
💡 **What**: Standardized table row interaction styles and implemented a "hover-reveal" pattern for CopyButtons across the Metrics browser, Experiment details (Guardrails), and Variant tables.

🎯 **Why**: Reduces visual noise by hiding secondary copy actions until needed, while maintaining clear visual feedback for the active row.

♿ **Accessibility**: Actions are revealed on keyboard focus via `group-focus-within`, and rows have clear focus indicators using `focus-within:ring-2`.

📸 **Verification**: Verified via Playwright screenshots and existing unit tests (`metric-browser`, `experiment-detail`, `variant-form`). All tests passed. Cleaned up dev artifacts.

---
*PR created automatically by Jules for task [4488326925514108303](https://jules.google.com/task/4488326925514108303) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->