### PR TITLE
🎨 Palette: Improve keyboard focus indicators and disabled state feedback in VariantForm

### DIFF
--- a/ui/src/__tests__/variant-form.test.tsx
+++ b/ui/src/__tests__/variant-form.test.tsx
@@ -108,11 +108,12 @@ describe('VariantForm', () => {
     expect(screen.queryByDisplayValue('extra')).not.toBeInTheDocument();
   });
 
-  it('disables remove button at minimum variant count for AB', () => {
+  it('disables remove button at minimum variant count for AB and shows tooltip', () => {
     render(<VariantForm variants={baseVariants} experimentType="AB" onSave={vi.fn()} />);
     const removeButtons = screen.getAllByText('Remove');
     removeButtons.forEach((btn) => {
       expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', 'Minimum of 2 variants required');
     });
   });
 

--- a/ui/src/components/variant-form.tsx
+++ b/ui/src/components/variant-form.tsx
@@ -161,7 +161,7 @@ export function VariantForm({ variants: initialVariants, experimentType, onSave 
                     aria-required="true"
                     aria-invalid={!!getError(i, 'name')}
                     aria-describedby={getError(i, 'name') ? `variant-${i}-name-error` : undefined}
-                    className={`w-full rounded border px-2 py-1 text-sm ${
+                    className={`w-full rounded border px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                       getError(i, 'name') ? 'border-red-500' : 'border-gray-300'
                     }`}
                   />
@@ -181,7 +181,7 @@ export function VariantForm({ variants: initialVariants, experimentType, onSave 
                     aria-label={`Variant ${i + 1} traffic`}
                     aria-invalid={!!getError(i, 'trafficFraction')}
                     aria-describedby={getError(i, 'trafficFraction') ? `variant-${i}-traffic-error` : undefined}
-                    className={`w-24 rounded border px-2 py-1 text-sm ${
+                    className={`w-24 rounded border px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                       getError(i, 'trafficFraction') ? 'border-red-500' : 'border-gray-300'
                     }`}
                   />
@@ -196,6 +196,7 @@ export function VariantForm({ variants: initialVariants, experimentType, onSave 
                     checked={v.isControl}
                     onChange={() => updateVariant(i, 'isControl', true)}
                     aria-label={`Set ${v.name || `variant ${i + 1}`} as control`}
+                    className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1"
                   />
                 </td>
                 <td className="px-4 py-2">
@@ -207,7 +208,7 @@ export function VariantForm({ variants: initialVariants, experimentType, onSave 
                     aria-invalid={!!getError(i, 'payloadJson')}
                     aria-describedby={getError(i, 'payloadJson') ? `variant-${i}-payload-error` : undefined}
                     rows={2}
-                    className={`w-full rounded border px-2 py-1 font-mono text-xs ${
+                    className={`w-full rounded border px-2 py-1 font-mono text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                       getError(i, 'payloadJson') ? 'border-red-500' : 'border-gray-300'
                     }`}
                   />
@@ -221,7 +222,8 @@ export function VariantForm({ variants: initialVariants, experimentType, onSave 
                     onClick={() => removeVariant(i)}
                     disabled={variants.length <= minVariants}
                     aria-label={`Remove variant ${v.name || i + 1}`}
-                    className="text-sm text-red-600 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400"
+                    title={variants.length <= minVariants ? `Minimum of ${minVariants} variant${minVariants > 1 ? 's' : ''} required` : undefined}
+                    className="rounded-sm text-sm text-red-600 hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:text-gray-400"
                   >
                     Remove
                   </button>


### PR DESCRIPTION
💡 **What:** Added standard `focus-visible` focus rings (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500`) to text, number, radio, and textarea inputs in `VariantForm`, as well as focus indicators and informative disabled state tooltips (`title="Minimum of X variants required"`) to the "Remove" button.
🎯 **Why:** Ensures keyboard accessibility parity across variant editing controls and provides clear visual feedback explaining why variant removal is disabled at minimum thresholds.
♿ **Accessibility:** Guarantees visible focus outlines during tab navigation and provides screen-reader/hover tooltip context for disabled state constraints.

---
*PR created automatically by Jules for task [10700055099458341661](https://jules.google.com/task/10700055099458341661) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->