### PR TITLE
🎨 Palette: Replace text exclamation with accessible warning icon in SrmBanner

### DIFF
--- a/ui/src/__tests__/components/srm-banner.test.tsx
+++ b/ui/src/__tests__/components/srm-banner.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { SrmBanner } from '@/components/srm-banner';
+import type { SrmResult } from '@/lib/types';
+
+describe('SrmBanner', () => {
+  it('renders nothing when there is no sample ratio mismatch', () => {
+    const srmResult: SrmResult = {
+      isMismatch: false,
+      pValue: 0.85,
+      chiSquared: 0.15,
+      observedCounts: { control: 500, treatment: 500 },
+      expectedCounts: { control: 500, treatment: 500 },
+    };
+
+    const { container } = render(<SrmBanner srmResult={srmResult} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the alert banner and counts table when a mismatch is detected', () => {
+    const srmResult: SrmResult = {
+      isMismatch: true,
+      pValue: 0.0001,
+      chiSquared: 15.42,
+      observedCounts: { control: 600, treatment: 400 },
+      expectedCounts: { control: 500, treatment: 500 },
+    };
+
+    render(<SrmBanner srmResult={srmResult} />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Sample Ratio Mismatch Detected')).toBeInTheDocument();
+    expect(screen.getByText(/Chi-squared = 15.42/)).toBeInTheDocument();
+    expect(screen.getByText(/p-value = < 0.001/)).toBeInTheDocument();
+
+    expect(screen.getByText('control')).toBeInTheDocument();
+    expect(screen.getByText('600')).toBeInTheDocument();
+    expect(screen.getByText('treatment')).toBeInTheDocument();
+    expect(screen.getByText('400')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/srm-banner.tsx
+++ b/ui/src/components/srm-banner.tsx
@@ -17,7 +17,20 @@ function SrmBannerInner({ srmResult }: SrmBannerProps) {
   return (
     <div className="mb-6 rounded-lg border border-red-300 bg-red-50 p-4" role="alert">
       <div className="flex items-start gap-3">
-        <span className="text-lg" aria-hidden="true">!</span>
+        <div className="flex-shrink-0 pt-0.5">
+          <svg
+            className="h-5 w-5 text-red-600"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </div>
         <div>
           <h3 className="font-semibold text-red-800">
             Sample Ratio Mismatch Detected


### PR DESCRIPTION
🎨 **Palette: Replace text exclamation with accessible warning icon in SrmBanner**

### 💡 What
Replaced the crude plain text `!` character in the Sample Ratio Mismatch (`SrmBanner`) component with a standard inline SVG warning triangle icon (`aria-hidden="true"`). Added unit tests in `src/__tests__/components/srm-banner.test.tsx`.

### 🎯 Why
The crude text `!` character in the alert banner was visually jarring and lacked consistent styling with other system alerts (such as `RetryableError`). The inline SVG warning icon provides cleaner visual hierarchy and professional aesthetics.

### ♿ Accessibility
- Preserved `role="alert"` on the main banner container.
- Added `aria-hidden="true"` to the decorative SVG warning icon to prevent screen readers from reading raw icon paths or characters.

### 🧪 Tests
- Created `ui/src/__tests__/components/srm-banner.test.tsx` verifying component renders `null` when `isMismatch` is `false`, and renders the alert banner with chi-squared values, p-values, and variant count tables when `isMismatch` is `true`. All tests pass cleanly.

---
*PR created automatically by Jules for task [8876344511442831979](https://jules.google.com/task/8876344511442831979) started by @wunderkennd*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wunderkennd/kaizen-experimentation/pull/791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->