### PR TITLE
🎨 Palette: Standardize focus indicators and gated button accessibility

### DIFF
--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -116,7 +116,7 @@ export default function AuditLogPage() {
               <p className="text-sm text-gray-500">No audit log entries match your filters.</p>
               <button
                 onClick={clearFilters}
-                className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+                className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
                 data-testid="clear-filters-empty"
               >
                 Clear filters
@@ -130,7 +130,7 @@ export default function AuditLogPage() {
                   <button
                     onClick={loadMore}
                     disabled={loadingMore}
-                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                     data-testid="load-more-button"
                   >
                     {loadingMore && (

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -89,16 +89,19 @@ function FlagListContent() {
         {canAtLeast('experimenter') ? (
           <Link
             href="/flags/new"
-            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             data-testid="new-flag-button"
           >
             New Flag
           </Link>
         ) : (
           <span
-            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             title={`Requires Experimenter role (you are ${user ? ROLE_LABELS[user.role] : 'Unknown'})`}
             data-testid="new-flag-disabled"
+            tabIndex={0}
+            role="button"
+            aria-disabled="true"
           >
             New Flag
           </span>
@@ -119,7 +122,7 @@ function FlagListContent() {
             <div className="mt-6">
               <Link
                 href="/flags/new"
-                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                 data-testid="create-first-flag"
               >
                 Create your first feature flag
@@ -199,7 +202,7 @@ function FlagListContent() {
               <p className="text-sm text-gray-500">No flags match your filters.</p>
               <button
                 onClick={clearFilters}
-                className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+                className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
                 data-testid="clear-filters-empty"
               >
                 Clear filters

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -365,16 +365,19 @@ function MetricBrowserContent() {
           canAtLeast('experimenter') ? (
             <Link
               href="/metrics/new"
-              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               data-testid="new-metric-button"
             >
               New Metric
             </Link>
           ) : (
             <span
-              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               title={`Requires Experimenter role (you are ${ROLE_LABELS[user.role]})`}
               data-testid="new-metric-disabled"
+              tabIndex={0}
+              role="button"
+              aria-disabled="true"
             >
               New Metric
             </span>
@@ -396,7 +399,7 @@ function MetricBrowserContent() {
             <div className="mt-6">
               <Link
                 href="/metrics/new"
-                className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+                className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                 data-testid="create-first-metric"
               >
                 Create your first metric
@@ -476,7 +479,7 @@ function MetricBrowserContent() {
             <p className="text-sm text-gray-500">No metrics match your filters.</p>
             <button
               onClick={clearFilters}
-              className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+              className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
               data-testid="clear-filters-empty"
             >
               Clear filters

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -95,16 +95,19 @@ export default function ExperimentListPage() {
           canCreate ? (
             <Link
               href="/experiments/new"
-              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500"
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               data-testid="new-experiment-link"
             >
               New Experiment
             </Link>
           ) : (
             <span
-              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed"
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white opacity-50 cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               title={`Requires Experimenter role (you are ${ROLE_LABELS[user.role]})`}
               data-testid="new-experiment-disabled"
+              tabIndex={0}
+              role="button"
+              aria-disabled="true"
             >
               New Experiment
             </span>
@@ -126,7 +129,7 @@ export default function ExperimentListPage() {
             <div className="mt-6">
               <Link
                 href="/experiments/new"
-                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                 data-testid="create-first-experiment"
               >
                 Create your first experiment
@@ -147,7 +150,7 @@ export default function ExperimentListPage() {
           <p className="text-sm text-gray-500">No experiments match your filters.</p>
           <button
             onClick={filters.clearFilters}
-            className="mt-2 text-sm text-indigo-600 hover:text-indigo-800"
+            className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             data-testid="clear-filters-empty"
           >
             Clear filters


### PR DESCRIPTION
Standardized focus-visible rings for primary action buttons across the Experiments, Flags, Metrics, and Audit Log pages. Also improved keyboard accessibility for permission-gated (disabled) buttons by adding tabIndex={0}, role="button", and aria-disabled="true", allowing users to discover required roles via tooltips.

---
*PR created automatically by Jules for task [16195198942459871788](https://jules.google.com/task/16195198942459871788) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->