### PR TITLE
🎨 Palette: add focus rings and aria-labels to CUPED and IPW switch toggles

### DIFF
--- a/ui/src/__tests__/results-dashboard.test.tsx
+++ b/ui/src/__tests__/results-dashboard.test.tsx
@@ -106,7 +106,7 @@ describe('Results Dashboard - homepage_recs_v2 (experiment 111...)', () => {
     expect(screen.queryByText('Sample Ratio Mismatch Detected')).not.toBeInTheDocument();
   });
 
-  it('CUPED toggle switches between raw and adjusted values', async () => {
+  it('CUPED toggle switches between raw and adjusted values and has proper accessibility attributes', async () => {
     const user = userEvent.setup();
     render(<ResultsPage />);
 
@@ -114,11 +114,15 @@ describe('Results Dashboard - homepage_recs_v2 (experiment 111...)', () => {
       expect(screen.getByText('CUPED Adjustment')).toBeInTheDocument();
     });
 
+    const toggle = screen.getByRole('switch', { name: 'CUPED Adjustment' });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-label', 'CUPED Adjustment');
+    expect(toggle.className).toContain('focus-visible:ring-2');
+
     // Default: raw values — click_through_rate effect is 0.014 → "+0.0140"
     expect(screen.getByText('+0.0140')).toBeInTheDocument();
 
     // Toggle CUPED on
-    const toggle = screen.getByRole('switch');
     await user.click(toggle);
 
     // CUPED adjusted: click_through_rate effect is 0.013 → "+0.0130"

--- a/ui/src/components/cuped-toggle.tsx
+++ b/ui/src/components/cuped-toggle.tsx
@@ -16,8 +16,9 @@ function CupedToggleInner({ enabled, onToggle, varianceReductionPct }: CupedTogg
         <button
           role="switch"
           aria-checked={enabled}
+          aria-label="CUPED Adjustment"
           onClick={onToggle}
-          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${
             enabled ? 'bg-indigo-600' : 'bg-gray-200'
           }`}
         >

--- a/ui/src/components/ipw-toggle.tsx
+++ b/ui/src/components/ipw-toggle.tsx
@@ -15,8 +15,9 @@ function IpwToggleInner({ enabled, onToggle }: IpwToggleProps) {
         <button
           role="switch"
           aria-checked={enabled}
+          aria-label="IPW Adjustment"
           onClick={onToggle}
-          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${
             enabled ? 'bg-amber-600' : 'bg-gray-200'
           }`}
         >


### PR DESCRIPTION
Added explicit aria-label attributes and platform-standard focus-visible rings (focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2) to the CupedToggle and IpwToggle switch controls to improve screen reader accessibility and keyboard navigation. Added unit test assertions to verify the presence of these accessibility attributes.

---
*PR created automatically by Jules for task [16279850345029314408](https://jules.google.com/task/16279850345029314408) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->