### PR TITLE
🎨 Palette: Standardise compare search input

### DIFF
--- a/ui/src/components/experiment-selector.tsx
+++ b/ui/src/components/experiment-selector.tsx
@@ -85,21 +85,47 @@ function ExperimentSelectorInner({
 
       {/* Search dropdown */}
       <div ref={containerRef} className="relative">
-        <input
-          id="experiment-search"
-          type="text"
-          value={query}
-          onChange={(e) => {
-            setQuery(e.target.value);
-            setIsOpen(true);
-          }}
-          onFocus={() => setIsOpen(true)}
-          placeholder={atLimit ? `Maximum ${maxSelections} experiments selected` : 'Search experiments by name or owner...'}
-          disabled={atLimit}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:bg-gray-100 disabled:cursor-not-allowed"
-          aria-label="Search experiments"
-          data-testid="experiment-search"
-        />
+        <div className="group relative w-full">
+          <svg
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            id="experiment-search"
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setIsOpen(true);
+            }}
+            onFocus={() => setIsOpen(true)}
+            placeholder={atLimit ? `Maximum ${maxSelections} experiments selected` : 'Search experiments by name or owner...'}
+            disabled={atLimit}
+            className="w-full rounded-md border border-gray-300 py-2 pl-9 pr-10 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:bg-gray-100 disabled:cursor-not-allowed"
+            aria-label="Search experiments"
+            data-testid="experiment-search"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+              }}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
+              aria-label="Clear search"
+              data-testid="clear-search-button"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          ) : null}
+        </div>
 
         {isOpen && !atLimit && (
           <ul


### PR DESCRIPTION
💡 What:
Standardized the search input in the `ExperimentSelector` component (`ui/src/components/experiment-selector.tsx`) to match the platform's standardized search input patterns.

🎯 Why:
To ensure visual consistency, usability, and accessibility across all filter/search components in the platform. The comparison page's selector now matches the main experiment and audit list filters.

♿ Accessibility & Polish:
- Wrapped input in a styled relative container `<div className="group relative w-full">`.
- Added absolute-positioned magnifying glass SVG with `pointer-events-none`.
- Added accessible "Clear search" button with `aria-label="Clear search"`, `data-testid="clear-search-button"`, and `focus-visible` styling.
- Adjusted padding classes `py-2 pl-9 pr-10` to perfectly offset text from icons.
- Retained exact label association and focus rings to pass all existing unit and accessibility test suites.

---
*PR created automatically by Jules for task [6761106937638889175](https://jules.google.com/task/6761106937638889175) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->