### PR TITLE
🎨 Palette: Standardize focus ring on ConfirmDialog Cancel button

### DIFF
--- a/ui/src/__tests__/accessibility.test.tsx
+++ b/ui/src/__tests__/accessibility.test.tsx
@@ -110,7 +110,7 @@ describe('Accessibility', () => {
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
-    it('focuses Cancel button on open', () => {
+    it('focuses Cancel button on open and button has accessibility focus ring classes', () => {
       render(
         <ConfirmDialog
           open={true}
@@ -122,7 +122,11 @@ describe('Accessibility', () => {
         />,
       );
 
-      expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }));
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+      expect(document.activeElement).toBe(cancelButton);
+      expect(cancelButton).toHaveClass('focus-visible:ring-2');
+      expect(cancelButton).toHaveClass('focus-visible:ring-indigo-500');
+      expect(cancelButton).toHaveClass('focus-visible:ring-offset-2');
     });
 
     it('title and message are linked via aria-labelledby/describedby', () => {

--- a/ui/src/components/confirm-dialog.tsx
+++ b/ui/src/components/confirm-dialog.tsx
@@ -97,7 +97,7 @@ export function ConfirmDialog({
             type="button"
             onClick={onCancel}
             disabled={loading}
-            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 disabled:opacity-50"
           >
             Cancel
           </button>


### PR DESCRIPTION
### 🎨 Palette: Standardize ConfirmDialog Cancel Button Focus Ring

#### 💡 What
Added standard platform focus-visible styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2`) to the `Cancel` button in `ConfirmDialog` (`ui/src/components/confirm-dialog.tsx`). Updated unit tests in `ui/src/__tests__/accessibility.test.tsx` to assert focus ring classes.

#### 🎯 Why
In `ConfirmDialog`, focus is programmatically shifted to the `Cancel` button on open (`cancelRef.current?.focus()`). Adding standardized offset ring focus styles gives immediate, clear visual feedback for keyboard navigators opening modals across the platform.

#### ♿ Accessibility
- Standardizes keyboard focus indicator on modal dialog cancellation action with an offset focus ring matching the platform's action and form button design system.

---
*PR created automatically by Jules for task [15162227706899524857](https://jules.google.com/task/15162227706899524857) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->