### PR TITLE
🎨 Palette: Add accessibility focus indicators to toolbar buttons

### DIFF
--- a/crates/experimentation-management/src/grpc.rs
+++ b/crates/experimentation-management/src/grpc.rs
@@ -439,8 +439,8 @@ impl ExperimentManagementService for ManagementServiceHandler {
                 is_cumulative_holdout: exp.is_cumulative_holdout,
                 type_config: &type_config,
                 sequential_method: seq_method,
-                planned_looks: planned_looks.and_then(|l| if l == 0 { None } else { Some(l) }),
-                overall_alpha: overall_alpha.and_then(|a| if a == 0.0 { None } else { Some(a) }),
+                planned_looks: planned_looks.filter(|&l| l != 0),
+                overall_alpha: overall_alpha.filter(|&a| a != 0.0),
                 surrogate_model_id,
                 variants: &variants,
             })

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -189,7 +189,7 @@ function FlagListContent() {
         {hasActiveFilters && (
           <button
             onClick={clearFilters}
-            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             data-testid="clear-filters-toolbar"
           >
             Clear filters

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -466,7 +466,7 @@ function MetricBrowserContent() {
         {hasActiveFilters && (
           <button
             onClick={clearFilters}
-            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             data-testid="clear-filters-toolbar"
           >
             Clear filters

--- a/ui/src/components/audit-filters.tsx
+++ b/ui/src/components/audit-filters.tsx
@@ -143,7 +143,7 @@ export function AuditFilters({
       {hasActiveFilters && (
         <button
           onClick={onClear}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
           data-testid="clear-filters-toolbar"
         >
           Clear filters

--- a/ui/src/components/experiment-filters.tsx
+++ b/ui/src/components/experiment-filters.tsx
@@ -98,7 +98,7 @@ export function ExperimentFiltersToolbar({ filters, totalCount, filteredCount }:
       {filters.hasActiveFilters && (
         <button
           onClick={filters.clearFilters}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50"
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
           data-testid="clear-filters-toolbar"
         >
           Clear filters


### PR DESCRIPTION
🎨 Palette: Standardized accessibility focus indicators for "Clear filters" buttons across the main dashboard list views (Experiments, Flags, Metrics, and Audit Log). This ensures that keyboard-only users have clear visual feedback when navigating and interacting with secondary toolbar actions, consistent with the platform's focus state patterns.

---
*PR created automatically by Jules for task [2561832017520805784](https://jules.google.com/task/2561832017520805784) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->