### PR TITLE
chore: add .venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ graphify-out/cache/
 # Go module build binaries (nested Pulumi programs)
 infra/github-governance/github-governance
 __pycache__/
+.venv/


### PR DESCRIPTION
## Summary
- Add `.venv/` to `.gitignore` so Python virtualenvs (root or `sdks/server-python/`) never show up as untracked noise or get committed.

## Test plan
- [x] `git check-ignore .venv sdks/server-python/.venv` matches after this change (unanchored dir pattern applies at any depth)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->