### PR TITLE
fix(infra): gRPC rules on bare ConnectRPC paths; restore m6 env dropped by automerge race

### DIFF
--- a/infra/pkg/aws/compute/services.go
+++ b/infra/pkg/aws/compute/services.go
@@ -711,6 +711,13 @@ func buildContainerDefsJSON(
 				envKV{Name: "BACKEND_METRICS_URL", Value: "http://m3-metrics.kaizen.local:50056"},
 				envKV{Name: "BACKEND_BANDIT_URL", Value: "http://m4b-policy.kaizen.local:50054"},
 				envKV{Name: "BACKEND_FLAGS_URL", Value: "http://m7-flags.kaizen.local:50057"},
+				envKV{Name: "BACKEND_ASSIGNMENT_URL", Value: "http://m1-assignment.kaizen.local:50051"},
+				// Next.js standalone binds to $HOSTNAME when set, and Docker
+				// injects the container hostname — leaving the server
+				// listening on the ENI address only. Loopback probes
+				// (container health check) then fail even though the ALB
+				// (task-IP) check passes. Force the dual-stack wildcard.
+				envKV{Name: "HOSTNAME", Value: "0.0.0.0"},
 			)
 		}
 

--- a/infra/pkg/aws/loadbalancer/target_groups.go
+++ b/infra/pkg/aws/loadbalancer/target_groups.go
@@ -146,10 +146,10 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 
 	// --- Listener Rules ---
 	// Priority ordering: lower number = evaluated first.
-	//   10: host = assign.kaizen.{domain} → M1
-	//   20: path = /api/*                 → M5
-	//   30: path = /flags/*               → M7
-	//  100: path = /* (catch-all)         → M6
+	//   10: host = assign.kaizen.{domain}       → M1
+	//   20: path = /experimentation.management.* → M5
+	//   30: path = /experimentation.flags.*      → M7
+	//  100: path = /* (catch-all, incl. UI pages and /api/rpc BFF) → M6
 
 	assignHost := fmt.Sprintf("assign.kaizen.%s", inputs.Domain)
 

--- a/infra/pkg/aws/loadbalancer/target_groups.go
+++ b/infra/pkg/aws/loadbalancer/target_groups.go
@@ -5,10 +5,22 @@
 //
 // Routing topology:
 //
