### PR TITLE
feat(infra): TLS-optional dev edge - :80 rules listener, LB attachment, M4b gate fix

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -4,7 +4,7 @@ config:
   kaizen-experimentation:vpcCidr: "10.0.0.0/16"
   kaizen-experimentation:rdsInstanceClass: db.t4g.medium
   kaizen-experimentation:rdsMultiAz: "false"
-  kaizen-experimentation:mskBrokerCount: "2"
+  kaizen-experimentation:mskBrokerCount: "3"
   kaizen-experimentation:mskInstanceType: kafka.t3.small
   kaizen-experimentation:redisNodeType: cache.t4g.medium
   kaizen-experimentation:m4bInstanceType: t3.large
@@ -13,4 +13,10 @@ config:
   kaizen-experimentation:fargateMinTasks: "1"
   kaizen-experimentation:cloudwatchRetentionDays: "7"
   kafka:saslUsername: kaizen-msk-user
-  kafka:saslPassword: CHANGE_ME_VIA_PULUMI_CONFIG_SET_SECRET
+  kafka:saslPassword:
+    secure: AAABAJAiI7O3D8ehY4mJBFeBVb5yh8Y2OUmVMMw/KS85rFrEplmi35Sdxd6s5dZqfhmhgx9aCTWMhYOsf7B3gA==
+  kaizen-experimentation:domain: wkv.ai
+  kaizen-experimentation:grafanaEnabled: "false"
+  kaizen-experimentation:manageKafkaTopics: "false"
+  kaizen-experimentation:mskAllowPlaintext: "true"
+  kaizen-experimentation:tlsEnabled: "false"

--- a/infra/main.go
+++ b/infra/main.go
@@ -262,6 +262,24 @@ func Deploy(ctx *pulumi.Context) error {
 	}
 
 	// =====================================================================
