### PR TITLE
fix(governance): default org ruleset enforcement to disabled — evaluate is Enterprise-gated

### DIFF
--- a/docs/coordination/harness-modernization-proposal.md
+++ b/docs/coordination/harness-modernization-proposal.md
@@ -357,11 +357,13 @@ The move, three layers (all landed with this section):
    blocks every merge). Auth = fine-grained PAT, Administration:write only — H5's first
    concrete credential.
 3. **Org mode encoded, not aspirational** — `orgMode: true` collapses the universal rules
-   into ONE organization ruleset (`evaluate` first) targeting `kaizen-*`/`kensho-*`;
-   per-repo rulesets keep only repo-specific CI contexts (rulesets aggregate). Migration
-   sequencing, per-repo re-pointing checklist (app installs, per-owner PATs, owner-qualified
-   `uses:` refs), and the org-plan gate (org rulesets are Team+) live in
-   `docs/runbooks/ecosystem-governance.md`.
+   into ONE organization ruleset targeting `kaizen-*`/`kensho-*` (default enforcement
+   `disabled` → `active`; the `evaluate` dry-run status is **Enterprise-only**, so the stack
+   never defaults to it — verified 2026-07-04 against github/docs); per-repo rulesets keep
+   only repo-specific CI contexts (rulesets aggregate). Migration sequencing, per-repo
+   re-pointing checklist (app installs, per-owner PATs, owner-qualified `uses:` refs), and
+   the plan gate (org rulesets need **Team+**; everything the harness requires fits Team)
+   live in `docs/runbooks/ecosystem-governance.md`.
 
 **Decision needed (owner)**: transfer timing. Recommended order: land governance-as-code
 (done) → transfer one low-traffic repo (kensho-repl) as the canary → rest of the fleet →

--- a/docs/runbooks/ecosystem-governance.md
+++ b/docs/runbooks/ecosystem-governance.md
@@ -154,11 +154,18 @@ Sequencing that keeps automation alive through the move:
 4. **kaizen-experimentation last** — it has the most automation wired to its
    identity (this session included).
 5. **After the whole fleet is over** and the org plan supports org rulesets
-   (Team+): flip `orgMode: true` — the universal rules collapse into ONE org
-   ruleset (`enforcement: evaluate` first — dry-run insights, then active);
-   per-repo entries keep only repo-specific CI contexts. Also set the
+   (**Team suffices** — verified 2026-07-04 against the github/docs source):
+   flip `orgMode: true` — the universal rules collapse into ONE org ruleset;
+   per-repo entries keep only repo-specific CI contexts. Start it `disabled`,
+   flip `active` once callers are fleet-wide — the `evaluate` dry-run status
+   (Rule Insights) is **Enterprise-only** and a Team org rejects it, which is
+   why the stack defaults `orgEnforcement` to `disabled`. Also set the
    `fallback-reviewer` input on automerge callers (an org can't be requested
    as a reviewer the way a user-owner can).
+
+   Plan gating summary (2026-07-04): repo rulesets — free on public repos,
+   Pro/Team for private; org rulesets — Team+; `evaluate` mode and the
+   audit-log API — Enterprise. Everything this harness *requires* fits Team.
 
 ## Troubleshooting
 

--- a/infra/github-governance/Pulumi.governance.yaml
+++ b/infra/github-governance/Pulumi.governance.yaml
@@ -12,8 +12,10 @@
 #
 # Org migration (wunderkind-ventures): move a repo's `owner:` here as it
 # transfers; when the whole fleet has moved AND the org plan supports org
-# rulesets, flip orgMode: true — universal rules then ride one org ruleset
-# (enforcement starts at "evaluate") and these entries keep only repo CI.
+# rulesets (Team plan suffices), flip orgMode: true — universal rules then
+# ride one org ruleset and these entries keep only repo CI. orgEnforcement
+# starts "disabled"; flip to "active" once callers are fleet-wide. "evaluate"
+# (dry-run + Rule Insights) is an Enterprise-plan feature — only set it on GHEC.
 #
 # NOTE on governanceChecks names: reusable-workflow check runs are named
 # "<caller job name> / <callee job name>". Verified live on the H6 PR.
@@ -24,7 +26,7 @@ config:
       - "Review gate / gate"
     orgMode: false
     orgName: wunderkind-ventures
-    orgEnforcement: evaluate
+    orgEnforcement: disabled
     orgRepoPatterns:
       - "kaizen-*"
       - "kensho-*"

