### PR TITLE
fix(infra): declare container health checks only where images can run them

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -19,4 +19,4 @@ config:
   kaizen-experimentation:grafanaEnabled: "false"
   kaizen-experimentation:manageKafkaTopics: "false"
   kaizen-experimentation:mskAllowPlaintext: "true"
-  kaizen-experimentation:tlsEnabled: "false"
+  kaizen-experimentation:tlsEnabled: "true"

--- a/infra/pkg/aws/compute/services.go
+++ b/infra/pkg/aws/compute/services.go
@@ -156,7 +156,6 @@ func serviceSpecs() []serviceSpec {
 			key: "m1", name: "m1-assignment", ecrKey: "assignment",
 			cpu: "512", memoryMB: "1024", ports: []int{50051},
 			lang:      "rust",
-			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50051"},
 			tier:      TierCore,
 			deps:      []healthDep{m5Dep},
 		},
@@ -164,7 +163,6 @@ func serviceSpecs() []serviceSpec {
 			key: "m2", name: "m2-pipeline", ecrKey: "pipeline",
 			cpu: "512", memoryMB: "1024", ports: []int{50052},
 			lang:      "rust",
-			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50052"},
 			tier:      TierCore,
 			deps:      []healthDep{m5Dep},
 		},
@@ -172,7 +170,6 @@ func serviceSpecs() []serviceSpec {
 			key: "m2-orch", name: "m2-orchestration", ecrKey: "orchestration",
 			cpu: "256", memoryMB: "512", ports: []int{50058},
 			lang:      "go",
-			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:50058/healthz || exit 1"},
 			tier:      TierCore,
 			deps:      []healthDep{m5Dep},
 		},
@@ -181,7 +178,6 @@ func serviceSpecs() []serviceSpec {
 			key: "m3", name: "m3-metrics", ecrKey: "metrics",
 			cpu: "1024", memoryMB: "2048", ports: []int{50056, 50059},
 			lang:      "go",
-			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:50056/healthz || exit 1"},
 			tier:      TierDependent,
 			deps:      tier1Deps,
 		},
@@ -189,7 +185,6 @@ func serviceSpecs() []serviceSpec {
 			key: "m4a", name: "m4a-analysis", ecrKey: "analysis",
 			cpu: "1024", memoryMB: "2048", ports: []int{50053},
 			lang:      "rust",
-			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50053"},
 			tier:      TierDependent,
 			deps:      tier1Deps,
 		},
@@ -205,7 +200,6 @@ func serviceSpecs() []serviceSpec {
 			key: "m7", name: "m7-flags", ecrKey: "flags",
 			cpu: "256", memoryMB: "512", ports: []int{50057},
 			lang:      "rust",
-			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50057"},
 			tier:      TierDependent,
 			deps:      tier1Deps,
 		},
@@ -774,13 +768,21 @@ func buildContainerDefsJSON(
 			LogConfiguration: logConfig,
 			Environment:      envVars,
 			Secrets:          secrets,
-			HealthCheck: &healthCheck{
+		}
+		// Container health checks only where the runtime image can execute
+		// them (m5 alpine + m6 node:alpine have busybox wget). Distroless
+		// and debian-slim images ship neither a shell nor grpc_health_probe,
+		// so a declared check would fail every probe and the deployment
+		// circuit breaker would kill otherwise-healthy rollouts. Liveness
+		// for the rest rides on ALB target health + health-gate sidecars.
+		if len(spec.healthCmd) > 0 {
+			mainDef.HealthCheck = &healthCheck{
 				Command:     spec.healthCmd,
 				Interval:    30,
 				Timeout:     5,
 				Retries:     3,
 				StartPeriod: 60,
-			},
+			}
 		}
 
 		// Chain main container to health-gate via container-level dependsOn.

--- a/infra/pkg/aws/compute/services_test.go
+++ b/infra/pkg/aws/compute/services_test.go
@@ -310,8 +310,17 @@ func TestAllSpecsHaveRequiredFields(t *testing.T) {
 		if s.lang == "" {
 			t.Errorf("spec %q has empty lang", s.key)
 		}
-		if len(s.healthCmd) == 0 {
-			t.Errorf("spec %q has no healthCmd", s.key)
+		// Container health checks exist only where the runtime image can
+		// execute them: m5 (alpine) and m6 (node:alpine) carry busybox
+		// wget. Distroless/debian-slim images have no shell and no
+		// grpc_health_probe, so a declared check would fail every probe
+		// and the circuit breaker would kill healthy rollouts.
+		canProbe := map[string]bool{"m5": true, "m6": true}
+		if canProbe[s.key] && len(s.healthCmd) == 0 {
+			t.Errorf("spec %q should declare a healthCmd (image has wget)", s.key)
+		}
+		if !canProbe[s.key] && len(s.healthCmd) != 0 {
+			t.Errorf("spec %q declares healthCmd its image cannot run", s.key)
 		}
 	}
 }

