### PR TITLE
🎨 Palette: Standardize focus indicators on sortable table headers

### DIFF
--- a/docs/guides/palette.md
+++ b/docs/guides/palette.md
@@ -76,3 +76,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-06-28 - Platform Navigation and Interaction Consistency
 **Learning:** Standardizing secondary navigation (breadcrumbs) and interaction patterns (disabled buttons vs. hiding) across all primary sections significantly reduces user disorientation and cognitive load. Providing explicit feedback on restricted actions (e.g., tooltips on disabled buttons) is more helpful than removing elements, as it clarifies permission boundaries without changing the UI layout.
 **Action:** Ensure all primary list and detail pages include breadcrumbs starting from the platform root. Use disabled states with role-requirement tooltips for permission-gated actions instead of hiding them.
+
+## 2026-07-10 - Standardizing Focus Styles on Sortable Headers
+**Learning:** Table header buttons used for sorting should implement standard visual focus indicators with a clear visual offset rather than tight inset rings. This consistent gap between the focus outline and the button text ensures clear spatial and visual indication for keyboard navigators, matching global navigation and primary button standards.
+**Action:** Always apply `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2` to table header sort buttons across both list views and portfolio grids instead of `focus-visible:ring-inset`.

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -34,7 +34,7 @@ function SortableHeader({
       <button
         type="button"
         onClick={() => onToggle(field)}
-        className="inline-flex cursor-pointer select-none items-center gap-1 hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 outline-none rounded-sm"
+        className="inline-flex cursor-pointer select-none items-center gap-1 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded-sm"
         title={`Sort by ${label}`}
       >
         {label}

--- a/ui/src/components/experiment-portfolio-table.tsx
+++ b/ui/src/components/experiment-portfolio-table.tsx
@@ -100,7 +100,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('name')}
-                className="group inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.name}`}
               >
                 {LABEL_MAP.name} <SortIndicator col="name" />
@@ -110,7 +110,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('effectSize')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.effectSize}`}
               >
                 {LABEL_MAP.effectSize} <SortIndicator col="effectSize" />
@@ -120,7 +120,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('variance')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.variance}`}
               >
                 {LABEL_MAP.variance} <SortIndicator col="variance" />
@@ -130,7 +130,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('allocatedTrafficPct')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.allocatedTrafficPct}`}
               >
                 {LABEL_MAP.allocatedTrafficPct} <SortIndicator col="allocatedTrafficPct" />
@@ -140,7 +140,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <button
                 type="button"
                 onClick={() => handleSort('priorityScore')}
-                className="group ml-auto inline-flex items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 hover:text-gray-700"
+                className="group ml-auto inline-flex items-center gap-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 hover:text-gray-700"
                 title={`Sort by ${LABEL_MAP.priorityScore}`}
               >
                 {LABEL_MAP.priorityScore} <SortIndicator col="priorityScore" />


### PR DESCRIPTION
Standardized sortable header buttons in both the main Experiment list page (`ui/src/app/page.tsx`) and the Experiment Portfolio table (`ui/src/components/experiment-portfolio-table.tsx`) by replacing `focus-visible:ring-inset` with the platform-standard, highly accessible focus ring pattern `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2`. This ensures WCAG 2.1 compliance and a clear, unified focus ring indicator across the platform.

---
*PR created automatically by Jules for task [16259669003774610989](https://jules.google.com/task/16259669003774610989) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->