### PR TITLE
🎨 Palette: standardize interactive table link focus styling

### DIFF
--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -13,6 +13,9 @@ import { AuthProvider } from '@/lib/auth-context';
 import type { AuthUser } from '@/lib/auth-context';
 import type { QueryLogEntry, Experiment } from '@/lib/types';
 import { ExperimentSelector } from '@/components/experiment-selector';
+import { MonitoringHealthTable } from '@/components/monitoring-health-table';
+import { ExperimentPortfolioTable } from '@/components/experiment-portfolio-table';
+import type { PortfolioExperiment } from '@/lib/types';
 
 const defaultUser: AuthUser = { email: 'test@streamco.com', role: 'experimenter' };
 
@@ -265,6 +268,67 @@ describe('Accessibility', () => {
       const nameLink = screen.getByRole('link', { name: 'homepage_recs_v2' });
       expect(nameLink).toHaveClass('focus-visible:ring-2');
       expect(nameLink).toHaveClass('focus-visible:ring-indigo-500');
+    });
+  });
+
+  describe('MonitoringHealthTable', () => {
+    it('experiment name links have focus-visible styling for keyboard accessibility', () => {
+      const mockRunningExperiments: Experiment[] = [
+        {
+          experimentId: 'exp-running-1',
+          name: 'Running Exp 1',
+          description: 'First mock experiment',
+          ownerEmail: 'owner1@streamco.com',
+          type: 'AB',
+          state: 'RUNNING',
+          variants: [],
+          layerId: 'layer-1',
+          hashSalt: 'salt',
+          primaryMetricId: 'metric-1',
+          secondaryMetricIds: [],
+          guardrailConfigs: [],
+          guardrailAction: 'ALERT_ONLY',
+          isCumulativeHoldout: false,
+          createdAt: '2026-01-01T00:00:00Z',
+          startedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+
+      render(
+        <MonitoringHealthTable
+          experiments={mockRunningExperiments}
+          analysisResults={{}}
+          guardrailStatuses={{}}
+        />,
+      );
+
+      const nameLink = screen.getByRole('link', { name: 'Running Exp 1' });
+      expect(nameLink).toHaveClass('focus-visible:ring-2');
+      expect(nameLink).toHaveClass('focus-visible:ring-indigo-500');
+      expect(nameLink).toHaveClass('focus-visible:ring-offset-2');
+    });
+  });
+
+  describe('ExperimentPortfolioTable', () => {
+    it('experiment name links have focus-visible styling for keyboard accessibility', () => {
+      const mockPortfolioExperiments: PortfolioExperiment[] = [
+        {
+          experimentId: 'exp-portfolio-1',
+          name: 'Portfolio Exp 1',
+          effectSize: 0.1,
+          variance: 0.01,
+          allocatedTrafficPct: 0.5,
+          priorityScore: 0.8,
+          userSegments: ['all'],
+        },
+      ];
+
+      render(<ExperimentPortfolioTable experiments={mockPortfolioExperiments} />);
+
+      const nameLink = screen.getByRole('link', { name: 'Portfolio Exp 1' });
+      expect(nameLink).toHaveClass('focus-visible:ring-2');
+      expect(nameLink).toHaveClass('focus-visible:ring-indigo-500');
+      expect(nameLink).toHaveClass('focus-visible:ring-offset-2');
     });
   });
 

--- a/ui/src/components/experiment-portfolio-table.tsx
+++ b/ui/src/components/experiment-portfolio-table.tsx
@@ -160,7 +160,7 @@ export function ExperimentPortfolioTable({ experiments }: ExperimentPortfolioTab
               <td className="py-3 pl-4 pr-3">
                 <Link
                   href={`/experiments/${exp.experimentId}`}
-                  className="font-medium text-indigo-600 hover:text-indigo-800"
+                  className="font-medium text-indigo-600 hover:text-indigo-800 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                   data-testid={`portfolio-row-name-${exp.experimentId}`}
                 >
                   {exp.name}

--- a/ui/src/components/monitoring-health-table.tsx
+++ b/ui/src/components/monitoring-health-table.tsx
@@ -153,7 +153,7 @@ export function MonitoringHealthTable({
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
                   <Link
                     href={`/experiments/${exp.experimentId}`}
-                    className="font-medium text-indigo-600 hover:text-indigo-900"
+                    className="font-medium text-indigo-600 hover:text-indigo-900 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
                     data-testid={`experiment-link-${exp.experimentId}`}
                   >
                     {exp.name}


### PR DESCRIPTION
Add standardized focus indicators (`rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2`) to the experiment name navigation links inside both the Monitoring page running experiments health table and the Portfolio active experiments table. This completes keyboard navigation accessibility parity and WCAG 2.1 compliance for standard list/table views, matching other dashboard list views and global navigation. Additionally, added comprehensive tests in `accessibility.test.tsx` to assert that they render with the correct accessibility class names and documented the learning in Palette's journal.

---
*PR created automatically by Jules for task [10358192114963450322](https://jules.google.com/task/10358192114963450322) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->