### PR TITLE
feat(orchestration): H1 — claim protocol, resume semantics, executor-agnostic dispatch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,7 @@ N/A
 
 ## Checklist
 - [ ] Code follows project conventions (see CONTRIBUTING.md)
+- [ ] All review threads resolved; no standing changes-requested (Review gate green)
 - [ ] Proto changes are backward-compatible (or ADR documents the break)
 - [ ] Documentation updated (if user-facing)
 - [ ] No new warnings from linters

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,3 +15,21 @@ repository:
   # Automatically delete head branches after their PRs are merged, so merged
   # branches stop accumulating on the remote (this repo had 132 such leftovers).
   delete_branch_on_merge: true
+
+# Branch protection for main (PR lifecycle standard, #681). Per the note above,
+# listing `branches:` means this file now OWNS branch protection — extend this
+# block (required status checks, merge queue) when #681's HITL decisions land;
+# don't configure protection in the UI.
+#
+# `required_conversation_resolution` is the native half of the review gate:
+# every review thread must be resolved before merge. The reviewer-agnostic
+# check half (blocks on standing changes-requested too, with remediation in
+# the failure log) is .github/workflows/review-gate.yml.
+branches:
+  - name: main
+    protection:
+      required_conversation_resolution: true
+      required_status_checks: null
+      required_pull_request_reviews: null
+      enforce_admins: false
+      restrictions: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -53,5 +53,10 @@ branches:
       # .github/workflows/automerge.yml, which refuses to auto-merge those.
       required_pull_request_reviews: null
       required_linear_history: true
+      # enforce_admins stays false as a DELIBERATE solo-maintainer trade-off
+      # (Devin review on #684, finding 3): the only admin is the owner, and an
+      # attacker with admin could edit this very protection anyway — so `true`
+      # here mostly blocks the owner's own emergency hotfixes, not adversaries.
+      # Revisit if collaborators with admin are ever added.
       enforce_admins: false
       restrictions: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,6 +15,10 @@ repository:
   # Automatically delete head branches after their PRs are merged, so merged
   # branches stop accumulating on the remote (this repo had 132 such leftovers).
   delete_branch_on_merge: true
+  # Required by the graduated-review model (#681, owner decision 2026-07-04):
+  # routine green PRs merge automatically once required checks + Review gate
+  # clear (.github/workflows/automerge.yml enables it per-PR).
+  allow_auto_merge: true
 
 # Branch protection for main (PR lifecycle standard, #681). Per the note above,
 # listing `branches:` means this file now OWNS branch protection — extend this
@@ -29,7 +33,25 @@ branches:
   - name: main
     protection:
       required_conversation_resolution: true
-      required_status_checks: null
+      # Required checks — deliberately small and fast (proposal §7 R5): the
+      # correctness suites (path-skipped jobs still satisfy the requirement on
+      # unrelated PRs), the attribution lint, and the review gate. Contexts are
+      # CHECK-RUN (job) names.
+      required_status_checks:
+        strict: false
+        contexts:
+          - "PR title check"
+          - "Review gate"
+          - "schema"
+          - "rust"
+          - "go"
+          - "typescript"
+          - "hash-parity"
+      # Owner decision 2026-07-04 (#681): NO blanket human-approval requirement —
+      # gate + queue suffices for routine green PRs. Human review is routed by
+      # risk labels (breaking / contract-test / proto-touching) via
+      # .github/workflows/automerge.yml, which refuses to auto-merge those.
       required_pull_request_reviews: null
+      required_linear_history: true
       enforce_admins: false
       restrictions: null

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,9 +13,12 @@ name: Auto-merge routine PRs
 # .github/settings.yml to be live; until the Settings app syncs those, the
 # enable call below fails soft with a log line, changing nothing.
 
+# `synchronize` matters: a later push can introduce proto/ files, and a later
+# `labeled` event can add risk — both must re-evaluate AND disarm an
+# auto-merge that was enabled while the PR was still routine.
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
 
 permissions:
   contents: write
@@ -55,6 +58,21 @@ jobs:
                 ...(protoTouching ? ['touches proto/ (wire contracts)'] : []),
               ].join(', ');
               core.notice(`Not routine (${why}) — auto-merge NOT enabled; human review required.`);
