### PR TITLE
feat(m1,m7): register grpc.health.v1 + restore strict health checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,6 +2042,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tonic-health",
  "tonic-web",
  "tower 0.5.3",
  "tracing",
@@ -2101,6 +2102,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tonic",
+ "tonic-health",
  "tonic-web",
  "tracing",
  "tracing-subscriber",
@@ -5737,6 +5739,19 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost 0.13.5",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.40", features = ["full"] }
 tonic = { version = "0.12", features = ["tls"] }
 tonic-build = "0.12"
 tonic-web = "0.12"
+tonic-health = "0.12"
 prost = "0.13"
 prost-types = "0.13"
 # Serialization

--- a/crates/experimentation-assignment/Cargo.toml
+++ b/crates/experimentation-assignment/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 tonic = { workspace = true }
 tonic-web = { workspace = true }
+tonic-health = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/experimentation-assignment/Dockerfile
+++ b/crates/experimentation-assignment/Dockerfile
@@ -14,6 +14,15 @@ RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/
 # grpc_health_probe: bundled for ECS/Cloud Run container HEALTHCHECK CMD.
 # TARGETARCH resolves to amd64|arm64 during buildx multi-arch push (#755).
 ADD --chmod=755 https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} /bin/grpc_health_probe
+# Verify the fetched binary against a per-arch pinned SHA256. Guards against
+# a tampered release asset silently landing as the HEALTHCHECK executable.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) SHA=7e564681110ee4563637457b91e42f62f96b79618a835bb05ae2305acdcc3db0 ;; \
+      arm64) SHA=3759148e22a494149a4abae269adee0d20c428b966683426e2319f9047da521d ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac; \
+    echo "${SHA}  /bin/grpc_health_probe" | sha256sum -c -
 COPY --from=builder /build/target/release/experimentation-assignment /usr/local/bin/service
 # Bootstrap experiment config: main.rs requires CONFIG_PATH to exist
 # (default dev/config.json). Baked until M5 StreamConfigUpdates (ADR-031)

--- a/crates/experimentation-assignment/Dockerfile
+++ b/crates/experimentation-assignment/Dockerfile
@@ -8,7 +8,12 @@ RUN apt-get update && apt-get install -y protobuf-compiler cmake
 RUN cargo build --release --package experimentation-assignment
 
 FROM debian:bookworm-slim
+ARG TARGETARCH
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.24
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+# grpc_health_probe: bundled for ECS/Cloud Run container HEALTHCHECK CMD.
+# TARGETARCH resolves to amd64|arm64 during buildx multi-arch push (#755).
+ADD --chmod=755 https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} /bin/grpc_health_probe
 COPY --from=builder /build/target/release/experimentation-assignment /usr/local/bin/service
 # Bootstrap experiment config: main.rs requires CONFIG_PATH to exist
 # (default dev/config.json). Baked until M5 StreamConfigUpdates (ADR-031)

--- a/crates/experimentation-assignment/src/main.rs
+++ b/crates/experimentation-assignment/src/main.rs
@@ -120,6 +120,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // M4b client are optional/best-effort (both spawned above with warnings on
     // failure), so "config loaded, service assembled" IS the honest ready
     // state — no fake NOT_SERVING→SERVING gate for deps we don't require.
+    //
+    // Note: tonic_health::server::health_reporter() initializes the empty
+    // service name "" (the overall server status) to Serving by default (see
+    // tonic-health 0.12.3 server.rs:44), so `grpc_health_probe -addr=:50051`
+    // and the ALB gRPC health check — both of which query with service="" —
+    // resolve to SERVING out of the box. set_serving::<T>() below adds
+    // per-service reporting for consumers that want to check the named
+    // AssignmentService specifically.
     let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter
         .set_serving::<AssignmentServiceServer<AssignmentServiceImpl>>()

--- a/crates/experimentation-assignment/src/main.rs
+++ b/crates/experimentation-assignment/src/main.rs
@@ -116,12 +116,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
+    // grpc.health.v1: register + mark SERVING right before bind. M5 stream and
+    // M4b client are optional/best-effort (both spawned above with warnings on
+    // failure), so "config loaded, service assembled" IS the honest ready
+    // state — no fake NOT_SERVING→SERVING gate for deps we don't require.
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_serving::<AssignmentServiceServer<AssignmentServiceImpl>>()
+        .await;
+
     tracing::info!(%grpc_addr, "starting gRPC server");
     tonic::transport::Server::builder()
         .tcp_nodelay(true)
         .concurrency_limit_per_connection(256)
         .initial_connection_window_size(1024 * 1024)
         .initial_stream_window_size(1024 * 1024)
