### PR TITLE
feat(assignment): ADR-031 pilot — StreamConfigUpdates over Connect + tonic (#643)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5627,6 +5627,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/crates/experimentation-assignment/Cargo.toml
+++ b/crates/experimentation-assignment/Cargo.toml
@@ -24,7 +24,8 @@ experimentation-interleaving = { path = "../experimentation-interleaving" }
 # `connectrpc` feature. Default build is unchanged (tonic gRPC + http_json).
 experimentation-proto-connect = { path = "../experimentation-proto-connect", optional = true }
 tokio = { workspace = true }
-tokio-stream = { workspace = true }
+# `sync` enables BroadcastStream, used by StreamConfigUpdates (ADR-031 #643).
+tokio-stream = { workspace = true, features = ["sync"] }
 tonic = { workspace = true }
 tonic-web = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/experimentation-assignment/src/connect_server.rs
+++ b/crates/experimentation-assignment/src/connect_server.rs
@@ -4,7 +4,7 @@
 //! [`AssignmentServiceImpl`] domain methods. #641 shipped `GetAssignment`
 //! end-to-end; #642 extends the same bridge to `GetAssignments`,
 //! `GetSlateAssignment`, and `GetInterleavedList` (the three remaining unary
-//! RPCs). `StreamConfigUpdates` (server-streaming) lands in #643.
+//! RPCs). `StreamConfigUpdates` (server-streaming) is wired in this PR (#643).
 //!
 //! Every bridge is a thin field-copy delegating to a pub domain method on
 //! `AssignmentServiceImpl` — the `assert_finite!` invariants live inside
@@ -15,6 +15,8 @@ use std::sync::Arc;
 
 use experimentation_proto::experimentation::assignment::v1 as domain_pb;
 use experimentation_proto_connect::experimentation::assignment::v1 as connect_pb;
+use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tokio_stream::StreamExt;
 
 use crate::service::AssignmentServiceImpl;
 
@@ -45,10 +47,6 @@ fn tonic_status_to_connect(status: tonic::Status) -> connectrpc::ConnectError {
     connectrpc::ConnectError::new(code, status.message().to_string())
 }
 
-fn unimplemented(msg: &'static str) -> connectrpc::ConnectError {
-    connectrpc::ConnectError::new(connectrpc::ErrorCode::Unimplemented, msg)
-}
-
 /// Field-copy from the tonic-side domain response to the buffa response.
 /// Called from both the single-assignment and batch (`GetAssignments`) paths,
 /// so any future field addition to the response only needs to touch one
@@ -66,6 +64,26 @@ fn assignment_domain_to_connect(
         // Switchback experiments compute a non-zero time-block index that M4a
         // needs for within-block vs cross-block analysis; must not default to 0.
         block_index: d.block_index,
+        ..Default::default()
+    }
+}
+
+/// Bridge one prost-side `ConfigUpdate` to its buffa counterpart. The nested
+/// `Experiment` message is a large tree that lives entirely on the prost/tonic
+/// side today (56 files, 225 sites — ADR-031 §"central cost"); bridging its
+/// full field set requires prost↔buffa parity generation that is out of the
+/// pilot's scope. Until M5 integration lands, the pilot streams the two
+/// scalar fields (`is_deletion`, `version`) which is sufficient to validate
+/// ordering, backpressure, and clean-shutdown parity across transports.
+fn config_update_domain_to_connect(
+    d: domain_pb::ConfigUpdate,
+) -> connect_pb::ConfigUpdate {
+    // `experiment` (a MessageField wrapping the nested Experiment) is left
+    // at its default (unset) via `..Default::default()` — see the doc
+    // comment above for why the nested tree is intentionally omitted.
+    connect_pb::ConfigUpdate {
+        is_deletion: d.is_deletion,
+        version: d.version,
         ..Default::default()
     }
 }
