### PR TITLE
🎨 Palette: Add Clear All selections button in comparison page

### DIFF
--- a/docs/guides/palette.md
+++ b/docs/guides/palette.md
@@ -80,3 +80,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-07-10 - Standardizing Focus Styles on Sortable Headers
 **Learning:** Table header buttons used for sorting should implement standard visual focus indicators with a clear visual offset rather than tight inset rings. This consistent gap between the focus outline and the button text ensures clear spatial and visual indication for keyboard navigators, matching global navigation and primary button standards.
 **Action:** Always apply `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2` to table header sort buttons across both list views and portfolio grids instead of `focus-visible:ring-inset`.
+
+## 2026-07-15 - Multi-Selection Reset Interaction Pattern
+**Learning:** For multi-selection workflows (such as selecting multiple experiments for side-by-side comparison), users find it highly tedious to individually close or remove each selection chip to reset or clear the view. Providing a dedicated, keyboard-accessible "Clear all" button alongside the chips significantly reduces interaction friction and facilitates quick, exploratory comparison flows.
+**Action:** When displaying a list of selected interactive items or chips, always render an adjacent "Clear all" reset button if multiple items are present. Ensure the button is fully navigable and styles its focus state with offset rings for maximum accessibility.

--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -557,5 +557,22 @@ describe('Accessibility', () => {
       expect(removeButton).toHaveClass('focus-visible:ring-indigo-500');
       expect(removeButton).toHaveClass('focus-visible:ring-offset-1');
     });
+
+    it('clear all button on selected chips has accessibility focus ring classes', () => {
+      render(
+        <ExperimentSelector
+          experiments={mockExperiments}
+          selectedIds={['exp-1']}
+          onSelect={vi.fn()}
+          onRemove={vi.fn()}
+          onClearAll={vi.fn()}
+        />,
+      );
+
+      const clearAllButton = screen.getByRole('button', { name: 'Clear all selections' });
+      expect(clearAllButton).toHaveClass('focus-visible:ring-2');
+      expect(clearAllButton).toHaveClass('focus-visible:ring-indigo-500');
+      expect(clearAllButton).toHaveClass('focus-visible:ring-offset-1');
+    });
   });
 });

--- a/ui/src/__tests__/comparison.test.tsx
+++ b/ui/src/__tests__/comparison.test.tsx
@@ -264,4 +264,42 @@ describe('Experiment Comparison Page', () => {
 
     expect(screen.getByText(/Select at least one more experiment/)).toBeInTheDocument();
   });
+
+  it('can clear all experiments from comparison with one click', async () => {
+    const user = userEvent.setup();
+    render(<ComparePage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('experiment-search')).toBeInTheDocument();
+    });
+
+    // Select two experiments
+    const searchInput = screen.getByTestId('experiment-search');
+    await user.click(searchInput);
+    await waitFor(() => { expect(screen.getByText('homepage_recs_v2')).toBeInTheDocument(); });
+    await user.click(screen.getByText('homepage_recs_v2'));
+
+    await user.click(searchInput);
+    await waitFor(() => { expect(screen.getByText('retention_nudge_v1')).toBeInTheDocument(); });
+    await user.click(screen.getByText('retention_nudge_v1'));
+
+    // Wait for comparison tables
+    await waitFor(() => {
+      expect(screen.getByTestId('metadata-table')).toBeInTheDocument();
+    });
+
+    // Verify Clear all button exists
+    const clearAllButton = screen.getByTestId('clear-all-selections');
+    expect(clearAllButton).toBeInTheDocument();
+
+    // Click Clear all
+    await user.click(clearAllButton);
+
+    // Should return to empty state
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('No experiments selected')).toBeInTheDocument();
+  });
 });

--- a/ui/src/app/compare/page.tsx
+++ b/ui/src/app/compare/page.tsx
@@ -85,6 +85,10 @@ export default function ComparePage() {
     setSelectedIds((prev) => prev.filter((sid) => sid !== id));
   }, []);
 
+  const handleClearAll = useCallback(() => {
+    setSelectedIds([]);
+  }, []);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12" role="status" aria-label="Loading">
@@ -115,6 +119,7 @@ export default function ComparePage() {
         selectedIds={selectedIds}
         onSelect={handleSelect}
         onRemove={handleRemove}
+        onClearAll={handleClearAll}
       />
 
       {/* Empty state */}

--- a/ui/src/components/experiment-selector.tsx
+++ b/ui/src/components/experiment-selector.tsx
@@ -9,6 +9,7 @@ interface ExperimentSelectorProps {
   selectedIds: string[];
   onSelect: (id: string) => void;
   onRemove: (id: string) => void;
+  onClearAll?: () => void;
   maxSelections?: number;
 }
 
@@ -17,6 +18,7 @@ function ExperimentSelectorInner({
   selectedIds,
   onSelect,
   onRemove,
+  onClearAll,
   maxSelections = 4,
 }: ExperimentSelectorProps) {
   const [query, setQuery] = useState('');
@@ -60,7 +62,7 @@ function ExperimentSelectorInner({
 
       {/* Selected experiment chips */}
       {selectedExperiments.length > 0 && (
-        <div className="mb-3 flex flex-wrap gap-2" data-testid="selected-experiments">
+        <div className="mb-3 flex flex-wrap items-center gap-2" data-testid="selected-experiments">
           {selectedExperiments.map((exp) => {
             const stateConfig = STATE_CONFIG[exp.state];
             return (
@@ -80,6 +82,17 @@ function ExperimentSelectorInner({
               </span>
             );
           })}
+          {onClearAll && (
+            <button
+              type="button"
+              onClick={onClearAll}
+              className="rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1"
+              data-testid="clear-all-selections"
+              aria-label="Clear all selections"
+            >
+              Clear all
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
### 💡 What
Added a "Clear all" selections button right next to selected experiment chips on the comparison page. This allows users to completely reset selection lists in one click.

### 🎯 Why
Without this, users with 2, 3, or 4 selections had to individually close each selection tag to reset the comparison view, which was highly tedious and high-friction.

### ♿ Accessibility
- Implemented keyboard accessibility for the "Clear all" button with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1` class matching standard interactive offset focus rings.
- Included descriptive `aria-label="Clear all selections"` for screen readers.

### ✅ Verification
- Wrote new functional tests in `ui/src/__tests__/comparison.test.tsx` and accessibility tests in `ui/src/__tests__/accessibility.test.tsx` confirming focus classes and clearing logic.
- Generated and visually checked Playwright screenshots demonstrating focused and cleared comparison states.
- Cleaned up all logs and temporary files prior to finalization.

---
*PR created automatically by Jules for task [10516657775889845083](https://jules.google.com/task/10516657775889845083) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->