### PR TITLE
🎨 Palette: Standardize focus indicators for metric creation form actions

### DIFF
--- a/docs/guides/palette.md
+++ b/docs/guides/palette.md
@@ -84,3 +84,7 @@ Critical UX and accessibility learnings from the Experimentation Platform.
 ## 2026-07-15 - Multi-Selection Reset Interaction Pattern
 **Learning:** For multi-selection workflows (such as selecting multiple experiments for side-by-side comparison), users find it highly tedious to individually close or remove each selection chip to reset or clear the view. Providing a dedicated, keyboard-accessible "Clear all" button alongside the chips significantly reduces interaction friction and facilitates quick, exploratory comparison flows.
 **Action:** When displaying a list of selected interactive items or chips, always render an adjacent "Clear all" reset button if multiple items are present. Ensure the button is fully navigable and styles its focus state with offset rings for maximum accessibility.
+
+## 2026-08-12 - Standard Focus Rings on Form Actions
+**Learning:** Primary form actions (like 'Cancel' and 'Create Metric') are crucial keyboard targets but are easily neglected during manual accessibility checks. Standardizing these with `focus-visible` offset rings prevents keyboard focus loss and ensures consistent interaction feedback across creation workflows, aligning them with global navigation elements.
+**Action:** Always apply `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2` to all primary and secondary form-level action buttons.

--- a/ui/src/app/metrics/new/page.tsx
+++ b/ui/src/app/metrics/new/page.tsx
@@ -339,7 +339,7 @@ export default function NewMetricPage() {
             <button
               type="button"
               onClick={handleCancel}
-              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               data-testid="metric-cancel-button"
             >
               Cancel
@@ -347,7 +347,7 @@ export default function NewMetricPage() {
             <button
               type="submit"
               disabled={state.submitting || !formValid}
-              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
               data-testid="metric-submit-button"
             >
               {state.submitting ? 'Creating…' : 'Create Metric'}


### PR DESCRIPTION
This PR implements standard focus indicators on form action buttons in the Create Metric page to resolve accessibility and keyboard-navigation gaps. All unit, integration, and lint tests pass cleanly, and visual focus indicators have been verified using Playwright.

---
*PR created automatically by Jules for task [13830074525541443464](https://jules.google.com/task/13830074525541443464) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->