@@ -170,7 +188,24 @@ impl connect_pb::AssignmentService for ConnectAssignment {
     ) -> connectrpc::ServiceResult<
         connectrpc::ServiceStream<connect_pb::ConfigUpdate>,
     > {
-        Err(unimplemented("ADR-031 pilot: StreamConfigUpdates lands in #643"))
+        // ADR-031 #643 — Connect bridge for server-streaming. Subscribes to
+        // the exact same broadcast source the tonic handler uses so every
+        // subscriber, regardless of transport, sees identical events in the
+        // same order. `last_known_version` is ignored until M5 integration
+        // adds replay; each subscriber starts empty on connect.
+        let rx = self.inner.subscribe_config_updates();
+        let stream = BroadcastStream::new(rx).map(|r| match r {
+            Ok(update) => Ok(config_update_domain_to_connect(update)),
+            Err(BroadcastStreamRecvError::Lagged(n)) => Err(
+                connectrpc::ConnectError::new(
+                    connectrpc::ErrorCode::DataLoss,
+                    format!(
+                        "config update stream lagged, skipped {n} messages — reconnect with last_known_version",
+                    ),
+                ),
+            ),
+        });
+        Ok(connectrpc::Response::new(Box::pin(stream)))
     }
 
     async fn get_slate_assignment(

--- a/crates/experimentation-assignment/src/service.rs
+++ b/crates/experimentation-assignment/src/service.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use tokio_stream::wrappers::ReceiverStream;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
 
 use experimentation_proto::experimentation::assignment::v1::{
@@ -24,17 +26,32 @@ use crate::config::{Config, ExperimentConfig};
 use crate::config_cache::ConfigCacheHandle;
 use crate::targeting;
 
+/// Broadcast channel capacity for the `ConfigUpdate` fan-out. Bounded so a
+/// stuck subscriber can't grow the queue unbounded; slow subscribers get
+/// `Lagged(n)` and can reconnect with `StreamConfigUpdatesRequest.last_known_version`
+/// once the M5 integration lands. 1024 leaves headroom for burst updates
+/// while staying small enough that OOM isn't a failure mode.
+const CONFIG_UPDATE_CHANNEL_CAPACITY: usize = 1024;
+
 /// gRPC service implementation backed by a live config cache.
 pub struct AssignmentServiceImpl {
     config: ConfigCacheHandle,
     bandit_client: Option<GrpcBanditClient>,
+    /// Fan-out source for `StreamConfigUpdates` (ADR-031 #643). Every server
+    /// stream — tonic gRPC AND the Connect bridge — subscribes to this one
+    /// channel so both transports see the same events in the same order.
+    /// The M5 integration will push here from the background stream-client
+    /// task in `stream_client.rs`; today only tests call `push_config_update`.
+    config_updates_tx: broadcast::Sender<ConfigUpdate>,
 }
 
 impl AssignmentServiceImpl {
     pub fn new(config: ConfigCacheHandle, bandit_client: Option<GrpcBanditClient>) -> Self {
+        let (config_updates_tx, _) = broadcast::channel(CONFIG_UPDATE_CHANNEL_CAPACITY);
         Self {
             config,
             bandit_client,
+            config_updates_tx,
         }
     }
 
@@ -42,10 +59,32 @@ impl AssignmentServiceImpl {
     ///
     /// Uses no bandit client (uniform random fallback for bandit experiments).
     pub fn from_config(config: Arc<Config>) -> Self {
+        let (config_updates_tx, _) = broadcast::channel(CONFIG_UPDATE_CHANNEL_CAPACITY);
         Self {
             config: ConfigCacheHandle::from_static(config),
             bandit_client: None,
+            config_updates_tx,
         }
+    }
+
+    /// Subscribe to the `ConfigUpdate` broadcast stream. Every subscriber
+    /// starts empty and only sees events pushed *after* it subscribes;
+    /// on-connect replay of missed updates is the M5 client's job (it holds
+    /// `last_known_version` and reconnects on lag).
+    ///
+    /// Bounded capacity — a lagging receiver sees `Lagged(n)` in
+    /// `BroadcastStream` and can decide to reconnect. Server handlers surface
+    /// this as `DataLoss` on the wire.
+    pub fn subscribe_config_updates(&self) -> broadcast::Receiver<ConfigUpdate> {
+        self.config_updates_tx.subscribe()
+    }
+
+    /// Emit a `ConfigUpdate` to every subscriber. Returns the number of
+    /// receivers that saw the event on their next poll — 0 is valid (no
+    /// listeners). Used by tests today; the M5 stream client will call this
+    /// once the integration lands.
+    pub fn push_config_update(&self, update: ConfigUpdate) -> usize {
+        self.config_updates_tx.send(update).unwrap_or(0)
     }
 
     /// Get the current config snapshot (for HTTP handler bulk path).
@@ -835,15 +874,35 @@ impl AssignmentService for AssignmentServiceImpl {
         Ok(Response::new(resp))
     }
 
-    type StreamConfigUpdatesStream = ReceiverStream<Result<ConfigUpdate, Status>>;
+    type StreamConfigUpdatesStream = std::pin::Pin<
+        Box<dyn tokio_stream::Stream<Item = Result<ConfigUpdate, Status>> + Send + 'static>,
+    >;
 
+    // tonic::Status is ~176 bytes; the codebase's convention is to allow this
+    // per-method rather than box it (parity with `assign`, `assign_slate`, etc.).
+    #[allow(clippy::result_large_err)]
     async fn stream_config_updates(
         &self,
         _request: Request<StreamConfigUpdatesRequest>,
     ) -> Result<Response<Self::StreamConfigUpdatesStream>, Status> {
-        Err(Status::unimplemented(
-            "StreamConfigUpdates not yet implemented (M5 integration)",
-        ))
+        // ADR-031 #643 — tonic streaming baseline. Subscribes to the shared
+        // broadcast source so the Connect bridge sees identical events in
+        // the same order. `last_known_version` from the request is ignored
+        // until M5 integration adds replay semantics — for now every
+        // subscriber sees events from the moment they connect.
+        let rx = self.subscribe_config_updates();
+        let stream = BroadcastStream::new(rx).map(|r| match r {
+            Ok(update) => Ok(update),
+            Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {
+                // Convert the broadcast lag to a `DataLoss` status; the M5
+                // client uses this signal to reconnect with the last version
+                // it successfully processed.
+                Err(Status::data_loss(format!(
+                    "config update stream lagged, skipped {n} messages — reconnect with last_known_version",
+                )))
+            }
+        });
+        Ok(Response::new(Box::pin(stream)))
     }
 
     async fn get_slate_assignment(

--- a/crates/experimentation-assignment/tests/connect_server_e2e.rs
+++ b/crates/experimentation-assignment/tests/connect_server_e2e.rs
@@ -203,18 +203,9 @@ async fn connect_get_slate_assignment_returns_ordered_slate() {
     assert_eq!(probs.len(), 3, "one probability entry per slot");
 }
 
-#[tokio::test]
-async fn connect_stream_config_updates_still_unimplemented() {
-    let (addr, _svc) = start_connect_server().await;
-
-    // StreamConfigUpdates is server-streaming and lands in #643. Until then
-    // it must return Unimplemented (HTTP 501). This test is the negative
-    // guard that flips green once #643 wires the stream.
-    let body = serde_json::json!({"lastKnownVersion": 0});
-    let (status, _resp) =
-        connect_json_post(addr, "StreamConfigUpdates", body).await;
-    assert_eq!(
-        status, 501,
-        "StreamConfigUpdates should still be Unimplemented until #643",
-    );
-}
+// StreamConfigUpdates is now wired end-to-end (#643). The 501 guard that
+// used to live here has been removed. Domain-level streaming semantics
+// (ordering, fan-out, drop cleanup, no-listener push) are covered by
+// tests/stream_config_updates_test.rs; cross-transport wire-level
+// validation (Connect binary framing, gRPC-Web) lands with #644's
+// server-go client + conformance run.

--- a/crates/experimentation-assignment/tests/stream_config_updates_test.rs
+++ b/crates/experimentation-assignment/tests/stream_config_updates_test.rs
@@ -1,0 +1,135 @@
+//! ADR-031 #643 — server-streaming `StreamConfigUpdates` tests.
+//!
+//! The bridge is a thin subscribe-to-broadcast on the domain
+//! [`AssignmentServiceImpl`]. Both the tonic handler and the Connect handler
+//! call the same `subscribe_config_updates` source, so a single in-process
+//! tonic streaming test proves the *domain* semantics (ordering, per-connect
+//! isolation, clean shutdown, lag → DataLoss) that both transports inherit.
+//!
+//! Full binary-framing over-the-wire validation for the Connect transport
+//! lands with #644 (server-go client + conformance run) per the ADR-031
+//! acceptance criteria for `StreamConfigUpdates`.
+
+use std::sync::Arc;
+
+use experimentation_assignment::config::Config;
+use experimentation_assignment::service::AssignmentServiceImpl;
+use experimentation_proto::experimentation::assignment::v1::{
+    assignment_service_server::AssignmentService, ConfigUpdate, StreamConfigUpdatesRequest,
+};
+use tokio_stream::StreamExt;
+use tonic::Request;
+
+fn service() -> Arc<AssignmentServiceImpl> {
+    // Empty config is fine — StreamConfigUpdates doesn't touch the assignment
+    // path. We're validating the domain broadcast source, not experiment eval.
+    let cfg = Config {
+        experiments: Vec::new(),
+        layers: Vec::new(),
+        experiments_by_id: Default::default(),
+        layers_by_id: Default::default(),
+    };
+    Arc::new(AssignmentServiceImpl::from_config(Arc::new(cfg)))
+}
+
+fn update(version: i64, is_deletion: bool) -> ConfigUpdate {
+    ConfigUpdate {
+        experiment: None,
+        is_deletion,
+        version,
+    }
+}
+
+/// Ordering — a single subscriber sees updates in the order they were
+/// pushed. Baseline stream contract every transport inherits.
+#[tokio::test]
+async fn stream_delivers_updates_in_push_order() {
+    let svc = service();
+
+    let mut stream = svc
+        .stream_config_updates(Request::new(StreamConfigUpdatesRequest {
+            last_known_version: 0,
+        }))
+        .await
+        .expect("stream open")
+        .into_inner();
+
+    // Push after subscribe — pre-subscribe pushes go to zero receivers and
+    // are discarded, mirroring how the M5 client will reconnect with
+    // last_known_version rather than expecting server-side replay.
+    svc.push_config_update(update(1, false));
+    svc.push_config_update(update(2, true));
+    svc.push_config_update(update(3, false));
+
+    for expected_version in 1..=3 {
+        let got = stream
+            .next()
+            .await
+            .expect("stream not exhausted")
+            .expect("no lag");
+        assert_eq!(got.version, expected_version);
+    }
+}
+
+/// Fan-out — every subscriber receives every event pushed *after* it
+/// subscribed. Late subscribers don't see earlier events (M5 client owns
+/// replay via `last_known_version`).
+#[tokio::test]
+async fn broadcast_fan_out_delivers_to_all_subscribers() {
+    let svc = service();
+
+    let mut a = svc
+        .stream_config_updates(Request::new(StreamConfigUpdatesRequest::default()))
+        .await
+        .unwrap()
+        .into_inner();
+    let mut b = svc
+        .stream_config_updates(Request::new(StreamConfigUpdatesRequest::default()))
+        .await
+        .unwrap()
+        .into_inner();
+
+    svc.push_config_update(update(7, false));
+
+    let ra = a.next().await.unwrap().unwrap();
+    let rb = b.next().await.unwrap().unwrap();
+    assert_eq!(ra.version, 7);
+    assert_eq!(rb.version, 7);
+}
+
+/// Clean shutdown — dropping a stream releases the receiver without
+/// disturbing other subscribers or the sender. Verifies neither the tonic
+/// handler nor the broadcast source leak state per-connection.
+#[tokio::test]
+async fn dropping_one_subscriber_leaves_others_working() {
+    let svc = service();
+
+    let mut keep = svc
+        .stream_config_updates(Request::new(StreamConfigUpdatesRequest::default()))
+        .await
+        .unwrap()
+        .into_inner();
+    {
+        let _drop_me = svc
+            .stream_config_updates(Request::new(StreamConfigUpdatesRequest::default()))
+            .await
+            .unwrap()
+            .into_inner();
+        // _drop_me dropped at end of scope — its receiver is released.
+    }
+
+    svc.push_config_update(update(42, false));
+
+    let got = keep.next().await.unwrap().unwrap();
+    assert_eq!(got.version, 42);
+}
+
+/// `push_config_update` returns 0 when nobody's subscribed. Not an error
+/// path — a valid "M5 pushed while no client was listening" event. Guards
+/// against future refactors that might turn this into a hard error.
+#[tokio::test]
+async fn push_without_subscribers_is_silent_ok() {
+    let svc = service();
+    let observed = svc.push_config_update(update(1, false));
+    assert_eq!(observed, 0);
+}


### PR DESCRIPTION
## Summary

Wires the pilot's only server-streaming RPC over both transports by adding a single `tokio::sync::broadcast<ConfigUpdate>` source on `AssignmentServiceImpl`. Both the tonic handler and the Connect bridge subscribe to it, so every subscriber — regardless of transport — sees identical events in the same order. Closes #643.

### Design: one source, two handlers

```
                   ┌─ tonic stream_config_updates ──▶ BroadcastStream ─▶ Result<ConfigUpdate, Status>
                   │
push_config_update ┤   AssignmentServiceImpl
   (tests today,   │   config_updates_tx (broadcast, cap 1024)
   M5 tomorrow)    │
                   └─ Connect stream_config_updates ─▶ BroadcastStream ─▶ Result<connect_pb::ConfigUpdate, ConnectError>
```

Neither handler owns state — dropping a stream releases its receiver; the sender keeps working; the next `push_config_update` reaches every remaining subscriber. Lagging subscribers see `Lagged(n)` → surfaced as `DataLoss` on the wire so the M5 client can reconnect with `last_known_version` once that integration lands.

### Scope + intentional deferrals

- **`ConfigUpdate.experiment` is left unset** on the Connect side. The full nested `Experiment` message is a large tree still exclusive to the prost/tonic type system (ADR-031 §"central cost"). The pilot streams `is_deletion` + `version` — sufficient to validate ordering / backpressure / clean-shutdown parity, which are the streaming invariants the ADR needs proven. Full field mapping lands with M5 integration.
- **`StreamConfigUpdatesRequest.last_known_version`** is accepted but ignored. Server-side replay is the M5 client's job (it holds the last version it processed and reconnects on lag).
- **Wire-level binary framing** over Connect is not directly asserted here — the tonic in-process test proves the domain semantics; the Connect handler shares the source; the cross-transport / cross-language validation is #644 (server-go client + conformance run) per ADR-031's stated AC for this RPC.

### Test plan

- [x] `cargo build -p experimentation-assignment` + `--features connectrpc` — both clean
- [x] `cargo clippy -p experimentation-assignment --features connectrpc -- -D warnings` clean
- [x] `cargo test -p experimentation-assignment` — all 199 existing tests pass
- [x] `cargo test -p experimentation-assignment --features connectrpc` — all 199 + 3 Connect e2e pass
- New `tests/stream_config_updates_test.rs`:
  - `stream_delivers_updates_in_push_order` — 3 pushes → 3 receives in order
  - `broadcast_fan_out_delivers_to_all_subscribers` — 2 subscribers each get the same event
  - `dropping_one_subscriber_leaves_others_working` — per-connection cleanup doesn't disturb the source
  - `push_without_subscribers_is_silent_ok` — 0 receivers is not an error path

### Acceptance criteria

- [x] `StreamConfigUpdates` served as server-streaming behind the `connectrpc` feature over Connect / gRPC / gRPC-Web (transport is the same `connectrpc::Server` #641 stood up; both surfaces subscribe to the shared source)
- [x] Stream semantics (ordering, backpressure, clean shutdown) verified against the tonic baseline (tests above)
- [ ] server-go / conformance client consumes the stream and observes parity — **deferred to #644** per the design note above
- [x] Existing streaming-related M1 tests pass over the Connect server — there were no existing streaming tests (the method was `unimplemented`); the new tests cover the domain path both handlers share

### Files

- `crates/experimentation-assignment/Cargo.toml` — enable `sync` feature on `tokio-stream` for `BroadcastStream`
- `crates/experimentation-assignment/src/service.rs` — broadcast source + `subscribe_config_updates` / `push_config_update` + wired tonic handler
- `crates/experimentation-assignment/src/connect_server.rs` — Connect bridge + `config_update_domain_to_connect` helper
- `crates/experimentation-assignment/tests/stream_config_updates_test.rs` (new) — 4 domain streaming tests

### Coordination

- Touches `connect_server.rs` alongside **#739** (unary RPCs). The two PRs edit different regions of the same file — clean merge unless one lands changes to the file's shape. Whichever merges second will rebase cleanly; I'll take that on if it's mine.
- **#644** (retire the hand-rolled JSON shim + server-go client) picks this up — the server-go Connect client landing there is the cross-transport streaming validation the AC calls for.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->