### PR TITLE
🎨 Palette: Improve Experiment Detail Metadata UX and Accessibility

### DIFF
--- a/ui/src/app/experiments/[id]/page.tsx
+++ b/ui/src/app/experiments/[id]/page.tsx
@@ -181,12 +181,20 @@ export default function ExperimentDetailPage() {
       )}
 
       {/* Metadata grid */}
-      <div className="mb-6 grid grid-cols-2 gap-4 rounded-lg border border-gray-200 bg-white p-4 sm:grid-cols-4">
-        <div>
+      <dl className="mb-6 grid grid-cols-2 gap-4 rounded-lg border border-gray-200 bg-white p-4 sm:grid-cols-4">
+        <div className="group">
           <dt className="text-xs font-medium uppercase text-gray-500">Owner</dt>
-          <dd className="mt-1 text-sm text-gray-900">{experiment.ownerEmail}</dd>
+          <dd className="mt-1 flex items-center gap-2 text-sm text-gray-900">
+            <span>{experiment.ownerEmail}</span>
+            <CopyButton
+              value={experiment.ownerEmail}
+              label="Copy owner email"
+              successMessage="Owner email copied"
+              className="opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
+            />
+          </dd>
         </div>
-        <div>
+        <div className="group">
           <dt className="text-xs font-medium uppercase text-gray-500">Primary Metric</dt>
           <dd className="mt-1 flex items-center gap-2 text-sm text-gray-900">
             <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
@@ -196,6 +204,7 @@ export default function ExperimentDetailPage() {
               value={experiment.primaryMetricId}
               label="Copy metric ID"
               successMessage="Metric ID copied"
+              className="opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
             />
           </dd>
         </div>
@@ -209,7 +218,7 @@ export default function ExperimentDetailPage() {
             {experiment.startedAt ? formatDate(experiment.startedAt) : '—'}
           </dd>
         </div>
-      </div>
+      </dl>
 
       {/* Variant section: editable form for DRAFT, read-only table otherwise */}
       <section className="mb-6">


### PR DESCRIPTION
💡 What: Refactored the metadata grid on the Experiment Detail page to use semantic `<dl>` tags and added a hover-reveal `CopyButton` for the experiment owner's email.
🎯 Why: Improves accessibility for screen readers by using proper semantic HTML and enhances developer productivity by making the owner email easily copyable without cluttering the UI.
♿ Accessibility: Uses `<dl>`, `<dt>`, and `<dd>` for correct semantic structure. Copy buttons are visible on keyboard focus.

---
*PR created automatically by Jules for task [15678486187065079915](https://jules.google.com/task/15678486187065079915) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->