### PR TITLE
fix(infra): m6 UI deployability + API routing — probe IPv4, HOSTNAME bind, ALB rule

### DIFF
--- a/infra/pkg/aws/compute/services.go
+++ b/infra/pkg/aws/compute/services.go
@@ -147,7 +147,10 @@ func serviceSpecs() []serviceSpec {
 			key: "m5", name: "m5-management", ecrKey: "management",
 			cpu: "512", memoryMB: "1024", ports: []int{50055, 50060},
 			lang:      "go",
-			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:50055/healthz || exit 1"},
+			// 127.0.0.1, not localhost: alpine resolves localhost to ::1
+			// first and busybox wget tries only that one address, so an
+			// IPv4-only listener would fail every probe.
+			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://127.0.0.1:50055/healthz || exit 1"},
 			tier:      TierFoundation,
 			deps:      nil, // No upstream dependencies.
 		},
@@ -192,7 +195,10 @@ func serviceSpecs() []serviceSpec {
 			key: "m6", name: "m6-ui", ecrKey: "ui",
 			cpu: "512", memoryMB: "1024", ports: []int{3000},
 			lang:      "ts",
-			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://localhost:3000/ || exit 1"},
+			// 127.0.0.1 required: Next.js standalone binds 0.0.0.0 (IPv4
+			// only), and busybox wget picks alpine's ::1 for localhost —
+			// the probe never passed and every rollout circuit-broke.
+			healthCmd: []string{"CMD-SHELL", "wget --spider -q http://127.0.0.1:3000/ || exit 1"},
 			tier:      TierDependent,
 			deps:      tier1Deps,
 		},

--- a/infra/test/compute_test.go
+++ b/infra/test/compute_test.go
@@ -170,7 +170,7 @@ func TestHealthzForGoServices(t *testing.T) {
 				t.Errorf("service %s: health check type = %q, want \"CMD-SHELL\"", spec.Key, healthCmd[0])
 			}
 
-			expectedCheck := fmt.Sprintf("wget --spider -q http://localhost:%d/healthz || exit 1", cfg.port)
+			expectedCheck := fmt.Sprintf("wget --spider -q http://127.0.0.1:%d/healthz || exit 1", cfg.port)
 			if healthCmd[1] != expectedCheck {
 				t.Errorf("service %s: health check = %q, want %q", spec.Key, healthCmd[1], expectedCheck)
 			}
@@ -209,7 +209,7 @@ func TestM6UIHealthCheck(t *testing.T) {
 			t.Errorf("M6 UI: health check type = %q, want \"CMD-SHELL\"", healthCmd[0])
 		}
 
-		expectedCheck := "wget --spider -q http://localhost:3000/ || exit 1"
+		expectedCheck := "wget --spider -q http://127.0.0.1:3000/ || exit 1"
 		if healthCmd[1] != expectedCheck {
 			t.Errorf("M6 UI: health check = %q, want %q", healthCmd[1], expectedCheck)
 		}


### PR DESCRIPTION
## Problems (all found on the live dev stack, #735)

1. **Container probes used `localhost`** — alpine resolves it to `::1` first and busybox wget tries only that one address.
2. **m6 still failed on `127.0.0.1`**: Next.js standalone binds to `$HOSTNAME`, which Docker sets to the container hostname → the server listened on the ENI address only. Every m6 rollout circuit-broke ("failed container health checks") while the ALB target check — which probes the task IP — stayed healthy. FAILED-latched deployments with a lone UNHEALTHY-but-serving task, every deploy.
3. **The ALB `/api/*` → M5 rule black-holed the UI's API calls.** The browser calls same-origin `/api/rpc/<module>/…`; M5 serves bare `/experimentation.<pkg>.<Service>/<Method>` ConnectRPC paths, so every page 404ed (the user-visible symptom: `RPC ListExperiments failed: 404` etc.).

## Fixes

- Probe `127.0.0.1` instead of `localhost` (m5, m6).
- `HOSTNAME=0.0.0.0` env on the m6 container (+ comment).
- Repoint the priority-20 rule from `/api/*` to `/experimentation.*`: keeps the M5 target group ALB-attached (ECS precondition) and gives grpcurl/SDKs direct Connect access to M5; `/api/rpc/*` now falls through the catch-all to the M6 BFF (companion ui PR #757).
- `BACKEND_ASSIGNMENT_URL` added to m6 env.

## Live verification

- Run 20 (probe fix alone): m6 still failed → confirmed the HOSTNAME diagnosis.
- Run 21 (HOSTNAME + rule): **m6 rollout COMPLETED on td :5, 0 failed tasks — fleet 9/9 COMPLETED**, listener rule updated in place.

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)