### PR TITLE
🎨 Palette: Add hover-reveal CopyButtons to experiment list

### DIFF
--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -184,7 +184,9 @@ describe('Accessibility', () => {
     it('experiment list loading spinner has role="status" and sr-only text', () => {
       render(
         <AuthProvider initialUser={defaultUser}>
-          <ExperimentListPage />
+          <ToastProvider>
+            <ExperimentListPage />
+          </ToastProvider>
         </AuthProvider>,
       );
 
@@ -200,7 +202,9 @@ describe('Accessibility', () => {
     it('renders a button inside <th> for keyboard access', async () => {
       render(
         <AuthProvider initialUser={defaultUser}>
-          <ExperimentListPage />
+          <ToastProvider>
+            <ExperimentListPage />
+          </ToastProvider>
         </AuthProvider>,
       );
 
@@ -217,7 +221,9 @@ describe('Accessibility', () => {
       const user = userEvent.setup();
       render(
         <AuthProvider initialUser={defaultUser}>
-          <ExperimentListPage />
+          <ToastProvider>
+            <ExperimentListPage />
+          </ToastProvider>
         </AuthProvider>,
       );
 

--- a/ui/src/__tests__/chaos-resilience.test.tsx
+++ b/ui/src/__tests__/chaos-resilience.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from 'msw';
 import { server } from '@/__mocks__/server';
 import { clearApiCache } from '@/lib/api';
 import { AuthProvider } from '@/lib/auth-context';
+import { ToastProvider } from '@/lib/toast-context';
 import ResultsPage from '@/app/experiments/[id]/results/page';
 import ExperimentListPage from '@/app/page';
 import ExperimentDetailPage from '@/app/experiments/[id]/page';
@@ -79,7 +80,7 @@ describe('Chaos: Full backend outage on list page', () => {
       }),
     );
 
-    render(<AuthProvider initialUser={defaultUser}><ExperimentListPage /></AuthProvider>);
+    render(<AuthProvider initialUser={defaultUser}><ToastProvider><ExperimentListPage /></ToastProvider></AuthProvider>);
 
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
@@ -102,7 +103,7 @@ describe('Chaos: Full backend outage on list page', () => {
       }),
     );
 
-    render(<AuthProvider initialUser={defaultUser}><ExperimentListPage /></AuthProvider>);
+    render(<AuthProvider initialUser={defaultUser}><ToastProvider><ExperimentListPage /></ToastProvider></AuthProvider>);
 
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();
@@ -307,7 +308,7 @@ describe('Chaos: Network error on list page', () => {
       }),
     );
 
-    render(<AuthProvider initialUser={defaultUser}><ExperimentListPage /></AuthProvider>);
+    render(<AuthProvider initialUser={defaultUser}><ToastProvider><ExperimentListPage /></ToastProvider></AuthProvider>);
 
     await waitFor(() => {
       expect(screen.getByTestId('retryable-error')).toBeInTheDocument();

--- a/ui/src/__tests__/experiment-empty-state.test.tsx
+++ b/ui/src/__tests__/experiment-empty-state.test.tsx
@@ -5,6 +5,7 @@ import { server } from '@/__mocks__/server';
 import ExperimentListPage from '@/app/page';
 import { AuthProvider } from '@/lib/auth-context';
 import type { AuthUser } from '@/lib/auth-context';
+import { ToastProvider } from '@/lib/toast-context';
 
 const MGMT_SVC = '*/experimentation.management.v1.ExperimentManagementService';
 
@@ -33,7 +34,9 @@ describe('Experiment List Empty State', () => {
     const experimenter: AuthUser = { email: 'exp@streamco.com', role: 'experimenter' };
     render(
       <AuthProvider initialUser={experimenter}>
-        <ExperimentListPage />
+        <ToastProvider>
+          <ExperimentListPage />
+        </ToastProvider>
       </AuthProvider>,
     );
 
@@ -56,7 +59,9 @@ describe('Experiment List Empty State', () => {
     const viewer: AuthUser = { email: 'viewer@streamco.com', role: 'viewer' };
     render(
       <AuthProvider initialUser={viewer}>
-        <ExperimentListPage />
+        <ToastProvider>
+          <ExperimentListPage />
+        </ToastProvider>
       </AuthProvider>,
     );
 
@@ -77,7 +82,9 @@ describe('Experiment List Empty State', () => {
 
     render(
       <AuthProvider initialUser={{ email: 'test@streamco.com', role: 'viewer' }}>
-        <ExperimentListPage />
+        <ToastProvider>
+          <ExperimentListPage />
+        </ToastProvider>
       </AuthProvider>,
     );
 

--- a/ui/src/__tests__/experiment-list.test.tsx
+++ b/ui/src/__tests__/experiment-list.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import ExperimentListPage from '@/app/page';
 import { AuthProvider } from '@/lib/auth-context';
 import type { AuthUser } from '@/lib/auth-context';
+import { ToastProvider } from '@/lib/toast-context';
 
 const defaultUser: AuthUser = { email: 'test@streamco.com', role: 'experimenter' };
 
@@ -24,7 +25,9 @@ vi.mock('next/link', () => ({
 async function renderAndWait(user: AuthUser = defaultUser) {
   render(
     <AuthProvider initialUser={user}>
-      <ExperimentListPage />
+      <ToastProvider>
+        <ExperimentListPage />
+      </ToastProvider>
     </AuthProvider>,
   );
   await waitFor(() => {

--- a/ui/src/components/experiment-card.tsx
+++ b/ui/src/components/experiment-card.tsx
@@ -5,6 +5,7 @@ import type { Experiment } from '@/lib/types';
 import { formatDate } from '@/lib/utils';
 import { StateBadge } from './state-badge';
 import { TypeBadge } from './type-badge';
+import { CopyButton } from './copy-button';
 
 interface ExperimentCardProps {
   experiment: Experiment;
@@ -42,17 +43,36 @@ export const ExperimentCard = ExperimentRow;
 
 export function ExperimentRow({ experiment }: ExperimentCardProps) {
   return (
-    <tr className="hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500">
+    <tr className="group hover:bg-gray-50 focus-within:bg-gray-50 focus-within:outline-none focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500">
       <td className="whitespace-nowrap px-4 py-3">
-        <Link
-          href={`/experiments/${experiment.experimentId}`}
-          className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
-        >
-          {experiment.name}
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/experiments/${experiment.experimentId}`}
+            className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          >
+            {experiment.name}
+          </Link>
+          <code className="hidden text-[10px] text-gray-400 sm:inline">
+            {experiment.experimentId.slice(0, 8)}
+          </code>
+          <CopyButton
+            value={experiment.experimentId}
+            label="Copy experiment ID"
+            successMessage="Experiment ID copied"
+            className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+          />
+        </div>
       </td>
       <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-600">
-        {experiment.ownerEmail}
+        <div className="flex items-center gap-2">
+          <span>{experiment.ownerEmail}</span>
+          <CopyButton
+            value={experiment.ownerEmail}
+            label="Copy owner email"
+            successMessage="Owner email copied"
+            className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+          />
+        </div>
       </td>
       <td className="whitespace-nowrap px-4 py-3">
         <TypeBadge type={experiment.type} />

--- a/ui/src/components/experiment-card.tsx
+++ b/ui/src/components/experiment-card.tsx
@@ -52,7 +52,7 @@ export function ExperimentRow({ experiment }: ExperimentCardProps) {
           >
             {experiment.name}
           </Link>
-          <code className="hidden text-[10px] text-gray-400 sm:inline">
+          <code className="hidden text-[10px] text-gray-500 sm:inline">
             {experiment.experimentId.slice(0, 8)}
           </code>
           <CopyButton


### PR DESCRIPTION
This PR introduces a micro-UX enhancement to the Experiments list page by adding "copy to clipboard" buttons for Experiment IDs and Owner emails. These buttons are only visible when hovering over the row or when focus is moved into the row, ensuring the interface remains clean and uncluttered.

### 💡 What:
- Added `CopyButton` components to each row in the experiments table.
- Included a truncated version of the Experiment ID next to the name.
- Styled the buttons to reveal on hover or focus using Tailwind's `group` pattern.
- Wrapped tests in `ToastProvider` to handle the feedback notifications.

### 🎯 Why:
Users often need to copy Experiment IDs or owner contact information. Previously, they had to click through to the detail page or manually select and copy text. This change provides a faster, more reliable way to grab this data directly from the list.

### ♿ Accessibility:
- Used `focus-within:opacity-100` to ensure buttons are visible to keyboard-only users when navigating via Tab.
- Buttons have appropriate ARIA labels ("Copy experiment ID", "Copy owner email").
- Visual feedback is provided via toast notifications and temporary icon changes.

### 📸 Before/After:
Before: Simple table with names and emails as plain text.
After: Hovering over a row reveals small copy icons next to the experiment name (and its shortened ID) and the owner's email.

Line count: ~35 lines added/modified.

---
*PR created automatically by Jules for task [1676201937224237047](https://jules.google.com/task/1676201937224237047) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->