### PR TITLE
chore(ci): queue review-gate runs instead of cancelling in-progress

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -43,7 +43,14 @@ permissions:
 # verdict AND cuts short its grace-window polling.
 concurrency:
   group: review-gate-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # queue, don't cancel: the gate takes ~15s, and cancel-in-progress turns
+  # every burst of near-simultaneous triggers (review submitted + thread
+  # resolved + push land within a second) into cancelled runs of a
+  # REQUIRED check. Rulesets count those cancelled check-runs as failing,
+  # which wedges otherwise-green PRs until every zombie run is manually
+  # re-run to success — and re-running joins this same group, cancelling
+  # any in-flight run, so the cure regenerates the disease (#763/#764).
+  cancel-in-progress: false
 
 jobs:
   gate:


### PR DESCRIPTION
## Problem — the zombie-cancelled-gate treadmill

`review-gate.yml` uses a per-PR concurrency group with `cancel-in-progress: true`. Gate triggers arrive in bursts (a review submission, a thread resolution, and a push often land within one second), so siblings cancel each other constantly. **Cancelled runs of a required check count as failing in the ruleset rollup**, wedging PRs whose real checks are all green.

Worse, the documented cure (sequentially re-running each cancelled run) **enters the same concurrency group and cancels any in-flight run** — while reviews are active, the cure regenerates the disease. #753 needed 4 reruns; #763/#764 needed 8 across three sessions and only converged during a quiet period; #764 then also needed a manual merge nudge because rerun completions don't re-trigger auto-merge evaluation.

## Fix

`cancel-in-progress: false` — bursts queue instead. The gate takes ~15s, so queuing is free; the newest queued run always evaluates the final thread/review state.

## Alternatives considered

- Per-SHA groups: still cancels within a burst on one SHA — same disease.
- Ruleset change to ignore cancelled runs: not expressible in rulesets today.

Case studies and reconciler follow-up tracked in #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->