### PR TITLE
🎨 Palette: Add copy-to-clipboard buttons to comparison table metrics

### DIFF
--- a/ui/src/__tests__/comparison.test.tsx
+++ b/ui/src/__tests__/comparison.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import ComparePage from '@/app/compare/page';
+import { ToastProvider } from '@/lib/toast-context';
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({}),
@@ -49,7 +50,11 @@ vi.mock('recharts', async () => {
 
 describe('Experiment Comparison Page', () => {
   it('renders page heading and experiment selector', async () => {
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Experiment Comparison' })).toBeInTheDocument();
@@ -59,7 +64,11 @@ describe('Experiment Comparison Page', () => {
   });
 
   it('shows empty state when no experiments selected', async () => {
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('empty-state')).toBeInTheDocument();
@@ -71,7 +80,11 @@ describe('Experiment Comparison Page', () => {
 
   it('selector shows available experiments (RUNNING/CONCLUDED)', async () => {
     const user = userEvent.setup();
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('experiment-search')).toBeInTheDocument();
@@ -100,7 +113,11 @@ describe('Experiment Comparison Page', () => {
 
   it('selecting experiments fetches and displays results', async () => {
     const user = userEvent.setup();
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('experiment-search')).toBeInTheDocument();
@@ -135,7 +152,11 @@ describe('Experiment Comparison Page', () => {
 
   it('comparison table shows metric results side-by-side', async () => {
     const user = userEvent.setup();
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('experiment-search')).toBeInTheDocument();
@@ -171,7 +192,11 @@ describe('Experiment Comparison Page', () => {
 
   it('chart renders with effect sizes', async () => {
     const user = userEvent.setup();
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('experiment-search')).toBeInTheDocument();
@@ -198,7 +223,11 @@ describe('Experiment Comparison Page', () => {
 
   it('metric alignment matrix shows shared metrics', async () => {
     const user = userEvent.setup();
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('experiment-search')).toBeInTheDocument();
@@ -232,7 +261,11 @@ describe('Experiment Comparison Page', () => {
 
   it('can remove an experiment from comparison', async () => {
     const user = userEvent.setup();
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('experiment-search')).toBeInTheDocument();
@@ -267,7 +300,11 @@ describe('Experiment Comparison Page', () => {
 
   it('can clear all experiments from comparison with one click', async () => {
     const user = userEvent.setup();
-    render(<ComparePage />);
+    render(
+      <ToastProvider>
+        <ComparePage />
+      </ToastProvider>
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('experiment-search')).toBeInTheDocument();

--- a/ui/src/components/comparison-table.tsx
+++ b/ui/src/components/comparison-table.tsx
@@ -3,6 +3,7 @@
 import { memo } from 'react';
 import type { Experiment, AnalysisResult, MetricResult } from '@/lib/types';
 import { formatEffect, formatPValue, formatDate, STATE_CONFIG, TYPE_LABELS } from '@/lib/utils';
+import { CopyButton } from './copy-button';
 
 interface ComparisonEntry {
   experiment: Experiment;
@@ -158,7 +159,17 @@ function ComparisonTableInner({ entries }: ComparisonTableProps) {
                 <td className="px-4 py-3 text-sm font-medium text-gray-900">Primary Metric</td>
                 {entries.map((e) => (
                   <td key={e.experiment.experimentId} className="px-4 py-3 text-sm text-gray-600 font-mono">
-                    {e.experiment.primaryMetricId}
+                    <div className="group flex items-center gap-2">
+                      <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+                        {e.experiment.primaryMetricId}
+                      </code>
+                      <CopyButton
+                        value={e.experiment.primaryMetricId}
+                        label="Copy primary metric ID"
+                        successMessage="Primary metric ID copied"
+                        className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+                      />
+                    </div>
                   </td>
                 ))}
               </tr>
@@ -239,8 +250,20 @@ function ComparisonTableInner({ entries }: ComparisonTableProps) {
             </thead>
             <tbody className="divide-y divide-gray-200 bg-white">
               {allMetricIds.map((metricId) => (
-                <tr key={metricId}>
-                  <td className="px-4 py-3 text-sm font-medium text-gray-900 font-mono">{metricId}</td>
+                <tr key={metricId} className="group">
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900 font-mono">
+                    <div className="flex items-center gap-2">
+                      <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">
+                        {metricId}
+                      </code>
+                      <CopyButton
+                        value={metricId}
+                        label="Copy metric ID"
+                        successMessage="Metric ID copied"
+                        className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+                      />
+                    </div>
+                  </td>
                   {entries.map((e) => {
                     const hasMetric = e.analysisResult.metricResults.some((m) => m.metricId === metricId);
                     return (


### PR DESCRIPTION
This PR adds hover-reveal `CopyButton` utilities to metric ID cells inside the Experiment Comparison tables. This makes copy-to-clipboard operations intuitive and friction-free for developers while keeping the dashboard visual layout dense and uncluttered.

---
*PR created automatically by Jules for task [13622560475227505185](https://jules.google.com/task/13622560475227505185) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->