--- a/infra/pkg/aws/loadbalancer/target_groups.go
+++ b/infra/pkg/aws/loadbalancer/target_groups.go
@@ -85,11 +85,16 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 
 	specs := []targetGroupSpec{
 		{
-			name:               "m1-assignment",
-			port:               50051,
-			protocolVersion:    "GRPC",
-			healthCheckPath:    "/grpc.health.v1.Health/Check",
-			healthCheckMatcher: "0",  // gRPC OK
+			name:            "m1-assignment",
+			port:            50051,
+			protocolVersion: "GRPC",
+			healthCheckPath: "/grpc.health.v1.Health/Check",
+			// M1/M7 don't register grpc.health.v1 (no tonic-health), so a
+			// strict "0" matcher would mark every target unhealthy
+			// (UNIMPLEMENTED=12) and the LB-integrated scheduler would kill
+			// the tasks. Any gRPC status proves the server answers HTTP/2;
+			// tighten back to "0" when tonic-health ships.
+			healthCheckMatcher: "0-99",
 		},
 		{
 			name:               "m5-management",
@@ -106,11 +111,12 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 			healthCheckMatcher: "200",
 		},
 		{
-			name:               "m7-flags",
-			port:               50057,
-			protocolVersion:    "GRPC",
-			healthCheckPath:    "/grpc.health.v1.Health/Check",
-			healthCheckMatcher: "0",
+			name:            "m7-flags",
+			port:            50057,
+			protocolVersion: "GRPC",
+			healthCheckPath: "/grpc.health.v1.Health/Check",
+			// See m1-assignment: no grpc.health.v1 service registered yet.
+			healthCheckMatcher: "0-99",
 		},
 	}
 

--- a/infra/test/compute_test.go
+++ b/infra/test/compute_test.go
@@ -101,7 +101,7 @@ func TestGRPCHealthChecksForRustServices(t *testing.T) {
 	}
 
 	for _, spec := range fargateSpecs {
-		expectedPort, isRust := rustServices[spec.Key]
+		_, isRust := rustServices[spec.Key]
 		if !isRust {
 			continue
 		}
@@ -111,20 +111,15 @@ func TestGRPCHealthChecksForRustServices(t *testing.T) {
 				t.Errorf("service %s: lang = %q, want \"rust\"", spec.Key, spec.Lang)
 			}
 
-			healthCmd := spec.HealthCmd
-			if len(healthCmd) < 2 {
-				t.Fatalf("service %s: health check command too short: %v", spec.Key, healthCmd)
-			}
-
-			// Rust services use CMD (exec form) with grpc_health_probe.
-			if healthCmd[0] != "CMD" {
-				t.Errorf("service %s: health check type = %q, want \"CMD\" (exec form for gRPC probe)", spec.Key, healthCmd[0])
-			}
-
-			expectedProbe := fmt.Sprintf("/bin/grpc_health_probe -addr=:%d", expectedPort)
-			actualCmd := strings.Join(healthCmd[1:], " ")
-			if actualCmd != expectedProbe {
-				t.Errorf("service %s: health check = %q, want %q", spec.Key, actualCmd, expectedProbe)
+			// Rust images (debian-slim/distroless) bundle no
+			// grpc_health_probe and the services don't register
+			// grpc.health.v1 (no tonic-health), so a container health
+			// check could never pass: every declared probe fails and the
+			// deployment circuit breaker kills healthy rollouts. Liveness
+			// rides on ALB target health (matcher 0-99) + health-gate
+			// sidecars until tonic-health + probe bundling ship.
+			if len(spec.HealthCmd) != 0 {
+				t.Errorf("service %s: declares container healthCmd %v its image cannot run", spec.Key, spec.HealthCmd)
 			}
 		})
 	}
