### PR TITLE
🎨 Palette: Standardize focus rings in Experiment Management UI

### DIFF
--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -146,7 +146,7 @@ export default function ExperimentDetailPage() {
           {experiment.state === 'CONCLUDED' && (
             <Link
               href={`/experiments/${experiment.experimentId}/results`}
-              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+              className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             >
               View Results
             </Link>
@@ -154,14 +154,14 @@ export default function ExperimentDetailPage() {
           {(experiment.type === 'MAB' || experiment.type === 'CONTEXTUAL_BANDIT') && experiment.state !== 'DRAFT' && (
             <Link
               href={`/experiments/${experiment.experimentId}/bandit`}
-              className="rounded-md bg-purple-600 px-3 py-2 text-sm font-medium text-white hover:bg-purple-700"
+              className="rounded-md bg-purple-600 px-3 py-2 text-sm font-medium text-white hover:bg-purple-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             >
               Bandit Dashboard
             </Link>
           )}
           <Link
             href={`/experiments/${experiment.experimentId}/sql`}
-            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
           >
             View SQL
           </Link>

--- a/ui/src/components/state-actions.tsx
+++ b/ui/src/components/state-actions.tsx
@@ -75,7 +75,7 @@ export function StateActions({ state, onTransition }: StateActionsProps) {
         onClick={() => allowed && setDialogOpen(true)}
         disabled={!allowed}
         title={tooltip}
-        className={`rounded-md px-3 py-2 text-sm font-medium ${config.buttonClass} ${
+        className={`rounded-md px-3 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${config.buttonClass} ${
           !allowed ? 'opacity-50 cursor-not-allowed' : ''
         }`}
       >

--- a/ui/src/components/variant-form.tsx
+++ b/ui/src/components/variant-form.tsx
@@ -246,14 +246,14 @@ export function VariantForm({ variants: initialVariants, experimentType, onSave 
         <button
           type="button"
           onClick={addVariant}
-          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
         >
           Add Variant
         </button>
         <button
           type="button"
           onClick={distributeTraffic}
-          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
           aria-label="Distribute traffic evenly across all variants"
         >
           Distribute Evenly
@@ -262,7 +262,7 @@ export function VariantForm({ variants: initialVariants, experimentType, onSave 
           type="button"
           onClick={handleSave}
           disabled={!dirty || saving || hasErrors}
-          className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {saving ? 'Saving...' : 'Save Variants'}
         </button>


### PR DESCRIPTION
💡 **What**: Standardized `focus-visible` ring indicators across primary and secondary action elements in the Experiment Detail page and Variant Form.
🎯 **Why**: Ensures keyboard-only users have clear visual feedback of their focus position, matching the accessibility patterns established in list views and feature flags.
♿ **Accessibility**: Implemented `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2` for all targeted buttons and links.

---
*PR created automatically by Jules for task [5839191389065526321](https://jules.google.com/task/5839191389065526321) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->