### PR TITLE
🎨 Palette: Hover-reveal copy buttons in experiment metadata grid

### DIFF
--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -118,12 +118,13 @@ export default function ExperimentDetailPage() {
       {/* Header */}
       <div className="mb-6 flex items-start justify-between">
         <div>
-          <div className="flex items-center gap-3">
+          <div className="group flex items-center gap-3">
             <h1 className="text-2xl font-bold text-gray-900">{experiment.name}</h1>
             <CopyButton
               value={experiment.experimentId}
               label="Copy experiment ID"
               successMessage="Experiment ID copied to clipboard"
+              className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
             />
             <StateBadge state={experiment.state} />
             <TypeBadge type={experiment.type} />
@@ -189,8 +190,8 @@ export default function ExperimentDetailPage() {
             <CopyButton
               value={experiment.ownerEmail}
               label="Copy owner email"
-              successMessage="Owner email copied"
-              className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+              successMessage="Owner email copied to clipboard"
+              className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
             />
           </dd>
         </div>
@@ -203,8 +204,8 @@ export default function ExperimentDetailPage() {
             <CopyButton
               value={experiment.primaryMetricId}
               label="Copy metric ID"
-              successMessage="Metric ID copied"
-              className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+              successMessage="Metric ID copied to clipboard"
+              className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
             />
           </dd>
         </div>
@@ -293,8 +294,8 @@ export default function ExperimentDetailPage() {
                         <CopyButton
                           value={g.metricId}
                           label="Copy metric ID"
-                          successMessage="Metric ID copied"
-                          className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+                          successMessage="Metric ID copied to clipboard"
+                          className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
                         />
                       </div>
                     </td>

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -190,7 +190,7 @@ export default function ExperimentDetailPage() {
               value={experiment.ownerEmail}
               label="Copy owner email"
               successMessage="Owner email copied"
-              className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+              className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
             />
           </dd>
         </div>
@@ -204,7 +204,7 @@ export default function ExperimentDetailPage() {
               value={experiment.primaryMetricId}
               label="Copy metric ID"
               successMessage="Metric ID copied"
-              className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+              className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
             />
           </dd>
         </div>

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -182,11 +182,19 @@ export default function ExperimentDetailPage() {
 
       {/* Metadata grid */}
       <div className="mb-6 grid grid-cols-2 gap-4 rounded-lg border border-gray-200 bg-white p-4 sm:grid-cols-4">
-        <div>
+        <div className="group">
           <dt className="text-xs font-medium uppercase text-gray-500">Owner</dt>
-          <dd className="mt-1 text-sm text-gray-900">{experiment.ownerEmail}</dd>
+          <dd className="mt-1 flex items-center gap-2 text-sm text-gray-900">
+            {experiment.ownerEmail}
+            <CopyButton
+              value={experiment.ownerEmail}
+              label="Copy owner email"
+              successMessage="Owner email copied"
+              className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+            />
+          </dd>
         </div>
-        <div>
+        <div className="group">
           <dt className="text-xs font-medium uppercase text-gray-500">Primary Metric</dt>
           <dd className="mt-1 flex items-center gap-2 text-sm text-gray-900">
             <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
@@ -196,6 +204,7 @@ export default function ExperimentDetailPage() {
               value={experiment.primaryMetricId}
               label="Copy metric ID"
               successMessage="Metric ID copied"
+              className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
             />
           </dd>
         </div>

--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -118,13 +118,12 @@ export default function ExperimentDetailPage() {
       {/* Header */}
       <div className="mb-6 flex items-start justify-between">
         <div>
-          <div className="group flex items-center gap-3">
+          <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold text-gray-900">{experiment.name}</h1>
             <CopyButton
               value={experiment.experimentId}
               label="Copy experiment ID"
               successMessage="Experiment ID copied to clipboard"
-              className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
             />
             <StateBadge state={experiment.state} />
             <TypeBadge type={experiment.type} />
@@ -191,7 +190,7 @@ export default function ExperimentDetailPage() {
               value={experiment.ownerEmail}
               label="Copy owner email"
               successMessage="Owner email copied to clipboard"
-              className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+              className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
             />
           </dd>
         </div>
@@ -205,7 +204,7 @@ export default function ExperimentDetailPage() {
               value={experiment.primaryMetricId}
               label="Copy metric ID"
               successMessage="Metric ID copied to clipboard"
-              className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+              className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
             />
           </dd>
         </div>
@@ -295,7 +294,7 @@ export default function ExperimentDetailPage() {
                           value={g.metricId}
                           label="Copy metric ID"
                           successMessage="Metric ID copied to clipboard"
-                          className="opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+                          className="h-4 w-4 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
                         />
                       </div>
                     </td>


### PR DESCRIPTION
Implemented a micro-UX improvement on the Experiment Detail page by applying a "hover-reveal" pattern to the metadata grid. This change adds a copy-to-clipboard button for the experiment owner's email and refines the existing copy button for the primary metric ID. By hiding these secondary actions until they are hovered or focused, we reduce visual noise while maintaining quick access to useful IDs and emails. The implementation ensures full keyboard accessibility by making the buttons visible when any child element receives focus.

---
*PR created automatically by Jules for task [17173337102341796078](https://jules.google.com/task/17173337102341796078) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->