@@ -137,14 +132,19 @@ func TestGRPCHealthChecksForRustServices(t *testing.T) {
 func TestHealthzForGoServices(t *testing.T) {
 	fargateSpecs := compute.ServiceSpecs()
 
-	goServices := map[string]int{
-		"m2-orch": 50058,
-		"m3":      50056,
-		"m5":      50055,
+	// Only m5 runs on a base image with busybox wget (alpine); the other
+	// Go services run distroless-static and cannot execute CMD-SHELL.
+	goServices := map[string]struct {
+		port    int
+		hasWget bool
+	}{
+		"m2-orch": {50058, false},
+		"m3":      {50056, false},
+		"m5":      {50055, true},
 	}
 
 	for _, spec := range fargateSpecs {
-		expectedPort, isGo := goServices[spec.Key]
+		cfg, isGo := goServices[spec.Key]
 		if !isGo {
 			continue
 		}
@@ -154,17 +154,23 @@ func TestHealthzForGoServices(t *testing.T) {
 				t.Errorf("service %s: lang = %q, want \"go\"", spec.Key, spec.Lang)
 			}
 
+			if !cfg.hasWget {
+				if len(spec.HealthCmd) != 0 {
+					t.Errorf("service %s: declares container healthCmd %v but its distroless image has no shell", spec.Key, spec.HealthCmd)
+				}
+				return
+			}
+
 			healthCmd := spec.HealthCmd
 			if len(healthCmd) < 2 {
 				t.Fatalf("service %s: health check command too short: %v", spec.Key, healthCmd)
 			}
 
-			// Go services use CMD-SHELL with wget --spider.
 			if healthCmd[0] != "CMD-SHELL" {
 				t.Errorf("service %s: health check type = %q, want \"CMD-SHELL\"", spec.Key, healthCmd[0])
 			}
 
-			expectedCheck := fmt.Sprintf("wget --spider -q http://localhost:%d/healthz || exit 1", expectedPort)
+			expectedCheck := fmt.Sprintf("wget --spider -q http://localhost:%d/healthz || exit 1", cfg.port)
 			if healthCmd[1] != expectedCheck {
 				t.Errorf("service %s: health check = %q, want %q", spec.Key, healthCmd[1], expectedCheck)
 			}
@@ -305,9 +311,11 @@ func TestHealthCheckTimingConstants(t *testing.T) {
 
 	for _, spec := range fargateSpecs {
 		t.Run(spec.Name, func(t *testing.T) {
-			// All health checks must have non-empty commands.
+			// Container health checks are declared only where the runtime
+			// image can execute them (see TestGRPCHealthChecksForRustServices
+			// and TestHealthzForGoServices); specs without one are valid.
 			if len(spec.HealthCmd) == 0 {
-				t.Error("health check command is empty")
+				return
 			}
 
 			// Verify the command format is either CMD (exec) or CMD-SHELL.


### PR DESCRIPTION
## Why

Every redeploy of m1 / m2-pipeline / m2-orchestration / m3 / m4a / m7 tripped the deployment circuit breaker with `failed container health checks` while old tasks kept serving — surfaced tonight because the first live deploy exercised task-definition replacements fleet-wide.

Root cause, per image:
- **Rust services** declare `["CMD", "/bin/grpc_health_probe", ...]` — no image bundles the probe binary, and M1/M7 don't register `grpc.health.v1` (no tonic-health), so the check is doubly impossible.
- **m2-orch / m3** run `gcr.io/distroless/static` — no shell, so `CMD-SHELL wget ...` can never execute.
- **m5 (alpine) and m6 (node:alpine)** carry busybox wget — exactly the two services whose rollouts kept completing.

## What

- `services.go`: `healthCmd` kept only for m5/m6; the container `HealthCheck` block is emitted only when a spec declares a command. Liveness for the rest rides on ALB target health + health-gate sidecars + Cloud Map (the platform's actual health model).
- `target_groups.go`: M1/M7 ALB gRPC health-check matcher widened to `0-99` — without `grpc.health.v1`, a strict `"0"` marks every target unhealthy (UNIMPLEMENTED=12) and the LB-integrated scheduler kills the tasks. Comment marks the tighten-back condition.
- Tests rewritten to enforce the image-capability contract (`canProbe` whitelist) instead of the old always-probe assumption.
- `Pulumi.dev.yaml`: `tlsEnabled: true` — NS delegation is live, the ACM cert is ISSUED, and runs 18/19 applied the HTTPS edge.

## Validation

- `go build && go vet && go test ./test/ ./pkg/...` green on this branch.
- Live: after this change m1/m2-pipeline/m2-orchestration rolled out **COMPLETED** for the first time since the td replacements; m1 registers **healthy** behind the ALB gRPC target group on :443; `https://kaizen.wkv.ai` terminates TLS with the ACM cert.

## Follow-up (separate issue)

Register `grpc.health.v1` via tonic-health in M1/M7, bundle `grpc_health_probe` (or move runtimes to a busybox-capable base), then restore strict matchers and container checks.

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->