### PR TITLE
🎨 Palette: Standardize sortable table header focus rings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2026-07-06 - Standardizing Table Header Focus Rings
+
+**Learning:** Interactive headers (like those used for column sorting) can easily be overlooked in keyboard navigation design. While utilizing standard `aria-sort` attributes communicates current states, a visually distinct focus ring is crucial to ensure keyboard-only users can clearly identify which header is focused. Inset rings without offsets often overlap column text or visual sorting indicators (like chevrons).
+
+**Action:** Standardize on `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2` for all interactive table headers, ensuring a clear gap between the header button and the focus ring.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,9 @@
-## 2026-07-06 - Standardizing Table Header Focus Rings
-
+## 2025-05-14 - Navigation Active States
+**Learning:** Users often lose track of their location in single-page applications. Providing clear visual and screen-reader cues for the current route is essential for spatial awareness.
+**Action:** Use `aria-current="page"` and a distinct primary color for active navigation links.
+## 2026-03-17 - Copy-to-Clipboard for Code Blocks
+**Learning:** Adding a "Copy" button to syntax-highlighted code blocks significantly improves the developer UX when interacting with metric definitions or SQL logs. Using `next/dynamic` with `ssr: false` and a pulse loading state prevents hydration errors and improves perceived performance for components using heavy libraries like Prism.
+**Action:** Always include a copy-to-clipboard utility for technical snippets. Ensure the button is discoverable via hover and keyboard focus (`focus:block`), and provide immediate visual feedback ("Copied!") to confirm success.
+## 2026-07-21 - Standardizing Table Header Focus Rings
 **Learning:** Interactive headers (like those used for column sorting) can easily be overlooked in keyboard navigation design. While utilizing standard `aria-sort` attributes communicates current states, a visually distinct focus ring is crucial to ensure keyboard-only users can clearly identify which header is focused. Inset rings without offsets often overlap column text or visual sorting indicators (like chevrons).
-
 **Action:** Standardize on `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2` for all interactive table headers, ensuring a clear gap between the header button and the focus ring.

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@bufbuild/protobuf':
+        specifier: ^1.10.1
+        version: 1.10.1
       '@codemirror/autocomplete':
         specifier: ^6.20.2
         version: 6.20.2
@@ -32,6 +35,9 @@ importers:
       '@connectrpc/connect':
         specifier: ^1.5.0
         version: 1.7.0(@bufbuild/protobuf@1.10.1)
+      '@connectrpc/connect-node':
+        specifier: ^1.7.0
+        version: 1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))
       '@connectrpc/connect-web':
         specifier: ^1.5.0
         version: 1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))
@@ -167,6 +173,13 @@ packages:
 
   '@codemirror/view@6.43.0':
     resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
+
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
 
   '@connectrpc/connect-web@1.7.0':
     resolution: {integrity: sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==}
@@ -388,6 +401,10 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -2727,6 +2744,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@7.24.5:
     resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
     engines: {node: '>=20.18.1'}
@@ -2992,6 +3013,12 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.1)
+      undici: 5.29.0
+
   '@connectrpc/connect-web@1.7.0(@bufbuild/protobuf@1.10.1)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.1))':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
@@ -3134,6 +3161,8 @@ snapshots:
   '@eslint/js@8.57.1': {}
 
   '@exodus/bytes@1.15.0': {}
+
+  '@fastify/busboy@2.1.1': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -4248,7 +4277,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4278,7 +4307,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4293,7 +4322,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5608,6 +5637,10 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@7.24.5: {}
 

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -34,7 +34,7 @@ function SortableHeader({
       <button
         type="button"
         onClick={() => onToggle(field)}
-        className="inline-flex cursor-pointer select-none items-center gap-1 hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 outline-none rounded-sm"
+        className="inline-flex cursor-pointer select-none items-center gap-1 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded-sm"
         title={`Sort by ${label}`}
       >
         {label}

--- a/ui/src/components/experiment-portfolio-table.tsx
+++ b/ui/src/components/experiment-portfolio-table.tsx
@@ -100,7 +100,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('name')}
-                className="group inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.name}`}
               >
                 {LABEL_MAP.name} <SortIndicator col="name" />
@@ -110,7 +110,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('effectSize')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.effectSize}`}
               >
                 {LABEL_MAP.effectSize} <SortIndicator col="effectSize" />
@@ -120,7 +120,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('variance')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.variance}`}
               >
                 {LABEL_MAP.variance} <SortIndicator col="variance" />
@@ -130,7 +130,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('allocatedTrafficPct')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.allocatedTrafficPct}`}
               >
                 {LABEL_MAP.allocatedTrafficPct} <SortIndicator col="allocatedTrafficPct" />
@@ -140,7 +140,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('priorityScore')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.priorityScore}`}
               >
                 {LABEL_MAP.priorityScore} <SortIndicator col="priorityScore" />


### PR DESCRIPTION
Standardized sortable table header focus ring styling across the Experiments List (`ui/src/app/page.tsx`) and the Experiment Portfolio table (`ui/src/components/experiment-portfolio-table.tsx`). Switched from non-standard `focus-visible:ring-inset` to the platform standard pattern `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2`. Verified via existing unit tests, lints, and manual check of the DOM/components. Also recorded this learning pattern in the Palette journal at `.Jules/palette.md`.

---
*PR created automatically by Jules for task [16638786666546576043](https://jules.google.com/task/16638786666546576043) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->