### PR TITLE
🎨 Palette: Restore focus to search inputs on clear click

### DIFF
--- a/ui/src/__tests__/search-clear-focus.test.tsx
+++ b/ui/src/__tests__/search-clear-focus.test.tsx
@@ -1,0 +1,224 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ExperimentSelector } from '@/components/experiment-selector';
+import { ExperimentFiltersToolbar } from '@/components/experiment-filters';
+import { AuditFilters } from '@/components/audit-filters';
+import { AuthProvider } from '@/lib/auth-context';
+import { ToastProvider } from '@/lib/toast-context';
+import FlagListPage from '@/app/flags/page';
+import MetricBrowserPage from '@/app/metrics/page';
+import type { Experiment } from '@/lib/types';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useParams: () => ({}),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+// Mock next/dynamic
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<{ default: React.ComponentType<unknown> }>) => {
+    let Comp: React.ComponentType<unknown> | null = null;
+    loader().then((mod) => { Comp = mod.default; });
+    return function DynamicMock(props: Record<string, unknown>) {
+      return Comp ? <Comp {...props} /> : null;
+    };
+  },
+}));
+
+const mockExperiments: Experiment[] = [
+  {
+    experimentId: 'exp-1',
+    name: 'Running Exp 1',
+    description: 'First mock experiment',
+    ownerEmail: 'owner1@streamco.com',
+    type: 'AB',
+    state: 'RUNNING',
+    variants: [],
+    layerId: 'layer-1',
+    hashSalt: 'salt',
+    primaryMetricId: 'metric-1',
+    secondaryMetricIds: [],
+    guardrailConfigs: [],
+    guardrailAction: 'ALERT_ONLY',
+    isCumulativeHoldout: false,
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+];
+
+describe('Search Clear Buttons Focus Restoration', () => {
+  it('ExperimentSelector restores focus to search input when clear search is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <ExperimentSelector
+        experiments={mockExperiments}
+        selectedIds={[]}
+        onSelect={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Search experiments' });
+    await user.type(input, 'test-query');
+    expect(input).toHaveValue('test-query');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear search' });
+    await user.click(clearButton);
+
+    expect(input).toHaveValue('');
+    expect(input).toHaveFocus();
+  });
+
+  it('ExperimentFiltersToolbar restores focus to search input when clear search is clicked', async () => {
+    const user = userEvent.setup();
+    const setQueryMock = vi.fn();
+    const mockFilters = {
+      query: 'test-filter-query',
+      setQuery: setQueryMock,
+      stateFilter: '' as const,
+      setStateFilter: vi.fn(),
+      typeFilter: '' as const,
+      setTypeFilter: vi.fn(),
+      sortField: 'createdAt' as const,
+      sortDir: 'desc' as const,
+      toggleSort: vi.fn(),
+      clearFilters: vi.fn(),
+      applyFilters: (exps: Experiment[]) => exps,
+      hasActiveFilters: true,
+    };
+
+    render(
+      <ExperimentFiltersToolbar
+        filters={mockFilters}
+        totalCount={1}
+        filteredCount={1}
+      />
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Search experiments' });
+    expect(input).toHaveValue('test-filter-query');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear search' });
+    await user.click(clearButton);
+
+    expect(setQueryMock).toHaveBeenCalledWith('');
+    expect(input).toHaveFocus();
+  });
+
+  it('AuditFilters restores focus to experiment search input when experiment search is cleared', async () => {
+    const user = userEvent.setup();
+    const onExperimentQueryChangeMock = vi.fn();
+
+    render(
+      <AuditFilters
+        experimentQuery="audit-exp-query"
+        onExperimentQueryChange={onExperimentQueryChangeMock}
+        actionFilter=""
+        onActionFilterChange={vi.fn()}
+        actorQuery=""
+        onActorQueryChange={vi.fn()}
+        totalCount={10}
+        filteredCount={5}
+        onClear={vi.fn()}
+        hasActiveFilters={true}
+      />
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Search by experiment name' });
+    expect(input).toHaveValue('audit-exp-query');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear experiment search' });
+    await user.click(clearButton);
+
+    expect(onExperimentQueryChangeMock).toHaveBeenCalledWith('');
+    expect(input).toHaveFocus();
+  });
+
+  it('AuditFilters restores focus to actor search input when actor search is cleared', async () => {
+    const user = userEvent.setup();
+    const onActorQueryChangeMock = vi.fn();
+
+    render(
+      <AuditFilters
+        experimentQuery=""
+        onExperimentQueryChange={vi.fn()}
+        actionFilter=""
+        onActionFilterChange={vi.fn()}
+        actorQuery="actor-query"
+        onActorQueryChange={onActorQueryChangeMock}
+        totalCount={10}
+        filteredCount={5}
+        onClear={vi.fn()}
+        hasActiveFilters={true}
+      />
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Filter by actor email' });
+    expect(input).toHaveValue('actor-query');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear actor search' });
+    await user.click(clearButton);
+
+    expect(onActorQueryChangeMock).toHaveBeenCalledWith('');
+    expect(input).toHaveFocus();
+  });
+
+  it('FlagListPage restores focus to search input when clear search is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AuthProvider initialUser={{ email: 'test@streamco.com', role: 'admin' }}>
+        <ToastProvider>
+          <FlagListPage />
+        </ToastProvider>
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search by name, ID, or description...')).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText('Search by name, ID, or description...');
+    await user.type(input, 'flag-query');
+    expect(input).toHaveValue('flag-query');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear search' });
+    await user.click(clearButton);
+
+    expect(input).toHaveValue('');
+    expect(input).toHaveFocus();
+  });
+
+  it('MetricBrowserPage restores focus to search input when clear search is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <AuthProvider initialUser={{ email: 'test@streamco.com', role: 'admin' }}>
+        <ToastProvider>
+          <MetricBrowserPage />
+        </ToastProvider>
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search by name, ID, or description...')).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText('Search by name, ID, or description...');
+    await user.type(input, 'metric-query');
+    expect(input).toHaveValue('metric-query');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear search' });
+    await user.click(clearButton);
+
+    expect(input).toHaveValue('');
+    expect(input).toHaveFocus();
+  });
+});

--- a/ui/src/app/flags/page.tsx
+++ b/ui/src/app/flags/page.tsx
@@ -158,7 +158,10 @@ function FlagListContent() {
           {search ? (
             <button
               type="button"
-              onClick={() => setSearch('')}
+              onClick={() => {
+                setSearch('');
+                inputRef.current?.focus();
+              }}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
               aria-label="Clear search"
               data-testid="clear-search-button"

--- a/ui/src/app/metrics/page.tsx
+++ b/ui/src/app/metrics/page.tsx
@@ -434,7 +434,10 @@ function MetricBrowserContent() {
           {search ? (
             <button
               type="button"
-              onClick={() => setSearch('')}
+              onClick={() => {
+                setSearch('');
+                inputRef.current?.focus();
+              }}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
               aria-label="Clear search"
               data-testid="clear-search-button"

--- a/ui/src/components/audit-filters.tsx
+++ b/ui/src/components/audit-filters.tsx
@@ -47,6 +47,7 @@ export function AuditFilters({
   hasActiveFilters,
 }: AuditFiltersProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const actorInputRef = useRef<HTMLInputElement>(null);
   useSearchShortcut(inputRef);
 
   return (
@@ -74,7 +75,10 @@ export function AuditFilters({
         {experimentQuery ? (
           <button
             type="button"
-            onClick={() => onExperimentQueryChange('')}
+            onClick={() => {
+              onExperimentQueryChange('');
+              inputRef.current?.focus();
+            }}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
             aria-label="Clear experiment search"
             data-testid="clear-search-button"
@@ -117,6 +121,7 @@ export function AuditFilters({
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
         <input
+          ref={actorInputRef}
           type="text"
           placeholder="Filter by actor..."
           value={actorQuery}
@@ -127,7 +132,10 @@ export function AuditFilters({
         {actorQuery && (
           <button
             type="button"
-            onClick={() => onActorQueryChange('')}
+            onClick={() => {
+              onActorQueryChange('');
+              actorInputRef.current?.focus();
+            }}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
             aria-label="Clear actor search"
             data-testid="clear-actor-search"

--- a/ui/src/components/experiment-filters.tsx
+++ b/ui/src/components/experiment-filters.tsx
@@ -50,7 +50,10 @@ export function ExperimentFiltersToolbar({ filters, totalCount, filteredCount }:
         {filters.query ? (
           <button
             type="button"
-            onClick={() => filters.setQuery('')}
+            onClick={() => {
+              filters.setQuery('');
+              inputRef.current?.focus();
+            }}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
             aria-label="Clear search"
             data-testid="clear-search-button"

--- a/ui/src/components/experiment-selector.tsx
+++ b/ui/src/components/experiment-selector.tsx
@@ -133,6 +133,7 @@ function ExperimentSelectorInner({
               type="button"
               onClick={() => {
                 setQuery('');
+                inputRef.current?.focus();
               }}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded-sm"
               aria-label="Clear search"


### PR DESCRIPTION
### What
Implemented focus-restoration back to text inputs when clicking the "Clear" button on search fields across multiple application views (Experiments Selector, Experiments Filters Toolbar, Audit Filters, Feature Flags Page, and Metric Definitions Page).

### Why
When a keyboard or screen reader user triggers a search-clear action, the clear button is unmounted from the DOM. Without focus restoration, focus is lost, resetting to the top of the body, which can be highly disorienting. Restoring focus directly back to the input field provides a smooth, accessible transition.

### Accessibility
- Ensures keyboard and screen reader focus is not lost on unmounting clear buttons.
- Fully WCAG 2.1 compliant keyboard interaction.
- Unit tests added to explicitly verify focus-restoration behavior in all relevant components.

---
*PR created automatically by Jules for task [2974785493210003936](https://jules.google.com/task/2974785493210003936) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->