-//	assign.kaizen.{domain}  →  M1 Assignment   (gRPC, port 50051)
-//	/api/*                  →  M5 Management   (HTTP/2, port 50055)
-//	/flags/*                →  M7 Flags        (gRPC, port 50057)
-//	/* (default)            →  M6 UI           (HTTP, port 3000)
+//	assign.kaizen.{domain}          →  M1 Assignment   (gRPC, port 50051)
+//	/experimentation.management.*   →  M5 Management   (bare ConnectRPC paths, port 50055)
+//	/experimentation.flags.*        →  M7 Flags        (gRPC, port 50057)
+//	/* (default)                    →  M6 UI           (HTTP, port 3000)
+//
+// gRPC/Connect rules MUST match on bare /package.Service/Method paths —
+// gRPC clients cannot mount a service under a path prefix, and a
+// human-facing prefix like the old /flags/* shadows the UI's page routes
+// (browsers got ALB 464 Incompatible-protocol on /flags/new because the
+// GET landed on the GRPC-protocol-version target group). The dot in
+// /experimentation.<module>.* keeps these disjoint from UI page routes.
+//
+// Browser API traffic (/api/rpc/<module>/...) intentionally falls through
+// to the M6 catch-all: the Next.js BFF route handler proxies it to the
+// backends over Cloud Map, since ALB cannot rewrite paths and the
+// backends serve bare /package.Service/Method ConnectRPC routes.
 package loadbalancer
 
 import (
@@ -164,6 +176,10 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 			},
 		},
 		{
+			// Direct ConnectRPC access to M5 (grpcurl, server SDKs). The
+			// UI does NOT use this path — its /api/rpc/* calls go to the
+			// M6 BFF via the catch-all. This rule also keeps the M5 target
+			// group attached to the ALB (an ECS service precondition).
 			name:     "m5-api",
 			priority: 20,
 			target:   "m5-management",
@@ -171,7 +187,7 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 				return lb.ListenerRuleConditionArray{
 					&lb.ListenerRuleConditionArgs{
 						PathPattern: &lb.ListenerRuleConditionPathPatternArgs{
-							Values: pulumi.StringArray{pulumi.String("/api/*")},
+							Values: pulumi.StringArray{pulumi.String("/experimentation.management.*")},
 						},
 					},
 				}
@@ -186,7 +202,7 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 				return lb.ListenerRuleConditionArray{
 					&lb.ListenerRuleConditionArgs{
 						PathPattern: &lb.ListenerRuleConditionPathPatternArgs{
-							Values: pulumi.StringArray{pulumi.String("/flags/*")},
+							Values: pulumi.StringArray{pulumi.String("/experimentation.flags.*")},
 						},
 					},
 				}

--- a/infra/pkg/aws/loadbalancer/target_groups_test.go
+++ b/infra/pkg/aws/loadbalancer/target_groups_test.go
@@ -87,9 +87,9 @@ func TestTargetGroupSpecs(t *testing.T) {
 func TestListenerRulePriorities(t *testing.T) {
 	// Verify listener rule priority ordering:
 	//   10: M1 (host-based, assign.kaizen.{domain})
-	//   20: M5 (/api/*)
-	//   30: M7 (/flags/*)
-	//  100: M6 (catch-all /*)
+	//   20: M5 (bare ConnectRPC paths /experimentation.management.*)
+	//   30: M7 (bare ConnectRPC paths /experimentation.flags.*)
+	//  100: M6 (catch-all /*; also carries /api/rpc/* for the BFF proxy)
 	type rule struct {
 		name     string
 		priority int
@@ -98,8 +98,8 @@ func TestListenerRulePriorities(t *testing.T) {
 
 	rules := []rule{
 		{name: "m1-host", priority: 10, pattern: "assign.kaizen.{domain}"},
-		{name: "m5-api", priority: 20, pattern: "/api/*"},
-		{name: "m7-flags", priority: 30, pattern: "/flags/*"},
+		{name: "m5-api", priority: 20, pattern: "/experimentation.management.*"},
+		{name: "m7-flags", priority: 30, pattern: "/experimentation.flags.*"},
 		{name: "m6-default", priority: 100, pattern: "/*"},
 	}
 


### PR DESCRIPTION
## Problem 1 — /flags/* rule shadowed UI pages (user-visible: HTTP 464)

Clicking **New Flag** navigates to `/flags/new` — a Next.js page. The ALB's priority-30 rule `path=/flags/*` forwarded that browser GET to the **GRPC-protocol-version** m7 target group, and ALB returns **464 Incompatible protocol** for HTTP/1.1 requests to gRPC TGs. Every `/flags/...` page was unreachable while bare `/flags` (no trailing segment, unmatched by the pattern) still rendered.

A path-prefix rule for a gRPC service is unusable anyway — gRPC/Connect clients always call `/package.Service/Method`. Both gRPC rules now match bare Connect paths:

| prio | pattern | target |
| --- | --- | --- |
| 20 | `/experimentation.management.*` | m5 |
| 30 | `/experimentation.flags.*` | m7 |

The dot keeps them disjoint from UI page routes (`/experiments`, `/flags`, …). Applied live in run 22; `/flags/new` now serves from m6.

## Problem 2 — main lost #756's tail commit (automerge race)

#756's second commit (`c9ac342`: m6 `HOSTNAME=0.0.0.0`, `BACKEND_ASSIGNMENT_URL`, first rule repoint) was pushed seconds **after** automerge merged the branch on the first commit's green checks — the push re-created the just-deleted branch and the commit silently never reached main. The deployed stack has it (deployed from the working tree); IaC-on-main didn't. This PR restores it. Filed as an addendum on #759 — same missing-reconciler family: nothing audits deployed-state vs main.

## Verification

- Live rules confirmed via `describe-rules` after run 22 (table above).
- `go build` + loadbalancer/compute/mock suites green.
- Flags **list** RPC still fails by design until #758 (tonic backends don't speak Connect-JSON) — now cleanly, through the BFF.

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->