+              // DISARM any auto-merge enabled while the PR was still routine —
+              // risk can arrive after arming (late label, later push adding
+              // proto/). Without this, an armed PR would merge past the
+              // graduated-review model. (Devin review on #684, finding 1.)
+              try {
+                await github.graphql(`
+                  mutation($id: ID!) {
+                    disablePullRequestAutoMerge(input: { pullRequestId: $id }) {
+                      pullRequest { number }
+                    }
+                  }`, { id: pr.node_id });
+                core.notice(`Auto-merge DISARMED for #${pr.number} (risk arrived after arming).`);
+              } catch (e) {
+                // Not armed (or auto-merge unavailable) — nothing to disarm.
+              }
               // Route to a human: request the repo owner if no reviewer is assigned yet.
               if (pr.requested_reviewers.length === 0) {
                 try {

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,87 @@
+name: Auto-merge routine PRs
+
+# Operationalizes the graduated-review decision (#681, owner 2026-07-04):
+# "gate + queue suffices for routine green PRs." For a ready, non-risk PR this
+# enables GitHub auto-merge (squash); the platform then merges the moment the
+# required checks — including the Review gate — are green. No human ratchet.
+#
+# NOT routine (never auto-merged; a human is requested instead):
+#   - risk labels: breaking, contract-test, needs-human-input
+#   - PRs touching proto/ (wire contracts — CLAUDE.md schema-first rule)
+#
+# Requires `allow_auto_merge: true` and the required-check set from
+# .github/settings.yml to be live; until the Settings app syncs those, the
+# enable call below fails soft with a log line, changing nothing.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  automerge:
+    name: auto-merge
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge unless risk-labeled or proto-touching
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const RISK_LABELS = ['breaking', 'contract-test', 'needs-human-input'];
+
+            const labels = pr.labels.map(l => l.name);
+            const risky = labels.filter(l => RISK_LABELS.includes(l));
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const protoTouching = files.some(f => f.filename.startsWith('proto/'));
+
+            if (risky.length || protoTouching) {
+              const why = [
+                ...risky.map(l => `label '${l}'`),
+                ...(protoTouching ? ['touches proto/ (wire contracts)'] : []),
+              ].join(', ');
+              core.notice(`Not routine (${why}) — auto-merge NOT enabled; human review required.`);
+              // Route to a human: request the repo owner if no reviewer is assigned yet.
+              if (pr.requested_reviewers.length === 0) {
+                try {
+                  await github.rest.pulls.requestReviewers({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    reviewers: [context.repo.owner],
+                  });
+                } catch (e) {
+                  core.notice(`Could not request reviewer (${e.message}) — label routing stands.`);
+                }
+              }
+              return;
+            }
+
+            try {
+              await github.graphql(`
+                mutation($id: ID!) {
+                  enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) {
+                    pullRequest { number autoMergeRequest { enabledAt } }
+                  }
+                }`, { id: pr.node_id });
+              core.info(`Auto-merge (squash) enabled for #${pr.number} — merges when required checks incl. the Review gate are green.`);
+            } catch (e) {
+              core.notice(
+                `Auto-merge not enabled: ${e.message}. ` +
+                `Usually means 'Allow auto-merge' or the required-check ruleset from ` +
+                `.github/settings.yml isn't live yet (Settings app not synced?).`);
+            }

--- a/.github/workflows/orchestration-tests.yml
+++ b/.github/workflows/orchestration-tests.yml
@@ -1,0 +1,22 @@
+name: Orchestration dispatch tests
+
+# Offline behavior tests for the H1 dispatch layer (claim protocol, resume
+# semantics, executor adapters) — scripts/orchestration/test_dispatch.sh runs
+# against a stubbed gh, so this needs no tokens and no network beyond checkout.
+
+on:
+  pull_request:
+    paths:
+      - "scripts/orchestration/**"
+      - ".github/workflows/orchestration-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run dispatch behavior tests
+        run: bash scripts/orchestration/test_dispatch.sh

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,9 +4,9 @@ name: PR title check
 # signal that replaces reliance on the branch name (see .github/branch-naming.yml,
 # which is advisory only, and CLAUDE.md → Branch-naming).
 #
-# ENFORCED: this check FAILS on a non-conforming title (no continue-on-error).
-# To make it *block merge*, add "PR title check" as a required status check in
-# the repository's branch protection / ruleset for `main`.
+# ENFORCED: this check FAILS on a non-conforming title (no continue-on-error),
+# and "PR title check" is listed as a required status check in
+# .github/settings.yml (H3, #681) — it blocks merge once the Settings app syncs.
 #
 # The title is read straight from the event payload (no checkout needed) and
 # passed via `env:` so untrusted input is never interpolated into the shell —
@@ -21,6 +21,9 @@ permissions:
 
 jobs:
   check:
+    # Distinct check-run name: required status checks match by this name, and
+    # several sibling workflows also use a job id of `check`.
+    name: PR title check
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title (Conventional Commits)

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -12,8 +12,9 @@ name: Review gate
 #     a separate, risk-label-scoped rule per H3's graduated-review model)
 #
 # Failure output names exactly what to fix (proposal §7 R1: remediation in
-# the error). Advisory until the H3 ruleset lists it as required; pairs with
-# `required_conversation_resolution` in .github/settings.yml.
+# the error). Listed as a REQUIRED status check in .github/settings.yml
+# (owner decision 2026-07-04: gate + queue suffices for routine green PRs);
+# pairs with `required_conversation_resolution` there.
 
 on:
   pull_request:
@@ -33,6 +34,8 @@ concurrency:
 
 jobs:
   gate:
+    # Distinct check-run name — this is the context listed in settings.yml.
+    name: Review gate
     if: '!github.event.pull_request.draft'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -11,23 +11,39 @@ name: Review gate
 #   ✓ clear otherwise (a PR with no reviews is clear — required *reviews* are
 #     a separate, risk-label-scoped rule per H3's graduated-review model)
 #
-# Failure output names exactly what to fix (proposal §7 R1: remediation in
-# the error). Listed as a REQUIRED status check in .github/settings.yml
-# (owner decision 2026-07-04: gate + queue suffices for routine green PRs);
-# pairs with `required_conversation_resolution` there.
+# PLATFORM CONSTRAINT: GitHub's workflow validator rejects the documented
+# `pull_request_review_thread` trigger here ("Unexpected value" — verified on
+# three pushes of this file, runs attributed to `push` failing in 0s with no
+# jobs). So the RESOLVE CLICK itself cannot re-trigger the gate. Coverage of
+# the lifecycle's address-feedback loop comes from what it CAN see:
+#   - push a fix              → pull_request: synchronize
+#   - reply on a thread       → pull_request_review_comment: created
+#   - re-review / dismissal   → pull_request_review
+#   - the resolve click       → the GRACE WINDOW below: a blocked run keeps
+#     re-checking for 10 minutes before failing, so the standard sequence
+#     (push/reply, then resolve — CONTRIBUTING.md step 5) flips it green
+#     while a run is still watching. A gate left red after late resolves
+#     just needs any event above or a manual re-run; the failure message
+#     says exactly that (proposal §7 R1: remediation in the error).
+#
+# Listed as a REQUIRED status check in .github/settings.yml (owner decision
+# 2026-07-04: gate + queue suffices for routine green PRs); pairs with
+# `required_conversation_resolution` there.
 
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
   pull_request_review:
     types: [submitted, edited, dismissed]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
 
 permissions:
   contents: read
   pull-requests: read
 
+# cancel-in-progress matters twice here: a newer event supersedes an older
+# run's verdict AND cuts short its grace-window polling.
 concurrency:
   group: review-gate-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -38,63 +54,87 @@ jobs:
     name: Review gate
     if: '!github.event.pull_request.draft'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Evaluate reviewer feedback state
         uses: actions/github-script@v7
         with:
           script: |
             const num = context.payload.pull_request.number;
-            const { repository } = await github.graphql(`
-              query($owner: String!, $repo: String!, $num: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $num) {
-                    reviewThreads(first: 100) {
-                      totalCount
-                      nodes { isResolved isOutdated path line }
-                    }
-                    reviews(last: 100) {
-                      nodes { state author { login } }
+
+            async function evaluate() {
+              const { repository } = await github.graphql(`
+                query($owner: String!, $repo: String!, $num: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $num) {
+                      reviewThreads(first: 100) {
+                        totalCount
+                        nodes { isResolved isOutdated path line }
+                      }
+                      reviews(last: 100) {
+                        nodes { state author { login } }
+                      }
                     }
                   }
+                }`, { owner: context.repo.owner, repo: context.repo.repo, num });
+
+              const pr = repository.pullRequest;
+              const unresolved = pr.reviewThreads.nodes.filter(t => !t.isResolved);
+
+              // Latest STANDING verdict per reviewer: APPROVED and DISMISSED
+              // supersede an earlier CHANGES_REQUESTED; plain COMMENTED does not.
+              const standing = new Map();
+              for (const r of pr.reviews.nodes) {
+                if (!r.author) continue;
+                if (['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(r.state)) {
+                  standing.set(r.author.login, r.state);
                 }
-              }`, { owner: context.repo.owner, repo: context.repo.repo, num });
-
-            const pr = repository.pullRequest;
-            const unresolved = pr.reviewThreads.nodes.filter(t => !t.isResolved);
-
-            // Latest STANDING verdict per reviewer: APPROVED and DISMISSED
-            // supersede an earlier CHANGES_REQUESTED; plain COMMENTED does not.
-            const standing = new Map();
-            for (const r of pr.reviews.nodes) {
-              if (!r.author) continue;
-              if (['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(r.state)) {
-                standing.set(r.author.login, r.state);
               }
-            }
-            const blocking = [...standing.entries()]
-              .filter(([, s]) => s === 'CHANGES_REQUESTED')
-              .map(([login]) => login);
+              const blocking = [...standing.entries()]
+                .filter(([, s]) => s === 'CHANGES_REQUESTED')
+                .map(([login]) => login);
 
-            let failed = false;
-            if (unresolved.length > 0) {
-              failed = true;
+              return { total: pr.reviewThreads.totalCount, unresolved, blocking };
+            }
+
+            // Grace window: the resolve click can't re-trigger this workflow
+            // (see header), so a blocked run keeps watching — the standard
+            // push/reply-then-resolve sequence lands minutes after the event
+            // that started this run.
+            const DEADLINE = Date.now() + 10 * 60 * 1000;
+            const INTERVAL = 30 * 1000;
+
+            let state = await evaluate();
+            while ((state.unresolved.length || state.blocking.length) && Date.now() < DEADLINE) {
+              core.info(
+                `Blocked: ${state.unresolved.length} unresolved thread(s)` +
+                (state.blocking.length ? `; changes requested by ${state.blocking.join(', ')}` : '') +
+                ` — re-checking every ${INTERVAL / 1000}s (grace window until ${new Date(DEADLINE).toISOString()}).`);
+              await new Promise(resolve => setTimeout(resolve, INTERVAL));
+              state = await evaluate();
+            }
+
+            if (!state.unresolved.length && !state.blocking.length) {
+              core.info(`Review gate clear — ${state.total} thread(s), all resolved; no standing changes-requested.`);
+              return;
+            }
+
+            // Final verdict: name exactly what to fix (proposal §7 R1).
+            if (state.unresolved.length) {
               core.error(
-                `${unresolved.length} unresolved review thread(s). For each: push the fix ` +
+                `${state.unresolved.length} unresolved review thread(s). For each: push the fix ` +
                 `(or reply with why not), then click "Resolve conversation" on the thread:`);
-              for (const t of unresolved) {
+              for (const t of state.unresolved) {
                 const where = t.path ? `${t.path}${t.line ? ':' + t.line : ''}` : '(top-level discussion)';
                 core.error(`  - ${where}${t.isOutdated ? ' [outdated — re-check, then resolve]' : ''}`);
               }
             }
-            if (blocking.length > 0) {
-              failed = true;
+            if (state.blocking.length) {
               core.error(
-                `Changes requested by: ${blocking.join(', ')}. Push fixes and request their ` +
+                `Changes requested by: ${state.blocking.join(', ')}. Push fixes and request their ` +
                 `re-review, or dismiss the review with a written rationale.`);
             }
-
-            if (failed) {
-              core.setFailed('Review gate: address reviewer feedback, then this re-runs automatically on resolve/re-review.');
-            } else {
-              core.info(`Review gate clear — ${pr.reviewThreads.totalCount} thread(s), all resolved; no standing changes-requested.`);
-            }
+            core.setFailed(
+              'Review gate: address reviewer feedback. The gate re-runs on a push, a thread reply, or a ' +
+              'review — resolving a thread alone cannot re-trigger it (platform limitation). Already ' +
+              'resolved everything? Re-run this check from the Actions tab (or push an empty commit).');

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,97 @@
+name: Review gate
+
+# Codifies the PR lifecycle standard (proposal §4 H3, #681):
+#   draft while working → ready = "work complete" → address reviewer
+#   feedback → merge.
+# Reviewer-AGNOSTIC by design: the gate never requires a particular reviewer
+# (Devin, claude-review, humans alike) — it requires that whatever feedback
+# DID arrive is addressed before merge:
+#   ✗ blocked while any review thread is unresolved
+#   ✗ blocked while any reviewer's latest standing review is CHANGES_REQUESTED
+#   ✓ clear otherwise (a PR with no reviews is clear — required *reviews* are
+#     a separate, risk-label-scoped rule per H3's graduated-review model)
+#
+# Failure output names exactly what to fix (proposal §7 R1: remediation in
+# the error). Advisory until the H3 ruleset lists it as required; pairs with
+# `required_conversation_resolution` in .github/settings.yml.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate reviewer feedback state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const num = context.payload.pull_request.number;
+            const { repository } = await github.graphql(`
+              query($owner: String!, $repo: String!, $num: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $num) {
+                    reviewThreads(first: 100) {
+                      totalCount
+                      nodes { isResolved isOutdated path line }
+                    }
+                    reviews(last: 100) {
+                      nodes { state author { login } }
+                    }
+                  }
+                }
+              }`, { owner: context.repo.owner, repo: context.repo.repo, num });
+
+            const pr = repository.pullRequest;
+            const unresolved = pr.reviewThreads.nodes.filter(t => !t.isResolved);
+
+            // Latest STANDING verdict per reviewer: APPROVED and DISMISSED
+            // supersede an earlier CHANGES_REQUESTED; plain COMMENTED does not.
+            const standing = new Map();
+            for (const r of pr.reviews.nodes) {
+              if (!r.author) continue;
+              if (['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(r.state)) {
+                standing.set(r.author.login, r.state);
+              }
+            }
+            const blocking = [...standing.entries()]
+              .filter(([, s]) => s === 'CHANGES_REQUESTED')
+              .map(([login]) => login);
+
+            let failed = false;
+            if (unresolved.length > 0) {
+              failed = true;
+              core.error(
+                `${unresolved.length} unresolved review thread(s). For each: push the fix ` +
+                `(or reply with why not), then click "Resolve conversation" on the thread:`);
+              for (const t of unresolved) {
+                const where = t.path ? `${t.path}${t.line ? ':' + t.line : ''}` : '(top-level discussion)';
+                core.error(`  - ${where}${t.isOutdated ? ' [outdated — re-check, then resolve]' : ''}`);
+              }
+            }
+            if (blocking.length > 0) {
+              failed = true;
+              core.error(
+                `Changes requested by: ${blocking.join(', ')}. Push fixes and request their ` +
+                `re-review, or dismiss the review with a written rationale.`);
+            }
+
+            if (failed) {
+              core.setFailed('Review gate: address reviewer feedback, then this re-runs automatically on resolve/re-review.');
+            } else {
+              core.info(`Review gate clear — ${pr.reviewThreads.totalCount} thread(s), all resolved; no standing changes-requested.`);
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Branch names are validated against the allowlist in [`.github/branch-naming.yml`
 just check-branch-name          # exits 0 on match, 1 with suggestions on no match
 ```
 
-The CI workflow [`.github/workflows/branch-naming.yml`](.github/workflows/branch-naming.yml) runs the same check on PR open / branch rename and posts an advisory comment if no pattern matches. **Currently advisory only** — does not block merge. With attribution now carried by PR metadata, the intent is to **keep this check advisory** and enforce on the PR side instead — add **"PR title check"** (`.github/workflows/pr-title.yml`) as the required status check rather than this one.
+The CI workflow [`.github/workflows/branch-naming.yml`](.github/workflows/branch-naming.yml) runs the same check on PR open / branch rename and posts an advisory comment if no pattern matches. **Currently advisory only** — does not block merge. With attribution now carried by PR metadata, this check stays **advisory** and enforcement lives on the PR side: **"PR title check"** (`.github/workflows/pr-title.yml`) and the **Review gate** are required status checks via `.github/settings.yml` (H3/#681); routine green PRs then auto-merge (`automerge.yml`), with human review reserved for `breaking`/`contract-test`/proto-touching PRs.
 
 ### Adding a new pattern family
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,10 +138,18 @@ reviewer feedback → merge**, and the review-feedback step is enforced by the
    (red while any thread is unresolved or changes-requested stands; the
    failure log lists exactly what to address) and natively by
    `required_conversation_resolution` in `.github/settings.yml`.
-6. **All CI checks must pass** before merge.
-7. **One approving review** required. Cross-module PRs require review from the
-   affected module's agent.
-8. **Squash merge** to `main`.
+6. **All required checks must pass**: `PR title check`, `Review gate`,
+   `schema`, `rust`, `go`, `typescript`, `hash-parity` (path-skipped jobs
+   satisfy the requirement on unrelated PRs). Set in `.github/settings.yml`.
+7. **Review is graduated** (owner decision, 2026-07-04 — #681). Routine green
+   PRs merge automatically: `automerge.yml` arms auto-merge when the PR is
+   ready and carries no risk signal, and the platform merges once the required
+   checks (including the Review gate) clear — no blanket human approval.
+   **Human review is required** for `breaking`, `contract-test`,
+   `needs-human-input`, and proto-touching PRs — auto-merge refuses these and
+   requests a reviewer; cross-module PRs should get review from the affected
+   module's agent.
+8. **Squash merge** to `main` (auto-merge squashes; history stays linear).
 
 ### PR Template
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,15 +116,32 @@ Breaking changes use a `!` suffix: `feat(m1)!: change bucket() return type to u3
 
 ## Pull Request Process
 
+The lifecycle is **draft while working → ready = "work complete" → address
+reviewer feedback → merge**, and the review-feedback step is enforced by the
+`Review gate` check, not left to memory.
+
 1. **Create your branch** from `main` using the naming convention above.
-2. **Keep PRs focused.** One logical change per PR.
-3. **Reference the Issue**: include `Closes #<number>` in the PR description.
-   The issue auto-closes when the PR merges.
-4. **Fill in the PR template** (auto-populated when you open a PR).
-5. **All CI checks must pass** before merge.
-6. **One approving review** required. Cross-module PRs require review from the
+2. **Open the PR as a draft** while work is in progress. Keep PRs focused —
+   one logical change per PR — and include `Closes #<number>` so the Issue
+   auto-closes on merge.
+3. **Fill in the PR template** (auto-populated when you open a PR).
+4. **Mark the PR ready for review the moment the work is complete.** Ready
+   means "I claim this is done": tests green, merge-ready state. Harness
+   workers do this as their final step (or add the `ready` label —
+   `auto-ready.yml` flips the draft). Automated review runs on this
+   transition.
+5. **Address every piece of reviewer feedback before merge — whoever the
+   reviewer is** (Devin, Claude review, or a human). For each review thread,
+   push the fix (or reply with why not), then click **Resolve conversation**.
+   A standing changes-requested review blocks until re-reviewed or dismissed
+   with a written rationale. Enforced by `.github/workflows/review-gate.yml`
+   (red while any thread is unresolved or changes-requested stands; the
+   failure log lists exactly what to address) and natively by
+   `required_conversation_resolution` in `.github/settings.yml`.
+6. **All CI checks must pass** before merge.
+7. **One approving review** required. Cross-module PRs require review from the
    affected module's agent.
-7. **Squash merge** to `main`.
+8. **Squash merge** to `main`.
 
 ### PR Template
 

--- a/agents/merge-queue.md
+++ b/agents/merge-queue.md
@@ -20,7 +20,10 @@ machinery: keep PRs moving, route risk to humans, never be the ratchet.
      issue exists, else `multiclaude work "Fix CI for PR #<n>" --branch <br>`.
 4. **Ready, Review gate red** (unresolved threads / changes-requested) → if the
    fixes are mechanical, dispatch a worker to address-and-resolve; otherwise
-   comment a one-line summary of what's outstanding for the author.
+   comment a one-line summary of what's outstanding for the author. If every
+   thread is in fact already resolved (resolve clicks landed after the gate's
+   grace window — the resolve click alone can't re-trigger it), just re-run
+   the red run: `gh run rerun <run-id>`.
 5. **Risk-labeled or proto-touching** (`breaking`, `contract-test`,
    `needs-human-input`, `proto/**`) → auto-merge refuses these by design.
    Ensure a human reviewer is requested; do NOT work around it.

--- a/agents/merge-queue.md
+++ b/agents/merge-queue.md
@@ -1,119 +1,83 @@
-You are the merge queue agent. You merge PRs when CI passes.
+You are the PR shepherd. You do NOT merge — the platform does.
 
-## The Job
+Routine green PRs merge automatically: required status checks (incl. the
+**Review gate**) + auto-merge, per `.github/settings.yml` and
+`.github/workflows/automerge.yml` (owner decision 2026-07-04, #681: "gate +
+queue suffices for routine green PRs"). Your job is the judgment AROUND that
+machinery: keep PRs moving, route risk to humans, never be the ratchet.
 
-You are the ratchet. CI passes → you merge → progress is permanent.
+## The Loop
 
-**Your loop:**
-1. Check main branch CI (`gh run list --branch main --limit 3`)
-2. If main is red → emergency mode (see below)
-3. Check open PRs (`gh pr list --label multiclaude`)
-4. For each PR: validate → merge or fix
+1. `gh pr list --state open` — classify each PR:
+2. **Draft, work looks done** (worker signalled completion in comments/progress)
+   → nudge: remind about the `ready` label / marking ready (`auto-ready.yml`
+   flips it).
+3. **Ready, red required check** → diagnose first:
+   - Flake → `gh run rerun <run-id> --failed` (note it; repeated flakes get an
+     issue).
+   - Real failure → dispatch a fix:
+     `bash scripts/orchestration/dispatch.sh <issue> <executor>` when a linked
+     issue exists, else `multiclaude work "Fix CI for PR #<n>" --branch <br>`.
+4. **Ready, Review gate red** (unresolved threads / changes-requested) → if the
+   fixes are mechanical, dispatch a worker to address-and-resolve; otherwise
+   comment a one-line summary of what's outstanding for the author.
+5. **Risk-labeled or proto-touching** (`breaking`, `contract-test`,
+   `needs-human-input`, `proto/**`) → auto-merge refuses these by design.
+   Ensure a human reviewer is requested; do NOT work around it.
+6. **Green routine PR without auto-merge enabled** (opened before the
+   automation, or the enable call failed) → `gh pr merge <n> --auto --squash`.
+7. **Conflicting with main** → dispatch a rebase task.
 
-## Before Merging Any PR
+## What you never do
 
-**Checklist:**
-- [ ] CI green? (`gh pr checks <number>`)
-- [ ] No "Changes Requested" reviews? (`gh pr view <number> --json reviews`)
-- [ ] No unresolved comments?
-- [ ] Scope matches title? (small fix ≠ 500+ lines)
-- [ ] Aligns with ROADMAP.md? (no out-of-scope features)
+- Merge directly (`gh pr merge` without `--auto`) — the ratchet is platform
+  machinery now; a direct merge bypasses the Review gate.
+- Resolve someone else's review threads or dismiss reviews to make the gate
+  pass.
+- Auto-merge anything risk-labeled or proto-touching.
 
-If all yes → `gh pr merge <number> --squash`
-Then → `git fetch origin main:main` (keep local in sync)
+## Emergency Mode (main is red)
 
-## When Things Fail
-
-**CI fails:**
-```bash
-multiclaude work "Fix CI for PR #<number>" --branch <pr-branch>
-```
-
-**Review feedback:**
-```bash
-multiclaude work "Address review feedback on PR #<number>" --branch <pr-branch>
-```
-
-**Scope mismatch or roadmap violation:**
-```bash
-gh pr edit <number> --add-label "needs-human-input"
-gh pr comment <number> --body "Flagged for review: [reason]"
-multiclaude message send supervisor "PR #<number> needs human review: [reason]"
-```
-
-## Emergency Mode
-
-Main branch CI red = stop everything.
-
-```bash
-# 1. Halt all merges
-multiclaude message send supervisor "EMERGENCY: Main CI failing. Merges halted."
-
-# 2. Spawn fixer
-multiclaude work "URGENT: Fix main branch CI"
-
-# 3. Wait for fix, merge it immediately when green
-
-# 4. Resume
-multiclaude message send supervisor "Emergency resolved. Resuming merges."
-```
+1. `multiclaude message send supervisor "EMERGENCY: main CI failing."`
+2. Add `needs-human-input` to all queued routine PRs (pauses auto-merge intent
+   — the label makes automerge.yml refuse on its next run) and disable
+   auto-merge on anything already armed: `gh pr merge <n> --disable-auto`.
+3. Dispatch the fixer: `multiclaude work "URGENT: fix main branch CI"`.
+4. When main is green: remove the labels, re-arm auto-merge (step 6 above),
+   `multiclaude message send supervisor "Emergency resolved."`
 
 ## PRs Needing Humans
 
-Some PRs get stuck on human decisions. Don't waste cycles retrying.
-
 ```bash
-# Mark it
-gh pr edit <number> --add-label "needs-human-input"
-gh pr comment <number> --body "Blocked on: [what's needed]"
-
-# Stop retrying until label removed or human responds
+gh pr edit <n> --add-label "needs-human-input"
+gh pr comment <n> --body "Blocked on: [what's needed]"
 ```
-
-Check periodically: `gh pr list --label "needs-human-input"`
+Check periodically: `gh pr list --label "needs-human-input"`. Don't retry
+until the label is removed or a human responds.
 
 ## Closing PRs
 
-You can close PRs when:
-- Superseded by another PR
-- Human approved closure
-- Approach is unsalvageable (document learnings in issue first)
-
-```bash
-gh pr close <number> --comment "Closing: [reason]. Work preserved in #<issue>."
-```
+Close only when superseded, human-approved, or unsalvageable (document
+learnings on the linked issue first):
+`gh pr close <n> --comment "Closing: [reason]. Work preserved in #<issue>."`
 
 ## Branch Cleanup
 
-Periodically delete stale `multiclaude/*` and `work/*` branches:
-
-```bash
-# Only if no open PR AND no active worker
-gh pr list --head "<branch>" --state open  # must return empty
-multiclaude work list                       # must not show this branch
-
-# Then delete
-git push origin --delete <branch>
-```
+Merged branches auto-delete (`delete_branch_on_merge`). For stale unmerged
+`multiclaude/*` / `work/*` branches: verify no open PR
+(`gh pr list --head <branch> --state open`) and no active worker
+(`multiclaude work list`), then `git push origin --delete <branch>`.
 
 ## Review Agents
 
-Spawn reviewers for deeper analysis:
-```bash
-multiclaude review https://github.com/owner/repo/pull/123
-```
-
-They'll post comments and message you with results. 0 blocking issues = safe to merge.
+`multiclaude review <pr-url>` spawns deeper reviewers. Their findings arrive
+as review comments — which feed the Review gate like any reviewer's.
 
 ## Communication
 
 ```bash
-# Ask supervisor
 multiclaude message send supervisor "Question here"
-
-# Check your messages
-multiclaude message list
-multiclaude message ack <id>
+multiclaude message list && multiclaude message ack <id>
 ```
 
 ## Labels
@@ -121,6 +85,8 @@ multiclaude message ack <id>
 | Label | Meaning |
 |-------|---------|
 | `multiclaude` | Our PR |
-| `needs-human-input` | Blocked on human |
+| `needs-human-input` | Blocked on a human (also pauses auto-merge) |
+| `breaking`, `contract-test` | Risk — human review required, never auto-merged |
+| `claimed` | Issue leased to a worker (claims.sh — H1) |
 | `out-of-scope` | Roadmap violation |
 | `superseded` | Replaced by another PR |

--- a/docs/coordination/harness-modernization-proposal.md
+++ b/docs/coordination/harness-modernization-proposal.md
@@ -269,6 +269,18 @@ alone), and `just morning` still reads Milestones over REST (`justfile:758`) —
 
 ### H3 — Platform merge path (~1 day + repo settings)
 
+> **Partial execution (2026-07-04, PR #684):** the review-half of the merge path
+> landed, generalized per the owner's direction — **reviewer-agnostic**, gating on
+> "feedback addressed" rather than on any particular reviewer. Pieces:
+> `.github/workflows/review-gate.yml` (red while any review thread is unresolved or a
+> standing changes-requested exists; remediation in the failure log per §7 R1),
+> `required_conversation_resolution` seeded as the `branches:` block in
+> `.github/settings.yml` (that block now owns branch protection — extend it, don't use
+> the UI), the PR lifecycle codified in CONTRIBUTING.md §Pull Request Process + a PR
+> template checkbox, and post-review conduct added to the H1 dispatch prompts.
+> Remaining for #681: required-status-check selection, merge queue, and the graduated
+> human-review decision (§8 Q2).
+
 - Extend `.github/settings.yml` (settings-as-code is already established by #670) with the
   ruleset: required status checks = `PR title check`, `rust`, `go`, `ts`, `schema`,
   `hash-parity` (branch-naming stays advisory, per CLAUDE.md's stated intent), linear

--- a/docs/coordination/harness-modernization-proposal.md
+++ b/docs/coordination/harness-modernization-proposal.md
@@ -278,8 +278,16 @@ alone), and `just morning` still reads Milestones over REST (`justfile:758`) —
 > `.github/settings.yml` (that block now owns branch protection — extend it, don't use
 > the UI), the PR lifecycle codified in CONTRIBUTING.md §Pull Request Process + a PR
 > template checkbox, and post-review conduct added to the H1 dispatch prompts.
-> Remaining for #681: required-status-check selection, merge queue, and the graduated
-> human-review decision (§8 Q2).
+> **Second tranche (2026-07-04, same PR): §8 Q2 DECIDED by owner — "gate + queue
+> suffices for routine green PRs."** Landed: required-check set in `settings.yml`
+> (PR title check, Review gate, schema, rust, go, typescript, hash-parity; linear
+> history; `allow_auto_merge`), `automerge.yml` (arms squash auto-merge on ready
+> non-risk PRs; refuses `breaking`/`contract-test`/`needs-human-input`/proto-touching
+> and requests a human instead), `agents/merge-queue.md` rewritten as the PR-shepherd
+> role (never merges directly), CONTRIBUTING §7 graduated review. Remaining for #681:
+> confirm the Settings app is installed so the ruleset syncs, and evaluate a native
+> merge queue (merge-group testing) once ruleset management is confirmed — auto-merge
+> delivers merge-when-green today.
 
 - Extend `.github/settings.yml` (settings-as-code is already established by #670) with the
   ruleset: required status checks = `PR title check`, `rust`, `go`, `ts`, `schema`,

--- a/justfile
+++ b/justfile
@@ -804,6 +804,9 @@ morning:
       just beads-close-sync 2>/dev/null || true
       echo ""
     fi
+    echo "--- Sweeping stale worker claims (H1 lease expiry, #679) ---"
+    bash scripts/orchestration/claims.sh sweep 2>/dev/null || true
+    echo ""
     echo "Next steps:"
     echo "  just autonomous-stop     # stop overnight workers"
     echo "  just interactive         # start Gas Town for the day"
@@ -946,14 +949,31 @@ check-branch-name:
     python3 scripts/check_branch_name.py
 
 # Launch a Multiclaude worker from a GitHub Issue number
-work-on issue:
+work-on issue executor="multiclaude":
+    @bash scripts/orchestration/dispatch.sh "{{issue}}" "{{executor}}"
+
+# Dispatch every ready issue for a raw sprint label via a chosen executor
+# (H1 generic façade; `autonomous-sprint` stays the sprint-number front door).
+sprint label executor="multiclaude":
     #!/usr/bin/env bash
     set -euo pipefail
-    TASK=$(gh issue view {{issue}} --json title,body -q '"\(.title)\n\n\(.body)"')
-    echo "=== Launching worker for Issue #{{issue}} ==="
-    echo "$TASK" | head -3
-    echo "..."
-    multiclaude worker create "$TASK. Branch: use the agent-N/feat/adr-XXX naming convention. PR must include 'Closes #{{issue}}'. Mark the PR ready for review (not draft) when the work is complete — or, if you opened a draft, add the 'ready' label as your final step."
+    COUNT=0; SKIPPED=0
+    while IFS= read -r line; do
+      num=$(echo "$line" | jq -r '.number')
+      echo "  → Issue #$num: $(echo "$line" | jq -r '.title')"
+      rc=0
+      bash scripts/orchestration/dispatch.sh "$num" "{{executor}}" || rc=$?
+      case "$rc" in
+        0) COUNT=$((COUNT + 1)) ;;
+        3) SKIPPED=$((SKIPPED + 1)); echo "    (already claimed — skipped)" ;;
+        *) echo "    ✗ dispatch failed for #$num (rc=$rc)" ;;
+      esac
+    done < <(bash scripts/orchestration/ready.sh "{{label}}")
+    echo "✓ {{label}} via {{executor}}: $COUNT dispatched, $SKIPPED already claimed"
+
+# Offline tests for the dispatch layer (stubbed gh; no network)
+test-orchestration:
+    @bash scripts/orchestration/test_dispatch.sh
 
 # --- Beads (GitHub Issues ↔ Gas Town projection) ---
 # GitHub Issues remain the source of truth. Beads are a read-side projection
@@ -1103,50 +1123,7 @@ autonomous-shutdown:
 # listed under "## Blocked by" in its body refers to a CLOSED issue (or no
 # blockers exist). Prefers beads ('bd ready') when initialized.
 _ready label:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    LABEL="{{label}}"
-    # In-flight PRs (open PRs that close any issue) — both code paths exclude these.
-    IN_FLIGHT=$(gh pr list --state open --limit 200 \
-      --json closingIssuesReferences \
-      --jq '[.[].closingIssuesReferences[].number] | unique | join(" ")' 2>/dev/null || echo "")
-    # Prefer beads when initialized: true DAG semantics with cycle detection.
-    if command -v bd >/dev/null 2>&1 && bd list --all --json >/dev/null 2>&1; then
-      bd ready --label "$LABEL" --json --limit 200 2>/dev/null \
-        | jq -c '.[] | select(.external_ref != null) | select(.external_ref | startswith("gh-")) | {number: (.external_ref | sub("^gh-"; "") | tonumber), title}' \
-        | while IFS= read -r issue; do
-            num=$(echo "$issue" | jq -r '.number')
-            if [ -n "$IN_FLIGHT" ] && echo " $IN_FLIGHT " | grep -q " $num "; then
-              continue
-            fi
-            echo "$issue"
-          done
-      exit 0
-    fi
-    # Fallback: parse "## Blocked by" from issue bodies.
-    gh issue list --label "$LABEL" --state open --limit 200 --json number,title,body \
-      | jq -c '.[]' \
-      | while IFS= read -r issue; do
-          num=$(echo "$issue" | jq -r '.number')
-          if [ -n "$IN_FLIGHT" ] && echo " $IN_FLIGHT " | grep -q " $num "; then
-            continue
-          fi
-          body=$(echo "$issue" | jq -r '.body // ""')
-          blockers=$(echo "$body" \
-            | awk '/^## Blocked by/{flag=1; next} /^## /{flag=0} flag' \
-            | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)
-          ready=true
-          for b in $blockers; do
-            state=$(gh issue view "$b" --json state -q '.state' 2>/dev/null || echo "MISSING")
-            if [ "$state" != "CLOSED" ]; then
-              ready=false
-              break
-            fi
-          done
-          if [ "$ready" = "true" ]; then
-            echo "$issue" | jq -c '{number, title}'
-          fi
-        done
+    @bash scripts/orchestration/ready.sh "{{label}}"
 
 # Sprint launchers read Issues by label (primary) with milestone fallback
 autonomous-sprint sprint_num:
@@ -1199,27 +1176,28 @@ autonomous-sprint sprint_num:
       exit 0
     fi
     COUNT=0
+    SKIPPED=0
     while IFS= read -r line; do
       num=$(echo "$line" | jq -r '.number')
       title=$(echo "$line" | jq -r '.title')
-      # Fetch full issue body separately to avoid newline parsing issues
-      body=$(gh issue view "$num" --json body -q '.body' 2>/dev/null | head -50)
       echo "  → Issue #$num: $title"
-      # Branch convention varies by sprint type:
-      #   IaC sprints  → infra-N/feat/description
-      #   Test cov     → agent-N/test/tc-NNN-slug
-      #   Phase 5/etc. → agent-N/feat/adr-XXX-description
+      # Branch convention varies by sprint type; carried into the dispatch prompt.
       if [[ "$LABEL" == sprint-I.* ]]; then
-        BRANCH_HINT="Branch: use infra-N/feat/description naming."
+        HINT="use infra-N/feat/description naming"
       elif [[ "$LABEL" == sprint-tc-* ]]; then
-        BRANCH_HINT="Branch: use agent-N/test/tc-NNN-slug naming (see test-coverage-improvement-plan.md spec for the exact slug)."
+        HINT="use agent-N/test/tc-NNN-slug naming (see test-coverage-improvement-plan.md for the exact slug)"
       else
-        BRANCH_HINT="Branch: use agent-N/feat/adr-XXX naming."
+        HINT="use agent-N/feat/adr-XXX-description naming"
       fi
-      multiclaude worker create "$title. $body. $BRANCH_HINT PR must include 'Closes #$num'. Mark the PR ready for review (not draft) when done — or add the 'ready' label as your final step."
-      COUNT=$((COUNT + 1))
+      rc=0
+      ORCH_BRANCH_HINT="$HINT" bash scripts/orchestration/dispatch.sh "$num" multiclaude || rc=$?
+      case "$rc" in
+        0) COUNT=$((COUNT + 1)) ;;
+        3) SKIPPED=$((SKIPPED + 1)); echo "    (already claimed — skipped)" ;;
+        *) echo "    ✗ dispatch failed for #$num (rc=$rc)" ;;
+      esac
     done <<< "$ISSUES"
-    echo "✓ Workers launched for $MS ($COUNT ready issues)"
+    echo "✓ Workers launched for $MS ($COUNT dispatched, $SKIPPED already claimed)"
     echo "Monitor: just autonomous-status"
 
 # --- Solo Mode ---

--- a/scripts/orchestration/README.md
+++ b/scripts/orchestration/README.md
@@ -1,0 +1,58 @@
+# Orchestration dispatch layer (harness H1, #679)
+
+Executor-agnostic issue dispatch with a claim protocol and resume semantics.
+Extracted from justfile heredocs so it is testable; the `just` façades are
+unchanged for callers. Design: `docs/coordination/harness-modernization-proposal.md`
+§4 H1 and §7 R2.
+
+## Commands
+
+```bash
+just work-on 642                        # dispatch one issue (default executor)
+just work-on 642 executor=claude-web    # …via the @claude GitHub Action
+just sprint sprint-I.3 executor=jules   # dispatch every ready issue of a label
+just autonomous-sprint I.3              # sprint-number front door (multiclaude)
+just _ready sprint-I.3                  # {number,title} per ready issue
+just test-orchestration                 # offline behavior tests (stubbed gh)
+bash scripts/orchestration/claims.sh sweep   # expire stale leases (also in `just morning`)
+```
+
+## How a dispatch works
+
+1. **Claim** (`claims.sh take`): add the `claimed` label + a lease comment
+   `claim: executor=<e> worker=<w> expires=<ISO8601>` (TTL
+   `ORCH_CLAIM_TTL_HOURS`, default 24). If an unexpired lease exists — or we
+   lose the post-claim race — exit **3** ("already claimed"). This closes the
+   double-dispatch window behind the #661/#663 and #664/#665/#666 duplicates.
+2. **Render** the task prompt from the Issue. Mode is **INIT** (create branch +
+   `progress.log.md` with OKF `log.md` conventions) unless a prior worker posted
+   `progress-branch: <name>` — then **RESUME**: fetch that branch, read
+   `progress.log.md` + git log, continue; duplicate PRs forbidden. Every prompt
+   carries the startup ritual (sync → read state → **verify baseline green**
+   before new work), the one-unit-per-session rule, merge-ready clean-state,
+   append-only progress, and `Closes #N`.
+3. **Adapt**: `dispatch.d/<executor>.sh` receives the prompt on stdin and the
+   issue number as `$1`. Shipped adapters: `multiclaude` (worker daemon),
+   `claude-web` (posts an `@claude` issue comment; `claude.yml` runs the session
+   in GitHub-hosted compute), `jules` (cloud VM). Adding an executor = adding
+   one file here — nothing else changes.
+4. **Release on failure**: if the adapter exits non-zero the claim is released
+   so the issue returns to the ready pool.
+
+Claim state lives on the Issue (label + comments), never in executor memory —
+externalized state per proposal §7 R2. An open PR with `Closes #N` supersedes a
+lease; `claims.sh sweep` (run by `just morning`) clears stale leases.
+
+## Ready predicate (`ready.sh`)
+
+open ∧ not claimed ∧ no open closing PR ∧ all `## Blocked by` refs closed
+(beads DAG preferred when initialized). H2 (#680) replaces the body parsing
+with native issue dependencies over GraphQL; the claimed/in-flight predicates
+stay.
+
+## Tests
+
+`test_dispatch.sh` stubs `gh` with a filesystem fake and records adapter calls;
+covers the #679 acceptance criteria: double-dispatch guard, sweep-then-reclaim,
+resume-mode prompts, ready exclusions, failure release. CI:
+`.github/workflows/orchestration-tests.yml`.

--- a/scripts/orchestration/claims.sh
+++ b/scripts/orchestration/claims.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Issue claim protocol (harness H1, #679). Subcommands:
+#
+#   claims.sh take <issue> <executor> <worker-id> [ttl-hours]
+#       Take a lease. Exit 0 = claimed; exit 3 = already claimed (someone
+#       else holds an unexpired lease, or we lost the post-claim race).
+#   claims.sh release <issue> <worker-id>
+#       Voluntarily release (adapter failed, worker done without a PR).
+#   claims.sh sweep
+#       Expire stale leases repo-wide: claimed label + expired lease + no
+#       open closing PR → claim-expired comment + label removed. A claimed
+#       issue whose lease is superseded by an open closing PR just loses
+#       the label (the PR is the stronger in-flight signal).
+#   claims.sh status <issue>
+#       Human-readable claim state; exit 0 active, 1 not claimed.
+#
+# Atomicity note: GitHub offers no CAS on labels/comments, so `take` is
+# check → label → comment → re-check. Two dispatchers racing both post
+# claims; the one whose claim comment sorts FIRST wins, the loser posts a
+# release and exits 3. The window is a few seconds; the loser always
+# detects it. This is deliberately dumb — any executor with `gh` can play.
+
+set -euo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+. "$HERE/lib.sh"
+
+take() {
+  local issue="$1" executor="$2" worker="$3" ttl="${4:-$CLAIM_TTL_HOURS}"
+  CLAIM_TTL_HOURS="$ttl"
+
+  local held
+  if held=$(active_claim "$issue"); then
+    echo "already claimed: issue #$issue held by ${held% *} until ${held#* }" >&2
+    return 3
+  fi
+
+  ensure_claim_label
+  gh issue edit "$issue" --add-label "$CLAIM_LABEL" >/dev/null
+  gh issue comment "$issue" \
+    --body "claim: executor=$executor worker=$worker expires=$(expiry_iso)" >/dev/null
+
+  # Post-claim race check: if another unexpired claim precedes ours in the
+  # marker stream (after the last release/expire), we lost — back off.
+  local stream first_claim first_worker
+  stream=$(claim_markers "$issue")
+  first_claim=$(printf '%s\n' "$stream" \
+    | awk '/^(claim-released|claim-expired):/{buf=""} /^claim:/{if(buf=="")buf=$0} END{print buf}')
+  first_worker=$(marker_field "$first_claim" worker)
+  if [ -n "$first_worker" ] && [ "$first_worker" != "$worker" ]; then
+    local fexp
+    fexp=$(marker_field "$first_claim" expires)
+    if [ -n "$fexp" ] && [[ "$fexp" > "$(now_iso)" ]]; then
+      gh issue comment "$issue" --body "claim-released: worker=$worker" >/dev/null
+      echo "already claimed: lost race to $first_worker on issue #$issue" >&2
+      return 3
+    fi
+  fi
+  echo "claimed: issue #$issue by $worker (ttl ${ttl}h)"
+}
+
+release() {
+  local issue="$1" worker="$2"
+  gh issue comment "$issue" --body "claim-released: worker=$worker" >/dev/null
+  gh issue edit "$issue" --remove-label "$CLAIM_LABEL" >/dev/null 2>&1 || true
+  echo "released: issue #$issue by $worker"
+}
+
+sweep() {
+  local in_flight nums n line worker expires
+  in_flight=$(in_flight_numbers)
+  nums=$(claimed_numbers)
+  [ -n "$nums" ] || { echo "sweep: no claimed issues"; return 0; }
+  for n in $nums; do
+    if contains_num "$in_flight" "$n"; then
+      # Open closing PR supersedes the lease — drop the label quietly.
+      gh issue edit "$n" --remove-label "$CLAIM_LABEL" >/dev/null 2>&1 || true
+      echo "sweep: #$n superseded by open PR — label removed"
+      continue
+    fi
+    if active_claim "$n" >/dev/null; then
+      echo "sweep: #$n lease still live"
+      continue
+    fi
+    line=$(last_marker "$n")
+    worker=$(marker_field "$line" worker)
+    case "$line" in
+      claim:*)
+        gh issue comment "$n" \
+          --body "claim-expired: worker=${worker:-unknown} at=$(now_iso)" >/dev/null
+        ;;
+    esac
+    gh issue edit "$n" --remove-label "$CLAIM_LABEL" >/dev/null 2>&1 || true
+    echo "sweep: #$n stale lease cleared (worker=${worker:-none})"
+  done
+}
+
+status() {
+  local issue="$1" held
+  if held=$(active_claim "$issue"); then
+    echo "issue #$issue: claimed by ${held% *} until ${held#* }"
+    return 0
+  fi
+  echo "issue #$issue: not claimed"
+  return 1
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  take)    take "$@" ;;
+  release) release "$@" ;;
+  sweep)   sweep "$@" ;;
+  status)  status "$@" ;;
+  *) echo "usage: claims.sh {take <issue> <executor> <worker> [ttl-h] | release <issue> <worker> | sweep | status <issue>}" >&2
+     exit 2 ;;
+esac

--- a/scripts/orchestration/dispatch.d/claude-web.sh
+++ b/scripts/orchestration/dispatch.d/claude-web.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Executor adapter: Claude Code via the GitHub Action (@claude mention).
+# Posts the rendered prompt as an @claude comment on the issue;
+# .github/workflows/claude.yml (anthropics/claude-code-action) picks it up and
+# runs the session in GitHub-hosted compute. No local daemon required.
+#
+# $1 = issue number; prompt on stdin.
+set -euo pipefail
+ISSUE="${1:?issue number required}"
+{ printf '@claude '; cat; } | gh issue comment "$ISSUE" --body-file -

--- a/scripts/orchestration/dispatch.d/jules.sh
+++ b/scripts/orchestration/dispatch.d/jules.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Executor adapter: Google Jules (async cloud VM).
+# $1 = issue number (context only); prompt on stdin.
+set -euo pipefail
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+jules remote new --repo "$REPO" --session "$(cat)"

--- a/scripts/orchestration/dispatch.d/multiclaude.sh
+++ b/scripts/orchestration/dispatch.d/multiclaude.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Executor adapter: multiclaude worker daemon (today's default overnight path).
+# Reads the rendered task prompt on stdin; $1 = issue number (unused here —
+# the prompt carries all context).
+set -euo pipefail
+multiclaude worker create "$(cat)"

--- a/scripts/orchestration/dispatch.sh
+++ b/scripts/orchestration/dispatch.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Executor-agnostic dispatch (harness H1, #679):
+#
+#   dispatch.sh <issue-number> [executor]
+#
+# claim → render task prompt from the Issue (init vs. resume) → hand to the
+# executor adapter → release the claim if the adapter fails to launch.
+#
+# Executors are pluggable: dispatch.d/<executor>.sh reads the rendered prompt
+# on stdin and receives the issue number as $1. Ships with: multiclaude
+# (worker daemon, today's default), claude-web (posts an @claude comment —
+# .github/workflows/claude.yml picks it up), jules (Google Jules cloud VM).
+#
+# Env knobs:
+#   ORCH_DEFAULT_EXECUTOR  default executor when $2 omitted (multiclaude)
+#   ORCH_BRANCH_HINT       branch-naming hint embedded in the prompt
+#   ORCH_CLAIM_TTL_HOURS   lease length (default 24)
+#
+# Exit codes: 0 dispatched; 3 already claimed; 1 adapter/usage failure.
+
+set -euo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+. "$HERE/lib.sh"
+
+ISSUE="${1:?usage: dispatch.sh <issue-number> [executor]}"
+EXECUTOR="${2:-${ORCH_DEFAULT_EXECUTOR:-multiclaude}}"
+ADAPTER_DIR="${ORCH_ADAPTER_DIR:-$HERE/dispatch.d}"
+ADAPTER="$ADAPTER_DIR/$EXECUTOR.sh"
+BRANCH_HINT="${ORCH_BRANCH_HINT:-use the agent-N/feat/adr-XXX-description naming convention (see CLAUDE.md Branch-naming)}"
+
+if [ ! -x "$ADAPTER" ] && [ ! -f "$ADAPTER" ]; then
+  echo "dispatch: unknown executor '$EXECUTOR' (no $ADAPTER)" >&2
+  echo "available: $(ls "$ADAPTER_DIR" | sed 's/\.sh$//' | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+WORKER="${EXECUTOR}-$(hostname -s 2>/dev/null || echo host)-$$-$(date +%s)"
+
+bash "$HERE/claims.sh" take "$ISSUE" "$EXECUTOR" "$WORKER" || exit $?
+
+TITLE=$(gh issue view "$ISSUE" --json title -q '.title')
+BODY=$(gh issue view "$ISSUE" --json body -q '.body // ""')
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "this repository")
+
+# Resume detection: a prior worker announces its branch with a
+# `progress-branch: <name>` comment after its first push.
+RESUME_BRANCH=$(gh issue view "$ISSUE" --json comments --jq '.comments[].body' 2>/dev/null \
+  | grep -E '^progress-branch: ' | tail -1 | sed 's/^progress-branch: //' || true)
+
+if [ -n "$RESUME_BRANCH" ]; then
+  MODE_BLOCK=$(cat <<EOF
+MODE: RESUME — a previous session already worked this issue on branch \`$RESUME_BRANCH\`.
+2. Fetch and check out \`$RESUME_BRANCH\`. Read \`progress.log.md\` at the branch root
+   and \`git log --oneline -15\` to learn exactly where work stopped. Do NOT start a
+   new branch and do NOT open a duplicate PR — continue the existing work.
+EOF
+)
+else
+  MODE_BLOCK=$(cat <<EOF
+MODE: INIT — first session on this issue.
+2. Create a fresh branch: $BRANCH_HINT. Create \`progress.log.md\` at the branch root
+   (OKF log.md conventions: \`## YYYY-MM-DD\` headings, newest first, append-only) and
+   record what you plan to do this session.
+EOF
+)
+fi
+
+PROMPT=$(cat <<EOF
+You are a harness worker dispatched against GitHub Issue #$ISSUE of $REPO.
+
+Issue title: $TITLE
+
+== Startup ritual — complete IN ORDER before any new work ==
+1. Sync main and read the repo context anchor (CLAUDE.md). Agent identity and
+   ownership live in docs/agents/registry/ if unclear.
+$MODE_BLOCK
+3. Verify the baseline is green BEFORE new work: run the narrowest relevant test
+   target from CLAUDE.md's Testing Commands for the paths you will touch. If the
+   baseline is red, fix or report that first — starting a feature on a broken
+   baseline makes it worse. Record the baseline result in progress.log.md.
+
+== Task (from the Issue body) ==
+$BODY
+
+== Working rules ==
+- One unit of work per session. Leave a merge-ready state: no half-implemented
+  features, code orderly and documented, tests green.
+- Commit incrementally with descriptive messages.
+- progress.log.md is append-only status: flip statuses and add dated entries;
+  it is unacceptable to remove or edit existing spec or test content.
+- After your FIRST push, post an issue comment that is exactly:
+  progress-branch: <your-branch-name>
+- Your PR description must include 'Closes #$ISSUE'. Mark the PR ready for
+  review (not draft) when the work is complete — or, if you opened a draft,
+  add the 'ready' label as your final step.
+EOF
+)
+
+echo "=== Dispatching issue #$ISSUE via $EXECUTOR (worker $WORKER) ==="
+if printf '%s\n' "$PROMPT" | bash "$ADAPTER" "$ISSUE"; then
+  echo "✓ dispatched #$ISSUE → $EXECUTOR"
+else
+  rc=$?
+  echo "✗ adapter '$EXECUTOR' failed (rc=$rc) — releasing claim" >&2
+  bash "$HERE/claims.sh" release "$ISSUE" "$WORKER" || true
+  exit 1
+fi

--- a/scripts/orchestration/dispatch.sh
+++ b/scripts/orchestration/dispatch.sh
@@ -94,6 +94,9 @@ $BODY
 - Your PR description must include 'Closes #$ISSUE'. Mark the PR ready for
   review (not draft) when the work is complete — or, if you opened a draft,
   add the 'ready' label as your final step.
+- If reviewers leave feedback after that, address every thread — push the fix
+  or reply with why not, then resolve the conversation. Merge is gated on zero
+  unresolved threads and no standing changes-requested (Review gate check).
 EOF
 )
 

--- a/scripts/orchestration/lib.sh
+++ b/scripts/orchestration/lib.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Shared helpers for the executor-agnostic dispatch layer (harness H1, #679).
+# Sourced by claims.sh / ready.sh / dispatch.sh — not executed directly.
+#
+# Claim state is carried on the GitHub Issue itself (externalized state, never
+# executor session memory — proposal §7 R2): a `claimed` label plus marker
+# comments. The LAST marker comment wins:
+#   claim:          executor=<e> worker=<w> expires=<ISO8601Z>   (active lease)
+#   claim-released: worker=<w>                                    (voluntary release)
+#   claim-expired:  worker=<w> at=<ISO8601Z>                      (swept lease)
+
+set -euo pipefail
+
+CLAIM_LABEL="claimed"
+CLAIM_TTL_HOURS="${ORCH_CLAIM_TTL_HOURS:-24}"
+
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+expiry_iso() {
+  # GNU date first (Linux/CI), BSD date fallback (macOS operator machines).
+  date -u -d "+${CLAIM_TTL_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v "+${CLAIM_TTL_HOURS}H" +%Y-%m-%dT%H:%M:%SZ
+}
+
+ensure_claim_label() {
+  gh label create "$CLAIM_LABEL" \
+    --color "d93f0b" \
+    --description "Leased to a harness worker (see latest 'claim:' comment)" \
+    2>/dev/null || true
+}
+
+# All marker comments on an issue, oldest→newest, one per line.
+claim_markers() {
+  gh issue view "$1" --json comments \
+    --jq '.comments[].body' 2>/dev/null \
+    | grep -E '^(claim|claim-released|claim-expired):' || true
+}
+
+# The governing marker (last one). Empty when no claim history.
+last_marker() { claim_markers "$1" | tail -1; }
+
+marker_field() { # marker_field "<line>" <key>
+  printf '%s\n' "$1" | grep -oE "${2}=[^ ]+" | head -1 | cut -d= -f2- || true
+}
+
+# Prints "worker expires" when the issue holds an UNEXPIRED active lease.
+active_claim() {
+  local line worker expires
+  line=$(last_marker "$1")
+  case "$line" in
+    claim:*) ;;
+    *) return 1 ;;
+  esac
+  worker=$(marker_field "$line" worker)
+  expires=$(marker_field "$line" expires)
+  [ -n "$expires" ] || return 1
+  if [[ "$expires" > "$(now_iso)" ]]; then
+    printf '%s %s\n' "$worker" "$expires"
+    return 0
+  fi
+  return 1
+}
+
+has_claim_label() {
+  gh issue view "$1" --json labels \
+    --jq '[.labels[].name] | any(. == "'"$CLAIM_LABEL"'")' 2>/dev/null | grep -q true
+}
+
+# Space-separated issue numbers with an open PR that closes them.
+in_flight_numbers() {
+  gh pr list --state open --limit 200 \
+    --json closingIssuesReferences \
+    --jq '[.[].closingIssuesReferences[].number] | unique | join(" ")' 2>/dev/null || echo ""
+}
+
+# Space-separated open issue numbers currently carrying the claim label.
+claimed_numbers() {
+  gh issue list --label "$CLAIM_LABEL" --state open --limit 200 \
+    --json number --jq '[.[].number] | join(" ")' 2>/dev/null || echo ""
+}
+
+contains_num() { # contains_num "<space list>" <num>
+  [ -n "$1" ] && printf ' %s ' "$1" | grep -q " $2 "
+}

--- a/scripts/orchestration/ready.sh
+++ b/scripts/orchestration/ready.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Emit one JSON object per line ({number, title}) for "ready" issues with the
+# given label (harness H1, #679; extracted from the justfile `_ready` recipe).
+#
+# An issue is ready when:
+#   1. it has NO open PR closing it (in-flight), AND
+#   2. it is NOT claimed by a worker (claim protocol — see claims.sh), AND
+#   3. every "#N" under its "## Blocked by" body section is CLOSED
+#      (or beads says so, when the bd DAG is initialized — preferred path).
+#
+# H2 (#680) replaces path 3's body parsing with native issue dependencies via
+# GraphQL; the claimed/in-flight predicates stay.
+
+set -euo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+. "$HERE/lib.sh"
+
+LABEL="${1:?usage: ready.sh <label>}"
+
+IN_FLIGHT=$(in_flight_numbers)
+CLAIMED=$(claimed_numbers)
+
+excluded() { contains_num "$IN_FLIGHT" "$1" || contains_num "$CLAIMED" "$1"; }
+
+# Prefer beads when initialized: true DAG semantics with cycle detection.
+if command -v bd >/dev/null 2>&1 && bd list --all --json >/dev/null 2>&1; then
+  bd ready --label "$LABEL" --json --limit 200 2>/dev/null \
+    | jq -c '.[] | select(.external_ref != null) | select(.external_ref | startswith("gh-")) | {number: (.external_ref | sub("^gh-"; "") | tonumber), title}' \
+    | while IFS= read -r issue; do
+        num=$(echo "$issue" | jq -r '.number')
+        excluded "$num" && continue
+        echo "$issue"
+      done
+  exit 0
+fi
+
+# Fallback: parse "## Blocked by" from issue bodies.
+gh issue list --label "$LABEL" --state open --limit 200 --json number,title,body \
+  | jq -c '.[]' \
+  | while IFS= read -r issue; do
+      num=$(echo "$issue" | jq -r '.number')
+      excluded "$num" && continue
+      body=$(echo "$issue" | jq -r '.body // ""')
+      blockers=$(echo "$body" \
+        | awk '/^## Blocked by/{flag=1; next} /^## /{flag=0} flag' \
+        | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)
+      ready=true
+      for b in $blockers; do
+        state=$(gh issue view "$b" --json state -q '.state' 2>/dev/null || echo "MISSING")
+        if [ "$state" != "CLOSED" ]; then
+          ready=false
+          break
+        fi
+      done
+      if [ "$ready" = "true" ]; then
+        echo "$issue" | jq -c '{number, title}'
+      fi
+    done

--- a/scripts/orchestration/test_dispatch.sh
+++ b/scripts/orchestration/test_dispatch.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Offline behavior tests for the H1 dispatch layer (#679). Stubs `gh` with a
+# filesystem-backed fake and the executor adapter with a recorder, then drives
+# claims.sh / ready.sh / dispatch.sh end-to-end. No network, no real gh.
+#
+# Covered acceptance criteria (#679):
+#   A. double dispatch → exactly one worker; second exits 3 "already claimed"
+#   B. stale lease sweeps clean and the issue becomes dispatchable again
+#   C. re-dispatch after a progress-branch comment renders a RESUME prompt
+#   D. ready.sh excludes claimed and in-flight issues
+#   E. adapter failure releases the claim
+#
+# Run: bash scripts/orchestration/test_dispatch.sh   (or `just test-orchestration`)
+
+set -euo pipefail
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+export GH_STATE="$WORK/state"
+mkdir -p "$GH_STATE"
+STUBS="$WORK/bin"
+mkdir -p "$STUBS"
+
+# ---------- filesystem-backed gh stub ----------
+cat > "$STUBS/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+S="$GH_STATE"
+die() { echo "gh-stub: unhandled: $*" >&2; exit 97; }
+
+labels_of() { cat "$S/issues/$1/labels" 2>/dev/null || true; }
+comments_of() { # bodies in creation order
+  local d="$S/issues/$1/comments"
+  [ -d "$d" ] && for f in $(ls "$d" | sort -n); do cat "$d/$f"; echo; done
+}
+
+case "$1 $2" in
+  "label create")
+    touch "$S/label_created_$3"; exit 0 ;;
+  "repo view")
+    echo "test/kaizen"; exit 0 ;;
+  "pr list")
+    # emit space-joined closing numbers per lib.in_flight_numbers jq
+    cat "$S/prs_closing" 2>/dev/null || echo ""; exit 0 ;;
+  "issue list")
+    shift 2
+    label=""; jsonf=""; jqx=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --label) label="$2"; shift 2 ;;
+        --json)  jsonf="$2"; shift 2 ;;
+        --jq)    jqx="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    nums=""
+    for d in "$S"/issues/*/; do
+      n=$(basename "$d")
+      [ "$(cat "$d/state" 2>/dev/null || echo OPEN)" = "OPEN" ] || continue
+      grep -qx "$label" "$d/labels" 2>/dev/null && nums="$nums $n"
+    done
+    nums=$(echo "$nums" | xargs -n1 2>/dev/null | sort -n | xargs || true)
+    if [ "$jsonf" = "number" ]; then
+      # claims.sh claimed_numbers path: join numbers with spaces
+      echo "$nums"; exit 0
+    fi
+    # ready.sh fallback path: full JSON array (script pipes to real jq)
+    printf '['
+    first=1
+    for n in $nums; do
+      [ $first -eq 0 ] && printf ','
+      first=0
+      title=$(cat "$S/issues/$n/title" 2>/dev/null || echo "issue $n")
+      body=$(cat "$S/issues/$n/body" 2>/dev/null || echo "")
+      jq -cn --arg t "$title" --arg b "$body" --argjson n "$n" \
+        '{number:$n,title:$t,body:$b}'
+    done
+    printf ']\n'; exit 0 ;;
+  "issue view")
+    n="$3"; shift 3
+    json=""; q=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --json) json="$2"; shift 2 ;;
+        --jq|-q) q="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    case "$json" in
+      comments) comments_of "$n"; exit 0 ;;
+      labels)
+        if labels_of "$n" | grep -qx claimed; then echo true; else echo false; fi
+        exit 0 ;;
+      title) cat "$S/issues/$n/title" 2>/dev/null || echo "issue $n"; exit 0 ;;
+      body)  cat "$S/issues/$n/body" 2>/dev/null || echo ""; exit 0 ;;
+      state) cat "$S/issues/$n/state" 2>/dev/null || echo "OPEN"; exit 0 ;;
+      *) die "issue view --json $json" ;;
+    esac ;;
+  "issue edit")
+    n="$3"; shift 3
+    mkdir -p "$S/issues/$n"
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --add-label)
+          grep -qx "$2" "$S/issues/$n/labels" 2>/dev/null || echo "$2" >> "$S/issues/$n/labels"
+          shift 2 ;;
+        --remove-label)
+          [ -f "$S/issues/$n/labels" ] && grep -vx "$2" "$S/issues/$n/labels" > "$S/issues/$n/labels.tmp" \
+            && mv "$S/issues/$n/labels.tmp" "$S/issues/$n/labels" || true
+          shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    exit 0 ;;
+  "issue comment")
+    n="$3"; shift 3
+    mkdir -p "$S/issues/$n/comments"
+    seq=$(( $(ls "$S/issues/$n/comments" 2>/dev/null | wc -l) + 1 ))
+    body=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --body) body="$2"; shift 2 ;;
+        --body-file) [ "$2" = "-" ] && body="$(cat)"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    printf '%s' "$body" > "$S/issues/$n/comments/$seq"
+    exit 0 ;;
+esac
+die "$@"
+STUB
+chmod +x "$STUBS/gh"
+
+# ---------- recording adapter ----------
+ADAPTERS="$WORK/adapters"
+mkdir -p "$ADAPTERS"
+cat > "$ADAPTERS/stubexec.sh" <<'A'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$GH_STATE/adapter"
+echo "$1" >> "$GH_STATE/adapter/calls"
+cat > "$GH_STATE/adapter/last_prompt_$1"
+A
+cat > "$ADAPTERS/failexec.sh" <<'A'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 9
+A
+chmod +x "$ADAPTERS"/*.sh
+
+export PATH="$STUBS:$PATH"
+export ORCH_ADAPTER_DIR="$ADAPTERS"
+
+mkissue() { # mkissue <n> <title> [label]
+  mkdir -p "$GH_STATE/issues/$1/comments"
+  echo "$2" > "$GH_STATE/issues/$1/title"
+  echo "Body of issue $1." > "$GH_STATE/issues/$1/body"
+  echo "OPEN" > "$GH_STATE/issues/$1/state"
+  : > "$GH_STATE/issues/$1/labels"
+  [ -n "${3:-}" ] && echo "$3" >> "$GH_STATE/issues/$1/labels"
+}
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  ok: $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+check() { # check <desc> <cmd...>
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then ok "$desc"; else bad "$desc"; fi
+}
+
+echo "== A. claim + dispatch, then double-dispatch guard =="
+mkissue 42 "Implement widget" "sprint-x"
+bash "$HERE/dispatch.sh" 42 stubexec
+check "adapter called once" test "$(wc -l < "$GH_STATE/adapter/calls")" = 1
+check "claimed label applied" grep -qx claimed "$GH_STATE/issues/42/labels"
+check "claim comment posted" grep -ql '^claim: executor=stubexec' "$GH_STATE/issues/42/comments/"*
+check "prompt says INIT" grep -q 'MODE: INIT' "$GH_STATE/adapter/last_prompt_42"
+check "prompt carries Closes" grep -q "Closes #42" "$GH_STATE/adapter/last_prompt_42"
+check "prompt demands progress artifact" grep -q 'progress.log.md' "$GH_STATE/adapter/last_prompt_42"
+check "prompt demands baseline check" grep -q 'baseline' "$GH_STATE/adapter/last_prompt_42"
+rc=0; bash "$HERE/dispatch.sh" 42 stubexec 2>/dev/null || rc=$?
+check "second dispatch exits 3" test "$rc" = 3
+check "adapter NOT called again" test "$(wc -l < "$GH_STATE/adapter/calls")" = 1
+
+echo "== B. stale lease sweeps clean and issue is reclaimable =="
+# force the lease into the past
+for f in "$GH_STATE/issues/42/comments/"*; do
+  sed -i 's/expires=[0-9T:Z-]*/expires=2020-01-01T00:00:00Z/' "$f"
+done
+bash "$HERE/claims.sh" sweep >/dev/null
+check "label removed by sweep" bash -c '! grep -qx claimed "$GH_STATE/issues/42/labels"'
+check "claim-expired recorded" grep -ql '^claim-expired:' "$GH_STATE/issues/42/comments/"*
+bash "$HERE/dispatch.sh" 42 stubexec >/dev/null
+check "reclaim after sweep dispatches" test "$(wc -l < "$GH_STATE/adapter/calls")" = 2
+
+echo "== C. resume mode after progress-branch comment =="
+mkissue 43 "Resumable task" "sprint-x"
+mkdir -p "$GH_STATE/issues/43/comments"
+printf 'progress-branch: agent-3/feat/adr-999-widget' > "$GH_STATE/issues/43/comments/1"
+bash "$HERE/dispatch.sh" 43 stubexec >/dev/null
+check "prompt says RESUME" grep -q 'MODE: RESUME' "$GH_STATE/adapter/last_prompt_43"
+check "prompt names the branch" grep -q 'agent-3/feat/adr-999-widget' "$GH_STATE/adapter/last_prompt_43"
+check "resume forbids duplicate PR" grep -q 'duplicate PR' "$GH_STATE/adapter/last_prompt_43"
+
+echo "== D. ready.sh excludes claimed and in-flight =="
+mkissue 50 "Free issue" "lbl"
+mkissue 51 "Claimed issue" "lbl"
+echo "claimed" >> "$GH_STATE/issues/51/labels"
+mkissue 52 "In-flight issue" "lbl"
+echo "52" > "$GH_STATE/prs_closing"
+READY=$(bash "$HERE/ready.sh" lbl)
+check "lists the free issue" bash -c 'echo "$0" | grep -q "\"number\":50"' "$READY"
+check "excludes the claimed issue" bash -c '! echo "$0" | grep -q "\"number\":51"' "$READY"
+check "excludes the in-flight issue" bash -c '! echo "$0" | grep -q "\"number\":52"' "$READY"
+
+echo "== E. adapter failure releases the claim =="
+mkissue 60 "Doomed dispatch" "sprint-x"
+rc=0; bash "$HERE/dispatch.sh" 60 failexec 2>/dev/null || rc=$?
+check "dispatch reports failure" test "$rc" = 1
+check "claim released on failure" grep -ql '^claim-released:' "$GH_STATE/issues/60/comments/"*
+check "label removed on failure" bash -c '! grep -qx claimed "$GH_STATE/issues/60/labels"'
+rc=0; bash "$HERE/dispatch.sh" 60 stubexec >/dev/null 2>&1 || rc=$?
+check "issue dispatchable after release" test "$rc" = 0
+
+echo
+echo "passed $PASS, failed $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
Three related tranches of the harness lifecycle — dispatch front-half (H1), review gate, and the graduated-review merge path (H3):

### Commit 1 — H1: claim protocol, resume semantics, executor-agnostic dispatch (Closes #679)
**`scripts/orchestration/`** (new — extracted from justfile heredocs, now testable):
- `claims.sh` — lease on the Issue itself: `claimed` label + `claim: executor=… worker=… expires=…` comment; `take` (exit 3 = already claimed, incl. post-claim race check), `release`, `sweep` (open `Closes #N` PR supersedes a lease), `status`.
- `ready.sh` — open ∧ **not claimed** ∧ no open closing PR ∧ blockers closed (beads-first until H2/#680).
- `dispatch.sh` — claim → render prompt → adapter → release-on-failure. **INIT** creates `progress.log.md` (OKF `log.md` conventions); **RESUME** (prior `progress-branch:` comment) continues the branch, duplicate PRs forbidden. Startup ritual in every prompt.
- `dispatch.d/{multiclaude,claude-web,jules}.sh` — pluggable executors; `claude-web` posts `@claude` so `claude.yml` runs it in GitHub compute.
- `test_dispatch.sh` — **22 offline assertions** (filesystem `gh` stub) covering the #679 acceptance criteria; CI job `orchestration-tests` green here.

**justfile**: `_ready`/`work-on` delegate (+`executor=`); new `sprint <label> executor=` + `test-orchestration`; claim-aware `autonomous-sprint`; `morning` sweeps leases.

### Commit 2 — reviewer-agnostic review gate (Part of #681)
Codifies **draft → ready = work complete → address feedback → merge**, requiring no *particular* reviewer — only that arrived feedback is addressed:
- `review-gate.yml` — red on unresolved threads or standing changes-requested; re-evaluates on ready/synchronize/review/thread-reply, plus a 10-min in-run grace window that catches the resolve click (this GitHub's workflow validator rejects the documented `pull_request_review_thread` trigger — found live, fixed in the fifth commit); remediation in the failure log.
- `settings.yml` `branches:` block seeded with `required_conversation_resolution`.
- CONTRIBUTING lifecycle, PR-template checkbox, post-review conduct in dispatch prompts.

### Commit 3 — graduated review: gate + auto-merge for routine green PRs (Part of #681)
Executes the owner decision on §8 Q2 — *&#34;gate + queue suffices for routine green PRs&#34;*:
- `settings.yml`: required checks `PR title check` · `Review gate` · `schema` · `rust` · `go` · `typescript` · `hash-parity` (small/fast; path-skipped satisfies), `required_linear_history`, `allow_auto_merge`; `required_pull_request_reviews: null` **by decision**.
- `automerge.yml`: arms squash auto-merge on ready non-risk PRs; **refuses** `breaking`/`contract-test`/`needs-human-input`/proto-touching and requests a human reviewer instead; fails soft until the Settings app syncs the ruleset.
- Distinct check-run names for the two lint jobs (three sibling workflows shared job id `check`).
- `agents/merge-queue.md` → **PR shepherd**: nudges, flake reruns, fix dispatch, risk routing; `gh pr merge --auto` only, never direct merges; emergency mode pauses auto-merge.
- CONTRIBUTING §6–8 + CLAUDE.md updated to match.

### Commits 4–5 — review fixes (Devin) + live-validation fix
- Devin findings: disarm auto-merge when risk arrives after arming; `synchronize` re-evaluation; `enforce_admins` rationale documented.
- `review-gate.yml` was rejected wholesale by the workflow validator (`Unexpected value 'pull_request_review_thread'` — three zero-duration failed runs); replaced the trigger with `pull_request_review_comment` + a 10-min grace window so the standard push/reply-then-resolve sequence still converges. Verified live: the **Review gate** check now runs and is green on this PR.

## Agent
— (harness/tooling; no single module owner)

## Type
feat

## Related Issues
Closes #679. Part of #681 (remaining there: verify Settings-app sync; evaluate native merge queue; one-week risk-label retro). Absorbs #521. Unblocks #680; with #681 opens Goal #682. Relates to #522.

## Contract Changes
N/A — no proto/API/crate interfaces touched. `just _ready` / `just work-on` contracts preserved (verified by tests).

## Testing
- [x] `bash scripts/orchestration/test_dispatch.sh` — 22/22 after every tranche
- [x] `orchestration-tests` CI job green on this PR
- [x] `settings.yml` YAML-parses; justfile rewiring integrity checked
- [x] `review-gate.yml` validated **live** (the local YAML parse missed a platform-side trigger rejection — see commit 5): real `Review gate` check run, green
- [ ] Unit tests (`make test-rust` / `make test-go` / `make test-ts`) — N/A, no product code

Note: `just` isn&#39;t installed in the authoring container, so the justfile wasn&#39;t parse-executed here — recipes are line-for-line ports; first `just morning` confirms.

## Checklist
- [x] Code follows project conventions (see CONTRIBUTING.md)
- [x] All review threads resolved; no standing changes-requested (Review gate green)
- [x] Proto changes are backward-compatible — N/A
- [x] Documentation updated (README, CONTRIBUTING, CLAUDE.md, proposal)
- [x] No new warnings from linters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5xx2Dii4UhS3k7gJoZMcM