+        .add_service(health_service)
         .add_service(AssignmentServiceServer::from_arc(svc))
         .serve_with_shutdown(grpc_addr, async move {
             tokio::signal::ctrl_c().await.ok();

--- a/crates/experimentation-flags/Cargo.toml
+++ b/crates/experimentation-flags/Cargo.toml
@@ -18,6 +18,7 @@ experimentation-proto = { path = "../experimentation-proto" }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tonic-web = { workspace = true }
+tonic-health = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/experimentation-flags/Dockerfile
+++ b/crates/experimentation-flags/Dockerfile
@@ -8,7 +8,12 @@ RUN apt-get update && apt-get install -y protobuf-compiler cmake g++ libssl-dev 
 RUN cargo build --release --package experimentation-flags
 
 FROM debian:bookworm-slim
+ARG TARGETARCH
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.24
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+# grpc_health_probe: bundled for ECS/Cloud Run container HEALTHCHECK CMD.
+# TARGETARCH resolves to amd64|arm64 during buildx multi-arch push (#755).
+ADD --chmod=755 https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} /bin/grpc_health_probe
 COPY --from=builder /build/target/release/experimentation-flags /usr/local/bin/service
 EXPOSE 50057
 CMD ["service"]

--- a/crates/experimentation-flags/Dockerfile
+++ b/crates/experimentation-flags/Dockerfile
@@ -14,6 +14,15 @@ RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/
 # grpc_health_probe: bundled for ECS/Cloud Run container HEALTHCHECK CMD.
 # TARGETARCH resolves to amd64|arm64 during buildx multi-arch push (#755).
 ADD --chmod=755 https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} /bin/grpc_health_probe
+# Verify the fetched binary against a per-arch pinned SHA256. Guards against
+# a tampered release asset silently landing as the HEALTHCHECK executable.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) SHA=7e564681110ee4563637457b91e42f62f96b79618a835bb05ae2305acdcc3db0 ;; \
+      arm64) SHA=3759148e22a494149a4abae269adee0d20c428b966683426e2319f9047da521d ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac; \
+    echo "${SHA}  /bin/grpc_health_probe" | sha256sum -c -
 COPY --from=builder /build/target/release/experimentation-flags /usr/local/bin/service
 EXPOSE 50057
 CMD ["service"]

