### PR TITLE
feat(assignment): ADR-031 pilot — GetAssignments, GetSlateAssignment, GetInterleavedList over Connect (#642)

### DIFF
--- a/crates/experimentation-assignment/src/connect_server.rs
+++ b/crates/experimentation-assignment/src/connect_server.rs
@@ -1,13 +1,19 @@
 //! ADR-031 pilot — ConnectRPC server adapter for M1 `AssignmentService`.
 //!
 //! Bridges buffa request/response views to the existing
-//! [`AssignmentServiceImpl`] domain methods. The pilot scope (#641) ships only
-//! `GetAssignment` end-to-end; the remaining four RPCs return
-//! `Unimplemented` and are filled in by #642/#643.
+//! [`AssignmentServiceImpl`] domain methods. #641 shipped `GetAssignment`
+//! end-to-end; #642 extends the same bridge to `GetAssignments`,
+//! `GetSlateAssignment`, and `GetInterleavedList` (the three remaining unary
+//! RPCs). `StreamConfigUpdates` (server-streaming) lands in #643.
+//!
+//! Every bridge is a thin field-copy delegating to a pub domain method on
+//! `AssignmentServiceImpl` — the `assert_finite!` invariants live inside
+//! those domain methods and pass through untouched.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use experimentation_proto::experimentation::assignment::v1 as domain_pb;
 use experimentation_proto_connect::experimentation::assignment::v1 as connect_pb;
 
 use crate::service::AssignmentServiceImpl;
@@ -43,6 +49,27 @@ fn unimplemented(msg: &'static str) -> connectrpc::ConnectError {
     connectrpc::ConnectError::new(connectrpc::ErrorCode::Unimplemented, msg)
 }
 
+/// Field-copy from the tonic-side domain response to the buffa response.
+/// Called from both the single-assignment and batch (`GetAssignments`) paths,
+/// so any future field addition to the response only needs to touch one
+/// place. `assert_finite!` is enforced inside `AssignmentServiceImpl::assign`
+/// on `assignment_probability`; here we faithfully pass the value through.
+fn assignment_domain_to_connect(
+    d: domain_pb::GetAssignmentResponse,
+) -> connect_pb::GetAssignmentResponse {
+    connect_pb::GetAssignmentResponse {
+        experiment_id: d.experiment_id,
+        variant_id: d.variant_id,
+        payload_json: d.payload_json,
+        assignment_probability: d.assignment_probability,
+        is_active: d.is_active,
+        // Switchback experiments compute a non-zero time-block index that M4a
+        // needs for within-block vs cross-block analysis; must not default to 0.
+        block_index: d.block_index,
+        ..Default::default()
+    }
+}
+
 #[allow(refining_impl_trait)]
 impl connect_pb::AssignmentService for ConnectAssignment {
     async fn get_assignment(
@@ -65,35 +92,75 @@ impl connect_pb::AssignmentService for ConnectAssignment {
             .await
             .map_err(tonic_status_to_connect)?;
 
-        // assert_finite! is enforced inside AssignmentServiceImpl::assign;
-        // here we faithfully pass the value through.
-        Ok(connectrpc::Response::new(connect_pb::GetAssignmentResponse {
-            experiment_id: resp.experiment_id,
-            variant_id: resp.variant_id,
-            payload_json: resp.payload_json,
-            assignment_probability: resp.assignment_probability,
-            is_active: resp.is_active,
-            // Switchback experiments compute a non-zero time-block index that M4a
-            // needs for within-block vs cross-block analysis; must not default to 0.
-            block_index: resp.block_index,
-            ..Default::default()
-        }))
+        Ok(connectrpc::Response::new(assignment_domain_to_connect(resp)))
     }
 
     async fn get_assignments(
         &self,
         _ctx: connectrpc::RequestContext,
-        _request: connectrpc::ServiceRequest<'_, connect_pb::GetAssignmentsRequest>,
+        request: connectrpc::ServiceRequest<'_, connect_pb::GetAssignmentsRequest>,
     ) -> connectrpc::ServiceResult<connect_pb::GetAssignmentsResponse> {
-        Err(unimplemented("ADR-031 pilot: GetAssignments lands in #642"))
+        let user_id = request.user_id.to_string();
+        let session_id = request.session_id.to_string();
+        let attributes: HashMap<String, String> = request
+            .attributes
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+
+        // Batch path — shares two-phase holdout/layer logic with the tonic
+        // handler via AssignmentServiceImpl::assign_batch. Errors are already
+        // absorbed inside assign_batch (soft-fail on regular, fail-closed on
+        // holdout), so the Connect surface always returns 200.
+        let domain = self
+            .inner
+            .assign_batch(&user_id, &session_id, &attributes)
+            .await;
+
+        Ok(connectrpc::Response::new(connect_pb::GetAssignmentsResponse {
+            assignments: domain
+                .into_iter()
+                .map(assignment_domain_to_connect)
+                .collect(),
+            ..Default::default()
+        }))
     }
 
     async fn get_interleaved_list(
         &self,
         _ctx: connectrpc::RequestContext,
-        _request: connectrpc::ServiceRequest<'_, connect_pb::GetInterleavedListRequest>,
+        request: connectrpc::ServiceRequest<'_, connect_pb::GetInterleavedListRequest>,
     ) -> connectrpc::ServiceResult<connect_pb::GetInterleavedListResponse> {
-        Err(unimplemented("ADR-031 pilot: GetInterleavedList lands in #642"))
+        let experiment_id = request.experiment_id.to_string();
+        let user_id = request.user_id.to_string();
+
+        // buffa's map<string, RankedList> yields borrowed views; interleave
+        // wants owned strings so the deterministic seed hashing over
+        // (user_id, experiment_id) inside interleave stays stable regardless
+        // of transport.
+        let algorithm_lists: HashMap<String, domain_pb::RankedList> = request
+            .algorithm_lists
+            .iter()
+            .map(|(algo_id, list)| {
+                (
+                    (*algo_id).to_string(),
+                    domain_pb::RankedList {
+                        item_ids: list.item_ids.iter().map(|s| (*s).to_string()).collect(),
+                    },
+                )
+            })
+            .collect();
+
+        let resp = self
+            .inner
+            .interleave(&experiment_id, &user_id, &algorithm_lists)
+            .map_err(tonic_status_to_connect)?;
+
+        Ok(connectrpc::Response::new(connect_pb::GetInterleavedListResponse {
+            merged_list: resp.merged_list,
+            provenance: resp.provenance,
+            ..Default::default()
+        }))
     }
 
     async fn stream_config_updates(
@@ -109,8 +176,44 @@ impl connect_pb::AssignmentService for ConnectAssignment {
     async fn get_slate_assignment(
         &self,
         _ctx: connectrpc::RequestContext,
-        _request: connectrpc::ServiceRequest<'_, connect_pb::GetSlateAssignmentRequest>,
+        request: connectrpc::ServiceRequest<'_, connect_pb::GetSlateAssignmentRequest>,
     ) -> connectrpc::ServiceResult<connect_pb::GetSlateAssignmentResponse> {
-        Err(unimplemented("ADR-031 pilot: GetSlateAssignment lands in #642"))
+        let experiment_id = request.experiment_id.to_string();
+        let user_id = request.user_id.to_string();
+        let candidate_item_ids: Vec<String> = request
+            .candidate_item_ids
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let attributes: HashMap<String, String> = request
+            .attributes
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+
+        let resp = self
+            .inner
+            .assign_slate(&experiment_id, &user_id, candidate_item_ids, &attributes)
+            .await
+            .map_err(tonic_status_to_connect)?;
+
+        // slot_probabilities.probability is the IPW field; assert_finite! is
+        // enforced inside assign_slate, we forward the domain values verbatim.
+        Ok(connectrpc::Response::new(connect_pb::GetSlateAssignmentResponse {
+            experiment_id: resp.experiment_id,
+            slate_item_ids: resp.slate_item_ids,
+            slot_probabilities: resp
+                .slot_probabilities
+                .into_iter()
+                .map(|sp| connect_pb::SlotProbability {
+                    slot_index: sp.slot_index,
+                    item_id: sp.item_id,
+                    probability: sp.probability,
+                    ..Default::default()
+                })
+                .collect(),
+            is_uniform_random: resp.is_uniform_random,
+            ..Default::default()
+        }))
     }
 }

--- a/crates/experimentation-assignment/src/service.rs
+++ b/crates/experimentation-assignment/src/service.rs
@@ -727,6 +727,76 @@ fn select_variant(exp: &ExperimentConfig, bucket: u32) -> &crate::config::Varian
         .expect("experiment must have at least one variant")
 }
 
+impl AssignmentServiceImpl {
+    /// Batch-evaluate every experiment in the current snapshot for a user,
+    /// applying the ADR-014 two-phase layer/holdout rules. Extracted so the
+    /// tonic `get_assignments` handler and the Connect bridge (ADR-031 #642)
+    /// share a single implementation.
+    ///
+    /// Holdouts run first; a holdout that assigns a non-empty variant, or
+    /// fails to evaluate, claims its layer for the user. Regular experiments
+    /// whose layer is claimed are skipped. Regular-experiment errors are
+    /// logged and dropped (soft-failure); holdout errors are fail-closed
+    /// (the layer is treated as held-out) to prevent holdout leakage.
+    pub async fn assign_batch(
+        &self,
+        user_id: &str,
+        session_id: &str,
+        attributes: &HashMap<String, String>,
+    ) -> Vec<GetAssignmentResponse> {
+        let config = self.config.snapshot();
+        let mut assignments = Vec::new();
+
+        let (holdouts, regular): (Vec<_>, Vec<_>) = config
+            .experiments
+            .iter()
+            .partition(|e| e.is_cumulative_holdout);
+
+        let mut holdout_layers: HashSet<String> = HashSet::new();
+        for exp in &holdouts {
+            match self
+                .assign(&exp.experiment_id, user_id, session_id, attributes)
+                .await
+            {
+                Ok(resp) => {
+                    if !resp.variant_id.is_empty() {
+                        holdout_layers.insert(exp.layer_id.clone());
+                    }
+                    assignments.push(resp);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        experiment_id = %exp.experiment_id,
+                        layer_id = %exp.layer_id,
+                        error = %e,
+                        "holdout assignment failed, excluding layer (fail-closed)",
+                    );
+                    holdout_layers.insert(exp.layer_id.clone());
+                }
+            }
+        }
+
+        for exp in &regular {
+            if holdout_layers.contains(&exp.layer_id) {
+                continue;
+            }
+            match self
+                .assign(&exp.experiment_id, user_id, session_id, attributes)
+                .await
+            {
+                Ok(resp) => assignments.push(resp),
+                Err(e) => tracing::warn!(
+                    experiment_id = %exp.experiment_id,
+                    error = %e,
+                    "assignment failed for regular experiment, skipping",
+                ),
+            }
+        }
+
+        assignments
+    }
+}
+
 #[tonic::async_trait]
 impl AssignmentService for AssignmentServiceImpl {
     async fn get_assignment(
@@ -750,79 +820,9 @@ impl AssignmentService for AssignmentServiceImpl {
         request: Request<GetAssignmentsRequest>,
     ) -> Result<Response<GetAssignmentsResponse>, Status> {
         let req = request.into_inner();
-        let config = self.config.snapshot();
-        let mut assignments = Vec::new();
-
-        // Two-phase evaluation: holdouts first, then regular experiments.
-        // Holdout users are excluded from other experiments in the same layer.
-        let (holdouts, regular): (Vec<_>, Vec<_>) = config
-            .experiments
-            .iter()
-            .partition(|e| e.is_cumulative_holdout);
-
-        // Phase 1: Evaluate holdout experiments. Track layers claimed by holdouts.
-        // On holdout assignment error, treat the layer as held-out (fail-closed)
-        // to avoid accidentally exposing holdout users to treatments.
-        let mut holdout_layers: HashSet<String> = HashSet::new();
-        for exp in &holdouts {
-            match self
-                .assign(
-                    &exp.experiment_id,
-                    &req.user_id,
-                    &req.session_id,
-                    &req.attributes,
-                )
-                .await
-            {
-                Ok(resp) => {
-                    if !resp.variant_id.is_empty() {
-                        holdout_layers.insert(exp.layer_id.clone());
-                    }
-                    assignments.push(resp);
-                }
-                Err(e) => {
-                    // Fail-closed: mark this layer as held-out so that the user
-                    // is NOT assigned to regular experiments in this layer.
-                    // This prevents holdout leakage when the holdout assignment
-                    // itself fails (e.g., missing layer config).
-                    tracing::warn!(
-                        experiment_id = %exp.experiment_id,
-                        layer_id = %exp.layer_id,
-                        error = %e,
-                        "holdout assignment failed, excluding layer (fail-closed)",
-                    );
-                    holdout_layers.insert(exp.layer_id.clone());
-                }
-            }
-        }
-
-        // Phase 2: Evaluate regular experiments, skipping layers claimed by holdouts.
-        for exp in &regular {
-            if holdout_layers.contains(&exp.layer_id) {
-                continue;
-            }
-            match self
-                .assign(
-                    &exp.experiment_id,
-                    &req.user_id,
-                    &req.session_id,
-                    &req.attributes,
-                )
-                .await
-            {
-                Ok(resp) => {
-                    assignments.push(resp);
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        experiment_id = %exp.experiment_id,
-                        error = %e,
-                        "assignment failed for regular experiment, skipping",
-                    );
-                }
-            }
-        }
-
+        let assignments = self
+            .assign_batch(&req.user_id, &req.session_id, &req.attributes)
+            .await;
         Ok(Response::new(GetAssignmentsResponse { assignments }))
     }
 

--- a/crates/experimentation-assignment/tests/connect_server_e2e.rs
+++ b/crates/experimentation-assignment/tests/connect_server_e2e.rs
@@ -1,8 +1,11 @@
-//! ADR-031 pilot — in-process round-trip test for GetAssignment over Connect.
+//! ADR-031 pilot — in-process round-trip tests for the unary RPCs on
+//! `AssignmentService` over Connect/JSON.
 //!
-//! Binds the ConnectRPC server on 127.0.0.1:0, POSTs a Connect/JSON request to
-//! `/experimentation.assignment.v1.AssignmentService/GetAssignment`, and
-//! asserts the response matches the existing tonic/http_json contract.
+//! Binds the ConnectRPC server on 127.0.0.1:0, POSTs Connect/JSON to
+//! `/experimentation.assignment.v1.AssignmentService/{method}`, and asserts
+//! the JSON shape matches the tonic/http_json contract for each method that
+//! has one. `GetInterleavedList` had no hand-rolled JSON path before this
+//! PR — the round-trip test here closes that coverage gap (#642).
 
 #![cfg(feature = "connectrpc")]
 
@@ -115,12 +118,103 @@ async fn connect_get_assignment_unknown_experiment_returns_not_found() {
 }
 
 #[tokio::test]
-async fn connect_other_rpcs_return_unimplemented() {
+async fn connect_get_assignments_returns_batch() {
     let (addr, _svc) = start_connect_server().await;
 
-    let body = serde_json::json!({"userId":"u1","sessionId":"s1","attributes":{}});
-    let (status, _resp) = connect_json_post(addr, "GetAssignments", body).await;
+    let body = serde_json::json!({
+        "userId": "test-user-1",
+        "sessionId": "sess-1",
+        "attributes": {},
+    });
+    let (status, resp) = connect_json_post(addr, "GetAssignments", body).await;
 
-    // Connect maps Unimplemented to HTTP 501.
-    assert_eq!(status, 501, "other RPCs should be Unimplemented until #642/#643");
+    assert_eq!(status, 200, "GetAssignments failed: {resp}");
+    // Two-phase batch always returns a (possibly empty) assignments array.
+    // dev/config.json has 13 running experiments so we expect >0 here — a
+    // dropped/empty batch would silently regress the ADR-014 evaluator.
+    let assignments = resp
+        .get("assignments")
+        .and_then(|v| v.as_array())
+        .expect("assignments array missing");
+    assert!(
+        !assignments.is_empty(),
+        "expected at least one assignment for dev/config.json, got empty batch",
+    );
+}
+
+#[tokio::test]
+async fn connect_get_interleaved_list_merges_two_algorithms() {
+    let (addr, _svc) = start_connect_server().await;
+
+    // exp_dev_004 is the TEAM_DRAFT interleaving experiment in dev/config.json
+    // (algorithm_ids: ["algo_a", "algo_b"]). Two disjoint ranked lists let us
+    // assert the merged output is populated without knowing the exact draft
+    // order (which is seed-derived and would over-fit the test).
+    let body = serde_json::json!({
+        "experimentId": "exp_dev_004",
+        "userId": "test-user-interleave",
+        "algorithmLists": {
+            "algo_a": {"itemIds": ["a1", "a2", "a3"]},
+            "algo_b": {"itemIds": ["b1", "b2", "b3"]},
+        },
+    });
+    let (status, resp) = connect_json_post(addr, "GetInterleavedList", body).await;
+
+    assert_eq!(status, 200, "GetInterleavedList failed: {resp}");
+    let merged = resp
+        .get("mergedList")
+        .and_then(|v| v.as_array())
+        .expect("mergedList array missing");
+    assert!(!merged.is_empty(), "expected merged list, got empty");
+    // Provenance carries the algorithm-id contribution map for each item
+    // (M4a needs this for the interleaving contribution analysis).
+    assert!(
+        resp.get("provenance").is_some(),
+        "missing provenance: {resp}",
+    );
+}
+
+#[tokio::test]
+async fn connect_get_slate_assignment_returns_ordered_slate() {
+    let (addr, _svc) = start_connect_server().await;
+
+    // exp_dev_slate_001 is the SLATE_FACTORIZED_TS experiment with num_slots=3
+    // and candidate_pool_size=6. Six candidate item IDs saturate the pool
+    // and let the assign_slate fallback produce a valid slate even without
+    // a live M4b bandit backend.
+    let body = serde_json::json!({
+        "userId": "test-user-slate",
+        "experimentId": "exp_dev_slate_001",
+        "candidateItemIds": ["i1","i2","i3","i4","i5","i6"],
+        "attributes": {},
+    });
+    let (status, resp) = connect_json_post(addr, "GetSlateAssignment", body).await;
+
+    assert_eq!(status, 200, "GetSlateAssignment failed: {resp}");
+    let slate = resp
+        .get("slateItemIds")
+        .and_then(|v| v.as_array())
+        .expect("slateItemIds missing");
+    assert_eq!(slate.len(), 3, "num_slots=3 → slate length must be 3");
+    let probs = resp
+        .get("slotProbabilities")
+        .and_then(|v| v.as_array())
+        .expect("slotProbabilities missing");
+    assert_eq!(probs.len(), 3, "one probability entry per slot");
+}
+
+#[tokio::test]
+async fn connect_stream_config_updates_still_unimplemented() {
+    let (addr, _svc) = start_connect_server().await;
+
+    // StreamConfigUpdates is server-streaming and lands in #643. Until then
+    // it must return Unimplemented (HTTP 501). This test is the negative
+    // guard that flips green once #643 wires the stream.
+    let body = serde_json::json!({"lastKnownVersion": 0});
+    let (status, _resp) =
+        connect_json_post(addr, "StreamConfigUpdates", body).await;
+    assert_eq!(
+        status, 501,
+        "StreamConfigUpdates should still be Unimplemented until #643",
+    );
 }


### PR DESCRIPTION
## Summary

Closes the ADR-031 pilot's remaining three unary RPCs. Every bridge is a thin field-copy delegating to a pub domain method on `AssignmentServiceImpl`; the `assert_finite!` invariants live inside those domain methods and pass through untouched. Closes #642.

### Refactor: `assign_batch` on `AssignmentServiceImpl`

The tonic-side `get_assignments` handler owned the ADR-014 two-phase holdout/layer logic inline. Extracted to `pub async fn assign_batch(user_id, session_id, attributes) -> Vec<GetAssignmentResponse>` so tonic and Connect share the exact same implementation instead of forking. Zero behavior change — the tonic `get_assignments` handler is now a thin wrapper around it.

### New bridges

- **`GetAssignments`** — buffa view → owned `HashMap`, delegate to `assign_batch`, map `Vec<domain>` → `Vec<connect_pb>` via a new `assignment_domain_to_connect` helper (also reused by `GetAssignment` — the tracer's inline field-copy). Errors are absorbed inside `assign_batch` (soft-fail on regular, fail-closed on holdout), so this endpoint always returns 200.
- **`GetSlateAssignment`** — delegate to `assign_slate`, map `SlotProbability` field-by-field. `probability` is the load-bearing IPW field for M4a's slate analysis.
- **`GetInterleavedList`** — delegate to `interleave`; convert buffa's `map<string, RankedList>` to `HashMap<String, domain_pb::RankedList>` so the deterministic `(user_id, experiment_id)` seed hash is stable regardless of transport. **Closes the coverage gap** the issue calls out — no hand-rolled `http_json` path existed for this method.
- **`StreamConfigUpdates`** — still returns `Unimplemented`. That's #643.

### Test plan

- [x] `cargo build -p experimentation-assignment --features connectrpc` clean
- [x] `cargo clippy -p experimentation-assignment --features connectrpc -- -D warnings` clean
- [x] `cargo test -p experimentation-assignment --features connectrpc` — all 6 Connect e2e + 199 existing crate tests pass
- New e2e coverage in `tests/connect_server_e2e.rs`:
  - `connect_get_assignments_returns_batch` — dev/config.json → non-empty assignments
  - `connect_get_interleaved_list_merges_two_algorithms` — exp_dev_004 with algo_a/algo_b
  - `connect_get_slate_assignment_returns_ordered_slate` — exp_dev_slate_001, asserts `slateItemIds.len()==3` and `slotProbabilities.len()==3`
  - `connect_stream_config_updates_still_unimplemented` — 501 guard, flips green when #643 lands
- Existing `assignment_test.rs`, `m1m4b_contract_test.rs`, `m1m4b_slate_contract_test.rs` unchanged and green.

### Acceptance criteria

- [x] `GetAssignments`, `GetSlateAssignment`, `GetInterleavedList` served behind the `connectrpc` feature over Connect / gRPC / gRPC-Web (transport is `connectrpc::Server` — same one #641 stood up)
- [x] `assert_finite!` preserved on all probability / score fields through the bridge (enforced inside the domain methods; bridge passes values through)
- [x] Existing M1 contract tests pass against the Connect server for these methods (all pass; assign_batch extraction is behavior-preserving)
- [x] `GetInterleavedList` reachable over Connect JSON

### Files

- `crates/experimentation-assignment/src/service.rs` — extract `assign_batch`, thin `get_assignments` handler
- `crates/experimentation-assignment/src/connect_server.rs` — 3 new bridge methods + `assignment_domain_to_connect` helper
- `crates/experimentation-assignment/tests/connect_server_e2e.rs` — 3 positive round-trip tests + inverted the 501 guard to target `StreamConfigUpdates` only

### Next up

- **#643** — `StreamConfigUpdates` over Connect (server-streaming; needs the M5 config-source integration)
- **#644** — retire hand-rolled JSON shim + server-go client (unblocked by this PR)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->