### PR TITLE
🎨 Palette: Standardize focus indicators on Portfolio navigation links

### DIFF
--- a/ui/src/app/portfolio/page.tsx
+++ b/ui/src/app/portfolio/page.tsx
@@ -122,7 +122,7 @@ export default function PortfolioDashboard() {
         </div>
         <Link
           href="/portfolio/provider-health"
-          className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          className="rounded-sm text-sm font-medium text-indigo-600 hover:text-indigo-800 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
           data-testid="provider-health-link"
         >
           Provider Health →


### PR DESCRIPTION
Standardized the keyboard focus visible ring on the "Provider Health" navigation link in the Portfolio view (`ui/src/app/portfolio/page.tsx`) to match platform-wide styles (`rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2`). This improves keyboard navigation compliance with WCAG 2.1.

---
*PR created automatically by Jules for task [13840913691989594188](https://jules.google.com/task/13840913691989594188) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->