--- a/crates/experimentation-flags/src/grpc.rs
+++ b/crates/experimentation-flags/src/grpc.rs
@@ -778,10 +778,20 @@ pub async fn serve(config: FlagsConfig, store: FlagStore, audit: Option<Arc<Audi
 
     let svc = FeatureFlagServiceServer::new(handler);
 
+    // grpc.health.v1: mark SERVING once the store connected and handler is
+    // built (checked above with `.await`). Reconciler + Kafka are optional
+    // background tasks; treating them as gates would keep M7 NOT_SERVING for
+    // the many deploys that run without M5_ADDR.
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter
+        .set_serving::<FeatureFlagServiceServer<FlagsServiceHandler>>()
+        .await;
+
     info!(%addr, "feature flag gRPC server starting (tonic-web enabled)");
 
     tonic::transport::Server::builder()
         .accept_http1(true)
+        .add_service(health_service)
         .add_service(tonic_web::enable(svc))
         .serve(addr)
         .await

--- a/crates/experimentation-flags/src/grpc.rs
+++ b/crates/experimentation-flags/src/grpc.rs
@@ -782,6 +782,14 @@ pub async fn serve(config: FlagsConfig, store: FlagStore, audit: Option<Arc<Audi
     // built (checked above with `.await`). Reconciler + Kafka are optional
     // background tasks; treating them as gates would keep M7 NOT_SERVING for
     // the many deploys that run without M5_ADDR.
+    //
+    // Note: tonic_health::server::health_reporter() initializes the empty
+    // service name "" (the overall server status) to Serving by default (see
+    // tonic-health 0.12.3 server.rs:44), so `grpc_health_probe -addr=:50057`
+    // and the ALB gRPC health check — both of which query with service="" —
+    // resolve to SERVING out of the box. set_serving::<T>() below adds
+    // per-service reporting for consumers that want to check the named
+    // FeatureFlagService specifically.
     let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter
         .set_serving::<FeatureFlagServiceServer<FlagsServiceHandler>>()

--- a/infra/pkg/aws/compute/services.go
+++ b/infra/pkg/aws/compute/services.go
@@ -159,6 +159,8 @@ func serviceSpecs() []serviceSpec {
 			key: "m1", name: "m1-assignment", ecrKey: "assignment",
 			cpu: "512", memoryMB: "1024", ports: []int{50051},
 			lang:      "rust",
+			// grpc.health.v1 via tonic-health (#755); probe bundled in Dockerfile.
+			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50051"},
 			tier:      TierCore,
 			deps:      []healthDep{m5Dep},
 		},
@@ -206,6 +208,8 @@ func serviceSpecs() []serviceSpec {
 			key: "m7", name: "m7-flags", ecrKey: "flags",
 			cpu: "256", memoryMB: "512", ports: []int{50057},
 			lang:      "rust",
+			// grpc.health.v1 via tonic-health (#755); probe bundled in Dockerfile.
+			healthCmd: []string{"CMD", "/bin/grpc_health_probe", "-addr=:50057"},
 			tier:      TierDependent,
 			deps:      tier1Deps,
 		},

--- a/infra/pkg/aws/compute/services_test.go
+++ b/infra/pkg/aws/compute/services_test.go
@@ -312,12 +312,14 @@ func TestAllSpecsHaveRequiredFields(t *testing.T) {
 		}
 		// Container health checks exist only where the runtime image can
 		// execute them: m5 (alpine) and m6 (node:alpine) carry busybox
-		// wget. Distroless/debian-slim images have no shell and no
-		// grpc_health_probe, so a declared check would fail every probe
-		// and the circuit breaker would kill healthy rollouts.
-		canProbe := map[string]bool{"m5": true, "m6": true}
+		// wget; m1 and m7 bundle /bin/grpc_health_probe in their debian
+		// runtime and register grpc.health.v1 via tonic-health (#755).
+		// Other distroless/debian-slim images still ship neither a shell
+		// nor grpc_health_probe, so a declared check would fail every
+		// probe and the circuit breaker would kill healthy rollouts.
+		canProbe := map[string]bool{"m1": true, "m5": true, "m6": true, "m7": true}
 		if canProbe[s.key] && len(s.healthCmd) == 0 {
-			t.Errorf("spec %q should declare a healthCmd (image has wget)", s.key)
+			t.Errorf("spec %q should declare a healthCmd (image has probe)", s.key)
 		}
 		if !canProbe[s.key] && len(s.healthCmd) != 0 {
 			t.Errorf("spec %q declares healthCmd its image cannot run", s.key)

--- a/infra/pkg/aws/loadbalancer/target_groups.go
+++ b/infra/pkg/aws/loadbalancer/target_groups.go
@@ -97,16 +97,11 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 
 	specs := []targetGroupSpec{
 		{
-			name:            "m1-assignment",
-			port:            50051,
-			protocolVersion: "GRPC",
-			healthCheckPath: "/grpc.health.v1.Health/Check",
-			// M1/M7 don't register grpc.health.v1 (no tonic-health), so a
-			// strict "0" matcher would mark every target unhealthy
-			// (UNIMPLEMENTED=12) and the LB-integrated scheduler would kill
-			// the tasks. Any gRPC status proves the server answers HTTP/2;
-			// tighten back to "0" when tonic-health ships.
-			healthCheckMatcher: "0-99",
+			name:               "m1-assignment",
+			port:               50051,
+			protocolVersion:    "GRPC",
+			healthCheckPath:    "/grpc.health.v1.Health/Check",
+			healthCheckMatcher: "0", // grpc.health.v1 registered via tonic-health (#755)
 		},
 		{
 			name:               "m5-management",
@@ -123,12 +118,11 @@ func NewTargetGroups(ctx *pulumi.Context, inputs *TargetGroupInputs) (*TargetGro
 			healthCheckMatcher: "200",
 		},
 		{
-			name:            "m7-flags",
-			port:            50057,
-			protocolVersion: "GRPC",
-			healthCheckPath: "/grpc.health.v1.Health/Check",
-			// See m1-assignment: no grpc.health.v1 service registered yet.
-			healthCheckMatcher: "0-99",
+			name:               "m7-flags",
+			port:               50057,
+			protocolVersion:    "GRPC",
+			healthCheckPath:    "/grpc.health.v1.Health/Check",
+			healthCheckMatcher: "0", // grpc.health.v1 registered via tonic-health (#755)
 		},
 	}
 

--- a/infra/test/compute_test.go
+++ b/infra/test/compute_test.go
@@ -93,16 +93,24 @@ func TestAllNineServicesInCatalogue(t *testing.T) {
 func TestGRPCHealthChecksForRustServices(t *testing.T) {
 	fargateSpecs := compute.ServiceSpecs()
 
-	rustServices := map[string]int{
-		"m1":  50051,
-		"m2":  50052,
-		"m4a": 50053,
-		"m7":  50057,
+	// Post-#755: m1 and m7 register grpc.health.v1 via tonic-health and
+	// bundle /bin/grpc_health_probe in their debian-slim runtime image, so
+	// their container HEALTHCHECK is a real probe. m2 and m4a still fall
+	// under the pre-#755 rule (no probe bundled, no health service
+	// registered) and MUST leave healthCmd empty until they're ported too.
+	rustWithProbe := map[string]int{
+		"m1": 50051,
+		"m7": 50057,
+	}
+	rustWithoutProbe := map[string]struct{}{
+		"m2":  {},
+		"m4a": {},
 	}
 
 	for _, spec := range fargateSpecs {
-		_, isRust := rustServices[spec.Key]
-		if !isRust {
+		port, wantsProbe := rustWithProbe[spec.Key]
+		_, noProbe := rustWithoutProbe[spec.Key]
+		if !wantsProbe && !noProbe {
 			continue
 		}
 
@@ -111,15 +119,22 @@ func TestGRPCHealthChecksForRustServices(t *testing.T) {
 				t.Errorf("service %s: lang = %q, want \"rust\"", spec.Key, spec.Lang)
 			}
 
-			// Rust images (debian-slim/distroless) bundle no
-			// grpc_health_probe and the services don't register
-			// grpc.health.v1 (no tonic-health), so a container health
-			// check could never pass: every declared probe fails and the
-			// deployment circuit breaker kills healthy rollouts. Liveness
-			// rides on ALB target health (matcher 0-99) + health-gate
-			// sidecars until tonic-health + probe bundling ship.
-			if len(spec.HealthCmd) != 0 {
-				t.Errorf("service %s: declares container healthCmd %v its image cannot run", spec.Key, spec.HealthCmd)
+			if noProbe {
+				if len(spec.HealthCmd) != 0 {
+					t.Errorf("service %s: declares container healthCmd %v its image cannot run (no grpc_health_probe bundled)", spec.Key, spec.HealthCmd)
+				}
+				return
+			}
+
+			// wantsProbe: expect exactly ["CMD", "/bin/grpc_health_probe", "-addr=:<port>"].
+			want := []string{"CMD", "/bin/grpc_health_probe", fmt.Sprintf("-addr=:%d", port)}
+			if len(spec.HealthCmd) != len(want) {
+				t.Fatalf("service %s: healthCmd = %v, want %v", spec.Key, spec.HealthCmd, want)
+			}
+			for i, w := range want {
+				if spec.HealthCmd[i] != w {
+					t.Errorf("service %s: healthCmd[%d] = %q, want %q", spec.Key, i, spec.HealthCmd[i], w)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- **M1 + M7** (experimentation-assignment, experimentation-flags) now register `grpc.health.v1` via `tonic-health` 0.12 — the reporter flips SERVING right before the tonic `Server` binds.
- Both **Dockerfiles bundle `/bin/grpc_health_probe`** via BuildKit `ADD --chmod=755` with `TARGETARCH`, so the multi-arch buildx push resolves the right amd64/arm64 binary per platform.
- **Reverts #754's workarounds** in `infra/pkg/aws/`: ALB target-group matcher back to `"0"`, per-service `healthCmd` restored for M1/M7, tests updated (`canProbe` now `{m1, m5, m6, m7}`; `TestGRPCHealthChecksForRustServices` split into wantsProbe/noProbe cohorts).

Closes #755. Unblocks the strict LB health checks for the M1/M7 live deploy path (#735) and closes the container-HEALTHCHECK gap that had every debian-slim Rust service silently unmonitored.

**Out of scope (follow-up):** M2-pipeline and M4a-analysis still register no health service and keep empty `healthCmd`. #755 calls those "ideally" — same 10-line pattern per service, but scoped out here so the merge that unblocks the live deploy stays focused. Will file a follow-up.

**Design note:** No fake NOT_SERVING→SERVING gate for optional deps. M1's M5-stream and M4b-bandit clients are best-effort (both `tokio::spawn`'d with warnings on failure); M7's reconciler + Kafka are opt-in via `M5_ADDR` / `FLAGS_KAFKA_ENABLED`. "Config loaded, service assembled" is the honest ready state — treating missing optional deps as NOT_SERVING would keep M7 unhealthy for every deploy that doesn't opt into M5.

## Test plan

- [x] `cargo build -p experimentation-assignment -p experimentation-flags`
- [x] `cargo build -p experimentation-assignment --features connectrpc` (ADR-031 pilot path)
- [x] `cargo test -p experimentation-assignment -p experimentation-flags --lib`
- [x] `cargo clippy -p experimentation-assignment -p experimentation-flags -- -D warnings`
- [x] `cargo check --workspace`
- [x] `go test ./infra/pkg/aws/compute/...`
- [x] `go test ./infra/pkg/aws/loadbalancer/...`
- [x] `go test ./infra/test/...`
- [ ] After merge: watch first m1/m7 deploy — ALB target health should flip to healthy on grpc `SERVING` response, `describe-target-health` should show `state: healthy` without the `-99` matcher window

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->