### PR TITLE
ci: drop gen/go heredoc overwrite; guard module-mode tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,24 +276,21 @@ jobs:
           name: generated-code
           path: gen/
 
-      - name: Create gen/go module files
-        run: |
-          cat > gen/go/go.mod << 'GOMOD'
-          module github.com/org/experimentation/gen/go
+      # gen/go/go.mod and go.sum are TRACKED files; the artifact contains only
+      # generated .go sources and overlays them without touching the module
+      # files. (A heredoc used to overwrite go.mod here with drifted contents —
+      # a `go 1.26` directive that broke module-mode docker builds against
+      # services' `go 1.25.0`. See #676.)
 
-          go 1.26
-
-          require (
-          	connectrpc.com/connect v1.17.0
-          	google.golang.org/protobuf v1.35.0
-          )
-
-          require (
-          	github.com/google/go-cmp v0.6.0 // indirect
-          	golang.org/x/net v0.29.0 // indirect
-          )
-          GOMOD
-          cd gen/go && go mod download
+      # Docker image builds copy services/ + gen/go/ without go.work, so they
+      # resolve in MODULE mode. Workspace mode (go.work) can satisfy imports
+      # the module graph can't, silently masking image-build breakage — this
+      # check fails the job instead. See #676.
+      - name: Module-mode tidy check (docker builds run without go.work)
+        working-directory: services
+        env:
+          GOWORK: "off"
+        run: go mod tidy -diff
 
       - name: Vet
         working-directory: services
@@ -485,23 +482,10 @@ jobs:
           name: generated-code
           path: gen/
 
-      - name: Create gen/go module file
-        run: |
-          cat > gen/go/go.mod << 'GOMOD'
-          module github.com/org/experimentation/gen/go
-
-          go 1.26
-
-          require (
-          	connectrpc.com/connect v1.17.0
-          	google.golang.org/protobuf v1.35.0
-          )
-
-          require (
-          	github.com/google/go-cmp v0.6.0 // indirect
-          	golang.org/x/net v0.29.0 // indirect
-          )
-          GOMOD
+      # gen/go/go.mod + go.sum are tracked in git; the artifact overlays only
+      # generated .go sources. No synthesized module file needed (the old
+      # heredoc here injected a drifted go.mod that broke module-mode builds —
+      # see #676).
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Summary

Fixes the `docker (metrics)` / `docker (management)` image-build failures on main (#676) — **by deletion, with zero Go file changes**. Net diff: −16 lines in one file.

### Root cause (sharper than the issue's original framing)

The `go` and `docker` jobs both **overwrote the tracked `gen/go/go.mod`** with a synthesized heredoc that had drifted from the repo:

| | tracked `gen/go/go.mod` | ci.yml heredoc |
| --- | --- | --- |
| `go` directive | `1.25.0` | `1.26` |
| protobuf | `v1.36.11` | `v1.35.0` |

In module mode — which docker image builds use, since Dockerfiles copy only `services/` + `gen/go/` and no `go.work` — a main module can't depend on a module with a newer `go` directive. The heredoc's `go 1.26` against `services/go.mod`'s `go 1.25.0` produced both historical layers of this failure: the `requires go >= 1.26` toolchain error (image-base half fixed by #669) and the current `go mod tidy` demand. CI's `go` job never caught it because workspace mode (`go.work`, `go 1.26.1`) governs there.

### The fix

1. **Delete both heredoc steps.** The `generated-code` artifact contains only generated `.go` sources (verified: zero `go.mod`/`go.sum` files in it), so the overlay leaves the tracked `gen/go/go.{mod,sum}` intact — they're simply authoritative now. With the heredocs gone, `services/go.mod` is *already tidy*; the go-directive skew never existed in the repo, only in the yaml.
2. **Add a module-mode guard** to the `go` job: `go mod tidy -diff` with `GOWORK=off`, replicating exactly how docker builds resolve. Workspace mode can no longer mask module-graph drift that only image builds hit.

### Verification (all local, against the real CI artifact from run 28596873830)

- [x] Reproduced the exact failure first (`GOWORK=off go build ./metrics/cmd/` → `updates to go.mod needed`) with the heredoc go.mod in place
- [x] With tracked go.mod: `GOWORK=off go mod tidy -diff` clean; metrics + management binaries build in module mode
- [x] **Both docker images build** from the repo context (`docker build -f services/{metrics,management}/Dockerfile .`)
- [x] Full services test suite passes (workspace mode, as CI runs it)
- [x] YAML parses
- [ ] Post-merge: main run's `docker (metrics)` / `docker (management)` legs go green (docker is main-only; this PR's run validates the go-job guard)

Closes #676

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->