### PR TITLE
🎨 Palette: Standardize ExperimentSelector accessibility and dropdown keyboard navigation

### DIFF
--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { ConfirmDialog } from '@/components/confirm-dialog';
@@ -11,7 +11,8 @@ import ExperimentListPage from '@/app/page';
 import ResultsPage from '@/app/experiments/[id]/results/page';
 import { AuthProvider } from '@/lib/auth-context';
 import type { AuthUser } from '@/lib/auth-context';
-import type { QueryLogEntry } from '@/lib/types';
+import type { QueryLogEntry, Experiment } from '@/lib/types';
+import { ExperimentSelector } from '@/components/experiment-selector';
 
 const defaultUser: AuthUser = { email: 'test@streamco.com', role: 'experimenter' };
 
@@ -358,6 +359,139 @@ describe('Accessibility', () => {
       // The dot is the first child span inside the badge
       const dot = container.querySelector('span > span');
       expect(dot).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  // --- ExperimentSelector ---
+
+  describe('ExperimentSelector Accessibility', () => {
+    const mockExperiments: Experiment[] = [
+      {
+        experimentId: 'exp-1',
+        name: 'Running Exp 1',
+        description: 'First mock experiment',
+        ownerEmail: 'owner1@streamco.com',
+        type: 'AB',
+        state: 'RUNNING',
+        variants: [
+          { variantId: 'v1', name: 'Control', trafficFraction: 0.5, isControl: true, payloadJson: '{}' },
+          { variantId: 'v2', name: 'Treatment', trafficFraction: 0.5, isControl: false, payloadJson: '{}' },
+        ],
+        layerId: 'layer-1',
+        hashSalt: 'salt',
+        primaryMetricId: 'metric-1',
+        secondaryMetricIds: [],
+        guardrailConfigs: [],
+        guardrailAction: 'ALERT_ONLY',
+        isCumulativeHoldout: false,
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        experimentId: 'exp-2',
+        name: 'Concluded Exp 2',
+        description: 'Second mock experiment',
+        ownerEmail: 'owner2@streamco.com',
+        type: 'AB',
+        state: 'CONCLUDED',
+        variants: [
+          { variantId: 'v3', name: 'Control', trafficFraction: 0.5, isControl: true, payloadJson: '{}' },
+          { variantId: 'v4', name: 'Treatment', trafficFraction: 0.5, isControl: false, payloadJson: '{}' },
+        ],
+        layerId: 'layer-2',
+        hashSalt: 'salt2',
+        primaryMetricId: 'metric-1',
+        secondaryMetricIds: [],
+        guardrailConfigs: [],
+        guardrailAction: 'ALERT_ONLY',
+        isCumulativeHoldout: false,
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    it('correctly associates label with the input element via htmlFor and id', () => {
+      render(
+        <ExperimentSelector
+          experiments={mockExperiments}
+          selectedIds={[]}
+          onSelect={vi.fn()}
+          onRemove={vi.fn()}
+        />,
+      );
+
+      const label = screen.getByText(/Select experiments to compare/);
+      expect(label).toHaveAttribute('for', 'experiment-search');
+
+      const input = screen.getByRole('textbox', { name: 'Search experiments' });
+      expect(input).toHaveAttribute('id', 'experiment-search');
+    });
+
+    it('input has focus-visible styling classes', () => {
+      render(
+        <ExperimentSelector
+          experiments={mockExperiments}
+          selectedIds={[]}
+          onSelect={vi.fn()}
+          onRemove={vi.fn()}
+        />,
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Search experiments' });
+      expect(input).toHaveClass('focus-visible:ring-2');
+      expect(input).toHaveClass('focus-visible:ring-indigo-500');
+      expect(input).toHaveClass('focus-visible:ring-offset-2');
+    });
+
+    it('provides keyboard-navigable and keyboard-selectable dropdown options', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+
+      render(
+        <ExperimentSelector
+          experiments={mockExperiments}
+          selectedIds={[]}
+          onSelect={onSelect}
+          onRemove={vi.fn()}
+        />,
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Search experiments' });
+      await user.click(input);
+      await user.keyboard('Running');
+
+      const options = await screen.findAllByRole('option');
+      expect(options).toHaveLength(1);
+      const option = options[0];
+
+      // Verify option is in the tab order (tabIndex={0}) and has focus styles
+      expect(option).toHaveAttribute('tabIndex', '0');
+      expect(option).toHaveClass('focus-visible:ring-2');
+      expect(option).toHaveClass('focus-visible:ring-indigo-500');
+
+      // Trigger selection with Enter key
+      await user.click(input); // focus input again
+      fireEvent.keyDown(option, { key: 'Enter', code: 'Enter' });
+      expect(onSelect).toHaveBeenCalledWith('exp-1');
+
+      // Trigger selection with Space key
+      onSelect.mockClear();
+      fireEvent.keyDown(option, { key: ' ', code: 'Space' });
+      expect(onSelect).toHaveBeenCalledWith('exp-1');
+    });
+
+    it('close button on selected chip has accessibility focus ring classes', () => {
+      render(
+        <ExperimentSelector
+          experiments={mockExperiments}
+          selectedIds={['exp-1']}
+          onSelect={vi.fn()}
+          onRemove={vi.fn()}
+        />,
+      );
+
+      const removeButton = screen.getByRole('button', { name: 'Remove Running Exp 1' });
+      expect(removeButton).toHaveClass('focus-visible:ring-2');
+      expect(removeButton).toHaveClass('focus-visible:ring-indigo-500');
+      expect(removeButton).toHaveClass('focus-visible:ring-offset-1');
     });
   });
 });

--- a/ui/src/components/experiment-selector.tsx
+++ b/ui/src/components/experiment-selector.tsx
@@ -54,7 +54,7 @@ function ExperimentSelectorInner({
 
   return (
     <div className="mb-6">
-      <label className="block text-sm font-medium text-gray-700 mb-2">
+      <label htmlFor="experiment-search" className="block text-sm font-medium text-gray-700 mb-2">
         Select experiments to compare (2-{maxSelections})
       </label>
 
@@ -72,7 +72,7 @@ function ExperimentSelectorInner({
                 <button
                   type="button"
                   onClick={() => onRemove(exp.experimentId)}
-                  className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-black/10"
+                  className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1"
                   aria-label={`Remove ${exp.name}`}
                 >
                   x
@@ -86,6 +86,7 @@ function ExperimentSelectorInner({
       {/* Search dropdown */}
       <div ref={containerRef} className="relative">
         <input
+          id="experiment-search"
           type="text"
           value={query}
           onChange={(e) => {
@@ -95,7 +96,7 @@ function ExperimentSelectorInner({
           onFocus={() => setIsOpen(true)}
           placeholder={atLimit ? `Maximum ${maxSelections} experiments selected` : 'Search experiments by name or owner...'}
           disabled={atLimit}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:bg-gray-100 disabled:cursor-not-allowed"
           aria-label="Search experiments"
           data-testid="experiment-search"
         />
@@ -118,6 +119,7 @@ function ExperimentSelectorInner({
                     key={exp.experimentId}
                     role="option"
                     aria-selected={false}
+                    tabIndex={0}
                     onClick={() => {
                       onSelect(exp.experimentId);
                       setQuery('');
@@ -125,7 +127,17 @@ function ExperimentSelectorInner({
                         setIsOpen(false);
                       }
                     }}
-                    className="cursor-pointer px-3 py-2 hover:bg-indigo-50 border-b border-gray-100 last:border-b-0"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onSelect(exp.experimentId);
+                        setQuery('');
+                        if (selectedIds.length + 1 >= maxSelections) {
+                          setIsOpen(false);
+                        }
+                      }
+                    }}
+                    className="cursor-pointer px-3 py-2 hover:bg-indigo-50 focus:bg-indigo-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 border-b border-gray-100 last:border-b-0"
                   >
                     <div className="flex items-center justify-between">
                       <div>


### PR DESCRIPTION
This PR introduces key accessibility and UX improvements to the `ExperimentSelector` component, making the experiment comparison experience more intuitive, accessible, and compliant with modern web standards.

💡 What:
- Connected selector label to search input using htmlFor/id.
- Standardized search input focus indicators using the platform-wide standard focus-visible classes.
- Added visual focus rings to close chip buttons on selected elements.
- Unlocked keyboard accessibility for dropdown selection lists by introducing tabIndex={0} and keyboard listeners (Enter/Space) to selectable list items with inset focus highlights.
- Added comprehensive Vitest tests in accessibility.test.tsx verifying the focus states and keyboard interactions.

🎯 Why:
Unlocks keyboard navigation for the comparison page, allowing keyboard-only and screen-reader users to select and remove compared experiments.

♿ Accessibility:
- Proper label-to-input association.
- Clear visual focus rings.
- Fully keyboard-driven selection flow.

---
*PR created automatically by Jules for task [2236076140701192110](https://jules.google.com/task/2236076140701192110) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->