### PR TITLE
🎨 Palette: Enhance Feature Flag Detail permission-gated Edit action

### DIFF
--- a/ui/src/__tests__/flag-detail-permissions.test.tsx
+++ b/ui/src/__tests__/flag-detail-permissions.test.tsx
@@ -1,0 +1,59 @@
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import FlagDetailPage from '@/app/flags/[id]/page';
+import { ToastProvider } from '@/lib/toast-context';
+import { getFlag } from '@/lib/api';
+import type { Flag } from '@/lib/types';
+
+vi.mock('@/lib/api', () => ({
+  getFlag: vi.fn(),
+  promoteToExperiment: vi.fn(),
+}));
+
+const mockFlag: Flag = {
+  flagId: 'test-flag-id',
+  name: 'Test Flag',
+  description: 'Test description',
+  type: 'BOOLEAN',
+  defaultValue: 'false',
+  enabled: true,
+  rolloutPercentage: 0.5,
+  variants: [
+    { variantId: 'control', value: 'false', trafficFraction: 0.5 },
+    { variantId: 'treatment', value: 'true', trafficFraction: 0.5 },
+  ],
+};
+
+// Mock AuthContext
+vi.mock('@/lib/auth-context', () => ({
+  useAuth: () => ({
+    user: { email: 'viewer@example.com', role: 'viewer' },
+    canAtLeast: (role: string) => role === 'viewer',
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'test-flag-id' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('Flag Detail Permissions', () => {
+  test('renders disabled Edit button with tooltip for insufficient roles', async () => {
+    vi.mocked(getFlag).mockResolvedValue(mockFlag);
+
+    render(
+      <ToastProvider>
+        <FlagDetailPage />
+      </ToastProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('flag-name')).toBeInTheDocument();
+    });
+
+    const editBtn = screen.getByTestId('edit-flag-disabled');
+    expect(editBtn).toBeInTheDocument();
+    expect(editBtn).toHaveAttribute('aria-disabled', 'true');
+    expect(editBtn).toHaveAttribute('title', 'Requires Experimenter role (you are Viewer)');
+  });
+});

--- a/ui/src/app/flags/[id]/page.tsx
+++ b/ui/src/app/flags/[id]/page.tsx
@@ -9,6 +9,7 @@ import { RetryableError } from '@/components/retryable-error';
 import { useAuth } from '@/lib/auth-context';
 import { CopyButton } from '@/components/copy-button';
 import { Breadcrumb } from '@/components/breadcrumb';
+import { ROLE_LABELS } from '@/lib/auth';
 
 const FLAG_TYPE_BADGE: Record<FlagType, string> = {
   BOOLEAN: 'bg-blue-100 text-blue-800',
@@ -20,7 +21,7 @@ const FLAG_TYPE_BADGE: Record<FlagType, string> = {
 function FlagDetailContent() {
   const params = useParams();
   const router = useRouter();
-  const { canAtLeast } = useAuth();
+  const { canAtLeast, user } = useAuth();
   const flagId = params.id as string;
 
   const [flag, setFlag] = useState<Flag | null>(null);
@@ -92,7 +93,7 @@ function FlagDetailContent() {
         <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${flag.enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
           {flag.enabled ? 'Enabled' : 'Disabled'}
         </span>
-        {canAtLeast('experimenter') && (
+        {canAtLeast('experimenter') ? (
           <Link
             href={`/flags/${flag.flagId}/edit`}
             className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:outline-none"
@@ -100,6 +101,17 @@ function FlagDetailContent() {
           >
             Edit
           </Link>
+        ) : (
+          <span
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 opacity-50 cursor-not-allowed focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+            title={`Requires Experimenter role (you are ${user ? ROLE_LABELS[user.role] : 'Unknown'})`}
+            data-testid="edit-flag-disabled"
+            tabIndex={0}
+            role="button"
+            aria-disabled="true"
+          >
+            Edit
+          </span>
         )}
       </div>
 


### PR DESCRIPTION
Added a role-gated disabled button with a descriptive title tooltip on the Feature Flag Detail page when user has insufficient permissions to edit the flag, matching established micro-UX and accessibility patterns.

---
*PR created automatically by Jules for task [9119915545167081867](https://jules.google.com/task/9119915545167081867) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->