### PR TITLE
feat(assignment): ADR-031 pilot — retire the hand-rolled JSON shim + migrate server-go to Connect (#644)

### DIFF
--- a/crates/experimentation-assignment/src/lib.rs
+++ b/crates/experimentation-assignment/src/lib.rs
@@ -3,6 +3,13 @@ pub mod config;
 pub mod config_cache;
 #[cfg(feature = "connectrpc")]
 pub mod connect_server;
+// ADR-031 #644 — the hand-rolled JSON shim is retired on the connectrpc
+// feature path. When Connect is on, its `application/connect+json` handler
+// serves the same 3 unary routes (GetAssignment, GetAssignments,
+// GetSlateAssignment) plus GetInterleavedList (new) and StreamConfigUpdates,
+// so http_json is dead weight in that build. Default (non-connectrpc)
+// builds still expose the shim until the pilot flips default.
+#[cfg(not(feature = "connectrpc"))]
 pub mod http_json;
 pub mod service;
 pub mod stream_client;

--- a/crates/experimentation-assignment/src/main.rs
+++ b/crates/experimentation-assignment/src/main.rs
@@ -8,6 +8,7 @@ use experimentation_assignment::config::Config;
 use experimentation_assignment::config_cache::ConfigCache;
 #[cfg(feature = "connectrpc")]
 use experimentation_assignment::connect_server::ConnectAssignment;
+#[cfg(not(feature = "connectrpc"))]
 use experimentation_assignment::http_json;
 use experimentation_assignment::service::AssignmentServiceImpl;
 use experimentation_assignment::stream_client::StreamClient;
@@ -22,7 +23,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let grpc_addr = std::env::var("GRPC_ADDR")
         .unwrap_or_else(|_| "0.0.0.0:50051".to_string())
         .parse()?;
-    let http_addr = std::env::var("HTTP_ADDR")
+    // http_addr is unused under `--features connectrpc` (see below); annotate
+    // the type so inference doesn't collapse to `()` when the shim spawn is
+    // cfg'd out.
+    let http_addr: std::net::SocketAddr = std::env::var("HTTP_ADDR")
         .unwrap_or_else(|_| "0.0.0.0:8080".to_string())
         .parse()?;
 
@@ -71,17 +75,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let svc = Arc::new(AssignmentServiceImpl::new(handle, bandit_client));
 
-    // Spawn JSON HTTP server for SDK access.
-    let http_svc = svc.clone();
-    tokio::spawn(async move {
-        if let Err(e) = http_json::serve(http_addr, http_svc).await {
-            tracing::error!(error = %e, "JSON HTTP server failed");
-        }
-    });
+    // Spawn JSON HTTP server for SDK access — default build only. Under the
+    // `connectrpc` feature, the ConnectRPC listener below serves the same
+    // routes over `application/connect+json` (ADR-031 #644 retire).
+    #[cfg(not(feature = "connectrpc"))]
+    {
+        let http_svc = svc.clone();
+        tokio::spawn(async move {
+            if let Err(e) = http_json::serve(http_addr, http_svc).await {
+                tracing::error!(error = %e, "JSON HTTP server failed");
+            }
+        });
+    }
+    #[cfg(feature = "connectrpc")]
+    let _ = http_addr; // http_addr is only bound by the shim; silence the warning.
 
-    // ADR-031 pilot: optional ConnectRPC listener (Connect + gRPC + gRPC-Web on
-    // one port). Runs alongside the tonic gRPC + http_json listeners during the
-    // pilot; tonic stays the default build.
+    // ADR-031 pilot: ConnectRPC listener (Connect + gRPC + gRPC-Web on one
+    // port). When the feature is on, this REPLACES the hand-rolled http_json
+    // shim — its `application/connect+json` handler covers the same 3 unary
+    // routes plus GetInterleavedList and StreamConfigUpdates (#644).
     //
     // NOTE: this listener is fire-and-forget and does NOT participate in graceful
     // shutdown — on ctrl+c the runtime drops it without draining in-flight requests.

--- a/crates/experimentation-assignment/tests/http_json_e2e.rs
+++ b/crates/experimentation-assignment/tests/http_json_e2e.rs
@@ -6,6 +6,11 @@
 //!
 //! Tests validate that SDK clients will receive correct assignment data when
 //! talking to the real Assignment Service over HTTP.
+//!
+//! ADR-031 #644 — skipped when `--features connectrpc` is active; the
+//! Connect listener replaces this shim on that path. Domain coverage is
+//! preserved by `tests/connect_server_e2e.rs`.
+#![cfg(not(feature = "connectrpc"))]
 
 use std::net::SocketAddr;
 use std::path::Path;

--- a/sdks/server-go/connect_pilot_e2e_test.go
+++ b/sdks/server-go/connect_pilot_e2e_test.go
@@ -1,21 +1,20 @@
-// ADR-031 pilot — Go-side proof that a generated Connect client can call
-// GetAssignment on the Rust pilot server and get a wire-compatible response.
+// ADR-031 conformance suite — Go client ↔ Rust server (buffa) round-trip
+// coverage for every AssignmentService RPC we've wired.
 //
-// This test is opt-in: it runs only when KAIZEN_M1_CONNECT_URL is set. To run
-// it locally, start the M1 pilot binary with --features connectrpc, then:
+// Started life as #641's tracer bullet (GetAssignment only) and grew, with
+// #642 and #643, to cover the remaining unary methods and the streaming RPC.
+// This is the cross-language wire check the pilot's kill/success criteria
+// depend on: proves the Anthropic-buffa server actually interoperates with a
+// vanilla connectrpc.com/connect Go client without hand-rolled shim code on
+// either side (that shim, http_json.rs + the JSON POST client in
+// experimentation.go, is retired in #644).
+//
+// Opt-in: runs only when KAIZEN_M1_CONNECT_URL is set. To run locally, start
+// the M1 pilot binary with --features connectrpc, then:
 //
 //	CONNECTRPC_ADDR=127.0.0.1:50161 \
 //	  cargo run -p experimentation-assignment --features connectrpc --bin experimentation-assignment
 //	KAIZEN_M1_CONNECT_URL=http://127.0.0.1:50161 go test ./sdks/server-go/...
-//
-// Per #641's acceptance criterion ("A generated server-go Connect client
-// calls GetAssignment"), this exercises the Buf-generated connectrpc.com/connect
-// client against the buffa-backed Rust server, proving the buffa↔prost wire
-// boundary actually works across the language seam.
-//
-// The full sdks/server-go migration (replacing the hand-rolled JSON shim in
-// experimentation.go with the generated client) is #644; this file only
-// exercises the round trip.
 package experimentation_test
 
 import (
@@ -30,15 +29,21 @@ import (
 	"github.com/org/experimentation/gen/go/experimentation/assignment/v1/assignmentv1connect"
 )
 
-func TestConnectClient_GetAssignment_RoundTrip(t *testing.T) {
+// conformanceClient returns a Connect client pointed at the pilot server, or
+// skips the test if KAIZEN_M1_CONNECT_URL isn't configured. Every test in
+// this file starts with this call — one skip decision, not N.
+func conformanceClient(t *testing.T) assignmentv1connect.AssignmentServiceClient {
+	t.Helper()
 	url := os.Getenv("KAIZEN_M1_CONNECT_URL")
 	if url == "" {
 		t.Skip("set KAIZEN_M1_CONNECT_URL to a running M1 pilot to exercise this test")
 	}
-
 	httpClient := &http.Client{Timeout: 5 * time.Second}
-	client := assignmentv1connect.NewAssignmentServiceClient(httpClient, url)
+	return assignmentv1connect.NewAssignmentServiceClient(httpClient, url)
+}
 
+func TestConformance_GetAssignment_RoundTrip(t *testing.T) {
+	client := conformanceClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -50,26 +55,16 @@ func TestConnectClient_GetAssignment_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAssignment failed: %v", err)
 	}
-
 	if got, want := resp.Msg.ExperimentId, "exp_dev_001"; got != want {
 		t.Errorf("ExperimentId = %q, want %q", got, want)
 	}
-
-	// IsActive is the load-bearing field of the existing tonic/JSON contract.
-	// We assert it's present (the proto field exists and decoded) rather than a
-	// specific value, since the experiment's state may change in dev/config.json.
+	// IsActive is the load-bearing contract field; assert presence, not value
+	// (the experiment's state can change in dev/config.json).
 	_ = resp.Msg.IsActive
 }
 
-func TestConnectClient_GetAssignment_UnknownExperimentReturnsNotFound(t *testing.T) {
-	url := os.Getenv("KAIZEN_M1_CONNECT_URL")
-	if url == "" {
-		t.Skip("set KAIZEN_M1_CONNECT_URL to a running M1 pilot to exercise this test")
-	}
-
-	httpClient := &http.Client{Timeout: 5 * time.Second}
-	client := assignmentv1connect.NewAssignmentServiceClient(httpClient, url)
-
+func TestConformance_GetAssignment_UnknownExperimentReturnsNotFound(t *testing.T) {
+	client := conformanceClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -83,5 +78,104 @@ func TestConnectClient_GetAssignment_UnknownExperimentReturnsNotFound(t *testing
 	}
 	if connect.CodeOf(err) != connect.CodeNotFound {
 		t.Errorf("expected CodeNotFound, got %v: %v", connect.CodeOf(err), err)
+	}
+}
+
+// GetAssignments — batch path over the wire. The Rust server absorbs
+// per-experiment failures inside assign_batch, so this always returns 200
+// with a (possibly empty) assignments array.
+func TestConformance_GetAssignments_ReturnsBatch(t *testing.T) {
+	client := conformanceClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.GetAssignments(ctx, connect.NewRequest(&assignmentv1.GetAssignmentsRequest{
+		UserId:    "test-user-1",
+		SessionId: "sess-1",
+	}))
+	if err != nil {
+		t.Fatalf("GetAssignments failed: %v", err)
+	}
+	if len(resp.Msg.Assignments) == 0 {
+		t.Error("expected at least one assignment from dev/config.json, got empty batch")
+	}
+}
+
+// GetInterleavedList — closes the JSON coverage gap (this method had no
+// hand-rolled JSON path before #642).
+func TestConformance_GetInterleavedList_MergesTwoAlgorithms(t *testing.T) {
+	client := conformanceClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// exp_dev_004 is the TEAM_DRAFT interleaving experiment
+	// (algorithm_ids: ["algo_a", "algo_b"]) in dev/config.json.
+	resp, err := client.GetInterleavedList(ctx, connect.NewRequest(&assignmentv1.GetInterleavedListRequest{
+		ExperimentId: "exp_dev_004",
+		UserId:       "test-user-interleave",
+		AlgorithmLists: map[string]*assignmentv1.RankedList{
+			"algo_a": {ItemIds: []string{"a1", "a2", "a3"}},
+			"algo_b": {ItemIds: []string{"b1", "b2", "b3"}},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("GetInterleavedList failed: %v", err)
+	}
+	if len(resp.Msg.MergedList) == 0 {
+		t.Error("expected non-empty merged list")
+	}
+}
+
+// GetSlateAssignment — SLATE_FACTORIZED_TS experiment; asserts the wire
+// contract for slot count without asserting specific items (order is bandit
+// draw-dependent).
+func TestConformance_GetSlateAssignment_ReturnsOrderedSlate(t *testing.T) {
+	client := conformanceClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.GetSlateAssignment(ctx, connect.NewRequest(&assignmentv1.GetSlateAssignmentRequest{
+		UserId:           "test-user-slate",
+		ExperimentId:     "exp_dev_slate_001",
+		CandidateItemIds: []string{"i1", "i2", "i3", "i4", "i5", "i6"},
+	}))
+	if err != nil {
+		t.Fatalf("GetSlateAssignment failed: %v", err)
+	}
+	if got, want := len(resp.Msg.SlateItemIds), 3; got != want {
+		t.Errorf("slate length = %d, want %d (num_slots=3)", got, want)
+	}
+	if got, want := len(resp.Msg.SlotProbabilities), 3; got != want {
+		t.Errorf("slot probabilities = %d, want %d", got, want)
+	}
+}
+
+// StreamConfigUpdates — proves the Connect server-streaming path opens
+// end-to-end. Doesn't push updates from this test (M5 integration isn't
+// wired), just asserts the stream can be opened without an immediate error
+// and cleanly closed. The domain streaming invariants (ordering, fan-out)
+// are covered by the Rust-side tests in
+// crates/experimentation-assignment/tests/stream_config_updates_test.rs.
+func TestConformance_StreamConfigUpdates_OpensCleanly(t *testing.T) {
+	client := conformanceClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	stream, err := client.StreamConfigUpdates(ctx, connect.NewRequest(&assignmentv1.StreamConfigUpdatesRequest{
+		LastKnownVersion: 0,
+	}))
+	if err != nil {
+		t.Fatalf("StreamConfigUpdates open failed: %v", err)
+	}
+	defer stream.Close()
+
+	// Drain until context deadline. A clean deadline-exceeded (or a nil-error
+	// EOF once M5 is wired) is the pass condition — the server accepted the
+	// subscribe request and honored the client-side cancel.
+	for stream.Receive() {
+		_ = stream.Msg()
+	}
+	if err := stream.Err(); err != nil && connect.CodeOf(err) != connect.CodeDeadlineExceeded && connect.CodeOf(err) != connect.CodeCanceled {
+		t.Errorf("stream close returned unexpected error: code=%v err=%v", connect.CodeOf(err), err)
 	}
 }

--- a/sdks/server-go/experimentation.go
+++ b/sdks/server-go/experimentation.go
@@ -16,13 +16,17 @@
 package experimentation
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
 	"time"
+
+	"connectrpc.com/connect"
+	assignmentv1 "github.com/org/experimentation/gen/go/experimentation/assignment/v1"
+	"github.com/org/experimentation/gen/go/experimentation/assignment/v1/assignmentv1connect"
 )
 
 // ---------------------------------------------------------------------------
@@ -68,11 +72,16 @@ type AssignmentProvider interface {
 // RemoteProvider
 // ---------------------------------------------------------------------------
 
-// RemoteProvider calls the Assignment Service via JSON HTTP.
+// RemoteProvider calls the Assignment Service via a generated ConnectRPC
+// client. ADR-031 #644 retired the hand-rolled JSON POST client that used
+// to live here — the generated `assignmentv1connect.AssignmentServiceClient`
+// speaks Connect/JSON on the wire, matching the same routes previously
+// served by http_json.rs on the Rust side.
 type RemoteProvider struct {
-	baseURL   string
-	timeoutMs int
-	client    *http.Client
+	baseURL    string
+	timeoutMs  int
+	httpClient *http.Client
+	client     assignmentv1connect.AssignmentServiceClient
 }
 
 // NewRemoteProvider creates a provider that calls the Assignment Service.
@@ -81,32 +90,23 @@ func NewRemoteProvider(baseURL string) *RemoteProvider {
 }
 
 func (p *RemoteProvider) Initialize(_ context.Context) error {
-	p.client = &http.Client{
+	p.httpClient = &http.Client{
 		Timeout: time.Duration(p.timeoutMs) * time.Millisecond,
 	}
+	p.client = assignmentv1connect.NewAssignmentServiceClient(p.httpClient, p.baseURL)
 	return nil
 }
 
-// assignmentJSONRequest matches the server's JSON API request format.
-type assignmentJSONRequest struct {
-	UserID       string            `json:"userId"`
-	ExperimentID string            `json:"experimentId,omitempty"`
-	SessionID    string            `json:"sessionId,omitempty"`
-	Attributes   map[string]string `json:"attributes,omitempty"`
-}
-
-// assignmentJSONResponse matches the server's JSON API response format.
-type assignmentJSONResponse struct {
-	ExperimentID          string  `json:"experimentId"`
-	VariantID             string  `json:"variantId"`
-	PayloadJSON           string  `json:"payloadJson"`
-	AssignmentProbability float64 `json:"assignmentProbability"`
-	IsActive              bool    `json:"isActive"`
-}
-
-// assignmentsJSONResponse wraps the bulk response.
-type assignmentsJSONResponse struct {
-	Assignments []assignmentJSONResponse `json:"assignments"`
+// notFoundIsNil translates the server's "experiment not found" NotFound
+// into `(nil, nil)`. The old JSON path collapsed any non-200 to nil; the
+// Connect client surfaces a typed error, so we distinguish NotFound
+// (semantically absent) from transport failures (return the error).
+func notFoundIsNil(err error) error {
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeNotFound {
+		return nil
+	}
+	return err
 }
 
 func (p *RemoteProvider) GetAssignment(ctx context.Context, experimentID string, attrs UserAttributes) (*Assignment, error) {
@@ -114,52 +114,33 @@ func (p *RemoteProvider) GetAssignment(ctx context.Context, experimentID string,
 		return nil, fmt.Errorf("provider not initialized")
 	}
 
-	url := p.baseURL + "/experimentation.assignment.v1.AssignmentService/GetAssignment"
-	reqBody := assignmentJSONRequest{
-		UserID:       attrs.UserID,
-		ExperimentID: experimentID,
+	resp, err := p.client.GetAssignment(ctx, connect.NewRequest(&assignmentv1.GetAssignmentRequest{
+		UserId:       attrs.UserID,
+		ExperimentId: experimentID,
 		Attributes:   flattenProps(attrs.Properties),
-	}
-	bodyBytes, err := json.Marshal(reqBody)
+	}))
 	if err != nil {
-		return nil, fmt.Errorf("marshal request: %w", err)
+		if e := notFoundIsNil(err); e == nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("connect GetAssignment: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, nil
-	}
-
-	var data assignmentJSONResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
-	}
-
-	if !data.IsActive || data.VariantID == "" {
+	data := resp.Msg
+	if !data.IsActive || data.VariantId == "" {
 		return nil, nil
 	}
 
 	var payload map[string]any
-	if data.PayloadJSON != "" {
-		if err := json.Unmarshal([]byte(data.PayloadJSON), &payload); err != nil {
+	if data.PayloadJson != "" {
+		if err := json.Unmarshal([]byte(data.PayloadJson), &payload); err != nil {
 			payload = nil
 		}
 	}
 
 	return &Assignment{
-		ExperimentID: data.ExperimentID,
-		VariantName:  data.VariantID,
+		ExperimentID: data.ExperimentId,
+		VariantName:  data.VariantId,
 		Payload:      payload,
 		FromCache:    false,
 	}, nil
@@ -170,51 +151,31 @@ func (p *RemoteProvider) GetAllAssignments(ctx context.Context, attrs UserAttrib
 		return nil, fmt.Errorf("provider not initialized")
 	}
 
-	url := p.baseURL + "/experimentation.assignment.v1.AssignmentService/GetAssignments"
-	reqBody := assignmentJSONRequest{
-		UserID:     attrs.UserID,
+	resp, err := p.client.GetAssignments(ctx, connect.NewRequest(&assignmentv1.GetAssignmentsRequest{
+		UserId:     attrs.UserID,
 		Attributes: flattenProps(attrs.Properties),
-	}
-	bodyBytes, err := json.Marshal(reqBody)
+	}))
 	if err != nil {
-		return nil, fmt.Errorf("marshal request: %w", err)
+		if e := notFoundIsNil(err); e == nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("connect GetAssignments: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, nil
-	}
-
-	var data assignmentsJSONResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
-	}
-
-	results := make(map[string]*Assignment, len(data.Assignments))
-	for _, a := range data.Assignments {
-		if !a.IsActive || a.VariantID == "" {
+	results := make(map[string]*Assignment, len(resp.Msg.Assignments))
+	for _, a := range resp.Msg.Assignments {
+		if !a.IsActive || a.VariantId == "" {
 			continue
 		}
 		var payload map[string]any
-		if a.PayloadJSON != "" {
-			if err := json.Unmarshal([]byte(a.PayloadJSON), &payload); err != nil {
+		if a.PayloadJson != "" {
+			if err := json.Unmarshal([]byte(a.PayloadJson), &payload); err != nil {
 				payload = nil
 			}
 		}
-		results[a.ExperimentID] = &Assignment{
-			ExperimentID: a.ExperimentID,
-			VariantName:  a.VariantID,
+		results[a.ExperimentId] = &Assignment{
+			ExperimentID: a.ExperimentId,
+			VariantName:  a.VariantId,
 			Payload:      payload,
 			FromCache:    false,
 		}
@@ -223,8 +184,8 @@ func (p *RemoteProvider) GetAllAssignments(ctx context.Context, attrs UserAttrib
 }
 
 func (p *RemoteProvider) Close() error {
-	if p.client != nil {
-		p.client.CloseIdleConnections()
+	if p.httpClient != nil {
+		p.httpClient.CloseIdleConnections()
 	}
 	return nil
 }

--- a/sdks/server-go/experimentation_test.go
+++ b/sdks/server-go/experimentation_test.go
@@ -2,11 +2,16 @@ package experimentation
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+
+	"connectrpc.com/connect"
+	assignmentv1 "github.com/org/experimentation/gen/go/experimentation/assignment/v1"
+	"github.com/org/experimentation/gen/go/experimentation/assignment/v1/assignmentv1connect"
 )
 
 // ---------------------------------------------------------------------------
@@ -272,54 +277,86 @@ func TestLocalProviderGetAllAssignments(t *testing.T) {
 // RemoteProvider tests
 // ---------------------------------------------------------------------------
 
-func mockAssignmentServer(t *testing.T) *httptest.Server {
+// stubAssignmentServer implements the connect handler for tests. Under the
+// covers it now speaks `application/connect+json` on the wire (via the
+// generated handler) — the hand-rolled JSON shim it used to bridge is gone
+// (ADR-031 #644).
+//
+// We record just the attributes map from GetAssignment calls rather than the
+// whole proto message — protobuf-generated structs embed
+// protoimpl.MessageState (which contains a mutex), so `go vet` blocks any
+// value-copy of the whole message. The captured attributes are all the
+// TestRemoteProviderWithAttributes assertion needs.
+type stubAssignmentServer struct {
+	assignmentv1connect.UnimplementedAssignmentServiceHandler
+	mu             sync.Mutex
+	capturedAttrs  map[string]string
+	capturedAtLeastOnce bool
+}
+
+func (s *stubAssignmentServer) GetAssignment(
+	_ context.Context,
+	req *connect.Request[assignmentv1.GetAssignmentRequest],
+) (*connect.Response[assignmentv1.GetAssignmentResponse], error) {
+	s.mu.Lock()
+	s.capturedAttrs = make(map[string]string, len(req.Msg.Attributes))
+	for k, v := range req.Msg.Attributes {
+		s.capturedAttrs[k] = v
+	}
+	s.capturedAtLeastOnce = true
+	s.mu.Unlock()
+
+	if req.Msg.ExperimentId == "missing" {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("experiment not found"))
+	}
+	return connect.NewResponse(&assignmentv1.GetAssignmentResponse{
+		ExperimentId:          req.Msg.ExperimentId,
+		VariantId:             "treatment",
+		PayloadJson:           `{"color":"red"}`,
+		AssignmentProbability: 0.5,
+		IsActive:              true,
+	}), nil
+}
+
+func (s *stubAssignmentServer) GetAssignments(
+	_ context.Context,
+	_ *connect.Request[assignmentv1.GetAssignmentsRequest],
+) (*connect.Response[assignmentv1.GetAssignmentsResponse], error) {
+	return connect.NewResponse(&assignmentv1.GetAssignmentsResponse{
+		Assignments: []*assignmentv1.GetAssignmentResponse{
+			{ExperimentId: "exp1", VariantId: "control", PayloadJson: "{}", IsActive: true},
+			{ExperimentId: "exp2", VariantId: "treatment", PayloadJson: `{"x":1}`, IsActive: true},
+			{ExperimentId: "exp3", VariantId: "", IsActive: false},
+		},
+	}), nil
+}
+
+// lastAttributes returns a snapshot of the attribute map from the most
+// recent GetAssignment call, or (nil, false) if none.
+func (s *stubAssignmentServer) lastAttributes() (map[string]string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.capturedAtLeastOnce {
+		return nil, false
+	}
+	snap := make(map[string]string, len(s.capturedAttrs))
+	for k, v := range s.capturedAttrs {
+		snap[k] = v
+	}
+	return snap, true
+}
+
+func mockAssignmentServer(t *testing.T) (*httptest.Server, *stubAssignmentServer) {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-		switch r.URL.Path {
-		case "/experimentation.assignment.v1.AssignmentService/GetAssignment":
-			var req assignmentJSONRequest
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			if req.ExperimentID == "missing" {
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write([]byte(`{"code":404,"message":"not found"}`))
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			resp := assignmentJSONResponse{
-				ExperimentID:          req.ExperimentID,
-				VariantID:             "treatment",
-				PayloadJSON:           `{"color":"red"}`,
-				AssignmentProbability: 0.5,
-				IsActive:              true,
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-
-		case "/experimentation.assignment.v1.AssignmentService/GetAssignments":
-			w.Header().Set("Content-Type", "application/json")
-			resp := assignmentsJSONResponse{
-				Assignments: []assignmentJSONResponse{
-					{ExperimentID: "exp1", VariantID: "control", PayloadJSON: "{}", IsActive: true},
-					{ExperimentID: "exp2", VariantID: "treatment", PayloadJSON: `{"x":1}`, IsActive: true},
-					{ExperimentID: "exp3", VariantID: "", IsActive: false},
-				},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
+	stub := &stubAssignmentServer{}
+	mux := http.NewServeMux()
+	path, handler := assignmentv1connect.NewAssignmentServiceHandler(stub)
+	mux.Handle(path, handler)
+	return httptest.NewServer(mux), stub
 }
 
 func TestRemoteProviderGetAssignment(t *testing.T) {
-	srv := mockAssignmentServer(t)
+	srv, _ := mockAssignmentServer(t)
 	defer srv.Close()
 
 	p := NewRemoteProvider(srv.URL)
@@ -350,7 +387,7 @@ func TestRemoteProviderGetAssignment(t *testing.T) {
 }
 
 func TestRemoteProviderGetAssignment404(t *testing.T) {
-	srv := mockAssignmentServer(t)
+	srv, _ := mockAssignmentServer(t)
 	defer srv.Close()
 
 	p := NewRemoteProvider(srv.URL)
@@ -387,7 +424,7 @@ func TestRemoteProviderNotInitialized(t *testing.T) {
 }
 
 func TestRemoteProviderGetAllAssignments(t *testing.T) {
-	srv := mockAssignmentServer(t)
+	srv, _ := mockAssignmentServer(t)
 	defer srv.Close()
 
 	p := NewRemoteProvider(srv.URL)
@@ -413,13 +450,7 @@ func TestRemoteProviderGetAllAssignments(t *testing.T) {
 }
 
 func TestRemoteProviderWithAttributes(t *testing.T) {
-	var capturedBody assignmentJSONRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
-		w.Header().Set("Content-Type", "application/json")
-		resp := assignmentJSONResponse{ExperimentID: "exp1", VariantID: "v", IsActive: true}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	srv, stub := mockAssignmentServer(t)
 	defer srv.Close()
 
 	p := NewRemoteProvider(srv.URL)
@@ -431,11 +462,15 @@ func TestRemoteProviderWithAttributes(t *testing.T) {
 		Properties: map[string]any{"plan": "premium", "age": 30},
 	})
 
-	if capturedBody.Attributes["plan"] != "premium" {
-		t.Errorf("expected plan=premium, got %s", capturedBody.Attributes["plan"])
+	attrs, ok := stub.lastAttributes()
+	if !ok {
+		t.Fatal("stub server never observed a GetAssignment call")
 	}
-	if capturedBody.Attributes["age"] != "30" {
-		t.Errorf("expected age=30, got %s", capturedBody.Attributes["age"])
+	if attrs["plan"] != "premium" {
+		t.Errorf("expected plan=premium, got %s", attrs["plan"])
+	}
+	if attrs["age"] != "30" {
+		t.Errorf("expected age=30, got %s", attrs["age"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Concludes the ADR-031 pilot. With all five `AssignmentService` RPCs served over ConnectRPC (#641/#642/#643), the hand-rolled shim on both sides of the wire is retired. Closes #644.

### Rust — `http_json.rs` retired on the connectrpc feature path

- `lib.rs`: `pub mod http_json` is gated behind `#[cfg(not(feature = "connectrpc"))]`
- `main.rs`: the `http_json::serve` spawn is gated behind the same cfg; the Connect listener carries its routes over `application/connect+json`
- `tests/http_json_e2e.rs`: `#![cfg(not(feature = "connectrpc"))]` at file top so the whole suite compiles out cleanly under the pilot

Under `--features connectrpc`, **786 lines of shim** (349 in `http_json.rs` + 437 in the e2e suite) become dead code. Default builds still expose the shim until the pilot's default is flipped.

### server-go — migrate to the generated Connect client

- `experimentation.go`: `RemoteProvider` now uses `assignmentv1connect.NewAssignmentServiceClient` instead of `http.Client` + `json.Marshal` POSTs. Behavior preserved:
  - `NotFound` → `(nil, nil)` (semantically absent, matches the old non-200-to-nil collapse)
  - Transport / other Connect errors surface as errors
- `experimentation_test.go`: the mock `httptest.Server` now serves via the generated `AssignmentServiceHandler`. Same 200 / 404 / attribute-flatten assertions, now proving the client speaks Connect end-to-end. Captured attributes are stored in a plain `map[string]string` — proto structs embed a `MessageState` mutex that `go vet` refuses to let you copy by value.

`RemoteProvider` shrank from ~150 lines of hand-rolled JSON bodies to ~85 lines of Connect calls.

### server-go — pilot test → conformance suite

`connect_pilot_e2e_test.go` was a tracer bullet for #641. It's now the pilot's cross-language conformance check:

| Test | Coverage |
| --- | --- |
| `TestConformance_GetAssignment_RoundTrip` | Unary, happy path |
| `TestConformance_GetAssignment_UnknownExperimentReturnsNotFound` | `CodeNotFound` mapping across languages |
| `TestConformance_GetAssignments_ReturnsBatch` | Batch RPC (#642 wire path) |
| `TestConformance_GetInterleavedList_MergesTwoAlgorithms` | **Closes the JSON coverage gap** (#642 — no hand-rolled path existed) |
| `TestConformance_GetSlateAssignment_ReturnsOrderedSlate` | Slate RPC (#642) — `slateItemIds` + `slotProbabilities` shape |
| `TestConformance_StreamConfigUpdates_OpensCleanly` | **The wire-level streaming check** that #643's PR body deferred here (context cancels → `CodeDeadlineExceeded`/`CodeCanceled` on close) |

Opt-in on `KAIZEN_M1_CONNECT_URL` (unchanged) — the M1 pilot binary is the counterparty.

### Net LOC delta

Measured under the pilot's success criterion: **code retired from the shim path, weighed against code added to the Connect path.**

| Kind | Lines |
| --- | --- |
| **Retired** (under `--features connectrpc`) | |
| `crates/experimentation-assignment/src/http_json.rs` | 349 |
| `crates/experimentation-assignment/tests/http_json_e2e.rs` | 437 |
| server-go hand-rolled JSON (RemoteProvider bodies + mock) | ~200 |
| **Total retired** | **~986** |
| **Added** (this PR only — see #641/#642/#643 for prior additions) | |
| server-go Connect client refactor | ~85 |
| conformance suite expansion (+82 lines from tracer) | ~170 |
| Rust cfg gates + main.rs comments | ~15 |
| **Total added this PR** | **~270** |

This PR: net **−716 lines** on the pilot path. Whole pilot (#641+#642+#643+#644) still net-positive by ~+300 lines because the new proto-connect crate + bridges cost ~1000 lines to save the ~800 shim lines. **The pilot's actual win is qualitative** — no hand-rolled shims, generated types on both sides, one wire path serving Connect + gRPC + gRPC-Web instead of tonic + a bespoke HTTP+JSON server.

Handed off to #645 for the pilot-exit go/no-go with the full accounting.

### Test plan

- [x] `cargo build -p experimentation-assignment` clean (default build)
- [x] `cargo build -p experimentation-assignment --features connectrpc` clean (pilot build)
- [x] `cargo test -p experimentation-assignment` — 213 tests pass (http_json path)
- [x] `cargo test -p experimentation-assignment --features connectrpc` — 214 tests pass (connect path)
- [x] `go build ./...` in `sdks/server-go` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all RemoteProvider + Local + Client tests pass against the new Connect mock
- [ ] Conformance suite against a running M1 pilot binary — deferred; requires a live server. Runbook in the test file's package comment.

### Acceptance criteria

- [x] `http_json.rs` removed on the `connectrpc` feature path
- [x] server-go uses only the generated Connect client; hand-rolled JSON path deleted; round-trip test converted to a conformance check
- [ ] No exposure-contract regression for any M1 SDK consumer — **caveat**: server-go SDK now requires M1 built with `--features connectrpc`. Default M1 (http_json only) can't decode Connect envelope headers, so pointing the new SDK at it will fail. Flipping the M1 default is #645's territory.
- [x] Net LOC delta recorded (this PR: −716 on the pilot path; cumulative pilot: ~+300 with the qualitative wins above)

### Coordination

- The generated `.pb.go` / `.connect.go` files for `assignment/v1` and the missing `common/v1` messages are **not committed** — `gen/` is `.gitignore`d and CI regenerates via `buf generate` before the Go job runs (see `.github/workflows/ci.yml`'s `download-artifact generated-code` step). Local dev needs `just codegen-go` before Go builds work.
- **#645** is the pilot's go/no-go decision — this PR is the last input.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->