### PR TITLE
feat(ui): BFF gRPC bridge for tonic-only flags backend (interim until connect-rust)

### DIFF
--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -20,9 +20,15 @@ plugins:
   #   out: gen/rust
 
   # TypeScript (connect-web)
-  - remote: buf.build/connectrpc/es
+  # Pinned to the protobuf-es v1 line: the UI runtime is
+  # @connectrpc/connect ^1.x / @bufbuild/protobuf ^1.x, and unpinned
+  # buf.build/bufbuild/es now floats to protoc-gen-es v2, whose output
+  # (codegenv2/wkt imports) is incompatible with both the v1 runtime and
+  # the v1.6.1 connect-es service stubs — the generated tree wouldn't
+  # even self-compile. Bump both lines together when migrating to v2.
+  - remote: buf.build/connectrpc/es:v1.6.1
     out: gen/ts
     opt: target=ts
-  - remote: buf.build/bufbuild/es
+  - remote: buf.build/bufbuild/es:v1.10.0
     out: gen/ts
     opt: target=ts

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,6 +1,19 @@
+const path = require('path');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  // Allow importing the repo-level generated protos (../gen/ts) — used by
+  // the BFF's gRPC bridge for tonic-only backends (see app/api/rpc route).
+  experimental: { externalDir: true },
+  webpack: (config) => {
+    // protobuf-es output uses ESM-style `./x_pb.js` imports for .ts files.
+    config.resolve.extensionAlias = { '.js': ['.ts', '.js'] };
+    // Files under ../gen/ts resolve bare imports (@bufbuild/protobuf)
+    // against ui/node_modules, which isn't on their walk-up path.
+    config.resolve.modules = [...(config.resolve.modules ?? ['node_modules']), path.resolve(__dirname, 'node_modules')];
+    return config;
+  },
   // NOTE: no rewrites() here. With standalone output, rewrites() runs at
   // BUILD time and its env-var destinations get frozen into the routes
   // manifest — deployed containers would proxy /api/rpc/* to the build

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,13 +8,16 @@
       "name": "experimentation-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1",
         "@codemirror/autocomplete": "^6.20.2",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-sql": "^6.10.0",
+        "@codemirror/language": "^6.12.3",
         "@codemirror/lint": "^6.9.6",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.43.0",
         "@connectrpc/connect": "^1.5.0",
+        "@connectrpc/connect-node": "^1.7.0",
         "@connectrpc/connect-web": "^1.5.0",
         "next": "^14.2.0",
         "prism-react-renderer": "^2.4.1",
@@ -134,6 +137,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -149,6 +153,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -179,8 +184,7 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
       "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.2",
