### PR TITLE
chore(ci): add workflow_dispatch trigger to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,7 +514,7 @@ jobs:
         id: aws-auth
         # Push-event gate: PR builds must stay build-only — without it any PR
         # would push :latest to ECR the moment AWS_DEPLOY_ROLE_ARN is set.
-        if: vars.AWS_DEPLOY_ROLE_ARN != '' && github.event_name == 'push'
+        if: vars.AWS_DEPLOY_ROLE_ARN != '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
@@ -529,7 +529,7 @@ jobs:
       - name: Authenticate to Google Cloud
         id: gcp-auth
         # Same push-event gate as aws-auth above.
-        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.GCP_CI_PUSH_SA != '' && github.event_name == 'push'
+        if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.GCP_CI_PUSH_SA != '' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger — needed because auto-merges performed by the automerge
+  # workflow's GITHUB_TOKEN do not fire `push` events (GitHub suppresses
+  # workflow-triggered triggers), so post-merge main CI (and the ECR image
+  # push) silently never ran for auto-merged PRs.
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,15 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-      go: ${{ steps.filter.outputs.go }}
+      # workflow_dispatch means "run the full pipeline": paths-filter can't
+      # diff a dispatch event (no base), so short-circuit to true instead of
+      # letting the step error and paint the run red.
+      rust: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.rust }}
+      go: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.go }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
+        if: github.event_name != 'workflow_dispatch'
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Why

PR #736 merged via auto-merge, but no main-branch CI ran — the automerge workflow arms auto-merge with the default `GITHUB_TOKEN`, and GitHub suppresses workflow triggers for pushes made by that token. Consequence: **post-merge main CI, including the ECR image push, has silently never run for any auto-merged PR.**

## What

Adds `workflow_dispatch:` to `ci.yml` so main CI can be triggered manually — both as the immediate recovery path (dispatching a run on `main` to build/push the 7 service images for the dev-stack bring-up, unblocking #735) and as a standing escape hatch.

## Follow-up (out of scope)

The proper fix is arming auto-merge with a GitHub App or PAT token so merge pushes fire `push` workflows natively — worth folding into the H3/H6 governance stack. Noted on #735.

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->