### PR TITLE
🎨 Palette: Integrate keyboard shortcut focusing in experiment selection

### DIFF
--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -574,5 +574,40 @@ describe('Accessibility', () => {
       expect(clearAllButton).toHaveClass('focus-visible:ring-indigo-500');
       expect(clearAllButton).toHaveClass('focus-visible:ring-offset-1');
     });
+
+    it('focuses search input on "/" keypress and handles disabled state at selection limit', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <ExperimentSelector
+          experiments={mockExperiments}
+          selectedIds={[]}
+          onSelect={vi.fn()}
+          onRemove={vi.fn()}
+        />,
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Search experiments' });
+      expect(input).not.toHaveFocus();
+
+      // Press '/' to focus
+      await user.keyboard('/');
+      expect(input).toHaveFocus();
+
+      // Rerender with max selections (limit of 4 reached)
+      rerender(
+        <ExperimentSelector
+          experiments={mockExperiments}
+          selectedIds={['exp-1', 'exp-2', 'exp-3', 'exp-4']}
+          onSelect={vi.fn()}
+          onRemove={vi.fn()}
+          maxSelections={4}
+        />,
+      );
+
+      // Input should be disabled, and hint "/" badge is not rendered
+      const disabledInput = screen.getByRole('textbox', { name: 'Search experiments' });
+      expect(disabledInput).toBeDisabled();
+      expect(screen.queryByText('/')).not.toBeInTheDocument();
+    });
   });
 });

--- a/ui/src/components/experiment-selector.tsx
+++ b/ui/src/components/experiment-selector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, memo } from 'react';
+import { useSearchShortcut } from '@/hooks/use-search-shortcut';
 import type { Experiment } from '@/lib/types';
 import { STATE_CONFIG, TYPE_LABELS } from '@/lib/utils';
 
@@ -24,6 +25,9 @@ function ExperimentSelectorInner({
   const [query, setQuery] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useSearchShortcut(inputRef);
 
   // Filter to experiments with results (RUNNING or CONCLUDED)
   const selectableExperiments = experiments.filter(
@@ -109,6 +113,7 @@ function ExperimentSelectorInner({
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
           <input
+            ref={inputRef}
             id="experiment-search"
             type="text"
             value={query}
@@ -137,6 +142,12 @@ function ExperimentSelectorInner({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
+          ) : !atLimit ? (
+            <div className="pointer-events-none absolute right-3 top-1/2 flex -translate-y-1/2 items-center group-focus-within:hidden group-hover:hidden">
+              <span className="flex h-5 w-5 items-center justify-center rounded border border-gray-300 bg-gray-50 text-[10px] font-medium text-gray-500">
+                /
+              </span>
+            </div>
           ) : null}
         </div>
 


### PR DESCRIPTION
Incorporated the `useSearchShortcut` hook in `ui/src/components/experiment-selector.tsx` to enable fast keyboard-driven focus using standard shortcuts (`/`, Cmd+K, Ctrl+K) on the Experiment Comparison page. Added the standard keyboard shortcut `/` hint badge, which hides automatically on hover/focus, when text is entered, or when the selector is disabled at its maximum selection limit. Included a comprehensive accessibility unit test to guarantee standard-compliant keyboard navigation and focus behavior.

---
*PR created automatically by Jules for task [15150266457372782211](https://jules.google.com/task/15150266457372782211) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->