@@ -271,9 +275,36 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
       "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@connectrpc/connect-web": {
@@ -374,7 +405,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -415,7 +445,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -924,6 +953,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2262,7 +2300,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -2347,7 +2386,6 @@
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2371,7 +2409,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2429,7 +2466,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3062,7 +3098,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3471,7 +3506,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4144,7 +4178,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4472,7 +4507,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4642,7 +4676,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6143,7 +6176,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -6595,6 +6627,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7225,7 +7258,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7263,7 +7295,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7296,6 +7327,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7311,6 +7343,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7384,7 +7417,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7397,7 +7429,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7411,7 +7442,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-smooth": {
       "version": "4.0.4",
@@ -8658,7 +8690,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8817,7 +8848,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@bufbuild/protobuf": "^1.10.1",
     "@codemirror/autocomplete": "^6.20.2",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-sql": "^6.10.0",
@@ -24,6 +25,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.0",
     "@connectrpc/connect": "^1.5.0",
+    "@connectrpc/connect-node": "^1.7.0",
     "@connectrpc/connect-web": "^1.5.0",
     "next": "^14.2.0",
     "prism-react-renderer": "^2.4.1",

--- a/ui/src/app/api/rpc/[module]/[...rpc]/route.ts
+++ b/ui/src/app/api/rpc/[module]/[...rpc]/route.ts
@@ -1,4 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { ConnectError, createPromiseClient, type Transport } from '@connectrpc/connect';
+import { createGrpcTransport } from '@connectrpc/connect-node';
+import type { MethodInfo, ServiceType } from '@bufbuild/protobuf';
+import { MethodKind } from '@bufbuild/protobuf';
+import { FeatureFlagService } from '../../../../../../../gen/ts/experimentation/flags/v1/flags_service_connect';
 
 // Runtime BFF proxy: /api/rpc/<module>/<pkg.Service>/<Method> → backend.
 //
@@ -21,6 +26,115 @@ const DEV_DEFAULTS: Record<string, string> = {
   flags: 'http://localhost:50057',
   assignment: 'http://localhost:50051',
 };
+
+// ---------------------------------------------------------------------------
+// TEMPORARY gRPC bridge — delete when connect-rust lands (#758).
+//
+// M7 Flags is tonic-only: it speaks native gRPC, not the Connect-JSON the
+// browser client sends, so a byte-level pass-through gets HTTP 400 back.
+// For modules listed here the BFF instead decodes the Connect-JSON request
+// with the generated protobuf-es schema and re-issues it over the gRPC
+// protocol (h2c prior knowledge, which tonic serves on its plaintext port).
+//
+// This is an interim shim, NOT the end state. The proper fix is adopting
+// the ADR-031 `connectrpc` runtime in M7 (and later M4a/M4b/M1), which
+// serves Connect + gRPC on one port and makes this bridge — and the JSON
+// decode/re-encode it pays per request — deletable. Tracked in #758;
+// fleet-wide connect-rust adoption is gated on the #645 pilot decision.
+// When M7 speaks Connect natively, remove its entry below and the plain
+// pass-through takes over unchanged.
+// ---------------------------------------------------------------------------
+const GRPC_BRIDGED: Record<string, ServiceType> = {
+  flags: FeatureFlagService,
+};
+
+// gRPC transports hold HTTP/2 sessions worth reusing across requests.
+const grpcTransports = new Map<string, Transport>();
+
+function grpcTransportFor(baseUrl: string): Transport {
+  let t = grpcTransports.get(baseUrl);
+  if (!t) {
+    t = createGrpcTransport({ baseUrl, httpVersion: '2' });
+    grpcTransports.set(baseUrl, t);
+  }
+  return t;
+}
+
+const CODE_NAMES: Record<number, string> = {
+  1: 'canceled', 2: 'unknown', 3: 'invalid_argument', 4: 'deadline_exceeded',
+  5: 'not_found', 6: 'already_exists', 7: 'permission_denied', 8: 'resource_exhausted',
+  9: 'failed_precondition', 10: 'aborted', 11: 'out_of_range', 12: 'unimplemented',
+  13: 'internal', 14: 'unavailable', 15: 'data_loss', 16: 'unauthenticated',
+};
+
+// Connect error code → HTTP status, close to the Connect protocol's own
+// unary mapping. The UI's error handling only reads status + message.
+const CODE_TO_HTTP: Record<number, number> = {
+  1: 408, 2: 500, 3: 400, 4: 408, 5: 404, 6: 409, 7: 403, 8: 429,
+  9: 412, 10: 409, 11: 400, 12: 501, 13: 500, 14: 503, 15: 500, 16: 401,
+};
+
+/** Headers forwarded to bridged gRPC backends (auth/RBAC parity with M5). */
+const BRIDGE_FORWARD_HEADERS = ['x-user-email', 'x-user-role', 'authorization'];
+
+async function bridgeGrpc(
+  req: NextRequest,
+  service: ServiceType,
+  rpc: string[],
+  base: string,
+): Promise<NextResponse> {
+  const [serviceName, methodName] = rpc;
+  if (rpc.length !== 2 || serviceName !== service.typeName) {
+    return NextResponse.json(
+      { code: 'unimplemented', message: `unknown RPC path /${rpc.join('/')} for bridged module` },
+      { status: 404 },
+    );
+  }
+
+  const entry = (Object.entries(service.methods) as Array<[string, MethodInfo]>).find(
+    ([, m]) => m.name === methodName,
+  );
+  if (!entry || entry[1].kind !== MethodKind.Unary) {
+    return NextResponse.json(
+      { code: 'unimplemented', message: `method ${methodName} not found or not unary` },
+      { status: 404 },
+    );
+  }
+  const [localName, method] = entry;
+
+  let requestJson: unknown = {};
+  try {
+    const raw = await req.text();
+    requestJson = raw.length > 0 ? JSON.parse(raw) : {};
+  } catch {
+    return NextResponse.json(
+      { code: 'invalid_argument', message: 'request body is not valid JSON' },
+      { status: 400 },
+    );
+  }
+
+  const headers = new Headers();
+  for (const name of BRIDGE_FORWARD_HEADERS) {
+    const v = req.headers.get(name);
+    if (v) headers.set(name, v);
+  }
+
+  try {
+    const request = method.I.fromJson(requestJson as never, { ignoreUnknownFields: true });
+    const client = createPromiseClient(service, grpcTransportFor(base)) as unknown as Record<
+      string,
+      (r: unknown, o: { headers: Headers }) => Promise<{ toJson: () => unknown }>
+    >;
+    const response = await client[localName](request, { headers });
+    return NextResponse.json(response.toJson() ?? {});
+  } catch (err) {
+    const ce = ConnectError.from(err);
+    return NextResponse.json(
+      { code: CODE_NAMES[ce.code] ?? 'unknown', message: ce.rawMessage },
+      { status: CODE_TO_HTTP[ce.code] ?? 500 },
+    );
+  }
+}
 
 function backendFor(module: string): string | undefined {
   const fromEnv = process.env[`BACKEND_${module.toUpperCase()}_URL`];
@@ -61,6 +175,12 @@ async function proxy(req: NextRequest, { params }: RouteParams): Promise<NextRes
       { code: 'unimplemented', message: `no backend configured for module "${params.module}"` },
       { status: 502 },
     );
+  }
+
+  // tonic-only backends can't parse Connect-JSON — translate to gRPC.
+  const bridged = GRPC_BRIDGED[params.module];
+  if (bridged) {
+    return bridgeGrpc(req, bridged, params.rpc, base);
   }
 
   const target = `${base.replace(/\/+$/, '')}/${params.rpc.map(encodeURIComponent).join('/')}${req.nextUrl.search}`;

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -13,7 +13,11 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "paths": { "@/*": ["./src/*"] },
+    "paths": {
+      "@/*": ["./src/*"],
+      "@bufbuild/protobuf": ["./node_modules/@bufbuild/protobuf/dist/cjs/index.d.ts"],
+      "@connectrpc/connect": ["./node_modules/@connectrpc/connect/dist/cjs/index.d.ts"]
+    },
     "types": ["vitest/globals"],
     "plugins": [{ "name": "next" }]
   },


