### PR TITLE
fix(flags): add C++ toolchain to the M7 image builder stage

### DIFF
--- a/crates/experimentation-flags/Dockerfile
+++ b/crates/experimentation-flags/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY proto/ proto/
-RUN apt-get update && apt-get install -y protobuf-compiler cmake
+RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev libcurl4-openssl-dev pkg-config
 RUN cargo build --release --package experimentation-flags
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
The M7 flags image has never built in CI: `rdkafka-sys` compiles vendored librdkafka via CMake, which requires a C++ compiler, and `rust:1.88-slim` ships none —

```
CMake Error at CMakeLists.txt:6 (project):
  The CMAKE_CXX_COMPILER:  c++  is not a full path and was not found in the PATH.
```

so `kaizen-flags` never reached ECR and `kaizen-dev-m7-flags` sits in `CannotPullContainerError`.

Fix: align the builder-stage apt list with `crates/experimentation-pipeline/Dockerfile`, which builds the identical rdkafka stack green in the same matrix (`g++ libssl-dev libcurl4-openssl-dev pkg-config` added).

After merge, a `ci.yml` dispatch on main publishes the first `kaizen-flags:latest`, then m7 gets a force-new-deployment.

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->