+	// Stage 5a: Edge (DNS, ALB, target groups) — before compute, because
+	// LB-facing ECS services attach their target groups at creation and
+	// ECS validates that the groups are already LB-associated (listener
+	// rules). Autoscaling/observability stay in Stage 6 (they consume
+	// compute outputs).
+	// =====================================================================
+	var (
+		edgeOut types.EdgeOutputs
+		tgOut   *loadbalancer.TargetGroupOutputs
+	)
+	if cfg.CloudProvider == "aws" {
+		edgeOut, tgOut, err = aws.NewEdge(ctx, cfg, netOut, storageOut)
+		if err != nil {
+			return err
+		}
+	}
+
+	// =====================================================================
 	// Stage 5: Compute (cluster, services, M4b, schema registry)
 	// =====================================================================
 	var (
@@ -272,7 +290,7 @@ func Deploy(ctx *pulumi.Context) error {
 	)
 	switch cfg.CloudProvider {
 	case "aws":
-		computeOut, svcOut, err = aws.NewCompute(ctx, cfg, netOut, cicdOut, secretsOut, streamOut)
+		computeOut, svcOut, err = aws.NewCompute(ctx, cfg, netOut, cicdOut, secretsOut, streamOut, tgOut)
 		if err != nil {
 			return err
 		}
@@ -293,16 +311,10 @@ func Deploy(ctx *pulumi.Context) error {
 	}
 
 	// =====================================================================
-	// Stage 6: Edge + Observability + HealthGate + Autoscaling
+	// Stage 6: Observability + HealthGate + Autoscaling (edge moved to 5a)
 	// =====================================================================
-	var edgeOut types.EdgeOutputs
 	switch cfg.CloudProvider {
 	case "aws":
-		var tgOut *loadbalancer.TargetGroupOutputs
-		edgeOut, tgOut, err = aws.NewEdge(ctx, cfg, netOut, storageOut)
-		if err != nil {
-			return err
-		}
 		// Autoscaling's ALBRequestCountPerTarget metric needs the ALB ARN
 		// suffix (e.g. "app/kaizen-dev-alb/50dc6c495c0c9188"), not the full
 		// ARN — see types.EdgeOutputs.LoadBalancerArnSuffix.

--- a/infra/pkg/aws/aws.go
+++ b/infra/pkg/aws/aws.go
@@ -414,6 +414,10 @@ func NewEdge(
 			Environment: cfg.Environment,
 			Project:     cfg.Project,
 			Env:         cfg.Env,
+			// TlsEnabled gates the cert-validation waiter in dns.go —
+			// omitting it here would zero-value it to false and skip
+			// validation everywhere, including prod.
+			TlsEnabled: cfg.TlsEnabled,
 		},
 	})
 	if err != nil {

--- a/infra/pkg/aws/aws.go
+++ b/infra/pkg/aws/aws.go
@@ -279,6 +279,7 @@ func NewCompute(
 	cicdOut types.CICDOutputs,
 	secretsOut types.SecretsOutputs,
 	streamOut types.StreamingOutputs,
+	tgOut *loadbalancer.TargetGroupOutputs,
 ) (types.ComputeOutputs, *compute.ServicesOutputs, error) {
 	clusterOut, err := compute.NewCluster(ctx, &compute.ClusterArgs{
 		Environment:        cfg.Environment,
@@ -317,8 +318,10 @@ func NewCompute(
 		RedisSecretArn:    secretsOut.RedisSecretRef,
 		AuthSecretArn:     secretsOut.AuthSecretRef,
 		KafkaBrokers:      streamOut.BootstrapBrokersPlaintext,
-		DesiredCount:      cfg.FargateMinTasks,
-		PreDeployDeps:     []pulumi.Resource{migOut.RunCommand},
+		TargetGroupArns: lbAttachableTargetGroups(cfg, tgOut),
+		LbRuleDeps:    tgOut.Rules,
+		DesiredCount:  cfg.FargateMinTasks,
+		PreDeployDeps: []pulumi.Resource{migOut.RunCommand},
 	})
 	if err != nil {
 		return types.ComputeOutputs{}, nil, err
@@ -378,6 +381,23 @@ func NewSchemaRegistry(
 	return out.SchemaRegistryUrl, out.ServiceName, nil
 }
 
+// lbAttachableTargetGroups returns the target groups ECS services may attach
+// to. In dev tlsEnabled=false mode the gRPC target groups (M1, M7) carry no
+// listener rules — ALB forbids GRPC/HTTP2 protocol versions behind the
+// plaintext :80 listener — and ECS rejects a LoadBalancers entry whose target
+// group is not attached to a load balancer.
+func lbAttachableTargetGroups(cfg *kconfig.Config, tgOut *loadbalancer.TargetGroupOutputs) map[string]pulumi.StringOutput {
+	arns := map[string]pulumi.StringOutput{
+		"m5": tgOut.M5ManagementTgArn,
+		"m6": tgOut.M6UITgArn,
+	}
+	if cfg.TlsEnabled {
+		arns["m1"] = tgOut.M1AssignmentTgArn
+		arns["m7"] = tgOut.M7FlagsTgArn
+	}
+	return arns
+}
+
 // ─── Stage 6: Edge + Observability ──────────────────────────────────────────
 
 // NewEdge creates DNS, ALB, DNS aliases, target groups, and (conditionally) WAF.
@@ -408,6 +428,7 @@ func NewEdge(
 		CertificateArn:  dnsOut.CertificateArn,
 		LogsBucketName:  storageOut.LogsBucketName,
 		Environment:     cfg.Environment,
+		TlsEnabled:      cfg.TlsEnabled,
 	})
 	if err != nil {
 		return types.EdgeOutputs{}, nil, err
@@ -429,6 +450,7 @@ func NewEdge(
 		HttpsListenerArn: albOut.HttpsListenerArn,
 		Domain:           cfg.Domain,
 		Environment:      cfg.Environment,
+		TlsEnabled:       cfg.TlsEnabled,
 	})
 	if err != nil {
 		return types.EdgeOutputs{}, nil, err
@@ -472,6 +494,7 @@ func NewAutoscaling(
 	args.ALBFullName = albArnSuffix
 	args.M1TargetGroupFullName = tgOut.M1AssignmentTgArnSuffix
 	args.M7TargetGroupFullName = tgOut.M7FlagsTgArnSuffix
+	args.AlbAttached = cfg.TlsEnabled
 	if svcOut != nil {
 		args.DependsOn = svcOut.AllServiceResources
 	}

--- a/infra/pkg/aws/compute/autoscaling.go
+++ b/infra/pkg/aws/compute/autoscaling.go
@@ -48,6 +48,13 @@ type AutoscalingArgs struct {
 	// M7TargetGroupFullName is the target group full name for M7 Flags.
 	M7TargetGroupFullName pulumi.StringInput
 
+	// AlbAttached reports whether the M1/M7 target groups actually route
+	// traffic (rules + ECS attachment). False in dev tlsEnabled=false mode:
+	// gRPC target groups can't sit behind the plaintext :80 listener, and
+	// PutScalingPolicy rejects ALBRequestCountPerTarget on an unattached
+	// target group. M1/M7 then fall back to CPU tracking.
+	AlbAttached bool
+
 	// DependsOn carries the ECS service resources. Scaling targets address
 	// services via constructed ResourceId strings, so without these edges
 	// target creation races service creation ("ECS service doesn't exist").
@@ -134,12 +141,23 @@ func NewAutoscaling(ctx *pulumi.Context, args *AutoscalingArgs) (*AutoscalingOut
 	}
 
 	for _, svc := range albServices {
-		target, policy, err := newALBScalingPolicy(
-			ctx, prefix, svc.key, svc.service,
-			args.ClusterName, svc.config,
-			args.ALBFullName, svc.targetGroupFull,
-			args.Environment, args.DependsOn,
-		)
+		var target *appautoscaling.Target
+		var policy *appautoscaling.Policy
+		var err error
+		if args.AlbAttached {
+			target, policy, err = newALBScalingPolicy(
+				ctx, prefix, svc.key, svc.service,
+				args.ClusterName, svc.config,
+				args.ALBFullName, svc.targetGroupFull,
+				args.Environment, args.DependsOn,
+			)
+		} else {
+			target, policy, err = newCPUScalingPolicy(
+				ctx, prefix, svc.key, svc.service,
+				args.ClusterName, svc.config,
+				args.Environment, args.DependsOn,
+			)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("creating ALB autoscaling for %s: %w", svc.key, err)
 		}

--- a/infra/pkg/aws/compute/services.go
+++ b/infra/pkg/aws/compute/services.go
@@ -50,6 +50,13 @@ type ServicesArgs struct {
 	// Dev wires the unauthenticated plaintext listener here — services
 	// carry no SASL/TLS Kafka client wiring yet.
 	KafkaBrokers pulumi.StringOutput
+	// TargetGroupArns maps spec key (m1, m5, m6, m7) → ALB target group
+	// ARN. Services with an entry here register tasks with the ALB.
+	TargetGroupArns map[string]pulumi.StringOutput
+	// LbRuleDeps are the listener-rule resources that attach the target
+	// groups to the load balancer — ECS validates the attachment at
+	// service create/update, so LB-facing services depend on these.
+	LbRuleDeps []pulumi.Resource
 	// DesiredCount is the initial task count per service.
 	DesiredCount int
 	// PreDeployDeps lists resources that must complete before the M5
@@ -121,12 +128,16 @@ type healthDep struct {
 // m5Dep is the health dependency on M5 Management (HTTP healthz).
 var m5Dep = healthDep{name: "M5", host: "m5-management.kaizen.local", port: 50055, proto: "http", path: "/healthz"}
 
-// tier1Deps are the health dependencies on Tier 1 services (M1, M2, M4b).
-// Used by Tier 2 services. M4b is included because it is logically Tier 1.
+// tier1Deps are the health dependencies on Tier 1 services (M1, M2).
+// Used by Tier 2 services. M4b is logically Tier 1 too, but no ECS
+// task/service for it exists yet — only its ASG, capacity provider, and
+// Cloud Map name (m4b.go provisions operational resources only). Gating
+// on a DNS name nothing registers deadlocks all of Tier 2, so M4b stays
+// out of the gate until the real EC2 service ships; consumers dial it
+// lazily via M4B_POLICY_ENDPOINT and degrade until then.
 var tier1Deps = []healthDep{
 	{name: "M1", host: "m1-assignment.kaizen.local", port: 50051, proto: "tcp"},
 	{name: "M2", host: "m2-pipeline.kaizen.local", port: 50052, proto: "tcp"},
-	{name: "M4b", host: "m4b-policy.kaizen.local", port: 50054, proto: "tcp"},
 }
 
 func serviceSpecs() []serviceSpec {
@@ -553,10 +564,32 @@ func newFargateService(
 		svcArgs.HealthCheckGracePeriodSeconds = pulumi.Int(120)
 	}
 
+	// ALB attachment for public-facing services: register tasks with the
+	// service's target group. Requires the TG to already be attached to
+	// the load balancer (via a listener rule) — LbRuleDeps carries that
+	// ordering.
+	if tgArn, ok := args.TargetGroupArns[spec.key]; ok {
+		svcArgs.LoadBalancers = ecs.ServiceLoadBalancerArray{
+			&ecs.ServiceLoadBalancerArgs{
+				TargetGroupArn: tgArn,
+				ContainerName:  pulumi.String(spec.name),
+				ContainerPort:  pulumi.Int(spec.ports[0]),
+			},
+		}
+		// The ALB health check needs the same grace period the gated
+		// services get, or slow-booting containers get cycled.
+		if svcArgs.HealthCheckGracePeriodSeconds == nil {
+			svcArgs.HealthCheckGracePeriodSeconds = pulumi.Int(120)
+		}
+	}
+
 	// Build Pulumi resource options: DependsOn from previous tier.
 	var opts []pulumi.ResourceOption
 	if len(pulumiDeps) > 0 {
 		opts = append(opts, pulumi.DependsOn(pulumiDeps))
+	}
+	if _, ok := args.TargetGroupArns[spec.key]; ok && len(args.LbRuleDeps) > 0 {
+		opts = append(opts, pulumi.DependsOn(args.LbRuleDeps))
 	}
 
 	ecsSvc, err := ecs.NewService(ctx, fmt.Sprintf("svc-%s", spec.name), svcArgs, opts...)

--- a/infra/pkg/aws/compute/services_test.go
+++ b/infra/pkg/aws/compute/services_test.go
@@ -125,7 +125,9 @@ func TestTier2DependsOnTier1Services(t *testing.T) {
 	requiredHosts := map[string]bool{
 		"m1-assignment.kaizen.local": true,
 		"m2-pipeline.kaizen.local":   true,
-		"m4b-policy.kaizen.local":    true,
+		// m4b-policy is deliberately absent: no ECS service exists for it
+		// yet, and gating on an unregistered DNS name deadlocks Tier 2
+		// (see tier1Deps in services.go).
 	}
 
 	for _, s := range specs {

--- a/infra/pkg/aws/dns/dns.go
+++ b/infra/pkg/aws/dns/dns.go
@@ -108,6 +108,19 @@ func NewDNS(ctx *pulumi.Context, args *Args) (*Outputs, error) {
 	}
 
 	// --- Wait for Certificate Validation ---
+	// Validation can only complete once the zone's NS delegation exists
+	// publicly. With TlsEnabled=false (dev, pre-delegation) the waiter is
+	// skipped and the raw cert ARN is returned; nothing consumes it until
+	// the HTTPS listener returns with TlsEnabled=true. The validation
+	// record above stays either way, so ACM completes on its own the
+	// moment delegation lands.
+	if !args.Config.TlsEnabled {
+		return &Outputs{
+			HostedZoneID:   zone.ID(),
+			CertificateArn: cert.Arn,
+		}, nil
+	}
+
 	certValidation, err := acm.NewCertificateValidation(ctx, "kaizen-cert-validation-wait", &acm.CertificateValidationArgs{
 		CertificateArn: cert.Arn,
 		ValidationRecordFqdns: pulumi.StringArray{

--- a/infra/pkg/aws/loadbalancer/alb.go
+++ b/infra/pkg/aws/loadbalancer/alb.go
@@ -18,11 +18,16 @@ type ALBInputs struct {
 	// Security group ID for the ALB (from pkg/network SecurityGroups["alb"]).
 	SecurityGroupId pulumi.StringInput
 	// ACM certificate ARN for the HTTPS listener (from pkg/dns).
+	// Unused when TlsEnabled is false.
 	CertificateArn pulumi.StringInput
 	// S3 bucket name for ALB access logs (from pkg/storage).
 	LogsBucketName pulumi.StringInput
 	// Environment name used for resource naming and tagging.
 	Environment string
+	// TlsEnabled gates the HTTPS listener. When false (dev before NS
+	// delegation), the HTTP :80 listener carries the routing rules
+	// directly instead of redirecting, and RulesListenerArn points at it.
+	TlsEnabled bool
 }
 
 // ALBOutputs are exported for downstream consumers (I.1.18 target groups,
@@ -36,9 +41,12 @@ type ALBOutputs struct {
 	AlbDnsName pulumi.StringOutput
 	// ALB canonical hosted zone ID — needed for Route 53 alias target.
 	AlbZoneId pulumi.StringOutput
-	// HTTPS listener ARN — I.1.18 attaches target group rules here.
+	// HttpsListenerArn is the ARN of the listener that carries the
+	// target-group routing rules: the HTTPS :443 listener when TLS is
+	// enabled, otherwise the HTTP :80 listener. (Name kept for schema
+	// stability; treat as "rules listener".)
 	HttpsListenerArn pulumi.StringOutput
-	// HTTP listener ARN (redirect-only, exposed for completeness).
+	// HTTP listener ARN (redirect-only when TLS is enabled).
 	HttpListenerArn pulumi.StringOutput
 	// AlbArnSuffix is the ARN suffix (e.g., "app/kaizen-dev-alb/50dc6c495c0c9188")
 	// used as the ALBFullName in autoscaling ALBRequestCountPerTarget metrics.
@@ -94,44 +102,46 @@ func NewALB(ctx *pulumi.Context, inputs *ALBInputs) (*ALBOutputs, error) {
 		return nil, fmt.Errorf("creating ALB: %w", err)
 	}
 
-	// --- HTTPS Listener (port 443) ---
-	// Default action is a 503 fixed-response until I.1.18 wires target groups.
-	// This allows the ALB to exist and serve health checks / return a clear
-	// "not yet routed" signal during initial deployment.
-	httpsListener, err := lb.NewListener(ctx, fmt.Sprintf("%s-https", namePrefix), &lb.ListenerArgs{
-		LoadBalancerArn: alb.Arn,
-		Port:            pulumi.Int(443),
-		Protocol:        pulumi.String("HTTPS"),
-		SslPolicy:       pulumi.String("ELBSecurityPolicy-TLS13-1-2-2021-06"),
-		CertificateArn:  inputs.CertificateArn,
-
-		DefaultActions: lb.ListenerDefaultActionArray{
-			&lb.ListenerDefaultActionArgs{
-				Type: pulumi.String("fixed-response"),
-				FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
-					ContentType: pulumi.String("text/plain"),
-					MessageBody: pulumi.String("Service not yet configured"),
-					StatusCode:  pulumi.String("503"),
-				},
+	// Shared 503 fixed-response default: rules from I.1.18 route real
+	// traffic; anything unmatched gets a clear "not yet routed" signal.
+	notRouted := lb.ListenerDefaultActionArray{
+		&lb.ListenerDefaultActionArgs{
+			Type: pulumi.String("fixed-response"),
+			FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
+				ContentType: pulumi.String("text/plain"),
+				MessageBody: pulumi.String("Service not yet configured"),
+				StatusCode:  pulumi.String("503"),
 			},
 		},
-
-		Tags: pulumi.StringMap{
-			"Project":     pulumi.String("kaizen-experimentation"),
-			"Environment": pulumi.String(inputs.Environment),
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating HTTPS listener: %w", err)
+	}
+	listenerTags := pulumi.StringMap{
+		"Project":     pulumi.String("kaizen-experimentation"),
+		"Environment": pulumi.String(inputs.Environment),
 	}
 
-	// --- HTTP Listener (port 80) → redirect to HTTPS ---
-	httpListener, err := lb.NewListener(ctx, fmt.Sprintf("%s-http", namePrefix), &lb.ListenerArgs{
-		LoadBalancerArn: alb.Arn,
-		Port:            pulumi.Int(80),
-		Protocol:        pulumi.String("HTTP"),
+	// --- HTTPS Listener (port 443) --- (TLS mode only)
+	var httpsListener *lb.Listener
+	if inputs.TlsEnabled {
+		httpsListener, err = lb.NewListener(ctx, fmt.Sprintf("%s-https", namePrefix), &lb.ListenerArgs{
+			LoadBalancerArn: alb.Arn,
+			Port:            pulumi.Int(443),
+			Protocol:        pulumi.String("HTTPS"),
+			SslPolicy:       pulumi.String("ELBSecurityPolicy-TLS13-1-2-2021-06"),
+			CertificateArn:  inputs.CertificateArn,
+			DefaultActions:  notRouted,
+			Tags:            listenerTags,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating HTTPS listener: %w", err)
+		}
+	}
 
-		DefaultActions: lb.ListenerDefaultActionArray{
+	// --- HTTP Listener (port 80) ---
+	// TLS mode: 301 redirect to HTTPS. Pre-delegation dev mode: this
+	// listener carries the routing rules itself.
+	httpDefault := notRouted
+	if inputs.TlsEnabled {
+		httpDefault = lb.ListenerDefaultActionArray{
 			&lb.ListenerDefaultActionArgs{
 				Type: pulumi.String("redirect"),
 				Redirect: &lb.ListenerDefaultActionRedirectArgs{
@@ -140,15 +150,22 @@ func NewALB(ctx *pulumi.Context, inputs *ALBInputs) (*ALBOutputs, error) {
 					StatusCode: pulumi.String("HTTP_301"),
 				},
 			},
-		},
-
-		Tags: pulumi.StringMap{
-			"Project":     pulumi.String("kaizen-experimentation"),
-			"Environment": pulumi.String(inputs.Environment),
-		},
+		}
+	}
+	httpListener, err := lb.NewListener(ctx, fmt.Sprintf("%s-http", namePrefix), &lb.ListenerArgs{
+		LoadBalancerArn: alb.Arn,
+		Port:            pulumi.Int(80),
+		Protocol:        pulumi.String("HTTP"),
+		DefaultActions:  httpDefault,
+		Tags:            listenerTags,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating HTTP listener: %w", err)
+	}
+
+	rulesListenerArn := httpListener.Arn
+	if inputs.TlsEnabled {
+		rulesListenerArn = httpsListener.Arn
 	}
 
 	return &ALBOutputs{
@@ -156,7 +173,7 @@ func NewALB(ctx *pulumi.Context, inputs *ALBInputs) (*ALBOutputs, error) {
 		AlbArn:           alb.Arn,
 		AlbDnsName:       alb.DnsName,
 		AlbZoneId:        alb.ZoneId,
-		HttpsListenerArn: httpsListener.Arn,
+		HttpsListenerArn: rulesListenerArn,
 		HttpListenerArn:  httpListener.Arn,
 		AlbArnSuffix:     alb.ArnSuffix,
 	}, nil

--- a/infra/pkg/aws/loadbalancer/target_groups.go
+++ b/infra/pkg/aws/loadbalancer/target_groups.go
@@ -29,6 +29,12 @@ type TargetGroupInputs struct {
 	Domain string
 	// Environment name used for resource naming and tagging.
 	Environment string
+	// TlsEnabled mirrors the ALB mode. ALB rejects GRPC/HTTP2
+	// protocol-version target groups behind a plaintext listener
+	// ("InvalidLoadBalancerAction: Listener protocol 'HTTP' is not
+	// supported…"), so when false the gRPC rules (M1, M7) are skipped and
+	// M5 falls back to HTTP/1.1 (ConnectRPC unary + /healthz both work).
+	TlsEnabled bool
 }
 
 // TargetGroupOutputs are exported for ECS service registration and monitoring.
@@ -45,6 +51,11 @@ type TargetGroupOutputs struct {
 	M1AssignmentTgArnSuffix pulumi.StringOutput
 	// M7FlagsTgArnSuffix is the target group ARN suffix for ALBRequestCountPerTarget.
 	M7FlagsTgArnSuffix pulumi.StringOutput
+	// Rules are the listener-rule resources. ECS services referencing the
+	// target groups must depend on these: a target group is only
+	// "attached to a load balancer" (an ECS create/update precondition)
+	// once a rule forwards to it.
+	Rules []pulumi.Resource
 }
 
 // targetGroupSpec defines a service target group configuration.
@@ -67,6 +78,11 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 		"Module":      pulumi.String("loadbalancer"),
 	}
 
+	m5ProtocolVersion := "HTTP2"
+	if !inputs.TlsEnabled {
+		m5ProtocolVersion = "HTTP1" // HTTP2 TGs are invalid behind the plaintext :80 rules listener
+	}
+
 	specs := []targetGroupSpec{
 		{
 			name:               "m1-assignment",
@@ -78,7 +94,7 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 		{
 			name:               "m5-management",
 			port:               50055,
-			protocolVersion:    "HTTP2",
+			protocolVersion:    m5ProtocolVersion,
 			healthCheckPath:    "/healthz",
 			healthCheckMatcher: "200",
 		},
@@ -120,15 +136,17 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 	assignHost := fmt.Sprintf("assign.kaizen.%s", inputs.Domain)
 
 	rules := []struct {
-		name     string
-		priority int
-		target   string
-		conditions func() lb.ListenerRuleConditionArray
+		name        string
+		priority    int
+		target      string
+		requiresTls bool // gRPC target groups only route behind an HTTPS listener
+		conditions  func() lb.ListenerRuleConditionArray
 	}{
 		{
-			name:     "m1-host",
-			priority: 10,
-			target:   "m1-assignment",
+			name:        "m1-host",
+			priority:    10,
+			target:      "m1-assignment",
+			requiresTls: true,
 			conditions: func() lb.ListenerRuleConditionArray {
 				return lb.ListenerRuleConditionArray{
 					&lb.ListenerRuleConditionArgs{
@@ -154,9 +172,10 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 			},
 		},
 		{
-			name:     "m7-flags",
-			priority: 30,
-			target:   "m7-flags",
+			name:        "m7-flags",
+			priority:    30,
+			target:      "m7-flags",
+			requiresTls: true,
 			conditions: func() lb.ListenerRuleConditionArray {
 				return lb.ListenerRuleConditionArray{
 					&lb.ListenerRuleConditionArgs{
@@ -183,8 +202,12 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 		},
 	}
 
+	var ruleResources []pulumi.Resource
 	for _, rule := range rules {
-		_, err := lb.NewListenerRule(ctx, fmt.Sprintf("%s-rule-%s", prefix, rule.name), &lb.ListenerRuleArgs{
+		if rule.requiresTls && !inputs.TlsEnabled {
+			continue
+		}
+		lr, err := lb.NewListenerRule(ctx, fmt.Sprintf("%s-rule-%s", prefix, rule.name), &lb.ListenerRuleArgs{
 			ListenerArn: inputs.HttpsListenerArn,
 			Priority:    pulumi.Int(rule.priority),
 			Actions: lb.ListenerRuleActionArray{
@@ -199,9 +222,11 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 		if err != nil {
 			return nil, fmt.Errorf("creating listener rule %q: %w", rule.name, err)
 		}
+		ruleResources = append(ruleResources, lr)
 	}
 
 	return &TargetGroupOutputs{
+		Rules:                   ruleResources,
 		M1AssignmentTgArn:       tgArns["m1-assignment"],
 		M5ManagementTgArn:       tgArns["m5-management"],
 		M6UITgArn:               tgArns["m6-ui"],
@@ -250,7 +275,10 @@ func newTargetGroup(
 		},
 
 		Tags: tags,
-	})
+		// Explicit Name + ForceNew fields (e.g. protocolVersion flipping with
+		// TlsEnabled) would otherwise collide: create-replacement-first hits
+		// "duplicate target group name".
+	}, pulumi.DeleteBeforeReplace(true))
 	if err != nil {
 		return nil, fmt.Errorf("creating target group %q: %w", spec.name, err)
 	}

--- a/infra/pkg/config/config.go
+++ b/infra/pkg/config/config.go
@@ -48,6 +48,15 @@ type Config struct {
 	// Defaults false.
 	MskAllowPlaintext bool
 
+	// TlsEnabled gates the ACM validation waiter and the HTTPS listener.
+	// Until the public NS delegation for the hosted zone exists, cert
+	// validation can never complete and everything chained on it (HTTPS
+	// listener → listener rules → target-group attachment → LB-facing
+	// services) deadlocks. With TlsEnabled=false the HTTP :80 listener
+	// carries the routing rules directly and the waiter is skipped; flip
+	// to true once DNS is delegated. Defaults true.
+	TlsEnabled bool
+
 	// Cache
 	RedisNodeType string
 
@@ -216,6 +225,13 @@ func LoadConfig(ctx *pulumi.Context) *Config {
 			// Same failure mode as a missing Require key: refuse to build
 			// a prod plan with the dev-only plaintext listener enabled.
 			panic("mskAllowPlaintext=true is dev-only: prod keeps TLS+SASL — remove the config key from the prod stack")
+		}
+		out.TlsEnabled = true
+		if v, err := cfg.TryBool("tlsEnabled"); err == nil {
+			out.TlsEnabled = v
+		}
+		if !out.TlsEnabled && out.IsProd() {
+			panic("tlsEnabled=false is dev-only: prod always terminates TLS — remove the config key from the prod stack")
 		}
 		out.FargateMinTasks = cfg.RequireInt("fargateMinTasks")
 		out.CloudwatchRetention = cfg.RequireInt("cloudwatchRetentionDays")

--- a/infra/test/edge_test.go
+++ b/infra/test/edge_test.go
@@ -30,6 +30,7 @@ func TestAlbCreated(t *testing.T) {
 			CertificateArn:  pulumi.String("arn:aws:acm:us-east-1:123456789:certificate/abc").ToStringOutput(),
 			LogsBucketName:  pulumi.String("kaizen-dev-logs").ToStringOutput(),
 			Environment:     "dev",
+			TlsEnabled:      true,
 		})
 		return err
 	}, pulumi.WithMocks("kaizen", "dev", mocks))
@@ -63,6 +64,7 @@ func TestAlbHttpsListener(t *testing.T) {
 			CertificateArn:  pulumi.String("arn:aws:acm:us-east-1:123456789:certificate/abc").ToStringOutput(),
 			LogsBucketName:  pulumi.String("kaizen-dev-logs").ToStringOutput(),
 			Environment:     "dev",
+			TlsEnabled:      true,
 		})
 		return err
 	}, pulumi.WithMocks("kaizen", "dev", mocks))
@@ -99,6 +101,7 @@ func TestAlbHttpRedirectListener(t *testing.T) {
 			CertificateArn:  pulumi.String("arn:aws:acm:us-east-1:123456789:certificate/abc").ToStringOutput(),
 			LogsBucketName:  pulumi.String("kaizen-dev-logs").ToStringOutput(),
 			Environment:     "dev",
+			TlsEnabled:      true,
 		})
 		return err
 	}, pulumi.WithMocks("kaizen", "dev", mocks))


### PR DESCRIPTION
## Why

Until the public NS delegation for `kaizen.wkv.ai` exists (GoDaddy records pending), ACM validation can never complete. Everything chained on it deadlocks: HTTPS listener → listener rules → target-group attachment → LB-facing services → M1/M7 ALB scaling policies. Runs 14–16 of the live dev deploy all died on links of this chain.

## What

New dev-only `tlsEnabled=false` config (panics on prod), gating each link:

- **dns.go** — skip the cert-validation waiter; the validation Route53 record stays, so ACM completes on its own the moment delegation lands.
- **alb.go** — HTTPS listener conditional; HTTP :80 carries the routing rules (shared 503 not-routed default). `HttpsListenerArn` output documented as "rules listener" for schema stability.
- **target_groups.go** — ALB rejects GRPC/HTTP2 protocol-version TGs behind a plaintext listener (`InvalidLoadBalancerAction`, run 16). M1/M7 rules are TLS-only; M5 falls back to HTTP/1.1 (ConnectRPC unary + `/healthz` both work over HTTP/1.1). Delete-before-replace on TGs: explicit names collide on protocol-version replaces.
- **services.go / main.go** — LB-facing services attach their TGs (`LoadBalancers` + health-check grace period), ordered after listener rules via `LbRuleDeps`; edge creation moves to Stage 5a (before compute) because ECS validates TG↔LB association at service create/update.
- **autoscaling.go** — M1/M7 fall back to CPU tracking when unattached (`PutScalingPolicy` rejects `ALBRequestCountPerTarget` on an unattached TG — the run-15 failure).
- **services.go tier gate** — M4b removed from tier-1 health deps: nothing registers `m4b-policy.kaizen.local` yet (no ECS service exists, #749), so the gate deadlocked all of tier 2 (M3/M4a/M6).
- **Pulumi.dev.yaml** — pinned at live steady state (encrypted SASL secret, `mskAllowPlaintext`, `tlsEnabled: false`).

## Validation

- `go build ./... && go vet ./... && go test ./test/ ./pkg/...` green on this branch.
- **Live**: `pulumi up` exits 0 against stack `wkv/dev` (update #38, run 17); M5 + M6 serving through the ALB on :80 with healthy targets; M1/M7 CPU-tracking policies created cleanly.
- Flip-back path: setting `tlsEnabled: true` restores the HTTPS listener, gRPC rules, M1/M7 attachment, and ALB-request-count scaling (TG protocol-version replaces are delete-before-replace).

Size note: 11 files / ~325 lines — one interlocking change set validated live as a unit; slicing would leave main in a state that cannot `pulumi up` cleanly.

Refs #735, #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->