### PR TITLE
fix(ui): runtime BFF proxy for /api/rpc — standalone freezes rewrites at build

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,35 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
-  async rewrites() {
-    const mgmtUrl = process.env.BACKEND_MANAGEMENT_URL || 'http://localhost:50055';
-    const metricsUrl = process.env.BACKEND_METRICS_URL || 'http://localhost:50056';
-    const analysisUrl = process.env.BACKEND_ANALYSIS_URL || 'http://localhost:50053';
-    const banditUrl = process.env.BACKEND_BANDIT_URL || 'http://localhost:50054';
-    const flagsUrl = process.env.BACKEND_FLAGS_URL || 'http://localhost:50057';
-
-    return [
-      {
-        source: '/api/rpc/management/:path*',
-        destination: `${mgmtUrl}/:path*`,
-      },
-      {
-        source: '/api/rpc/metrics/:path*',
-        destination: `${metricsUrl}/:path*`,
-      },
-      {
-        source: '/api/rpc/analysis/:path*',
-        destination: `${analysisUrl}/:path*`,
-      },
-      {
-        source: '/api/rpc/bandit/:path*',
-        destination: `${banditUrl}/:path*`,
-      },
-      {
-        source: '/api/rpc/flags/:path*',
-        destination: `${flagsUrl}/:path*`,
-      },
-    ];
-  },
+  // NOTE: no rewrites() here. With standalone output, rewrites() runs at
+  // BUILD time and its env-var destinations get frozen into the routes
+  // manifest — deployed containers would proxy /api/rpc/* to the build
+  // machine's localhost regardless of runtime BACKEND_*_URL values.
+  // src/app/api/rpc/[module]/[...rpc]/route.ts handles these paths at
+  // runtime instead.
 };
 module.exports = nextConfig;

--- a/ui/src/app/api/rpc/[module]/[...rpc]/route.ts
+++ b/ui/src/app/api/rpc/[module]/[...rpc]/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Runtime BFF proxy: /api/rpc/<module>/<pkg.Service>/<Method> → backend.
+//
+// This replaces the next.config.js rewrites() that previously served these
+// paths. With `output: 'standalone'`, rewrites are resolved at BUILD time
+// and frozen into the routes manifest — the BACKEND_*_URL values present in
+// the deployed container were never read, so every destination pointed at
+// the build machine's localhost. A route handler reads process.env on each
+// request, so one image works in every environment.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// Same defaults the deleted rewrites used, so `next dev` against locally
+// running services keeps working without any env setup.
+const DEV_DEFAULTS: Record<string, string> = {
+  management: 'http://localhost:50055',
+  metrics: 'http://localhost:50056',
+  analysis: 'http://localhost:50053',
+  bandit: 'http://localhost:50054',
+  flags: 'http://localhost:50057',
+  assignment: 'http://localhost:50051',
+};
+
+function backendFor(module: string): string | undefined {
+  const fromEnv = process.env[`BACKEND_${module.toUpperCase()}_URL`];
+  return fromEnv || DEV_DEFAULTS[module];
+}
+
+// Hop-by-hop headers (RFC 9110 §7.6.1) plus fields the proxy must own.
+const STRIP_REQUEST_HEADERS = new Set([
+  'host',
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'upgrade',
+  'te',
+  'trailer',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'content-length',
+  'accept-encoding',
+]);
+
+const STRIP_RESPONSE_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'content-encoding',
+  'content-length',
+]);
+
+interface RouteParams {
+  params: { module: string; rpc: string[] };
+}
+
+async function proxy(req: NextRequest, { params }: RouteParams): Promise<NextResponse> {
+  const base = backendFor(params.module);
+  if (!base) {
+    return NextResponse.json(
+      { code: 'unimplemented', message: `no backend configured for module "${params.module}"` },
+      { status: 502 },
+    );
+  }
+
+  const target = `${base.replace(/\/+$/, '')}/${params.rpc.map(encodeURIComponent).join('/')}${req.nextUrl.search}`;
+
+  const headers = new Headers();
+  req.headers.forEach((value, key) => {
+    if (!STRIP_REQUEST_HEADERS.has(key.toLowerCase())) headers.set(key, value);
+  });
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: req.method,
+      headers,
+      // All UI RPCs are unary; buffering keeps us off duplex-stream quirks.
+      body: req.method === 'GET' || req.method === 'HEAD' ? undefined : await req.arrayBuffer(),
+      cache: 'no-store',
+      redirect: 'manual',
+    });
+  } catch {
+    return NextResponse.json(
+      { code: 'unavailable', message: `backend for "${params.module}" unreachable` },
+      { status: 502 },
+    );
+  }
+
+  const responseHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    if (!STRIP_RESPONSE_HEADERS.has(key.toLowerCase())) responseHeaders.set(key, value);
+  });
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}
+
+export { proxy as GET, proxy as POST };


### PR DESCRIPTION
## Problem

Every page on the deployed dev UI (https://kaizen.wkv.ai) failed with `RPC <Method> failed: 404`.

Two stacked causes:
1. The browser bundle was built without `NEXT_PUBLIC_*_URL`, so the client correctly falls back to same-origin `/api/rpc/<module>/...` paths — which are supposed to be proxied by the Next server.
2. But with `output: 'standalone'`, **`rewrites()` is evaluated at build time** and its resolved destinations are frozen into `routes-manifest.json`. CI builds without `BACKEND_*_URL`, so every destination was baked as `http://localhost:5005x` — the runtime env vars the infra sets on the task were never read. (The ALB's old `/api/*` → M5 rule masked this as a 404 from M5; infra companion PR #756 repoints that rule.)

## Fix

- Delete `rewrites()` from `next.config.js`.
- Add `src/app/api/rpc/[module]/[...rpc]/route.ts`: a runtime BFF proxy that resolves `BACKEND_<MODULE>_URL` per request (falling back to the same localhost defaults, so `next dev` DX is unchanged), forwards method/headers/body minus hop-by-hop headers, and returns Connect-style JSON errors (`502 unavailable` / `unimplemented`) when a backend is unreachable or unmapped.

## Verification (built standalone server)

| Probe | Result |
| --- | --- |
| POST `/api/rpc/metrics/experimentation.metrics.v1.MetricComputationService/ListMetrics` with echo backend | 200; upstream saw bare `/experimentation.metrics.v1...` path, body, and `X-User-Email` header |
| POST with backend down | `502 {"code":"unavailable",...}` |
| POST unknown module | `502 {"code":"unimplemented",...}` |

Note: tonic-only backends (flags/analysis/bandit/assignment) still need a Connect bridge to serve browser JSON — tracked separately; this PR restores the ConnectRPC-speaking pages (management: experiments, metric definitions, audit log, monitoring, portfolio; metrics: M3).

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->