### PR TITLE
fix(infra): allow HTTPS egress to S3 gateway endpoint and public registries

### DIFF
--- a/infra/pkg/aws/network/vpc_endpoints.go
+++ b/infra/pkg/aws/network/vpc_endpoints.go
@@ -110,6 +110,40 @@ func NewVpcEndpoints(ctx *pulumi.Context, args *VpcEndpointArgs) (*VpcEndpointOu
 		return nil, fmt.Errorf("m4b-out-vpce: %w", err)
 	}
 
+	// The SG-to-SG rules above only cover interface-endpoint ENIs. Three
+	// HTTPS paths terminate at public IPs and need CIDR egress:
+	//   - ECR image layers redirect to S3 public IPs (the gateway endpoint
+	//     routes them privately but does not rewrite the destination, so an
+	//     SG-to-SG rule can never match — pulls fail with dial timeouts)
+	//   - Schema Registry pulls confluentinc/* from Docker Hub via NAT
+	//   - M4b EC2 ECS agents register with the ECS control plane (no
+	//     interface endpoint provisioned for com.amazonaws.<region>.ecs)
+	// S3 traffic still rides the free gateway endpoint: the prefix-list
+	// route is more specific than the NAT default route.
+	if _, err = ec2.NewSecurityGroupRule(ctx, "kaizen-ecs-out-https", &ec2.SecurityGroupRuleArgs{
+		Type:            pulumi.String("egress"),
+		SecurityGroupId: args.EcsSecurityGroupId.ToStringOutput(),
+		Protocol:        pulumi.String("tcp"),
+		FromPort:        pulumi.Int(443),
+		ToPort:          pulumi.Int(443),
+		CidrBlocks:      pulumi.StringArray{pulumi.String("0.0.0.0/0")},
+		Description:     pulumi.String("HTTPS egress - ECR layers via S3 gateway endpoint, public registries"),
+	}); err != nil {
+		return nil, fmt.Errorf("ecs-out-https: %w", err)
+	}
+
+	if _, err = ec2.NewSecurityGroupRule(ctx, "kaizen-m4b-out-https", &ec2.SecurityGroupRuleArgs{
+		Type:            pulumi.String("egress"),
+		SecurityGroupId: args.M4bSecurityGroupId.ToStringOutput(),
+		Protocol:        pulumi.String("tcp"),
+		FromPort:        pulumi.Int(443),
+		ToPort:          pulumi.Int(443),
+		CidrBlocks:      pulumi.StringArray{pulumi.String("0.0.0.0/0")},
+		Description:     pulumi.String("HTTPS egress - ECR layers via S3 gateway endpoint, ECS control plane"),
+	}); err != nil {
+		return nil, fmt.Errorf("m4b-out-https: %w", err)
+	}
+
 	// ── S3 Gateway Endpoint ─────────────────────────────────────────────
 	// Gateway endpoints route traffic via prefix lists in route tables,
 	// so they don't need security groups or subnet placement.

--- a/infra/test/network_test.go
+++ b/infra/test/network_test.go
@@ -1084,16 +1084,37 @@ func TestFullNetworkStackIntegration(t *testing.T) {
 			if !ok || !cidrs.IsArray() {
 				continue
 			}
+			open := false
 			for _, cidr := range cidrs.ArrayValue() {
-				if cidr.StringValue() != "0.0.0.0/0" {
-					continue
-				}
-				for _, prefix := range internalPrefixes {
-					if strings.Contains(rule.Name, prefix) {
-						t.Errorf("rule %q has 0.0.0.0/0 on internal group", rule.Name)
-					}
+				if cidr.StringValue() == "0.0.0.0/0" {
+					open = true
 				}
 			}
+			if !open {
+				continue
+			}
+			internal := false
+			for _, prefix := range internalPrefixes {
+				if strings.Contains(rule.Name, prefix) {
+					internal = true
+				}
+			}
+			if !internal {
+				continue
+			}
+			// 443-only egress to 0.0.0.0/0 is required from private
+			// subnets: ECR layer blobs resolve to S3 public IPs (the
+			// gateway endpoint routes them privately but does not
+			// rewrite destinations, so SG-to-SG rules cannot match),
+			// and M4b ECS agents reach the ECS control plane via NAT.
+			// Open ingress or broader egress stays an error.
+			if ruleType, hasType := rule.Inputs["type"]; hasType &&
+				ruleType.StringValue() == "egress" &&
+				rule.Inputs["fromPort"].NumberValue() == 443 &&
+				rule.Inputs["toPort"].NumberValue() == 443 {
+				continue
+			}
+			t.Errorf("rule %q has 0.0.0.0/0 on internal group", rule.Name)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

First live `pulumi up` against AWS: every ECS task that had a real image in ECR failed with:

```
CannotPullContainerError: ... dial tcp 52.217.76.160:443: i/o timeout
```

52.217.76.160 is an **S3-range IP**. ECR auth and manifest fetch succeeded (they ride the `ecr.api`/`ecr.dkr` interface endpoints, covered by the SG-to-SG 443 rule), but layer blobs redirect to S3 public IPs. The S3 **gateway** endpoint routes that traffic privately without rewriting the destination address, so an SG-to-SG egress rule can never match it — the SYN is dropped and the pull times out.

Same gap also blocks:
- Schema Registry pulling `confluentinc/cp-schema-registry:7.5.3` from Docker Hub (via NAT)
- M4b EC2 ECS agents reaching the ECS control plane (no `com.amazonaws.<region>.ecs` interface endpoint exists)

## Fix

Add `443/tcp → 0.0.0.0/0` egress to the ECS and M4b security groups (`kaizen-ecs-out-https`, `kaizen-m4b-out-https`).

Cost note: S3 traffic still rides the free gateway endpoint — the prefix-list route is more specific than the NAT default route. The SG rule only *permits* the connection; it does not reroute anything.

## Verification

- `go build` + `go test ./test/` (network suite) green
- Live: run 10 on the dev stack deploys with this rule; migration task pull is the canary

Refs #735 (dev-stack standup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->