### PR TITLE
fix(ui): initialize RPC auth headers to dev defaults, not empty

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -46,8 +46,13 @@ const ASSIGNMENT_URL = process.env.NEXT_PUBLIC_ASSIGNMENT_URL || '/api/rpc/assig
 const ASSIGNMENT_SVC = 'experimentation.assignment.v1.AssignmentService';
 
 // --- Auth header injection ---
-let _authEmail = '';
-let _authRole = '';
+// Initialized to the same defaults AuthProvider derives, not empty strings:
+// AuthProvider syncs these via useEffect, but React runs child effects
+// before parent effects, so the first page's fetch fires before that sync
+// lands — an empty default made every cold navigation send no X-User-Email
+// and fail M5's RBAC check. setApiAuth still overrides at runtime.
+let _authEmail = process.env.NEXT_PUBLIC_USER_EMAIL || 'dev@streamco.com';
+let _authRole = process.env.NEXT_PUBLIC_USER_ROLE || 'experimenter';
 
 /** Set auth credentials injected into all RPC calls. Called by AuthProvider. */
 export function setApiAuth(email: string, role: string): void {


### PR DESCRIPTION
## Symptom

First navigation to any M5-backed page (reported on Experiments) fails with:

```
Failed to load experiments
missing X-User-Email header
```

Reload / client-side re-navigation works.

## Cause

`AuthProvider` syncs auth into `api.ts` with `useEffect(() => setApiAuth(...))`, but React fires **child** effects before **parent** effects — page components' fetch effects run before the provider's sync on a cold mount. `_authEmail` started as `''`, so the first RPC omitted `X-User-Email`/`X-User-Role` and M5's RBAC interceptor rejected it. Masked until now because those RPCs never reached M5 before the routing/BFF fixes (#756/#757/#763).

## Fix

Initialize the module-level auth state to the same defaults `AuthProvider` derives (`NEXT_PUBLIC_USER_EMAIL || 'dev@streamco.com'`, `NEXT_PUBLIC_USER_ROLE || 'experimenter'`). `setApiAuth` still overrides at runtime (dev role switcher and tests unaffected — both auth-header tests set state explicitly and stay green: 37/37 wire-format tests pass).

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->