### PR TITLE
fix(metrics): bake dev seed config into the M3 image

### DIFF
--- a/services/metrics/Dockerfile
+++ b/services/metrics/Dockerfile
@@ -7,5 +7,9 @@ RUN CGO_ENABLED=0 go build -o /app ./metrics/cmd/
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /app /app
+# cmd/main.go falls back to a source-tree relative path when CONFIG_PATH is
+# unset — that path doesn't exist in the image, so bake the dev seed in.
+COPY services/metrics/internal/config/testdata/seed_config.json /seed_config.json
+ENV CONFIG_PATH=/seed_config.json
 EXPOSE 50056
 CMD ["/app"]


### PR DESCRIPTION
M3's `cmd/main.go` falls back to `internal/config/testdata/seed_config.json` when `CONFIG_PATH` is unset — a source-tree relative path that doesn't exist in the distroless image, so every ECS task exited 1 before its first log line (the error only surfaced once the tier-1 health gate opened and M3 started launching for real).

Bake the seed file into the image and set `ENV CONFIG_PATH=/seed_config.json`, mirroring the M1 assignment fix (`crates/experimentation-assignment/Dockerfile`).

Validated live: a hand-built image with exactly this layout was pushed to `kaizen-metrics:latest`; this PR makes CI produce the same shape.

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->