### PR DESCRIPTION
## What

The Flags page fails with `RPC ListFlags failed: 400`: M7 is tonic gRPC-only and can't parse the browser's Connect-JSON POSTs, so the BFF's byte-level pass-through faithfully relayed tonic's rejection. This PR teaches the BFF to **translate** for modules listed in `GRPC_BRIDGED`: decode Connect-JSON with the generated protobuf-es schema, re-issue over native gRPC (h2c prior knowledge — no tonic-web dependency), map `ConnectError` codes back to Connect-style JSON errors, and forward `x-user-email`/`x-user-role` for RBAC parity.

## ⚠️ Interim shim — connect-rust is the real fix

**This bridge must eventually be replaced by adopting the ADR-031 `connectrpc` (connect-rust) runtime in M7** — and later M4a/M4b/M1 — which serves Connect + gRPC on one port and makes both the bridge and its per-request JSON↔protobuf round-trip deletable (remove the module's `GRPC_BRIDGED` entry; the pass-through takes over unchanged). Tracked in #758; fleet-wide adoption is gated on the #645 pilot decision. The route file carries the same banner comment.

## Drive-by fix: unpinned buf TS plugins generate broken code

`buf.gen.yaml` left the remote TS plugins unpinned. `buf.build/bufbuild/es` now resolves to protoc-gen-es **v2.12.1** while `buf.build/connectrpc/es` tops out at **v1.6.1** — fresh generation produces v2-style messages (`codegenv2`/`wkt` entry points) consumed by v1-style service stubs: the tree doesn't self-compile, and the UI runtime is the v1 line (`@connectrpc/connect ^1.5`). Pinned both to the v1 line (`es:v1.10.0`, `connectrpc/es:v1.6.1`) — matching the vintage of every existing consumer. Surfaced now because this PR is the first TS compilation of `gen/ts`. (CI's docker jobs restore the schema-stage artifact into `gen/`, so the pinned regeneration flows through unchanged.)

## Build plumbing

- `experimental.externalDir` + webpack `extensionAlias`/`resolve.modules` so `../gen/ts` compiles inside the UI build (protobuf-es ESM `.js` specifiers, bare imports resolving to `ui/node_modules`).
- tsconfig path mappings so tsc types `@bufbuild/protobuf`/`@connectrpc/connect` for the external files.
- New deps: `@connectrpc/connect-node@^1.5.0`, `@bufbuild/protobuf@^1.10.0`.

## Verification (built standalone server + raw-gRPC fake backend)

| Probe | Result |
| --- | --- |
| `ListFlags` with `X-User-Email` | **200** `{}` — full JSON→gRPC→JSON round trip |
| `ListFlags` without header | **401** `unauthenticated` — header forwarding is load-bearing |
| `GetFlag` (backend returns grpc-status 5) | **404** `{"code":"not_found","message":"flag missing"}` |
| Unknown method | **404** `unimplemented`, no backend call |
| Wrong service in path | **404** |
| Non-bridged module, dead backend | **502** `unavailable` — pass-through unchanged |

Refs #758, #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->