### PR TITLE
🎨 Palette: Standardize accessibility focus indicators across navigation and filters

### DIFF
--- a/ui/src/app/audit/page.tsx
+++ b/ui/src/app/audit/page.tsx
@@ -116,7 +116,7 @@ export default function AuditLogPage() {
               <p className="text-sm text-gray-500">No audit log entries match your filters.</p>
               <button
                 onClick={clearFilters}
-                className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                 data-testid="clear-filters-empty"
               >
                 Clear filters

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -203,7 +203,7 @@ function FlagListContent() {
               <p className="text-sm text-gray-500">No flags match your filters.</p>
               <button
                 onClick={clearFilters}
-                className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                 data-testid="clear-filters-empty"
               >
                 Clear filters

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -479,7 +479,7 @@ function MetricBrowserContent() {
             <p className="text-sm text-gray-500">No metrics match your filters.</p>
             <button
               onClick={clearFilters}
-              className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               data-testid="clear-filters-empty"
             >
               Clear filters

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -150,7 +150,7 @@ export default function ExperimentListPage() {
           <p className="text-sm text-gray-500">No experiments match your filters.</p>
           <button
             onClick={filters.clearFilters}
-            className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            className="mt-2 rounded-sm text-sm text-indigo-600 hover:text-indigo-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             data-testid="clear-filters-empty"
           >
             Clear filters

--- a/ui/src/components/nav-header.tsx
+++ b/ui/src/components/nav-header.tsx
@@ -22,14 +22,14 @@ export function NavHeader() {
         <div className="flex items-center gap-6">
           <Link
             href="/"
-            className={`rounded-sm text-lg font-semibold outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${pathname === '/' || pathname.startsWith('/experiments') ? 'text-indigo-600' : 'text-gray-900'}`}
+            className={`rounded-sm text-lg font-semibold outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${pathname === '/' || pathname.startsWith('/experiments') ? 'text-indigo-600' : 'text-gray-900'}`}
             aria-current={pathname === '/' || pathname.startsWith('/experiments') ? 'page' : undefined}
           >
             Experimentation Platform
           </Link>
           <Link
             href="/flags"
-            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${pathname.startsWith('/flags') ? 'text-indigo-600' : 'text-gray-600'}`}
+            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${pathname.startsWith('/flags') ? 'text-indigo-600' : 'text-gray-600'}`}
             aria-current={pathname.startsWith('/flags') ? 'page' : undefined}
             data-testid="nav-flags"
           >
@@ -37,7 +37,7 @@ export function NavHeader() {
           </Link>
           <Link
             href="/metrics"
-            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${pathname.startsWith('/metrics') ? 'text-indigo-600' : 'text-gray-600'}`}
+            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${pathname.startsWith('/metrics') ? 'text-indigo-600' : 'text-gray-600'}`}
             aria-current={pathname.startsWith('/metrics') ? 'page' : undefined}
             data-testid="nav-metrics"
           >
@@ -45,7 +45,7 @@ export function NavHeader() {
           </Link>
           <Link
             href="/audit"
-            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${pathname.startsWith('/audit') ? 'text-indigo-600' : 'text-gray-600'}`}
+            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${pathname.startsWith('/audit') ? 'text-indigo-600' : 'text-gray-600'}`}
             aria-current={pathname.startsWith('/audit') ? 'page' : undefined}
             data-testid="nav-audit"
           >
@@ -53,7 +53,7 @@ export function NavHeader() {
           </Link>
           <Link
             href="/monitoring"
-            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${pathname.startsWith('/monitoring') ? 'text-indigo-600' : 'text-gray-600'}`}
+            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${pathname.startsWith('/monitoring') ? 'text-indigo-600' : 'text-gray-600'}`}
             aria-current={pathname.startsWith('/monitoring') ? 'page' : undefined}
             data-testid="nav-monitoring"
           >
@@ -61,7 +61,7 @@ export function NavHeader() {
           </Link>
           <Link
             href="/portfolio"
-            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${pathname.startsWith('/portfolio') ? 'text-indigo-600' : 'text-gray-600'}`}
+            className={`rounded-sm text-sm font-medium transition-colors hover:text-gray-900 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${pathname.startsWith('/portfolio') ? 'text-indigo-600' : 'text-gray-600'}`}
             aria-current={pathname.startsWith('/portfolio') ? 'page' : undefined}
             data-testid="nav-portfolio"
           >
@@ -75,7 +75,7 @@ export function NavHeader() {
             <select
               value={user.role}
               onChange={(e) => setDevRole(e.target.value as UserRole)}
-              className="rounded border border-dashed border-orange-400 bg-orange-50 px-2 py-1 text-xs text-orange-700"
+              className="rounded border border-dashed border-orange-400 bg-orange-50 px-2 py-1 text-xs text-orange-700 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               data-testid="dev-role-switcher"
               aria-label="Dev role switcher"
             >


### PR DESCRIPTION
### 💡 What
Standardized the use of accessibility focus rings by adding `focus-visible:ring-offset-2` to key interactive elements:
- Global navigation links and the dev role switcher in `NavHeader`.
- "Clear filters" buttons in "No results" empty states across all dashboard list pages (Experiments, Flags, Metrics, Audit).

### 🎯 Why
Consistency in focus indicators is crucial for keyboard accessibility. Adding a ring offset provides a clear visual gap between the focused element and the indicator, significantly improving visibility and meeting platform-wide UX standards.

### 📸 Before/After
Focus rings now have a consistent 2px offset from the element boundary, matching the pattern used in toolbars and primary action buttons.

### ♿ Accessibility
- Improved visual focus feedback for keyboard-only and screen reader users.
- Ensured interactive empty-state buttons are as accessible as their toolbar counterparts.

---
*PR created automatically by Jules for task [16913234264362375798](https://jules.google.com/task/16913234264362375798) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->