--- a/infra/github-governance/main.go
+++ b/infra/github-governance/main.go
@@ -29,7 +29,8 @@ import (
 type RepoSpec struct {
 	Owner string `json:"owner"`
 	Name  string `json:"name"`
-	// Enforcement: "active", "evaluate", or "disabled". Siblings default to
+	// Enforcement: "active", "evaluate" (Enterprise-gated — see OrgEnforcement),
+	// or "disabled". Siblings default to
 	// "disabled" until their caller workflows exist — a required check that
 	// never reports would otherwise block every merge.
 	Enforcement string `json:"enforcement"`
@@ -55,8 +56,10 @@ type Spec struct {
 	// OrgRepoPatterns select which org repos the org ruleset targets,
 	// fnmatch-style (e.g. "kaizen-*", "kensho-*").
 	OrgRepoPatterns []string `json:"orgRepoPatterns"`
-	// OrgEnforcement: enforcement for the org ruleset ("evaluate" is a
-	// useful dry-run while the fleet onboards).
+	// OrgEnforcement: enforcement for the org ruleset. Defaults to
+	// "disabled" — NOT "evaluate": the evaluate (dry-run) status is an
+	// Enterprise-plan feature (docs: ifversion repo-rules-enterprise); a
+	// Team-plan org rejects it. Set it explicitly only on GHEC.
 	OrgEnforcement string `json:"orgEnforcement"`
 }
 
@@ -187,7 +190,9 @@ func Deploy(ctx *pulumi.Context, spec Spec) error {
 		}
 		orgEnforcement := spec.OrgEnforcement
 		if orgEnforcement == "" {
-			orgEnforcement = "evaluate"
+			// "disabled", not "evaluate": evaluate is Enterprise-gated and a
+			// Team-plan org would reject the ruleset outright.
+			orgEnforcement = "disabled"
 		}
 		patterns := pulumi.StringArray{}
 		for _, p := range spec.OrgRepoPatterns {

--- a/infra/github-governance/main.go
+++ b/infra/github-governance/main.go
@@ -29,10 +29,13 @@ import (
 type RepoSpec struct {
 	Owner string `json:"owner"`
 	Name  string `json:"name"`
-	// Enforcement: "active", "evaluate" (Enterprise-gated — see OrgEnforcement),
-	// or "disabled". Siblings default to
-	// "disabled" until their caller workflows exist — a required check that
-	// never reports would otherwise block every merge.
+	// Enforcement: "active", "evaluate", or "disabled". "evaluate" (dry-run
+	// + Rule Insights) is Enterprise-only for BOTH repo- and org-level
+	// rulesets: github/docs gates the entire Evaluate status behind the
+	// repo-rules-enterprise flag (ghec/ghes versions only — no fpt entry),
+	// verified 2026-07-04. Siblings default to "disabled" until their
+	// caller workflows exist — a required check that never reports would
+	// otherwise block every merge.
 	Enforcement string `json:"enforcement"`
 	// RequiredChecks: repo-specific CI contexts (e.g. kaizen-experimentation's
 	// schema/rust/go/typescript/hash-parity). Universal governance checks are

--- a/infra/github-governance/main_test.go
+++ b/infra/github-governance/main_test.go
@@ -170,8 +170,8 @@ func TestOrgModeEmitsOrgRulesetAndSlimsRepoRulesets(t *testing.T) {
 		t.Fatalf("want exactly 1 org ruleset, got %d", len(orgs))
 	}
 	org := orgs[0]
-	if got := org.Inputs["enforcement"].StringValue(); got != "evaluate" {
-		t.Fatalf("org enforcement default = %q, want evaluate (dry-run while onboarding)", got)
+	if got := org.Inputs["enforcement"].StringValue(); got != "disabled" {
+		t.Fatalf("org enforcement default = %q, want disabled (evaluate is Enterprise-gated)", got)
 	}
 	patterns := org.Inputs["conditions"].ObjectValue()["repositoryName"].
 		ObjectValue()["includes"].ArrayValue()


### PR DESCRIPTION
## Summary
Answering "does wunderkind-ventures need Enterprise, or does Team suffice?" surfaced a plan-gating bug in the H6 stack (#687). Verified against the `github/docs` source (2026-07-04):

- **Org rulesets need Team or Enterprise** — the org-ruleset creation page says *"For customers on Team or Enterprise plans you can create rulesets"* (the Enterprise-only phrasing on the `about-rulesets` overview is stale).
- **The `evaluate` (dry-run + Rule Insights) enforcement status is Enterprise-only** (`ifversion repo-rules-enterprise`).
- Repo rulesets: free on public repos; Pro/Team for private.

The stack defaulted `orgEnforcement` to `evaluate` — a Team-plan `wunderkind-ventures` org would have had its org ruleset **rejected outright** on `pulumi up`. Now:

- `main.go`: `orgEnforcement` default `evaluate` → `disabled`, with the gating rationale in the field comment; test expectation updated (7/7 green, `-race`).
- `Pulumi.governance.yaml`: `orgEnforcement: disabled` + corrected header comment.
- Runbook + proposal H6: migration step now reads `disabled` → `active` (set `evaluate` explicitly only on GHEC) and both gain the verified plan-gating summary: **everything the harness requires fits the Team plan**.

## Agent
— (harness/tooling; no single module owner)

## Type
fix

## Related Issues
Part of #681 follow-through; corrects H6 machinery shipped in #687 (closed #686).

## Contract Changes
N/A — config default + docs only. No proto/API/crate interfaces.

## Testing
- [x] `go build && go vet && go test -race ./...` in `infra/github-governance` — 7/7
- [x] `Pulumi.governance.yaml` YAML-parses
- [ ] Unit tests (`just test-rust` / `just test-go` / `just test-ts`) — N/A, no product code

## Checklist
- [x] Code follows project conventions (see CONTRIBUTING.md)
- [ ] All review threads resolved; no standing changes-requested (Review gate green) — *no reviews yet*
- [x] Proto changes are backward-compatible — N/A
- [x] Documentation updated (runbook, proposal H6)
- [x] No new warnings from linters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5xx2Dii4UhS3k7gJoZMcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5xx2Dii4UhS3k7gJoZMcM)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->